### PR TITLE
Use ProseMirror Sub-views to implement editability of Vue-component slot content

### DIFF
--- a/examples/Components/Routes/VueSlots/StaffList/DefaultBlockSlotExtension.js
+++ b/examples/Components/Routes/VueSlots/StaffList/DefaultBlockSlotExtension.js
@@ -15,7 +15,7 @@ export default class extends Node {
       selectable: false,
       draggable: false,
       parseDOM: [{
-        tag: 'template[v-slot:default]',
+        tag: 'template[v-slot\\:default]',
         getAttrs: dom => ({
           'v-slot:default': dom.getAttribute('v-slot:default'),
         }),

--- a/examples/Components/Routes/VueSlots/StaffList/DefaultBlockSlotExtension.js
+++ b/examples/Components/Routes/VueSlots/StaffList/DefaultBlockSlotExtension.js
@@ -1,0 +1,26 @@
+import Node from '../../../../../packages/tiptap/src/Utils/Node'
+
+export default class extends Node {
+  get name() {
+    return 'stafflistdefaultblockslot'
+  }
+
+  get schema() {
+    return {
+      content: 'block*',
+      group: 'block',
+      attrs: {
+        'v-slot:default': { default: 'slotProps' },
+      },
+      selectable: false,
+      draggable: false,
+      parseDOM: [{
+        tag: 'template[v-slot:default]',
+        getAttrs: dom => ({
+          'v-slot:default': dom.getAttribute('v-slot:default'),
+        }),
+      }],
+      toDOM: node => ['template', node.attrs, 0],
+    }
+  }
+}

--- a/examples/Components/Routes/VueSlots/StaffList/Node.js
+++ b/examples/Components/Routes/VueSlots/StaffList/Node.js
@@ -1,0 +1,32 @@
+import Node from '../../../../../packages/tiptap/src/Utils/Node'
+import toggleWrap from '../../../../../packages/tiptap-commands/src/commands/toggleWrap'
+
+export default function (component) {
+  return class extends Node {
+    get name() {
+      return 'stafflist'
+    }
+
+    get schema() {
+      return {
+        content: 'stafflistdefaultblockslot staffmemberslot',
+        group: 'block',
+        defining: true,
+        selectable: true,
+        draggable: true,
+        parseDOM: [{
+          tag: 'staff-list',
+        }],
+        toDOM: () => ['staff-list', 0],
+      }
+    }
+
+    get view() {
+      return component
+    }
+
+    commands({ type }) {
+      return () => toggleWrap(type)
+    }
+  }
+}

--- a/examples/Components/Routes/VueSlots/StaffList/StaffMemberSlotExtension.js
+++ b/examples/Components/Routes/VueSlots/StaffList/StaffMemberSlotExtension.js
@@ -14,7 +14,7 @@ export default class extends Node {
       selectable: false,
       draggable: false,
       parseDOM: [{
-        tag: 'template[v-slot:staff-members]',
+        tag: 'template[v-slot\\:staff-members]',
         getAttrs: dom => ({
           'v-slot:staff-members': dom.getAttribute('v-slot:staff-members'),
         }),

--- a/examples/Components/Routes/VueSlots/StaffList/StaffMemberSlotExtension.js
+++ b/examples/Components/Routes/VueSlots/StaffList/StaffMemberSlotExtension.js
@@ -1,0 +1,25 @@
+import Node from '../../../../../packages/tiptap/src/Utils/Node'
+
+export default class extends Node {
+  get name() {
+    return 'staffmemberslot'
+  }
+
+  get schema() {
+    return {
+      content: 'staffmember*',
+      attrs: {
+        'v-slot:staff-members': { default: 'slotProps' },
+      },
+      selectable: false,
+      draggable: false,
+      parseDOM: [{
+        tag: 'template[v-slot:staff-members]',
+        getAttrs: dom => ({
+          'v-slot:staff-members': dom.getAttribute('v-slot:staff-members'),
+        }),
+      }],
+      toDOM: node => ['template', node.attrs, 0],
+    }
+  }
+}

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -13,40 +13,17 @@
 
 <script>
 
-import Node from '../../../../../packages/tiptap/src/Utils/Node'
-import toggleWrap from '../../../../../packages/tiptap-commands/src/commands/toggleWrap'
+import Node from './Node'
+import DefaultBlockSlotExtension from './DefaultBlockSlotExtension'
+import StaffMemberSlotExtension from './StaffMemberSlotExtension'
 
 const component = {}
 
-const Extension = class extends Node {
-  get name() {
-    return 'stafflist'
-  }
-
-  get schema() {
-    return {
-      content: 'defaultblockslot staffmemberslot',
-      group: 'block',
-      defining: true,
-      selectable: true,
-      draggable: true,
-      parseDOM: [{
-        tag: 'staff-list',
-      }],
-      toDOM: () => ['staff-list', 0],
-    }
-  }
-
-  get view() {
-    return component
-  }
-
-  commands({ type }) {
-    return () => toggleWrap(type)
-  }
+component.extensions = {
+  DefaultBlockSlotExtension,
+  StaffMemberSlotExtension,
+  NodeExtension: Node(component),
 }
-
-component.Extension = Extension
 
 export default component
 

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="stafflist">
+    <div class="stafflist__content">
+      <slot>
+        <h3>Our Team</h3>
+        <p>Meet them all.</p>
+      </slot>
+    </div>
+    <div class="stafflist__itemsregion">
+    </div>
+  </div>
+</template>
+
+<script>
+
+import Node from '../../../../../packages/tiptap/src/Utils/Node'
+import toggleWrap from '../../../../../packages/tiptap-commands/src/commands/toggleWrap'
+
+const component = {}
+
+const Extension = class extends Node {
+  get name() {
+    return 'stafflist'
+  }
+
+  get schema() {
+    return {
+      content: 'defaultblockslot staffmemberslot',
+      group: 'block',
+      defining: true,
+      selectable: true,
+      draggable: true,
+      parseDOM: [{
+        tag: 'staff-list',
+      }],
+      toDOM: () => ['staff-list', 0],
+    }
+  }
+
+  get view() {
+    return component
+  }
+
+  commands({ type }) {
+    return () => toggleWrap(type)
+  }
+}
+
+component.Extension = Extension
+
+export default component
+
+</script>

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -7,6 +7,7 @@
       </slot>
     </div>
     <div class="stafflist__itemsregion">
+      <staff-member name="Mr Default Value"><p>Junior Not Meant To Be Here Clerk</p></staff-member>
     </div>
   </div>
 </template>
@@ -16,8 +17,13 @@
 import Node from './Node'
 import DefaultBlockSlotExtension from './DefaultBlockSlotExtension'
 import StaffMemberSlotExtension from './StaffMemberSlotExtension'
+import StaffMember from '../StaffMember'
 
-const component = {}
+const component = {
+  components: {
+    'staff-member': StaffMember,
+  },
+}
 
 component.extensions = {
   DefaultBlockSlotExtension,

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -27,10 +27,10 @@ const component = {
   },
 }
 
-component.extensions = {
-  DefaultBlockSlotExtension,
-  StaffMemberSlotExtension,
-  NodeExtension: Node(component),
+component.Extension = Node(component)
+component.slotExtensions = {
+  default: DefaultBlockSlotExtension,
+  'staff-members': StaffMemberSlotExtension,
 }
 
 export default component

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -40,3 +40,12 @@ component.slotExtensions = {
 export default component
 
 </script>
+
+<style>
+.stafflist {
+  border-radius: 5px;
+  padding: 10px;
+  background-color: #efefef;
+}
+
+</style>

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -8,7 +8,11 @@
     </div>
     <div class="stafflist__itemsregion">
       <slot name="staff-members">
-        <staff-member name="Mr Default Value"><p>Junior Not Meant To Be Here Clerk</p></staff-member>
+        <staff-member name="Mr Default Value">
+          <template v-slot:default="slotProps">
+            <p>Junior Not Meant To Be Here Clerk</p>
+          </template>
+        </staff-member>
       </slot>
     </div>
   </div>

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -7,13 +7,7 @@
       </slot>
     </div>
     <div class="stafflist__itemsregion">
-      <slot name="staff-members">
-        <staff-member name="Mr Default Value">
-          <template v-slot:default="slotProps">
-            <p>Junior Not Meant To Be Here Clerk</p>
-          </template>
-        </staff-member>
-      </slot>
+      <slot name="staff-members"></slot>
     </div>
   </div>
 </template>

--- a/examples/Components/Routes/VueSlots/StaffList/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffList/index.vue
@@ -7,7 +7,9 @@
       </slot>
     </div>
     <div class="stafflist__itemsregion">
-      <staff-member name="Mr Default Value"><p>Junior Not Meant To Be Here Clerk</p></staff-member>
+      <slot name="staff-members">
+        <staff-member name="Mr Default Value"><p>Junior Not Meant To Be Here Clerk</p></staff-member>
+      </slot>
     </div>
   </div>
 </template>

--- a/examples/Components/Routes/VueSlots/StaffMember/DefaultBlockSlotExtension.js
+++ b/examples/Components/Routes/VueSlots/StaffMember/DefaultBlockSlotExtension.js
@@ -1,0 +1,26 @@
+import Node from '../../../../../packages/tiptap/src/Utils/Node'
+
+export default class extends Node {
+  get name() {
+    return 'staffmemberdefaultblockslot'
+  }
+
+  get schema() {
+    return {
+      content: 'block*',
+      group: 'block',
+      attrs: {
+        'v-slot:default': { default: 'slotProps' },
+      },
+      selectable: false,
+      draggable: false,
+      parseDOM: [{
+        tag: 'template[v-slot:default]',
+        getAttrs: dom => ({
+          'v-slot:default': dom.getAttribute('v-slot:default'),
+        }),
+      }],
+      toDOM: node => ['template', node.attrs, 0],
+    }
+  }
+}

--- a/examples/Components/Routes/VueSlots/StaffMember/DefaultBlockSlotExtension.js
+++ b/examples/Components/Routes/VueSlots/StaffMember/DefaultBlockSlotExtension.js
@@ -15,7 +15,7 @@ export default class extends Node {
       selectable: false,
       draggable: false,
       parseDOM: [{
-        tag: 'template[v-slot:default]',
+        tag: 'template[v-slot\\:default]',
         getAttrs: dom => ({
           'v-slot:default': dom.getAttribute('v-slot:default'),
         }),

--- a/examples/Components/Routes/VueSlots/StaffMember/Node.js
+++ b/examples/Components/Routes/VueSlots/StaffMember/Node.js
@@ -1,0 +1,36 @@
+import Node from '../../../../../packages/tiptap/src/Utils/Node'
+import toggleWrap from '../../../../../packages/tiptap-commands/src/commands/toggleWrap'
+
+export default function (component) {
+  return class extends Node {
+    get name() {
+      return 'staffmember'
+    }
+
+    get schema() {
+      return {
+        content: 'staffmemberdefaultblockslot',
+        attrs: {
+          name: {},
+        },
+        selectable: true,
+        draggable: true,
+        parseDOM: [{
+          tag: 'staff-member',
+          getAttrs: dom => ({
+            name: dom.getAttribute('name'),
+          }),
+        }],
+        toDOM: node => ['staff-member', node.attrs, 0],
+      }
+    }
+
+    get view() {
+      return component
+    }
+
+    commands({ type }) {
+      return () => toggleWrap(type)
+    }
+  }
+}

--- a/examples/Components/Routes/VueSlots/StaffMember/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffMember/index.vue
@@ -21,9 +21,10 @@ const component = {
   },
 }
 
-component.extensions = {
-  DefaultBlockSlotExtension,
-  NodeExtension: Node(component),
+component.Extension = Node(component)
+
+component.slotExtensions = {
+  default: DefaultBlockSlotExtension,
 }
 
 export default component

--- a/examples/Components/Routes/VueSlots/StaffMember/index.vue
+++ b/examples/Components/Routes/VueSlots/StaffMember/index.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="staffmember">
+    <div class="staffmember__name">{{ name }}</div>
+    <div class="staffmember__position">
+      <slot><p>Chief Speculative Programming Officer</p></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+
+import Node from './Node'
+import DefaultBlockSlotExtension from './DefaultBlockSlotExtension'
+
+const component = {
+  props: {
+    name: {
+      type: String,
+      default: 'Mr En Jibby',
+    },
+  },
+}
+
+component.extensions = {
+  DefaultBlockSlotExtension,
+  NodeExtension: Node(component),
+}
+
+export default component
+
+</script>

--- a/examples/Components/Routes/VueSlots/index.vue
+++ b/examples/Components/Routes/VueSlots/index.vue
@@ -49,7 +49,19 @@ export default {
           new StaffMember.extensions.NodeExtension(),
         ],
         content: `
-          <p>Insert a staff list</p>
+          <staff-list>
+            <template v-slot:default="slotProps">
+              <h3>Our Staff</h3>
+              <p>We are all beautiful!</p>
+            </template>
+            <template v-slot:staff-members="slotProps">
+              <staff-member name="Mr En Jibby" avatar="enjibby-grinning.jpg">
+                <template v-slot:default="slotProps">
+                  <p>Chief Speculative Programming Officer<p>
+                </template>
+              </staff-member>
+            </template>
+          </staff-list>
         `,
       }),
     }

--- a/examples/Components/Routes/VueSlots/index.vue
+++ b/examples/Components/Routes/VueSlots/index.vue
@@ -1,0 +1,218 @@
+<template>
+  <div class="editor">
+    <editor-menu-bar :editor="editor" v-slot="{ commands, isActive }">
+      <div class="menubar">
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.bold() }"
+          @click="commands.bold"
+        >
+          <icon name="bold" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.italic() }"
+          @click="commands.italic"
+        >
+          <icon name="italic" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.strike() }"
+          @click="commands.strike"
+        >
+          <icon name="strike" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.underline() }"
+          @click="commands.underline"
+        >
+          <icon name="underline" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.code() }"
+          @click="commands.code"
+        >
+          <icon name="code" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.paragraph() }"
+          @click="commands.paragraph"
+        >
+          <icon name="paragraph" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.heading({ level: 1 }) }"
+          @click="commands.heading({ level: 1 })"
+        >
+          H1
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.heading({ level: 2 }) }"
+          @click="commands.heading({ level: 2 })"
+        >
+          H2
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.heading({ level: 3 }) }"
+          @click="commands.heading({ level: 3 })"
+        >
+          H3
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.bullet_list() }"
+          @click="commands.bullet_list"
+        >
+          <icon name="ul" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.ordered_list() }"
+          @click="commands.ordered_list"
+        >
+          <icon name="ol" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.blockquote() }"
+          @click="commands.blockquote"
+        >
+          <icon name="quote" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.code_block() }"
+          @click="commands.code_block"
+        >
+          <icon name="code" />
+        </button>
+
+        <button
+          class="menubar__button"
+          @click="commands.horizontal_rule"
+        >
+          <icon name="hr" />
+        </button>
+
+        <button
+          class="menubar__button"
+          @click="commands.undo"
+        >
+          <icon name="undo" />
+        </button>
+
+        <button
+          class="menubar__button"
+          @click="commands.redo"
+        >
+          <icon name="redo" />
+        </button>
+
+      </div>
+    </editor-menu-bar>
+
+    <editor-content class="editor__content" :editor="editor" />
+  </div>
+</template>
+
+<script>
+import Icon from 'Components/Icon'
+import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
+import {
+  Blockquote,
+  CodeBlock,
+  HardBreak,
+  Heading,
+  HorizontalRule,
+  OrderedList,
+  BulletList,
+  ListItem,
+  TodoItem,
+  TodoList,
+  Bold,
+  Code,
+  Italic,
+  Link,
+  Strike,
+  Underline,
+  History,
+} from 'tiptap-extensions'
+
+export default {
+  components: {
+    EditorContent,
+    EditorMenuBar,
+    Icon,
+  },
+  data() {
+    return {
+      editor: new Editor({
+        extensions: [
+          new Blockquote(),
+          new BulletList(),
+          new CodeBlock(),
+          new HardBreak(),
+          new Heading({ levels: [1, 2, 3] }),
+          new HorizontalRule(),
+          new ListItem(),
+          new OrderedList(),
+          new TodoItem(),
+          new TodoList(),
+          new Link(),
+          new Bold(),
+          new Code(),
+          new Italic(),
+          new Strike(),
+          new Underline(),
+          new History(),
+        ],
+        content: `
+          <h2>
+            Hi there,
+          </h2>
+          <p>
+            this is a very <em>basic</em> example of tiptap.
+          </p>
+          <pre><code>body { display: none; }</code></pre>
+          <ul>
+            <li>
+              A regular list
+            </li>
+            <li>
+              With regular items
+            </li>
+          </ul>
+          <blockquote>
+            It's amazing 👏
+            <br />
+            – mom
+          </blockquote>
+        `,
+      }),
+    }
+  },
+  beforeDestroy() {
+    this.editor.destroy()
+  },
+}
+</script>

