### PR TITLE
Extend Non-Empty Marks

### DIFF
--- a/docs/src/demos/Marks/Link/index.vue
+++ b/docs/src/demos/Marks/Link/index.vue
@@ -6,6 +6,9 @@
     <button @click="editor.chain().focus().unsetLink().run()" v-if="editor.isActive('link')">
       remove
     </button>
+    <button @click="editor.chain().focus().extendMarkRange('link').unsetLink().run()" v-if="editor.isActive('link')">
+      remove entire link
+    </button>
     <editor-content :editor="editor" />
   </div>
 </template>

--- a/docs/src/demos/Marks/Link/index.vue
+++ b/docs/src/demos/Marks/Link/index.vue
@@ -43,7 +43,7 @@ export default {
       ],
       content: `
         <p>
-          Wow, this editor has support for links to the whole <strong><a href="https://en.wikipedia.org/wiki/World_Wide_Web">world wide web</a></strong>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
+          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web">world <strong>wide web</strong></a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
         </p>
         <p>
           By default every link will get a \`rel="noopener noreferrer nofollow"\` attribute. It’s configurable though.

--- a/docs/src/demos/Marks/Link/index.vue
+++ b/docs/src/demos/Marks/Link/index.vue
@@ -6,8 +6,8 @@
     <button @click="editor.chain().focus().unsetLink().run()" v-if="editor.isActive('link')">
       remove
     </button>
-    <button @click="editor.chain().focus().extendMarkRange('link').unsetLink().run()" v-if="editor.isActive('link')">
-      remove entire link
+    <button @click="editor.chain().focus().extendMarkRange('link').setLink({href: 'https://www.google.com'}).run()" v-if="editor.isActive('link')">
+      update link
     </button>
     <editor-content :editor="editor" />
   </div>
@@ -43,7 +43,7 @@ export default {
       ],
       content: `
         <p>
-          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web">world <strong>wide web</strong></a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
+          Wow, this editor has support for links to the whole <strong><a href="https://en.wikipedia.org/wiki/World_Wide_Web">world wide web</a></strong>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
         </p>
         <p>
           By default every link will get a \`rel="noopener noreferrer nofollow"\` attribute. It’s configurable though.

--- a/docs/src/docPages/api/commands/extend-mark-range.md
+++ b/docs/src/docPages/api/commands/extend-mark-range.md
@@ -1,7 +1,5 @@
-# clearContent
-The `extendMarkRange` command expands the current selection to encompas the bounds of a current mark.
-
-Note that if the current selection has no marks, the selection won't be altered. Additionally, if no mark type or name is provided, the selection can't be expanded, as it's impossible to know _which_ mark to use when extending the range.
+# extendMarkRange
+The `extendMarkRange` command expands the current selection to encompass the bounds of a current mark. If the current selection has no marks, the selection won't be altered. Additionally, if no mark `typeOrName` is provided, the selection can't be expanded, as it's impossible to know _which_ mark's range to use.
 
 ## Parameters
 `typeOrName: string`

--- a/docs/src/docPages/api/commands/extend-mark-range.md
+++ b/docs/src/docPages/api/commands/extend-mark-range.md
@@ -1,3 +1,14 @@
-# extendMarkRange
+# clearContent
+The `extendMarkRange` command expands the current selection to encompas the bounds of a current mark.
 
-<ContentMissing />
+Note that if the current selection has no marks, the selection won't be altered. Additionally, if no mark type or name is provided, the selection can't be expanded, as it's impossible to know _which_ mark to use when extending the range.
+
+## Parameters
+`typeOrName: string`
+
+## Usage
+```js
+// Expand selection to include the rest of a link
+editor.commands.extendMarkRange("link")
+```
+

--- a/docs/src/docPages/api/commands/extend-mark-range.md
+++ b/docs/src/docPages/api/commands/extend-mark-range.md
@@ -1,5 +1,5 @@
 # extendMarkRange
-The `extendMarkRange` command expands the current selection to encompass the bounds of a current mark. If the current selection has no marks, the selection won't be altered. Additionally, if no mark `typeOrName` is provided, the selection can't be expanded, as it's impossible to know _which_ mark's range to use.
+The `extendMarkRange` command expands the current selection to encompass the current mark. If the current selection doesn't have the specified mark, nothing changes. If the selection contains multiple marks of the specified type, the first one is selected. `typeOrName` is required, since it's impossible to know _which_ mark's range to use without it.
 
 ## Parameters
 `typeOrName: string`

--- a/packages/core/src/commands/extendMarkRange.ts
+++ b/packages/core/src/commands/extendMarkRange.ts
@@ -18,9 +18,8 @@ declare module '@tiptap/core' {
 export const extendMarkRange: RawCommands['extendMarkRange'] = typeOrName => ({ tr, state, dispatch }) => {
   const type = getMarkType(typeOrName, state.schema)
   const { doc, selection } = tr
-  const { $from, empty } = selection
-
-  if (empty && dispatch) {
+  const { $from } = selection
+  if (dispatch) {
     const range = getMarkRange($from, type)
 
     if (range) {


### PR DESCRIPTION
### Motivation

<img width="417" alt="Screen Shot 2021-05-15 at 6 18 27 PM" src="https://user-images.githubusercontent.com/83977912/118384018-f9944180-b5d0-11eb-9ac2-cf7df384ba9e.png">

I'm trying to add the ability to edit a link's `href` attribute whenever any part of the link is selected. Currently, the commands for updating links only update the selected portion of the mark, as expected, and I wanted to use `extendMarkRange` to make sure I could update the whole mark, but it nooped on non-empty selections..

### Changes
- Removes the requirement for a selection to be empty in order to extend the selection to contain the whole mark.
- Adds to the `Link` example to show how to update an entire link (though you could do this for any mark, now)
- Adds `extendMarkedRange` documentation

### Testing
- Manually validated that it works as expected (using the updated Link use case)
- Manually validated that when this is done for adjacent marks (ie. one link directly next to another) that the extend only encompasses the selected mark. @philippkuehn I wasn't able to introduce the edge-case you mentioned in discord about two adjacent links being grabbed, and if the selection contains two link marks, only the first is selected.