### PR TITLE
Package json updated for tiptap package to fetch latest prosemirror-model

### DIFF
--- a/packages/tiptap/package.json
+++ b/packages/tiptap/package.json
@@ -25,7 +25,7 @@
     "prosemirror-gapcursor": "1.1.5",
     "prosemirror-inputrules": "1.1.2",
     "prosemirror-keymap": "1.1.4",
-    "prosemirror-model": "1.11.2",
+    "prosemirror-model": "^1.11.2",
     "prosemirror-state": "1.3.3",
     "prosemirror-view": "1.15.7",
     "tiptap-commands": "^1.15.0",


### PR DESCRIPTION
In tiptap package prosemirror-model is locked at 1.11.2 and in other packages it is marked to fetch latest, which results in multiple versions of prosemirror-model being loaded, more info- https://github.com/ueberdosis/tiptap/issues/577