### PR TITLE
FIX: add empty string arg to DOMImplementation.createHTMLDocument Method

### DIFF
--- a/packages/core/src/helpers/getHTMLFromFragment.ts
+++ b/packages/core/src/helpers/getHTMLFromFragment.ts
@@ -5,7 +5,7 @@ export default function getHTMLFromFragment(doc: Node, schema: Schema): string {
     .fromSchema(schema)
     .serializeFragment(doc.content)
 
-  const temporaryDocument = document.implementation.createHTMLDocument()
+  const temporaryDocument = document.implementation.createHTMLDocument('')
   const container = temporaryDocument.createElement('div')
   container.appendChild(fragment)
 


### PR DESCRIPTION
I used transpiled tiptap editor in IE11.
It's worked with this change.

reference:
https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument
