### PR TITLE
feat: use composition-api to init  EditorContent

### DIFF
--- a/packages/vue-2/package.json
+++ b/packages/vue-2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.9",
     "@tiptap/extension-floating-menu": "^2.0.0-beta.6",
+    "@vue/composition-api": "^1.0.0-rc.8",
     "prosemirror-view": "^1.18.2"
   }
 }

--- a/packages/vue-2/src/BubbleMenu.ts
+++ b/packages/vue-2/src/BubbleMenu.ts
@@ -1,7 +1,10 @@
-import Vue, { PropType } from 'vue'
 import { BubbleMenuPlugin, BubbleMenuPluginKey, BubbleMenuPluginProps } from '@tiptap/extension-bubble-menu'
+import Vue from 'vue'
+import VueCompositionAPI, { defineComponent, PropType } from '@vue/composition-api'
 
-export const BubbleMenu = Vue.extend({
+Vue.use(VueCompositionAPI)
+
+export const BubbleMenu = defineComponent({
   name: 'BubbleMenu',
 
   props: {

--- a/packages/vue-2/src/EditorContent.ts
+++ b/packages/vue-2/src/EditorContent.ts
@@ -1,9 +1,11 @@
-import Vue, { PropType } from 'vue'
+import Vue from 'vue'
 import { Editor } from './Editor'
+import VueCompositionAPI, { defineComponent, PropType } from '@vue/composition-api'
 
-export const EditorContent = Vue.extend({
+Vue.use(VueCompositionAPI)
+
+export const EditorContent = defineComponent({
   name: 'EditorContent',
-
   props: {
     editor: {
       default: null,
@@ -14,7 +16,7 @@ export const EditorContent = Vue.extend({
   watch: {
     editor: {
       immediate: true,
-      handler(editor: Editor) {
+      handler(this: Vue, editor: Editor) {
         if (editor && editor.options.element) {
           this.$nextTick(() => {
             const element = this.$el

--- a/packages/vue-2/src/FloatingMenu.ts
+++ b/packages/vue-2/src/FloatingMenu.ts
@@ -1,7 +1,9 @@
-import Vue, { PropType } from 'vue'
 import { FloatingMenuPlugin, FloatingMenuPluginKey, FloatingMenuPluginProps } from '@tiptap/extension-floating-menu'
+import Vue from 'vue'
+import VueCompositionAPI, { defineComponent, PropType } from '@vue/composition-api'
 
-export const FloatingMenu = Vue.extend({
+Vue.use(VueCompositionAPI)
+export const FloatingMenu = defineComponent({
   name: 'FloatingMenu',
 
   props: {

--- a/packages/vue-2/src/NodeViewContent.ts
+++ b/packages/vue-2/src/NodeViewContent.ts
@@ -1,6 +1,8 @@
 import Vue from 'vue'
+import VueCompositionAPI, { defineComponent, h } from '@vue/composition-api'
 
-export const NodeViewContent = Vue.extend({
+Vue.use(VueCompositionAPI)
+export const NodeViewContent = defineComponent({
   props: {
     as: {
       type: String,
@@ -8,8 +10,9 @@ export const NodeViewContent = Vue.extend({
     },
   },
 
-  render(createElement) {
-    return createElement(
+  render() {
+    return h(
+      // @ts-ignore
       this.as, {
         style: {
           whiteSpace: 'pre-wrap',

--- a/packages/vue-2/src/NodeViewWrapper.ts
+++ b/packages/vue-2/src/NodeViewWrapper.ts
@@ -1,6 +1,9 @@
 import Vue from 'vue'
+import VueCompositionAPI, { defineComponent, h } from '@vue/composition-api'
 
-export const NodeViewWrapper = Vue.extend({
+Vue.use(VueCompositionAPI)
+
+export const NodeViewWrapper = defineComponent({
   props: {
     as: {
       type: String,
@@ -10,8 +13,9 @@ export const NodeViewWrapper = Vue.extend({
 
   inject: ['onDragStart', 'decorationClasses'],
 
-  render(createElement) {
-    return createElement(
+  render() {
+    return h(
+      // @ts-ignore
       this.as, {
         // @ts-ignore
         class: this.decorationClasses.value,

--- a/packages/vue-2/src/VueRenderer.ts
+++ b/packages/vue-2/src/VueRenderer.ts
@@ -1,11 +1,14 @@
 import Vue from 'vue'
 import { VueConstructor } from 'vue/types/umd'
+import VueCompositionAPI, { defineComponent } from '@vue/composition-api'
+
+Vue.use(VueCompositionAPI)
 
 export class VueRenderer {
   ref!: Vue
 
   constructor(component: Vue | VueConstructor, props: any) {
-    const Component = Vue.extend(component)
+    const Component = defineComponent(component)
 
     this.ref = new Component(props).$mount()
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2650,6 +2650,13 @@
     sass "^1.18.0"
     stylus "^0.54.5"
 
+"@vue/composition-api@^1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-rc.8.tgz#ace0f1c8cc7d5b193825fabdc7c4b919bb182a9e"
+  integrity sha512-9ZW2+2WW7iNywVFeaz9K18DW/aA4MLncz+FiUpjtMUKzHpiN1GtYQ8rRYOhHfGXD2Hmp4tTFjqaTM4WeAbB1ig==
+  dependencies:
+    tslib "^2.2.0"
+
 "@vue/reactivity@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.11.tgz#07b588349fd05626b17f3500cbef7d4bdb4dbd0b"
@@ -14251,7 +14258,7 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==


### PR DESCRIPTION
### This PR
- [x] uses @vue/composition-api to initialise EditorContent component for @tiptap/vue-2 
- [x] closes #1219 

[@vue/composition-api](https://github.com/vuejs/composition-api) provides better TS support and vue@2 compatible. 