### PR TITLE
fix: blockquote unwrap not working

### DIFF
--- a/packages/tiptap-extensions/src/nodes/Blockquote.js
+++ b/packages/tiptap-extensions/src/nodes/Blockquote.js
@@ -20,8 +20,8 @@ export default class Blockquote extends Node {
     }
   }
 
-  commands({ type, schema }) {
-    return () => toggleWrap(type, schema.nodes.paragraph)
+  commands({ type }) {
+    return () => toggleWrap(type)
   }
 
   keys({ type }) {


### PR DESCRIPTION
Closes #803

## Known Limitations
The unwrapping is limited to the current Node, so if you have multiple nodes (2 Paragraphs or in this case a Paragraph and a Heading) only the selected node gets lifted... 
![319e6ad6-4093-4107-9bba-13452e1e7b8f](https://user-images.githubusercontent.com/6141652/92933487-98670d80-f446-11ea-8911-531f10709631.gif)
