### PR TITLE
Make HTML in docs valid

### DIFF
--- a/docs/src/docPages/installation/cdn.md
+++ b/docs/src/docPages/installation/cdn.md
@@ -2,7 +2,8 @@
 For testing purposes or demos, use our [Skypack](https://www.skypack.dev/) CDN builds. Here are the few lines of code you need to get started:
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
+<html>
 <head>
   <meta charset="utf-8">
 </head>


### PR DESCRIPTION
You were missing an `<html>`-starter tag,  so users who copy-pasted the code would have experienced errors - not a very good first impression…
(Furthermore, I changed `<!doctype html>` to `<!DOCTYPE html>`since that's just more common)