### PR TITLE
Use correct reference for options.editorProps

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -133,6 +133,12 @@ export class Editor extends EventEmitter {
    */
   public setOptions(options: Partial<EditorOptions> = {}): void {
     this.options = { ...this.options, ...options }
+
+    // Update editorProps directly on the view and store reference to configured props
+    if (this.view) {
+      if (options.editorProps) this.view.setProps(options.editorProps)
+      this.options.editorProps = this.view.props
+    }
   }
 
   /**
@@ -251,6 +257,9 @@ export class Editor extends EventEmitter {
     // So we’ll have access to it for tests.
     const dom = this.view.dom as HTMLElement
     dom.editor = this
+
+    // Reference the resulting view props in our options
+    this.options.editorProps = this.view.props
   }
 
   /**

--- a/tests/cypress/integration/core/editorProps.spec.ts
+++ b/tests/cypress/integration/core/editorProps.spec.ts
@@ -1,0 +1,55 @@
+/// <reference types="cypress" />
+
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+
+describe('editorProps', () => {
+  it('editorProps can be set while constructing Editor', () => {
+    function transformPastedHTML(html: string) {
+      return html
+    }
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      editorProps: { transformPastedHTML },
+    })
+
+    expect(transformPastedHTML)
+      .to.eq(editor.options.editorProps.transformPastedHTML)
+      .and.to.eq(editor.options.editorProps.transformPastedHTML)
+  })
+
+  it('editorProps can be set through setOptions', () => {
+    function transformPastedHTML(html: string) {
+      return html
+    }
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+    })
+
+    editor.setOptions({ editorProps: { transformPastedHTML } })
+
+    expect(transformPastedHTML)
+      .to.eq(editor.options.editorProps.transformPastedHTML)
+      .and.to.eq(editor.options.editorProps.transformPastedHTML)
+  })
+
+  it('editorProps can be set directly through options', () => {
+    function transformPastedHTML(html: string) {
+      return html
+    }
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+    })
+
+    editor.options.editorProps.transformPastedHTML = transformPastedHTML
+
+    expect(transformPastedHTML)
+      .to.eq(editor.options.editorProps.transformPastedHTML)
+      .and.to.eq(editor.options.editorProps.transformPastedHTML)
+  })
+})


### PR DESCRIPTION
This change ensures that `Editor.options.editorProps` correctly references the ProseMirror View props `this.view.props`.It enables users to read and manipulate the props as expected. Additionally calls `view.setProps(...)` when `editor.setOptions(...)` is being called with `editorProps` so they can be set and updated through this method as well.

Includes tests, closes https://github.com/ueberdosis/tiptap/issues/1518 