### PR TITLE
Fix: nodeInputRule() support for group match

### DIFF
--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -10,14 +10,20 @@ export default function (regexp: RegExp, type: NodeType, getAttributes?: (match:
 
     if (match[1]) {
       const offset = match[0].lastIndexOf(match[1])
-      start += offset
-      if (start > end) {
-        start = end;
+      let matchStart = start + offset
+      if (matchStart > end) {
+        matchStart = end
       }
       else {
-        end = start + match[1].length
+        end = matchStart + match[1].length
       }
-      tr.replaceWith(start, end, type.create(attributes))
+
+      // insert last typed character
+      const lastChar = match[0][match[0].length - 1]
+      tr.insertText(lastChar, start + match[0].length - 1)
+
+      // insert node from input rule
+      tr.replaceWith(matchStart, end, type.create(attributes))
     } else if (match[0]) {
       tr.replaceWith(start, end, type.create(attributes))
     }

--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -8,8 +8,18 @@ export default function (regexp: RegExp, type: NodeType, getAttributes?: (match:
       : getAttributes
     const { tr } = state
 
-    if (match[0]) {
-      tr.replaceWith(start - 1, end, type.create(attributes))
+    if (match[1]) {
+      const offset = match[0].lastIndexOf(match[1])
+      start += offset
+      if (start > end) {
+        start = end;
+      }
+      else {
+        end = start + match[1].length
+      }
+      tr.replaceWith(start, end, type.create(attributes))
+    } else if (match[0]) {
+      tr.replaceWith(start, end, type.create(attributes))
     }
 
     return tr


### PR DESCRIPTION
Fixes in nodeInputRule()
- add support for "first group match, if any" similar to https://prosemirror.net/docs/ref/#inputrules
- fix issue where rewriting includes extra unnecessary character from the match