### PR TITLE
Custom matcher of SuggestionsPlugin 

### DIFF
--- a/packages/tiptap-extensions/src/plugins/Suggestions.js
+++ b/packages/tiptap-extensions/src/plugins/Suggestions.js
@@ -68,6 +68,7 @@ function triggerCharacter({
 }
 
 export default function SuggestionsPlugin({
+  // matcher allow a function
   matcher = {
     char: '@',
     allowSpaces: false,
@@ -189,7 +190,7 @@ export default function SuggestionsPlugin({
 
           // Try to match against where our cursor currently is
           const $position = selection.$from
-          const match = triggerCharacter(matcher)($position)
+          const match = typeof matcher === "function" ? matcher($position) : triggerCharacter(matcher)($position)
           const decorationId = (Math.random() + 1).toString(36).substr(2, 5)
 
           // If we found a match, update the current state to show it


### PR DESCRIPTION
The SuggestionPlugin is very easy to use, but there is no other way to duplicate the Suggestion Plugin when we want to customize the match process.
For example, I want to use a matcher that matches even if there is no space immediately before, like this:

```js
function triggerCharacter({ char }) {
  return $position => {
    if ($position.depth <= 0) {
      return false
    }

    const escapedChar = `\\${char}`
    const text = $position.doc.textBetween($position.before(), $position.end(), '\0', '\0')
    const match = new RegExp(`${escapedChar}[^\\s${escapedChar}]*$`, 'gm').exec(text)
    if (match === null) {
      return null
    }

    const from = match.index + $position.start()
    var hasNode = false
    $position.doc.nodesBetween(from, $position.end(), (node) => {
      if (!(node.isTextblock || node.isText)) {
        hasNode = true
      }
    })

    if (hasNode) {
      return null
    }

    return {
      range: {
        from: from,
        to: $position.end(),
      },
      query: match[0].slice(char.length),
      text: match[0],
    }
  }
}
```

This PR allows us specify a function as a matcher from outside.