### PR TITLE
use forwardRef for react wrappers

### DIFF
--- a/packages/react/src/NodeViewContent.tsx
+++ b/packages/react/src/NodeViewContent.tsx
@@ -20,5 +20,5 @@ export const NodeViewContent: React.FC<NodeViewContentProps> =
         }}
       />
     )
-  }
-}
+  })
+  

--- a/packages/react/src/NodeViewContent.tsx
+++ b/packages/react/src/NodeViewContent.tsx
@@ -5,17 +5,20 @@ export interface NodeViewContentProps {
   as?: React.ElementType,
 }
 
-export const NodeViewContent: React.FC<NodeViewContentProps> = props => {
-  const Tag = props.as || 'div'
+export const NodeViewContent: React.FC<NodeViewContentProps> =
+  React.forwardRef((props, ref) => {
+    const Tag = props.as || 'div'
 
-  return (
-    <Tag
-      {...props}
-      data-node-view-content=""
-      style={{
-        ...props.style,
-        whiteSpace: 'pre-wrap',
-      }}
-    />
-  )
+    return (
+      <Tag
+        {...props}
+        ref={ref}
+        data-node-view-content=""
+        style={{
+          ...props.style,
+          whiteSpace: 'pre-wrap',
+        }}
+      />
+    )
+  }
 }

--- a/packages/react/src/NodeViewWrapper.tsx
+++ b/packages/react/src/NodeViewWrapper.tsx
@@ -6,19 +6,22 @@ export interface NodeViewWrapperProps {
   as?: React.ElementType,
 }
 
-export const NodeViewWrapper: React.FC<NodeViewWrapperProps> = props => {
-  const { onDragStart } = useReactNodeView()
-  const Tag = props.as || 'div'
+export const NodeViewWrapper: React.FC<NodeViewWrapperProps> =
+  React.forwardRef((props, ref) => {
+    const { onDragStart } = useReactNodeView()
+    const Tag = props.as || 'div'
 
-  return (
-    <Tag
-      {...props}
-      data-node-view-wrapper=""
-      onDragStart={onDragStart}
-      style={{
-        ...props.style,
-        whiteSpace: 'normal',
-      }}
-    />
-  )
+    return (
+      <Tag
+        {...props}
+        ref={ref}
+        data-node-view-wrapper=""
+        onDragStart={onDragStart}
+        style={{
+          ...props.style,
+          whiteSpace: 'normal',
+        }}
+      />
+    )
+  }
 }

--- a/packages/react/src/NodeViewWrapper.tsx
+++ b/packages/react/src/NodeViewWrapper.tsx
@@ -23,5 +23,4 @@ export const NodeViewWrapper: React.FC<NodeViewWrapperProps> =
         }}
       />
     )
-  }
-}
+  })


### PR DESCRIPTION
These changes allow developers to get a ref to the Tag rendered by NodeViewContent / NodeViewWrapper. E.g., now this is possible:

```
<NodeViewWrapper ref={myRef} />
```

and myRef would be hooked up to the div