### PR TITLE
Trim suggestion matches to cursor position

### DIFF
--- a/packages/tiptap-extensions/src/plugins/Suggestions.js
+++ b/packages/tiptap-extensions/src/plugins/Suggestions.js
@@ -39,6 +39,12 @@ function triggerCharacter({
         // The absolute position of the match in the document
         const from = match.index + $position.start()
         let to = from + match[0].length
+        
+        // trim match to cursor position
+        if (allowSpaces) {
+            to = $position.pos;
+            match[0] = match[0].substr(0, to - from);
+        }
 
         // Edge case handling; if spaces are allowed and we're directly in between
         // two triggers

--- a/packages/tiptap-extensions/src/plugins/Suggestions.js
+++ b/packages/tiptap-extensions/src/plugins/Suggestions.js
@@ -39,11 +39,11 @@ function triggerCharacter({
         // The absolute position of the match in the document
         const from = match.index + $position.start()
         let to = from + match[0].length
-        
+
         // trim match to cursor position
         if (allowSpaces) {
-            to = $position.pos;
-            match[0] = match[0].substr(0, to - from);
+            to = $position.pos
+            match[0] = match[0].substr(0, to - from)
         }
 
         // Edge case handling; if spaces are allowed and we're directly in between


### PR DESCRIPTION
Otherwise it will match to the end of the node, possibly matching much more than needed.