### PR TITLE
feat(mention): add class attr to mentions multiple mention classes

### DIFF
--- a/packages/tiptap-extensions/src/nodes/Mention.js
+++ b/packages/tiptap-extensions/src/nodes/Mention.js
@@ -25,7 +25,9 @@ export default class Mention extends Node {
       attrs: {
         id: {},
         label: {},
-        class: '',
+        class: {
+          default: this.options.mentionClass,
+        },
       },
       group: 'inline',
       inline: true,
@@ -34,7 +36,7 @@ export default class Mention extends Node {
       toDOM: node => [
         'span',
         {
-          class: node.attrs.class || this.options.mentionClass,
+          class: node.attrs.class,
           'data-mention-id': node.attrs.id,
         },
         `${this.options.matcher.char}${node.attrs.label}`,

--- a/packages/tiptap-extensions/src/nodes/Mention.js
+++ b/packages/tiptap-extensions/src/nodes/Mention.js
@@ -25,6 +25,7 @@ export default class Mention extends Node {
       attrs: {
         id: {},
         label: {},
+        class: '',
       },
       group: 'inline',
       inline: true,
@@ -33,7 +34,7 @@ export default class Mention extends Node {
       toDOM: node => [
         'span',
         {
-          class: this.options.mentionClass,
+          class: node.attrs.class || this.options.mentionClass,
           'data-mention-id': node.attrs.id,
         },
         `${this.options.matcher.char}${node.attrs.label}`,
@@ -44,7 +45,8 @@ export default class Mention extends Node {
           getAttrs: dom => {
             const id = dom.getAttribute('data-mention-id')
             const label = dom.innerText.split(this.options.matcher.char).join('')
-            return { id, label }
+            const className = dom.getAttribute('class')
+            return { id, label, class: className }
           },
         },
       ],


### PR DESCRIPTION
this PR adds a class attribute to the mention node

this allows developers to pass a class when inserting a suggestion
giving the mention element a custom class if desired 

otherwise fallback to the class passed into the options object

example use  
```js
    selectSuggestion(suggestion) {
      this.insertSuggestion({
        range: this.suggestionRange,
        attrs: {
          id: suggestion.key,
          label: `@${suggestion.label}`,
          class: condition ? this.oneclass : this.otherclass
        }
      })
    },
```