### PR TITLE
make Suggestions only match text nodes

### DIFF
--- a/packages/tiptap-extensions/src/plugins/Suggestions.js
+++ b/packages/tiptap-extensions/src/plugins/Suggestions.js
@@ -15,6 +15,9 @@ function triggerCharacter({
       return false
     }
 
+    // Allow only text nodes after the current caret position
+    if (!$position.nodeAfter.isText) return false
+
     // Matching expressions used for later
     const escapedChar = `\\${char}`
     const suffix = new RegExp(`\\s${escapedChar}$`)

--- a/packages/tiptap-extensions/src/plugins/Suggestions.js
+++ b/packages/tiptap-extensions/src/plugins/Suggestions.js
@@ -16,7 +16,7 @@ function triggerCharacter({
     }
 
     // Allow only text nodes after the current caret position
-    if (!$position.nodeAfter.isText) return false
+    if ($position.nodeAfter && !$position.nodeAfter.isText) return false
 
     // Matching expressions used for later
     const escapedChar = `\\${char}`


### PR DESCRIPTION
The suggestion plugin is looking for text to match with the help of the `textBetween()` method;
```js
const text = $position.doc.textBetween(textFrom, textTo, '\0', '\0')
```

But is not checking whether the range `from` and `to` contains any non-text-nodes. This leads to unexpected results, if the node behind the caret is not a text node (It can't find anything, because it's matching an atom node which is non-editable by default, I guess? In the example the caret is displayed inside the suggestion node, which is technically not true):

![ezgif-5-96654b013643](https://user-images.githubusercontent.com/8270488/84964969-e9988700-b10d-11ea-9c2a-337880cc23b8.gif)

The proposed solution is to check if the next node is a text node:

```js
// Allow only text nodes after the current caret position
if (!$position.nodeAfter.isText) return false
```

Then, if the next node is not a text node, the autocomplete is not triggered.
(I used this plugin to let the user create new entries and found out, it would wrap not only text nodes, but try to do the same with other node types)