### PR TITLE
Exit code on right arrow

### DIFF
--- a/packages/extension-code/src/code.ts
+++ b/packages/extension-code/src/code.ts
@@ -68,6 +68,39 @@ export const Code = Mark.create<CodeOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-e': () => this.editor.commands.toggleCode(),
+      ArrowRight: () => {
+        const state = this.editor.state
+        const { from, to } = state.selection
+
+        if (from > 1 && from === to) {
+          let codeOnLeft = false
+          state.doc.nodesBetween(from - 1, to - 1, node => {
+            const code = node.marks.find(markItem => markItem.type.name === 'code')
+            if (code) codeOnLeft = true
+          })
+
+          let noCodeUnderCursor = true
+          state.doc.nodesBetween(from, to, node => {
+            const code = node.marks.find(markItem => markItem.type.name === 'code')
+            if (code) noCodeUnderCursor = false
+          })
+
+          let nothingOnRight = true
+          state.doc.nodesBetween(from + 1, to + 1, node => {
+            if (node) nothingOnRight = false
+          })
+
+          if (codeOnLeft && noCodeUnderCursor && nothingOnRight) {
+            return this.editor
+              .chain()
+              .unsetCode()
+              .insertContent([{ type: 'text', text: ' ' }])
+              .run()
+          }
+        }
+
+        return false
+      },
     }
   },
 


### PR DESCRIPTION
Hey :wave:

This PR adds functionality to `extension-code` and allows the user to exit by pressing `RightArrow`:

![leave-code](https://user-images.githubusercontent.com/7985185/115712074-0086b600-a37d-11eb-9128-b534845629cc.gif)
