### PR TITLE
Hide the BubbleMenu when the editor loses focus / the user is selecting (optional)

### DIFF
--- a/docs/src/docPages/api/extensions/bubble-menu.md
+++ b/docs/src/docPages/api/extensions/bubble-menu.md
@@ -15,10 +15,11 @@ yarn add @tiptap/extension-bubble-menu
 ```
 
 ## Settings
-| Option       | Type          | Default | Description                                                             |
-| ------------ | ------------- | ------- | ----------------------------------------------------------------------- |
-| element      | `HTMLElement` | `null`  | The DOM element that contains your menu.                                |
-| tippyOptions | `Object`      | `{}`    | [Options for tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/) |
+| Option            | Type          | Default | Description                                                             |
+| ----------------- | ------------- | ------- | ----------------------------------------------------------------------- |
+| element           | `HTMLElement` | `null`  | The DOM element that contains your menu.                                |
+| hideWhenSelecting | `Boolean`     | `false` | Hide the menu when the user is selecting text.                          |
+| tippyOptions      | `Object`      | `{}`    | [Options for tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/) |
 
 ## Source code
 [packages/extension-bubble-menu/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bubble-menu/)

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -11,6 +11,7 @@ import tippy, { Instance, Props } from 'tippy.js'
 export interface BubbleMenuPluginProps {
   editor: Editor,
   element: HTMLElement,
+  hideWhenSelecting?: boolean
   tippyOptions?: Partial<Props>,
 }
 
@@ -25,21 +26,29 @@ export class BubbleMenuView {
 
   public view: EditorView
 
+  public hideWhenSelecting: boolean
+
   public preventHide = false
+
+  public viewSelecting = false
 
   public tippy!: Instance
 
   constructor({
     editor,
     element,
+    hideWhenSelecting = false,
     view,
     tippyOptions,
   }: BubbleMenuViewProps) {
     this.editor = editor
     this.element = element
+    this.hideWhenSelecting = hideWhenSelecting
     this.view = view
     this.element.addEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.view.dom.addEventListener('dragstart', this.dragstartHandler)
+    this.view.dom.addEventListener('mousedown', this.viewMousedownHandler)
+    this.view.dom.addEventListener('mouseup', this.viewMouseupHandler)
     this.editor.on('focus', this.focusHandler)
     this.editor.on('blur', this.blurHandler)
     this.createTooltip(tippyOptions)
@@ -76,6 +85,16 @@ export class BubbleMenuView {
     this.hide()
   }
 
+  viewMousedownHandler = () => {
+    this.viewSelecting = true
+  }
+
+  viewMouseupHandler = () => {
+    this.viewSelecting = false
+    // we use `setTimeout` to make sure `selection` is already updated
+    setTimeout(() => this.update(this.editor.view));
+  }
+
   createTooltip(options: Partial<Props> = {}) {
     this.tippy = tippy(this.view.dom, {
       duration: 0,
@@ -90,11 +109,12 @@ export class BubbleMenuView {
   }
 
   update(view: EditorView, oldState?: EditorState) {
+    const { viewSelecting } = this
     const { state, composing } = view
     const { doc, selection } = state
 
-    const hasFocus = view.hasFocus()
-    if (!hasFocus) {
+    const hideSelecting = this.hideWhenSelecting && viewSelecting
+    if (!view.hasFocus() || hideSelecting) {
         this.hide()
         return;
     }
@@ -151,6 +171,8 @@ export class BubbleMenuView {
     this.tippy.destroy()
     this.element.removeEventListener('mousedown', this.mousedownHandler)
     this.view.dom.removeEventListener('dragstart', this.dragstartHandler)
+    this.view.dom.removeEventListener('mousedown', this.viewMousedownHandler)
+    this.view.dom.removeEventListener('mouseup', this.viewMouseupHandler)
     this.editor.off('focus', this.focusHandler)
     this.editor.off('blur', this.blurHandler)
   }

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -92,8 +92,14 @@ export class BubbleMenuView {
   update(view: EditorView, oldState?: EditorState) {
     const { state, composing } = view
     const { doc, selection } = state
-    const isSame = oldState && oldState.doc.eq(doc) && oldState.selection.eq(selection)
 
+    const hasFocus = view.hasFocus()
+    if (!hasFocus) {
+        this.hide()
+        return;
+    }
+
+    const isSame = oldState && oldState.doc.eq(doc) && oldState.selection.eq(selection)
     if (composing || isSame) {
       return
     }

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -10,6 +10,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
 
   defaultOptions: {
     element: null,
+    hideWhenSelecting: false,
     tippyOptions: {},
   },
 
@@ -22,6 +23,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
       BubbleMenuPlugin({
         editor: this.editor,
         element: this.options.element,
+        hideWhenSelecting: this.options.hideWhenSelecting,
         tippyOptions: this.options.tippyOptions,
       }),
     ]

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -9,11 +9,12 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
   const element = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const { editor, tippyOptions } = props
+    const { editor, hideWhenSelecting, tippyOptions } = props
 
     editor.registerPlugin(BubbleMenuPlugin({
       editor,
       element: element.current as HTMLElement,
+      hideWhenSelecting,
       tippyOptions,
     }))
 


### PR DESCRIPTION
I've come across a few use cases where the BubbleMenu is displayed, where I don't think it should be.

### Editor loses focus

When the user selects a block of text
And clicks a button in the BubbleMenu that puts focus on an input outside of the editor
Then the user should not see the BubbleMenu

### User is selecting text

When the user is selecting text
Then the user should not be able to put focus on the BubbleMenu

The PR gives the developer an option to hide the BubbleMenu via `hideWhenSelecting` while the user is selecting text (like Dropbox Paper), so the BubbleMenu isn't in the user's way when they are selecting text.

Todo
- [ ] Add `hideWhenSelecting` as an option in the `vue-2` and `vue-3` packages