### PR TITLE
Constrain `from` to non-negative numbers

### DIFF
--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -3,7 +3,7 @@ import { Plugin, PluginKey } from 'prosemirror-state'
 function textRange(node, from, to) {
   const range = document.createRange()
   range.setEnd(node, to == null ? node.nodeValue.length : to)
-  range.setStart(node, from || 0)
+  range.setStart(node, Math.max(from, 0))
   return range
 }
 


### PR DESCRIPTION
Fix #954

There is an issue where `document.createRange()` is being called with negative values which throws an error.

This pull request constrains it to be always greater than 0, so the error doesn't happen any more.  I've tested this and it seems to work okay.

I'm not sure why the `from` variable is being returned as -1 sometimes, so perhaps this is an underlying issue that needs to be fixed too.