### PR TITLE
Update package.json

### DIFF
--- a/packages/tiptap/package.json
+++ b/packages/tiptap/package.json
@@ -25,7 +25,7 @@
     "prosemirror-gapcursor": "1.1.5",
     "prosemirror-inputrules": "1.1.2",
     "prosemirror-keymap": "1.1.4",
-    "prosemirror-model": "1.11.2",
+    "prosemirror-model": "^1.11.2",
     "prosemirror-state": "1.3.3",
     "prosemirror-view": "1.15.7",
     "tiptap-commands": "^1.15.0",


### PR DESCRIPTION
Update package.json to fix the prosemirror-model mismatch versions.
See my comment here: https://github.com/ueberdosis/tiptap/issues/577#issuecomment-728143889

https://github.com/ueberdosis/tiptap/blob/main/packages/tiptap/package.json
https://github.com/ueberdosis/tiptap/blob/main/packages/tiptap-extensions/package.json

Using the latest tiptap (1.30.0) and tiptap-extensions (1.32.2) versions.

tiptap requires `"prosemirror-model": "1.11.2"` while tiptap-extensions and others require `"prosemirror-model": "^1.11.2"`. Hence both `1.11.2` and `1.12.0` are installed, resulting in a "looks like multiple versions of prosemirror-model were loaded" error.
This should fix the issue.