### PR TITLE
add width/height to image extension

### DIFF
--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -16,7 +16,7 @@ declare module '@tiptap/core' {
       /**
        * Add an image
        */
-      setImage: (options: { src: string, alt?: string, title?: string }) => Command,
+      setImage: (options: { src: string, alt?: string, title?: string, width?: number, height?: number }) => Command,
     }
   }
 }
@@ -50,6 +50,12 @@ export const Image = Node.create<ImageOptions>({
         default: null,
       },
       title: {
+        default: null,
+      },
+      width: {
+        default: null,
+      },
+      height: {
         default: null,
       },
     }


### PR DESCRIPTION
fixes https://github.com/ueberdosis/tiptap/issues/1365

Allows users to also add the width/height attributes to images to prevent layout shift as images load.