### PR TITLE
Prevent tiptap from creating duplicate style tags when injecting css

### DIFF
--- a/packages/core/src/utilities/createStyleTag.ts
+++ b/packages/core/src/utilities/createStyleTag.ts
@@ -1,6 +1,13 @@
 export default function createStyleTag(style: string): HTMLStyleElement {
+  const tipTapStyleTag = (<HTMLStyleElement>document.querySelector('style[data-tiptap-style]'))
+
+  if (tipTapStyleTag !== null) {
+    return tipTapStyleTag
+  }
+
   const styleNode = document.createElement('style')
 
+  styleNode.setAttribute('data-tiptap-style', '');
   styleNode.innerHTML = style
   document.getElementsByTagName('head')[0].appendChild(styleNode)
 


### PR DESCRIPTION
Code sandbox example [here](https://codesandbox.io/s/objective-glitter-mj9t0?file=/src/App.vue)

When using multiple Editor instances on the same page with `injectCSS` (which defaults to true), you get duplicate style that apply the same styles in the head.

This prevents those duplicate entries

![image](https://user-images.githubusercontent.com/10237069/120224905-99de9d00-c244-11eb-9a9c-9e56391fe8b5.png)
