### PR TITLE
Remove content expression from Mention nodes

### DIFF
--- a/packages/tiptap-extensions/src/nodes/Mention.js
+++ b/packages/tiptap-extensions/src/nodes/Mention.js
@@ -33,7 +33,6 @@ export default class Mention extends Node {
       },
       group: 'inline',
       inline: true,
-      content: 'inline*',
       selectable: false,
       atom: true,
       toDOM: node => [


### PR DESCRIPTION
Fixes sibling Mention creation inside the same paragraph
Fixes https://github.com/ueberdosis/tiptap/issues/874 🤞 

Tested the Suggestions example over at the [GitPod demo](https://gitpod.io/#https://github.com/ueberdosis/tiptap/) and it didn't seem to have any side effects besides allowing multiple Mention nodes in the same paragraph. If someone could validate this, that'd be top 🙏 

@Priestch maybe you can share some insight into why the `content: 'inline*'` addition was necessary - https://github.com/ueberdosis/tiptap/commit/9ccfa168f8336a018e5abf4c126c4864ad7e41c1?