### PR TITLE
Add getText() function to Editor

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -15,6 +15,7 @@ import createDocument from './helpers/createDocument'
 import getHTMLFromFragment from './helpers/getHTMLFromFragment'
 import isNodeEmpty from './helpers/isNodeEmpty'
 import createStyleTag from './utilities/createStyleTag'
+import textBetween from './utilities/textBetween';
 import CommandManager from './CommandManager'
 import ExtensionManager from './ExtensionManager'
 import EventEmitter from './EventEmitter'
@@ -399,6 +400,13 @@ export class Editor extends EventEmitter {
    */
   public getHTML(): string {
     return getHTMLFromFragment(this.state.doc, this.schema)
+  }
+
+  /**
+   * Get the document as text.
+   */
+  public getText(blockSeparator?: string, leafText?: string): string {
+    return textBetween(this, 0, this.state.doc.content.size, blockSeparator, leafText);
   }
 
   /**

--- a/packages/core/src/extensions/clipboardTextSerializer.ts
+++ b/packages/core/src/extensions/clipboardTextSerializer.ts
@@ -1,37 +1,7 @@
 import { Editor } from '@tiptap/core'
 import { Plugin, PluginKey } from 'prosemirror-state'
 import { Extension } from '../Extension'
-
-const textBetween = (
-  editor: Editor,
-  from: number,
-  to: number,
-  blockSeparator?: string,
-  leafText?: string,
-): string => {
-  let text = ''
-  let separated = true
-
-  editor.state.doc.nodesBetween(from, to, (node, pos) => {
-    const textSerializer = editor.extensionManager.textSerializers[node.type.name]
-
-    if (textSerializer) {
-      text += textSerializer({ node })
-      separated = !blockSeparator
-    } else if (node.isText) {
-      text += node?.text?.slice(Math.max(from, pos) - pos, to - pos)
-      separated = !blockSeparator
-    } else if (node.isLeaf && leafText) {
-      text += leafText
-      separated = !blockSeparator
-    } else if (!separated && node.isBlock) {
-      text += blockSeparator
-      separated = true
-    }
-  }, 0)
-
-  return text
-}
+import textBetween from '../utilities/textBetween';
 
 export const ClipboardTextSerializer = Extension.create({
   name: 'editable',

--- a/packages/core/src/utilities/textBetween.ts
+++ b/packages/core/src/utilities/textBetween.ts
@@ -1,0 +1,32 @@
+import { Editor } from '@tiptap/core'
+
+export default function textBetween(
+  editor: Editor,
+  from: number,
+  to: number,
+  blockSeparator?: string,
+  leafText?: string,
+): string {
+  let text = ''
+  let separated = true
+
+  editor.state.doc.nodesBetween(from, to, (node, pos) => {
+    const textSerializer = editor.extensionManager.textSerializers[node.type.name]
+
+    if (textSerializer) {
+      text += textSerializer({ node })
+      separated = !blockSeparator
+    } else if (node.isText) {
+      text += node?.text?.slice(Math.max(from, pos) - pos, to - pos)
+      separated = !blockSeparator
+    } else if (node.isLeaf && leafText) {
+      text += leafText
+      separated = !blockSeparator
+    } else if (!separated && node.isBlock) {
+      text += blockSeparator
+      separated = true
+    }
+  }, 0)
+
+  return text
+}


### PR DESCRIPTION
This PR adds an ability to get editor's content as text using `editor.getText()` function.