### PR TITLE
Make drop cursor default to regular caret color

### DIFF
--- a/packages/extension-dropcursor/src/dropcursor.ts
+++ b/packages/extension-dropcursor/src/dropcursor.ts
@@ -11,7 +11,7 @@ export const Dropcursor = Extension.create<DropcursorOptions>({
   name: 'dropCursor',
 
   defaultOptions: {
-    color: 'black',
+    color: 'currentcolor',
     width: 1,
     class: null,
   },


### PR DESCRIPTION
Currently drop cursor defaults to black rather than the text color, which is what normal carets default to. Using `currentcolor` should provide a better default value.