### PR TITLE
Exit code block on down arrow

### DIFF
--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -115,6 +115,24 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
 
         return false
       },
+      ArrowDown: () => {
+        const state = this.editor.state
+        const { from, to } = state.selection
+
+        if (from > 1 && from === to) {
+          let inCodeBlock = false
+          state.doc.nodesBetween(from - 1, to - 1, node => {
+            if (node.type.name === 'codeBlock') inCodeBlock = true
+          })
+
+          const cursorAtEnd = to === state.doc.content.size - 1
+          if (inCodeBlock && cursorAtEnd) {
+            return this.editor.commands.exitCode()
+          }
+        }
+
+        return false
+      },
     }
   },
 


### PR DESCRIPTION
👋

This PR adds functionality to `extension-code-block` and allows the user to exit by pressing `DownArrow`:

![exit-code-block-down-arrow](https://user-images.githubusercontent.com/7985185/115847029-2ff3fc00-a42b-11eb-813b-dc1cbdd993fa.gif)
