### PR TITLE
use contentWrapperRef for react nodeviews

### DIFF
--- a/packages/react/src/NodeViewContent.tsx
+++ b/packages/react/src/NodeViewContent.tsx
@@ -12,7 +12,6 @@ export const NodeViewContent: React.FC<NodeViewContentProps> = React.forwardRef(
     <Tag
       {...props}
       ref={ref}
-      data-node-view-content=""
       style={{
         ...props.style,
         whiteSpace: 'pre-wrap',


### PR DESCRIPTION
This PR refactors React NodeViews to get the contentWrapper element via a `ref`. This fixes two things:

1. We were previously relying on `update` being called to move the contentDOMElement. React and Prosemirror's lifecycles don't interop nicely; while React renders asynchronously, Prosemirror instantly needs a result for `contentDOM` and `dom`. When Prosemirror calls `contentDOM`, we call `maybeMoveContentDOM`, but we can't know for sure that the React tree has already been rendered and the element with `[data-node-view-content]` is readily available. I've encountered cases where this is breaking because ProseMirror didn't call `contentDOM` anymore afterwards (only before it was available).
2. It removes the need to query for `[data-node-view-content]`, which arguably is not a very nice pattern.

(Ideally, I would have gotten rid of the `contentDOMElement` wrapper entirely, but I didn't get that to work as we'd need to force prosemirror to rerender. Maybe this is possible by adding a decoration to force a rerender of the nodeView.)

Unfortunately this is a breaking change, as consumers now need to use the following:

```
<NodeViewContent ref={props.contentWrapperRef} />
```

Looking forward to your feedback,

PS: 
1) I can give a demo of the related issue in our codebase. As it only occured with nested react nodeviews, it's a bit cumbersome to replicate.
2) I can update the docs / tests if you'd be ok with the suggested change