### PR TITLE
update task-item.ts nodeview to update data-checked

### DIFF
--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -132,6 +132,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
             return false
           }
 
+          listItem.dataset.checked = updatedNode.attrs.checked
           if (updatedNode.attrs.checked) {
             checkbox.setAttribute('checked', 'checked')
           } else {

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -111,6 +111,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
         }
       })
 
+      listItem.dataset.checked = node.attrs.checked
       if (node.attrs.checked) {
         checkbox.setAttribute('checked', 'checked')
       }


### PR DESCRIPTION
#1566 

Another alternative would be to remove the label wrapper element so the nodeview output is

```html
<li data-checked="true" class="">
  <input type="checkbox">
  <div><p>A list item</p></div>
</li>
```

This would allow people to style the content of the todo-item with a sibling css selector:

```css
ul[data-type=taskList] > li > input[type=checkbox] + div { 
  text-decoration: line-through;
}
```