### PR TITLE
Fix sending of emptystring class for Prosemirror decoration

### DIFF
--- a/packages/tiptap-extensions/src/plugins/Highlight.js
+++ b/packages/tiptap-extensions/src/plugins/Highlight.js
@@ -47,6 +47,11 @@ function getDecorations({ doc, name }) {
         }
       })
       .forEach(node => {
+        if (node.classes.length === 0) {
+          // Do not emit empty decorations.
+          return
+        }
+
         const decoration = Decoration.inline(node.from, node.to, {
           class: node.classes.join(' '),
         })


### PR DESCRIPTION
Prosemirror does not handle emptystring classes well for decorations when the decoration applies to a range that has other decorations. For example, both a spellchecking plugin and the tiptap highlighting plugin.

See this debugger screenshot in prosemirror showing the code that merges decorations together before they're applied. There are two decorations - one from a spellchecker, and one from the Highlight plugin that has no class because the specific range did not receive any specific highlight:
![image](https://user-images.githubusercontent.com/5017521/111707716-cff1b080-8801-11eb-8544-df46a953c613.png)

The above results in a string like `"spellcheck-error "`, which is then re-split by prosemirror into an array `["spellcheck-error", ""]`. This is in turn fed into `HTMLElement.classList.add(...)`, which throws an error when it receives emptystring:
![image](https://user-images.githubusercontent.com/5017521/111707866-147d4c00-8802-11eb-9ebf-b35d7f3878b7.png)

However, there's no reason to send an empty decoration to prosemirror at all, so this change elects to omit such decorations entirely. This both fixes the issue at hand, and also slightly improve performance.
