### PR TITLE
render(h) function support for TodoItem

### DIFF
--- a/packages/tiptap-extensions/src/nodes/TodoItem.js
+++ b/packages/tiptap-extensions/src/nodes/TodoItem.js
@@ -60,7 +60,7 @@ export default class TodoItem extends Node {
             },
             ref: 'content',
           }),
-        ]);
+        ])
       },
     }
   }

--- a/packages/tiptap-extensions/src/nodes/TodoItem.js
+++ b/packages/tiptap-extensions/src/nodes/TodoItem.js
@@ -29,6 +29,39 @@ export default class TodoItem extends Node {
           <div class="todo-content" ref="content" :contenteditable="view.editable.toString()"></div>
         </li>
       `,
+      /*
+        The render function enables TodoItem to work in `runtimeonly` builds,
+        which is required for frameworks requiring strict CSP policies. For
+        example, doing this is required in Chrome Extensions. Having both
+        the template and the render function ensures there are no issues
+        converting the node to JSON and rendering the component.
+      */
+      render(h) {
+        return h('li', {
+          attrs: {
+            'data-type': this.node.type.name,
+            'data-done': this.node.attrs.done.toString(),
+            'data-drag-handle': '',
+          },
+        }, [
+          h('span', {
+            class: 'todo-checkbox',
+            attrs: {
+              contenteditable: false,
+            },
+            on: {
+              click: this.onChange,
+            },
+          }),
+          h('div', {
+            class: 'todo-content',
+            attrs: {
+              contenteditable: this.view.editable.toString(),
+            },
+            ref: 'content',
+          }),
+        ]);
+      },
     }
   }
 


### PR DESCRIPTION
This is in reference to https://github.com/scrumpy/tiptap/issues/69, which is closed but is still relevant for any project that requires a strict CSP (content security policy), such as a Chrome Extension or many enterprise apps.

Having both a render function and the template is required, as having only a render(h) causes errors with converting the node to JSON. It also makes the render(h) function more legible, as you have something to reference when reading the render(h) function. 

In that file, I added a comment that should further document why the render(h) function is embedded. 