### PR TITLE
Allow to manually set the active state on the EditorMenuBubble

### DIFF
--- a/examples/Components/Routes/Links/index.vue
+++ b/examples/Components/Routes/Links/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="editor">
-    <editor-menu-bubble class="menububble" :editor="editor" @hide="hideLinkMenu" v-slot="{ commands, isActive, getMarkAttrs, menu }">
+    <editor-menu-bubble class="menububble" :editor="editor" @hide="hideLinkMenu" :is-active-callback="({ isActive }) => isActive.link()" v-slot="{ commands, isActive, getMarkAttrs, menu }">
       <div
         class="menububble"
         :class="{ 'is-active': menu.isActive }"
@@ -15,6 +15,13 @@
         </form>
 
         <template v-else>
+          <a
+            class="menububble__link"
+            v-if="isActive.link()"
+            :href="getMarkAttrs('link').href"
+          >
+            {{ getMarkAttrs('link').href }}
+          </a>
           <button
             class="menububble__button"
             @click="showLinkMenu(getMarkAttrs('link'))"
@@ -71,7 +78,9 @@ export default {
           new OrderedList(),
           new TodoItem(),
           new TodoList(),
-          new Link(),
+          new Link({
+            openOnClick: false
+          }),
           new Bold(),
           new Code(),
           new Italic(),

--- a/examples/assets/sass/menububble.scss
+++ b/examples/assets/sass/menububble.scss
@@ -25,6 +25,7 @@
     margin-right: 0.2rem;
     border-radius: 3px;
     cursor: pointer;
+    white-space: nowrap;
 
     &:last-child {
       margin-right: 0;
@@ -37,6 +38,13 @@
     &.is-active {
       background-color: rgba($color-white, 0.2);
     }
+  }
+
+  &__link {
+    font-size: 0.8rem;
+    color: $color-white;
+    display: inline-flex;
+    padding: 0.2rem 0.5rem;
   }
 
   &__form {

--- a/packages/tiptap/src/Components/EditorMenuBubble.js
+++ b/packages/tiptap/src/Components/EditorMenuBubble.js
@@ -11,6 +11,10 @@ export default {
       default: true,
       type: Boolean,
     },
+    isActiveCallback: {
+      default: undefined,
+      type: Function,
+    },
   },
 
   data() {
@@ -33,6 +37,7 @@ export default {
               editor,
               element: this.$el,
               keepInBounds: this.keepInBounds,
+              isActiveCallback: this.isActiveCallback,
               onUpdate: menu => {
                 // the second check ensures event is fired only once
                 if (menu.isActive && this.menu.isActive === false) {

--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -56,6 +56,7 @@ class Menu {
   constructor({ options, editorView }) {
     this.options = {
       ...{
+        isActiveCallback: undefined,
         element: null,
         keepInBounds: true,
         onUpdate: () => false,
@@ -63,7 +64,8 @@ class Menu {
       ...options,
     }
     this.editorView = editorView
-    this.isActive = false
+    this.isActive = this.options.isActiveCallback
+      ? this.options.isActiveCallback({ isActive: this.options.editor.isActive }) : false
     this.left = 0
     this.bottom = 0
     this.top = 0
@@ -103,8 +105,10 @@ class Menu {
       return
     }
 
-    // Hide the tooltip if the selection is empty
-    if (state.selection.empty) {
+    // Hide the tooltip if the selection is empty and the is active callback is not returning true
+    const manualActiveState = this.options.isActiveCallback
+      && !this.options.isActiveCallback({ isActive: this.options.editor.isActive })
+    if (state.selection.empty && (!this.options.isActiveCallback || manualActiveState)) {
       this.hide()
       return
     }
@@ -161,7 +165,8 @@ class Menu {
       return
     }
 
-    this.isActive = false
+    this.isActive = this.options.isActiveCallback
+      ? this.options.isActiveCallback({ isActive: this.options.editor.isActive }) : false
     this.sendUpdate()
   }
 


### PR DESCRIPTION
This change allows to manually overwrite the active state of the EditorMenuBubble component, so that it can be shown based on conditions provided by the user.

A common use case is shown in the Link example, where you don't open a link directly on click, but show the menu bubble as a hint to show the URL before actually opening the link.

I've updated the link example to use that since I was unsure if it makes sense to actually add another extra example page.

![image](https://user-images.githubusercontent.com/3404133/75259860-facd2900-57e8-11ea-943b-09e15389bc91.png)
