### PR TITLE
Add options to enable / disable dropCursor and gapCursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ export default {
 | `extensions` | `Array` | `[]` | A list of extensions used, by the editor. This can be `Nodes`, `Marks` or `Plugins`. |
 | `useBuiltInExtensions` | `Boolean` | `true` | By default tiptap adds a `Doc`, `Paragraph` and `Text` node to the Prosemirror schema. |
 | `dropCursor` | `Object` | `{}` | Config for `prosemirror-dropcursor`. |
+| `enableDropCursor` | `Boolean` | `true` | Option to enable / disable the dropCursor plugin`. |
+| `enableGapCursor` | `Boolean` | `true` | Option to enable / disable the gapCursor plugin`. |
 | `parseOptions` | `Object` | `{}` | A list of [Prosemirror parseOptions](https://prosemirror.net/docs/ref/#model.ParseOptions). |
 | `onInit` | `Function` | `undefined` | This will return an Object with the current `state` and `view` of Prosemirror on init. |
 | `onFocus` | `Function` | `undefined` | This will return an Object with the `event` and current `state` and `view` of Prosemirror on focus. |

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -50,6 +50,8 @@ export default class Editor extends Emitter {
       disableInputRules: false,
       disablePasteRules: false,
       dropCursor: {},
+      enableDropCursor: true,
+      enableGapCursor: true,
       parseOptions: {},
       injectCSS: true,
       onInit: () => {},
@@ -211,8 +213,8 @@ export default class Editor extends Emitter {
           Backspace: undoInputRule,
         }),
         keymap(baseKeymap),
-        dropCursor(this.options.dropCursor),
-        gapCursor(),
+        ...(enableDropCursor ? [dropCursor(this.options.dropCursor)] : []),
+        ...(enableGapCursor ? [gapCursor()] : []),
         new Plugin({
           key: new PluginKey('editable'),
           props: {


### PR DESCRIPTION
The title says it all :)

It's very important that tiptap **suggests**, but doesn't **enforce** plugins, so optional enable / disable parameters must exist.