### PR TITLE
SetCellAttr in prosemirror-tables needs parameters

### DIFF
--- a/packages/tiptap-extensions/src/nodes/Table.js
+++ b/packages/tiptap-extensions/src/nodes/Table.js
@@ -73,7 +73,7 @@ export default class Table extends Node {
       toggleHeaderColumn: () => toggleHeaderColumn,
       toggleHeaderRow: () => toggleHeaderRow,
       toggleHeaderCell: () => toggleHeaderCell,
-      setCellAttr: ({name, value}) => setCellAttr(name, value),
+      setCellAttr: ({ name, value }) => setCellAttr(name, value),
       fixTables: () => fixTables,
     }
   }

--- a/packages/tiptap-extensions/src/nodes/Table.js
+++ b/packages/tiptap-extensions/src/nodes/Table.js
@@ -73,7 +73,7 @@ export default class Table extends Node {
       toggleHeaderColumn: () => toggleHeaderColumn,
       toggleHeaderRow: () => toggleHeaderRow,
       toggleHeaderCell: () => toggleHeaderCell,
-      setCellAttr: () => setCellAttr,
+      setCellAttr: ({name, value}) => setCellAttr(name, value),
       fixTables: () => fixTables,
     }
   }


### PR DESCRIPTION
The `setCellAttr` command has no use if we can't pass parameters to it. My issue was setting the background color of a cell in a table.

Fixes #862.