### PR TITLE
Include children in placeholder plugin

### DIFF
--- a/packages/extension-placeholder/src/placeholder.ts
+++ b/packages/extension-placeholder/src/placeholder.ts
@@ -12,6 +12,7 @@ export interface PlaceholderOptions {
   }) => string) | string,
   showOnlyWhenEditable: boolean,
   showOnlyCurrent: boolean,
+  includeChildren: boolean,
 }
 
 export const Placeholder = Extension.create<PlaceholderOptions>({
@@ -23,6 +24,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
     placeholder: 'Write something …',
     showOnlyWhenEditable: true,
     showOnlyCurrent: true,
+    includeChildren: false,
   },
 
   addProseMirrorPlugins() {
@@ -62,7 +64,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
                 decorations.push(decoration)
               }
 
-              return false
+              return this.options.includeChildren
             })
 
             return DecorationSet.create(doc, decorations)


### PR DESCRIPTION
Adds an option to the placeholder plugin to include children in the search for empty nodes.

Consider the use case in which there is a `header` node with `title` and `subtitle` nodes. Currently, the header node will be the only one that receives the `.is-empty` class. Therefore, typing something into the title node makes the subtitle placeholder disappear, which is confusing to users. With the modifications in this PR, the search for empty nodes can be continued to children. Therefore, the subtitle node would retain its placeholder until modified.

I'd like to get some feedback on this before updating the docs and such.