### PR TITLE
More flexible matching of trigger character

### DIFF
--- a/packages/tiptap-extensions/src/plugins/Suggestions.js
+++ b/packages/tiptap-extensions/src/plugins/Suggestions.js
@@ -38,6 +38,7 @@ function triggerCharacter({
   char = '@',
   allowSpaces = false,
   startOfLine = false,
+  allowMatchWithin = false,
 }) {
 
   return $position => {
@@ -66,7 +67,7 @@ function triggerCharacter({
       // or the line beginning
       const matchPrefix = match.input.slice(Math.max(0, match.index - 1), match.index)
 
-      if (/^[\s\0]?$/.test(matchPrefix)) {
+      if (allowMatchWithin || /^[\s\0]?$/.test(matchPrefix)) {
         // The absolute position of the match in the document
         const from = match.index + $position.start()
         let to = from + match[0].length


### PR DESCRIPTION
Adds an option `allowMatchWithin` to allow matching the trigger character from within text (i.e. not at the beginning of the line or preceded by a space).