--- a/examples/Components/Routes/VueSlots/index.vue
+++ b/examples/Components/Routes/VueSlots/index.vue
@@ -5,129 +5,19 @@
 
         <button
           class="menubar__button"
-          :class="{ 'is-active': isActive.bold() }"
-          @click="commands.bold"
+          :class="{ 'is-active': isActive.stafflist() }"
+          @click="commands.stafflist"
         >
           <icon name="bold" />
         </button>
 
         <button
           class="menubar__button"
-          :class="{ 'is-active': isActive.italic() }"
-          @click="commands.italic"
+          :class="{ 'is-active': isActive.staffmember() }"
+          @click="commands.staffmember"
         >
           <icon name="italic" />
         </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.strike() }"
-          @click="commands.strike"
-        >
-          <icon name="strike" />
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.underline() }"
-          @click="commands.underline"
-        >
-          <icon name="underline" />
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.code() }"
-          @click="commands.code"
-        >
-          <icon name="code" />
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.paragraph() }"
-          @click="commands.paragraph"
-        >
-          <icon name="paragraph" />
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.heading({ level: 1 }) }"
-          @click="commands.heading({ level: 1 })"
-        >
-          H1
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.heading({ level: 2 }) }"
-          @click="commands.heading({ level: 2 })"
-        >
-          H2
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.heading({ level: 3 }) }"
-          @click="commands.heading({ level: 3 })"
-        >
-          H3
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.bullet_list() }"
-          @click="commands.bullet_list"
-        >
-          <icon name="ul" />
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.ordered_list() }"
-          @click="commands.ordered_list"
-        >
-          <icon name="ol" />
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.blockquote() }"
-          @click="commands.blockquote"
-        >
-          <icon name="quote" />
-        </button>
-
-        <button
-          class="menubar__button"
-          :class="{ 'is-active': isActive.code_block() }"
-          @click="commands.code_block"
-        >
-          <icon name="code" />
-        </button>
-
-        <button
-          class="menubar__button"
-          @click="commands.horizontal_rule"
-        >
-          <icon name="hr" />
-        </button>
-
-        <button
-          class="menubar__button"
-          @click="commands.undo"
-        >
-          <icon name="undo" />
-        </button>
-
-        <button
-          class="menubar__button"
-          @click="commands.redo"
-        >
-          <icon name="redo" />
-        </button>
-
       </div>
     </editor-menu-bar>
 
