### PR TITLE
Add getAttributes command to docs

### DIFF
--- a/docs/src/docPages/api/commands.md
+++ b/docs/src/docPages/api/commands.md
@@ -168,6 +168,7 @@ Have a look at all of the core commands listed below. They should give you a goo
 | .createParagraphNear()  | Create a paragraph nearby.                                | [More](/api/commands/create-paragraph-near)  |
 | .extendMarkRange()      | Extends the text selection to the current mark.           | [More](/api/commands/extend-mark-range)  |
 | .exitCode()             | Exit from a code block.                                   | [More](/api/commands/exit-code)  |
+| .getAttributes()        | Gets the attributes of a node.                            | [More](/api/commands/get-attributes)  |
 | .joinBackward()         | Join two nodes backward.                                  | [More](/api/commands/join-backward)  |
 | .joinForward()          | Join two nodes forward.                                   | [More](/api/commands/join-forward)  |
 | .lift()                 | Removes an existing wrap.                                 | [More](/api/commands/lift)  |

--- a/docs/src/docPages/api/commands/get-attributes.md
+++ b/docs/src/docPages/api/commands/get-attributes.md
@@ -1,0 +1,3 @@
+# getAttributes
+
+<ContentMissing />


### PR DESCRIPTION
This PR adds the getAttributes (as mentioned in this discussion https://github.com/ueberdosis/tiptap/discussions/1342) command to the API docs.