### PR TITLE
Make Horizontal Rule compatible with Typography extension

### DIFF
--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -70,7 +70,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
 
   addInputRules() {
     return [
-      nodeInputRule(/^(?:---|___\s|\*\*\*\s)$/, this.type),
+      nodeInputRule(/^(?:---|\—-|___\s|\*\*\*\s)$/, this.type),
     ]
   },
 })


### PR DESCRIPTION
The Typography extension automatically converts two hyphens `--` into an em dash `–`, which means typing three hyphens in a row results in an em dash and a hyphen `–-`, instead of triggering an hr. 

I propose adding the `–-` pattern to this extension‘s `nodeInputRule` so typing three hyphens in a row will still trigger an hr, even if 'smart dashes' are enabled via the Typography extension or otherwise.