@@ -138,25 +28,7 @@
 <script>
 import Icon from 'Components/Icon'
 import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
-import {
-  Blockquote,
-  CodeBlock,
-  HardBreak,
-  Heading,
-  HorizontalRule,
-  OrderedList,
-  BulletList,
-  ListItem,
-  TodoItem,
-  TodoList,
-  Bold,
-  Code,
-  Italic,
-  Link,
-  Strike,
-  Underline,
-  History,
-} from 'tiptap-extensions'
+import StaffList from './StaffList'
 
 export default {
   components: {
@@ -168,45 +40,10 @@ export default {
     return {
       editor: new Editor({
         extensions: [
-          new Blockquote(),
-          new BulletList(),
-          new CodeBlock(),
-          new HardBreak(),
-          new Heading({ levels: [1, 2, 3] }),
-          new HorizontalRule(),
-          new ListItem(),
-          new OrderedList(),
-          new TodoItem(),
-          new TodoList(),
-          new Link(),
-          new Bold(),
-          new Code(),
-          new Italic(),
-          new Strike(),
-          new Underline(),
-          new History(),
+          new StaffList.Extension(),
         ],
         content: `
-          <h2>
-            Hi there,
-          </h2>
-          <p>
-            this is a very <em>basic</em> example of tiptap.
-          </p>
-          <pre><code>body { display: none; }</code></pre>
-          <ul>
-            <li>
-              A regular list
-            </li>
-            <li>
-              With regular items
-            </li>
-          </ul>
-          <blockquote>
-            It's amazing 👏
-            <br />
-            – mom
-          </blockquote>
+          <p>Insert a staff list</p>
         `,
       }),
     }

--- a/examples/Components/Routes/VueSlots/index.vue
+++ b/examples/Components/Routes/VueSlots/index.vue
@@ -23,14 +23,24 @@
     </editor-menu-bar>
 
     <editor-content class="editor__content" :editor="editor" />
+
+    <pre>
+      {{ content }}
+    </pre>
+
+    <component v-bind:is="wrappedContent && {template:wrappedContent}"></component>
   </div>
 </template>
 
 <script>
+import Vue from 'vue'
 import Icon from 'Components/Icon'
 import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
 import StaffList from './StaffList'
 import StaffMember from './StaffMember'
+
+Vue.component('staff-list', StaffList)
+Vue.component('staff-member', StaffMember)
 
 const StaffListDefaultSlotExtension = StaffList.slotExtensions.default
 const StaffListStaffMembersSlotExtension = StaffList.slotExtensions['staff-members']
@@ -43,7 +53,22 @@ export default {
     Icon,
   },
   data() {
+    const content = `
+<staff-list>
+  <template v-slot:default="">
+    <h3>Hello there!</h3>
+  </template>
+  <template v-slot:staff-members="">
+    <staff-member name="Mr Not Default">
+      <template v-slot:default="slotProps">
+        <p>Junior Replace Default Clerk</p>
+      </template>
+    </staff-member>
+  </template>
+</staff-list>`
+
     return {
+      content,
       editor: new Editor({
         extensions: [
           new StaffListDefaultSlotExtension(),
@@ -52,26 +77,26 @@ export default {
           new StaffMemberDefaultSlotExtension(),
           new StaffMember.Extension(),
         ],
-        content: `
-          <staff-list>
-            <template v-slot:default="slotProps">
-              <h3>Our Staff</h3>
-              <p>We are all beautiful!</p>
-            </template>
-            <template v-slot:staff-members="slotProps">
-              <staff-member name="Mr En Jibby" avatar="enjibby-grinning.jpg">
-                <template v-slot:default="slotProps">
-                  <p>Chief Speculative Programming Officer<p>
-                </template>
-              </staff-member>
-            </template>
-          </staff-list>
-        `,
+        content,
+        onUpdate: ({ getHTML }) => {
+          this.content = getHTML()
+        },
       }),
     }
+  },
+  computed: {
+    wrappedContent() {
+      return this.content
+    },
   },
   beforeDestroy() {
     this.editor.destroy()
   },
 }
 </script>
+
+<style>
+div.editor pre {
+  word-wrap: normal;
+}
+</style>

--- a/examples/Components/Routes/VueSlots/index.vue
+++ b/examples/Components/Routes/VueSlots/index.vue
@@ -18,6 +18,7 @@
         >
           <icon name="italic" />
         </button>
+
       </div>
     </editor-menu-bar>
 
@@ -29,6 +30,7 @@
 import Icon from 'Components/Icon'
 import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
 import StaffList from './StaffList'
+import StaffMember from './StaffMember'
 
 export default {
   components: {
@@ -40,7 +42,11 @@ export default {
     return {
       editor: new Editor({
         extensions: [
-          new StaffList.Extension(),
+          new StaffList.extensions.DefaultBlockSlotExtension(),
+          new StaffList.extensions.StaffMemberSlotExtension(),
+          new StaffList.extensions.NodeExtension(),
+          new StaffMember.extensions.DefaultBlockSlotExtension(),
+          new StaffMember.extensions.NodeExtension(),
         ],
         content: `
           <p>Insert a staff list</p>

--- a/examples/Components/Routes/VueSlots/index.vue
+++ b/examples/Components/Routes/VueSlots/index.vue
@@ -86,7 +86,7 @@ export default {
   },
   computed: {
     wrappedContent() {
-      return this.content
+      return `<div>${this.content}</div>`
     },
   },
   beforeDestroy() {

--- a/examples/Components/Routes/VueSlots/index.vue
+++ b/examples/Components/Routes/VueSlots/index.vue
@@ -32,6 +32,10 @@ import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
 import StaffList from './StaffList'
 import StaffMember from './StaffMember'
 
+const StaffListDefaultSlotExtension = StaffList.slotExtensions.default
+const StaffListStaffMembersSlotExtension = StaffList.slotExtensions['staff-members']
+const StaffMemberDefaultSlotExtension = StaffMember.slotExtensions.default
+
 export default {
   components: {
     EditorContent,
@@ -42,11 +46,11 @@ export default {
     return {
       editor: new Editor({
         extensions: [
-          new StaffList.extensions.DefaultBlockSlotExtension(),
-          new StaffList.extensions.StaffMemberSlotExtension(),
-          new StaffList.extensions.NodeExtension(),
-          new StaffMember.extensions.DefaultBlockSlotExtension(),
-          new StaffMember.extensions.NodeExtension(),
+          new StaffListDefaultSlotExtension(),
+          new StaffListStaffMembersSlotExtension(),
+          new StaffList.Extension(),
+          new StaffMemberDefaultSlotExtension(),
+          new StaffMember.Extension(),
         ],
         content: `
           <staff-list>

--- a/examples/Components/Subnavigation/index.vue
+++ b/examples/Components/Subnavigation/index.vue
@@ -66,6 +66,9 @@
     <router-link class="subnavigation__link" to="/export">
       Export HTML or JSON
     </router-link>
+    <router-link class="subnavigation__link" to="/vue-slots">
+      Nested Vue
+    </router-link>
   </div>
 </template>
 

--- a/examples/main.js
+++ b/examples/main.js
@@ -165,6 +165,13 @@ const routes = [
       githubUrl: 'https://github.com/ueberdosis/tiptap/tree/main/examples/Components/Routes/Export',
     },
   },
+  {
+    path: '/vue-slots',
+    component: () => import('Components/Routes/VueSlots'),
+    meta: {
+      githubUrl: 'https://github.com/ueberdosis/tiptap/tree/main/examples/Components/Routes/VueSlots',
+    },
+  },
 ]
 
 const router = new VueRouter({

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -27,6 +27,7 @@ import {
 } from './Utils'
 import { Doc, Paragraph, Text } from './Nodes'
 import css from './style.css'
+import NodeSlotView from './Utils/NodeSlotView'
 
 export default class Editor extends Emitter {
 
@@ -327,9 +328,35 @@ export default class Editor extends Emitter {
           })
         }
 
+        let nodeSlotViews = []
+        if (extension.view.slotExtensions) {
+          const slotExts = extension.view.slotExtensions
+          nodeSlotViews = Object.keys(slotExts).reduce((reduction, name) => {
+            const nodeSlotView = (node, view, getPos, decorations) => {
+              const parentComponent = extension.view
+              const slotExtension = slotExts[name]
+
+              return new NodeSlotView(parentComponent, {
+                editor: this,
+                extension: slotExtension,
+                node,
+                view,
+                getPos,
+                decorations,
+              })
+            }
+
+            return {
+              ...reduction,
+              [`${extension.name}_${name}`]: nodeSlotView,
+            }
+          }, {})
+        }
+
         return {
           ...nodeViews,
           [extension.name]: nodeView,
+          ...nodeSlotViews,
         }
       }, {})
   }

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -31,7 +31,6 @@ export default class ComponentView {
     this.captureEvents = true
     this.dom = this.createDOM()
     this.contentDOM = this.vm.$refs.content
-    this.innerDOM = this.vm.$refs.inner
   }
 
   createDOM() {
@@ -61,6 +60,7 @@ export default class ComponentView {
       propsData: props,
     }).$mount()
 
+    this.innerDOM = this.vm.$refs.inner
     this.innerView = null
     if (this.innerDOM) {
       this.innerView = new EditorView(this.innerDOM, {

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -130,11 +130,7 @@ export default class ComponentView {
         let { a: endA, b: endB } = node.content.findDiffEnd(state.doc.content)
         const overlap = start - Math.min(endA, endB)
         if (overlap > 0) { endA += overlap; endB += overlap }
-        this.innerView.dispatch(
-          state.tr
-            .replace(start, endB, node.slice(start, endA))
-            .setMeta('fromOutside', true)
-        )
+        this.innerView.dispatch(state.tr.replace(start, endB, node.slice(start, endA)).setMeta('fromOutside', true))
       }
     }
 

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -94,7 +94,7 @@ export default class ComponentView {
     this.innerView.updateState(state)
 
     if (!tr.getMeta('fromOutside')) {
-      const outerTr = this.outerView.state.tr
+      const outerTr = this.view.state.tr
       const offsetMap = StepMap.offset(this.getPos() + 1)
       for (let i = 0; i < transactions.length; i += 1) {
         const { steps } = transactions[i]

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -1,7 +1,8 @@
 import Vue from 'vue'
 
 import { getMarkRange } from 'tiptap-utils'
-import { EditorView, EditorState } from 'prosemirror-view'
+import { EditorView } from 'prosemirror-view'
+import { EditorState } from 'prosemirror-state'
 import { keymap } from 'prosemirror-keymap'
 import { undo, redo } from 'prosemirror-history'
 import { StepMap } from 'prosemirror-transform'

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -60,8 +60,6 @@ export default class ComponentView {
       propsData: props,
     })
 
-    this.vm.$slots.default = ['Hello!']
-
     if (this.component && this.component.slotExtensions) {
       Object.keys(this.component.slotExtensions).every(this.initSlot.bind(this))
     }
@@ -72,35 +70,34 @@ export default class ComponentView {
   }
 
   initSlot(slotName) {
-    const node = this.editor.extensions.extensions.find(this.isSlot.bind(this, slotName))
-    const el = this.vm.$createElement('template')
+    const el = this.vm.$createElement('div')
     this.vm.$slots[slotName] = [el]
 
-    this.slotViews[slotName] = new EditorView(el, {
+    this.slotViews[slotName] = new EditorView(el.elm, {
       // You can use any node as an editor document
       state: EditorState.create({
-        doc: node,
+        doc: this.node,
         plugins: [keymap({
           'Mod-z': () => undo(this.view.state, this.view.dispatch),
           'Mod-y': () => redo(this.view.state, this.view.dispatch),
         })],
-        dispatchTransaction: this.dispatchInner.bind(this, slotName),
-        handleDOMEvents: {
-          mousedown: () => {
-            // Kludge to prevent issues due to the fact that the whole
-            // footnote is node-selected (and thus DOM-selected) when
-            // the parent editor is focused.
-            if (this.view.hasFocus()) this.slotViews[slotName].focus()
-          },
-        },
       }),
+      dispatchTransaction: this.dispatchInner.bind(this, slotName),
+      handleDOMEvents: {
+        mousedown: () => {
+          // Kludge to prevent issues due to the fact that the whole
+          // footnote is node-selected (and thus DOM-selected) when
+          // the parent editor is focused.
+          if (this.view.hasFocus()) this.slotViews[slotName].focus()
+        },
+      },
     })
 
     return this.slotViews[slotName]
   }
 
   isSlot(slotName, testExtension) {
-    return testExtension.name === (new this.component.slotExtensions[slotName]()).name
+    return testExtension.name === (new (this.component.slotExtensions[slotName])()).name
   }
 
   dispatchInner(slotName, tr) {

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -2,9 +2,9 @@ import Vue from 'vue'
 
 import { getMarkRange } from 'tiptap-utils'
 import { EditorView, EditorState } from 'prosemirror-view'
-import { keymap } from "prosemirror-keymap"
-import { undo, redo } from "prosemirror-history"
-import { StepMap } from "prosemirror-transform"
+import { keymap } from 'prosemirror-keymap'
+import { undo, redo } from 'prosemirror-history'
+import { StepMap } from 'prosemirror-transform'
 
 export default class ComponentView {
 
@@ -95,9 +95,9 @@ export default class ComponentView {
     if (!tr.getMeta('fromOutside')) {
       const outerTr = this.outerView.state.tr
       const offsetMap = StepMap.offset(this.getPos() + 1)
-      for (let i = 0; i < transactions.length; i = i + 1) {
-        const steps = transactions[i].steps
-        for (let j = 0; j < steps.length; j = j + 1) {
+      for (let i = 0; i < transactions.length; i += 1) {
+        const { steps } = transactions[i]
+        for (let j = 0; j < steps.length; j += 1) {
           outerTr.step(steps[j].map(offsetMap))
         }
       }

--- a/packages/tiptap/src/Utils/NodeSlotView.js
+++ b/packages/tiptap/src/Utils/NodeSlotView.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import { EditorView } from 'prosemirror-view'
 import { EditorState } from 'prosemirror-state'
 import { keymap } from 'prosemirror-keymap'

--- a/packages/tiptap/src/Utils/NodeSlotView.js
+++ b/packages/tiptap/src/Utils/NodeSlotView.js
@@ -1,19 +1,71 @@
+import Vue from 'vue'
+import { EditorView } from 'prosemirror-view'
+import { EditorState } from 'prosemirror-state'
+import { keymap } from 'prosemirror-keymap'
+import { StepMap } from 'prosemirror-transform'
+import { undo, redo } from 'prosemirror-history'
+
 export default class NodeSlotView {
 
   constructor(parentComponent, {
     editor,
     extension,
+    parent,
     node,
     view,
-    getPos,
     decorations,
+    getPos,
   }) {
     this.parentComponent = parentComponent
     this.editor = editor
     this.extension = extension
+    this.parent = parent
     this.node = node
     this.view = view
     this.getPos = getPos
     this.decorations = decorations
+    this.dom = this.createDOM()
+    console.log(this)
+  }
+
+  createDOM() {
+    this.vm = new EditorView(this.view, {
+      // You can use any node as an editor document
+      state: EditorState.create({
+        doc: this.node,
+        plugins: [keymap({
+          'Mod-z': () => undo(this.view.state, this.view.dispatch),
+          'Mod-y': () => redo(this.view.state, this.view.dispatch),
+        })],
+        dispatchTransaction: this.dispatchInner.bind(this),
+        handleDOMEvents: {
+          mousedown: () => {
+            // Kludge to prevent issues due to the fact that the whole
+            // footnote is node-selected (and thus DOM-selected) when
+            // the parent editor is focused.
+            if (this.view.hasFocus()) this.view.focus()
+          },
+        },
+      }),
+    })
+
+    return this.vm
+  }
+
+  dispatchInner(slotName, tr) {
+    const { state, transactions } = this.vm.state.applyTransaction(tr)
+    this.view.updateState(state)
+
+    if (!tr.getMeta('fromOutside')) {
+      const outerTr = this.view.state.tr
+      const offsetMap = StepMap.offset(this.getPos() + 1)
+      for (let i = 0; i < transactions.length; i += 1) {
+        const { steps } = transactions[i]
+        for (let j = 0; j < steps.length; j += 1) {
+          outerTr.step(steps[j].map(offsetMap))
+        }
+      }
+      if (outerTr.docChanged) this.view.dispatch(outerTr)
+    }
   }
 }

--- a/packages/tiptap/src/Utils/NodeSlotView.js
+++ b/packages/tiptap/src/Utils/NodeSlotView.js
@@ -1,0 +1,19 @@
+export default class NodeSlotView {
+
+  constructor(parentComponent, {
+    editor,
+    extension,
+    node,
+    view,
+    getPos,
+    decorations,
+  }) {
+    this.parentComponent = parentComponent
+    this.editor = editor
+    this.extension = extension
+    this.node = node
+    this.view = view
+    this.getPos = getPos
+    this.decorations = decorations
+  }
+}

--- a/packages/tiptap/src/Utils/NodeSlotView.js
+++ b/packages/tiptap/src/Utils/NodeSlotView.js
@@ -25,7 +25,6 @@ export default class NodeSlotView {
     this.getPos = getPos
     this.decorations = decorations
     this.dom = this.createDOM()
-    console.log(this)
   }
 
   createDOM() {


### PR DESCRIPTION
Please understand the the code in its current strate is very much a work in progress, but I will be attempting to improve this to a point where things make a little more sense.

This includes the pre-cursor work to implement the inner-view code from [this example](https://prosemirror.net/examples/footnote/).