### PR TITLE
Fix an issue with with parsing custom extensions

### DIFF
--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -274,7 +274,7 @@ export default class Editor extends Emitter {
     if (typeof content === 'string') {
       const htmlString = `<div>${content}</div>`
       const parser = new window.DOMParser()
-      const element = parser.parseFromString(htmlString, 'text/html').body
+      const element = parser.parseFromString(htmlString, 'text/html').body.firstElementChild
       return DOMParser.fromSchema(this.schema).parse(element, parseOptions)
     }
 


### PR DESCRIPTION
see details in #747:

>This PR implements my suggestion at #713 however, it left out a crucial part where we get the parsed DOM first element as the root element.

>This PR parses the HTML string using the browser's native DOMParser and passes the body as the root DOM node. However, in order to parse the HTML string, we wrapped the content in a single div root node. This makes Tiptap break on certain occasions when using custom extensions. I have yet to understand why it happens, but it seems like that just passing the body.firstElementChild as the root DOM solves this issue effortlessly.