### PR TITLE
Improve pasteRules for Link mark

### DIFF
--- a/packages/tiptap-extensions/src/marks/Link.js
+++ b/packages/tiptap-extensions/src/marks/Link.js
@@ -56,7 +56,7 @@ export default class Link extends Mark {
   pasteRules({ type }) {
     return [
       pasteRule(
-        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z]{2,}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
+        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z]{2,}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/gi,
         type,
         url => ({ href: url }),
       ),

--- a/packages/tiptap-extensions/src/marks/Link.js
+++ b/packages/tiptap-extensions/src/marks/Link.js
@@ -56,7 +56,7 @@ export default class Link extends Mark {
   pasteRules({ type }) {
     return [
       pasteRule(
-        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-zA-Z]{2,}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
+        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z]{2,}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
         type,
         url => ({ href: url }),
       ),


### PR DESCRIPTION
This PR improves the pasteRules for the Link mark. It allows domains to be a single letter (e. g. https://t.me) or uppercase (e. g. https://GOOGLE.COM).

Fixes #745