### PR TITLE
Add keyboard shortcuts to toggle superscript and subscript marks.

### DIFF
--- a/packages/extension-subscript/src/subscript.ts
+++ b/packages/extension-subscript/src/subscript.ts
@@ -66,4 +66,10 @@ export const Subscript = Mark.create<SubscriptExtensionOptions>({
       },
     }
   },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-,': () => this.editor.commands.toggleSubscript(),
+    }
+  },
 })

--- a/packages/extension-superscript/src/superscript.ts
+++ b/packages/extension-superscript/src/superscript.ts
@@ -66,4 +66,10 @@ export const Superscript = Mark.create<SuperscriptExtensionOptions>({
       },
     }
   },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-.': () => this.editor.commands.toggleSuperscript(),
+    }
+  },
 })


### PR DESCRIPTION
Shortcuts based on how Google Docs handles superscript and subscript keyboard shortcuts: https://support.google.com/docs/answer/179738.