### PR TITLE
Allow Links to use their individual attrs.target

### DIFF
--- a/packages/tiptap-extensions/src/marks/Link.js
+++ b/packages/tiptap-extensions/src/marks/Link.js
@@ -38,7 +38,7 @@ export default class Link extends Mark {
       toDOM: node => ['a', {
         ...node.attrs,
         rel: 'noopener noreferrer nofollow',
-        target: node.attrs.target || this.options.target,
+        target: node.attrs.target || this.options.target,
       }, 0],
     }
   }

--- a/packages/tiptap-extensions/src/marks/Link.js
+++ b/packages/tiptap-extensions/src/marks/Link.js
@@ -38,7 +38,7 @@ export default class Link extends Mark {
       toDOM: node => ['a', {
         ...node.attrs,
         rel: 'noopener noreferrer nofollow',
-        target: this.options.target,
+        target: node.attrs.target || this.options.target,
       }, 0],
     }
   }


### PR DESCRIPTION
Currently there seems to be no way to use `target="value"` on some Link marks and `target="other"` on another Link mark, because in `toDOM` the value of `node.attrs.target` will always be overwritten with `defaultOptions.target`. 
I think this was introduced in #619.

With the PR, the individual values are preferred and the `defaultOptions.target` will only be used as a fallback.