### PR TITLE
doc update: onSelection → onSelectionUpdate

### DIFF
--- a/docs/src/docPages/guide/custom-extensions.md
+++ b/docs/src/docPages/guide/custom-extensions.md
@@ -404,7 +404,7 @@ const CustomExtension = Extension.create({
   onUpdate() {
     // The content has changed.
   },
-  onSelection() {
+  onSelectionUpdate({editor}) {
     // The selection has changed.
   },
   onTransaction({ transaction }) {


### PR DESCRIPTION
PR to check my understanding, has this API changed?

Live doc: https://www.tiptap.dev/guide/custom-extensions#events

Edit: typescript doesn't like `{editor}` as the argument, though it seems to work in practice.

```
Type '({ editor }: { editor: any; }) => void' is not assignable to type '(this: { name: string; options: unknown; editor: Editor; parent: ... | null | undefined; }) => void'.ts(2322)
(property) onSelectionUpdate?: ((this: {
    name: string;
    options: unknown;
    editor: Editor;
    parent: ... | null | undefined;
}) => void) | null | undefined
```