### PR TITLE
Allow passing of DependencyList to useEditor

### DIFF
--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, DependencyList } from 'react'
 import { EditorOptions } from '@tiptap/core'
 import { Editor } from './Editor'
 
@@ -8,7 +8,7 @@ function useForceUpdate() {
   return () => setValue(value => value + 1)
 }
 
-export const useEditor = (options: Partial<EditorOptions> = {}) => {
+export const useEditor = (options: Partial<EditorOptions> = {}, deps: DependencyList = []) => {
   const [editor, setEditor] = useState<Editor | null>(null)
   const forceUpdate = useForceUpdate()
 
@@ -22,7 +22,7 @@ export const useEditor = (options: Partial<EditorOptions> = {}) => {
     return () => {
       instance.destroy()
     }
-  }, [])
+  }, deps)
 
   return editor
 }


### PR DESCRIPTION
in case the options depend on props of the consuming component, it would be nice to be able to pass a dependencylist to `useEditor`. Unless there's a better way to handle dependency updates