### PR TITLE
Fix returning true/false in can().chain().run()

### DIFF
--- a/packages/core/src/CommandManager.ts
+++ b/packages/core/src/CommandManager.ts
@@ -54,7 +54,7 @@ export default class CommandManager {
         view.dispatch(tr)
       }
 
-      return () => callbacks.every(callback => callback === true)
+      return callbacks.every(callback => callback === true)
     }
 
     const chain = {


### PR DESCRIPTION
I think this was previously meant to return a function in the proxy object getter, but now it's a standalone function and should return the result of the callbacks.