### PR TITLE
Mention: Add text attribute

### DIFF
--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -62,19 +62,19 @@ export const Mention = Node.create<MentionOptions>({
           }
         },
       },
-      text: {
+      label: {
         default: null,
         parseHTML: element => {
           return {
-            text: element.getAttribute('data-text'),
+            text: element.getAttribute('data-label'),
           };
         },
         renderHTML: attributes => {
-          if (!attributes.text) {
+          if (!attributes.label) {
             return {};
           }
           return {
-            'data-text': attributes.text,
+            'data-label': attributes.label,
           };
         },
       },
@@ -93,12 +93,12 @@ export const Mention = Node.create<MentionOptions>({
     return [
       'span',
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
-      `${this.options.suggestion.char}${node.attrs.text ?? node.attrs.id}`,
+      `${this.options.suggestion.char}${node.attrs.label ?? node.attrs.id}`,
     ]
   },
 
   renderText({ node }) {
-    return `${this.options.suggestion.char}${node.attrs.text ?? node.attrs.id}`
+    return `${this.options.suggestion.char}${node.attrs.label ?? node.attrs.id}`
   },
 
   addKeyboardShortcuts() {

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -77,12 +77,12 @@ export const Mention = Node.create<MentionOptions>({
     return [
       'span',
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
-      `${this.options.suggestion.char}${node.attrs.id}`,
+      `${this.options.suggestion.char}${node.attrs.text ?? node.attrs.id}`,
     ]
   },
 
   renderText({ node }) {
-    return `${this.options.suggestion.char}${node.attrs.id}`
+    return `${this.options.suggestion.char}${node.attrs.text ?? node.attrs.id}`
   },
 
   addKeyboardShortcuts() {

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -66,7 +66,7 @@ export const Mention = Node.create<MentionOptions>({
         default: null,
         parseHTML: element => {
           return {
-            text: element.getAttribute('data-label'),
+            label: element.getAttribute('data-label'),
           };
         },
         renderHTML: attributes => {

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -62,6 +62,22 @@ export const Mention = Node.create<MentionOptions>({
           }
         },
       },
+      text: {
+        default: null,
+        parseHTML: element => {
+          return {
+            text: element.getAttribute('data-text'),
+          };
+        },
+        renderHTML: attributes => {
+          if (!attributes.text) {
+            return {};
+          }
+          return {
+            'data-text': attributes.text,
+          };
+        },
+      },
     }
   },
 


### PR DESCRIPTION
This PR allows you to change the text that is to be rendered in the DOM when a selection is made from the suggestion.

This is so that you may want the `data-mention` attribute to use a user's ID but the user's name would be displayed instead of the ID e.g. "@JohnSmith" instead of "@1".