### PR TITLE
Readd russian history shortcuts

### DIFF
--- a/docs/src/demos/Examples/MarkdownShortcuts/Vue/index.spec.js
+++ b/docs/src/demos/Examples/MarkdownShortcuts/Vue/index.spec.js
@@ -58,7 +58,7 @@ context('/demos/Examples/MarkdownShortcuts/Vue', () => {
       .should('contain', '$foobar')
   })
 
-  it.skip('should create a code block without language', () => {
+  it('should create a code block without language', () => {
     cy.get('.ProseMirror')
       .type('``` {enter}const foo = bar{enter}```')
       .find('pre')
@@ -86,14 +86,14 @@ context('/demos/Examples/MarkdownShortcuts/Vue', () => {
       .should('contain', 'foobar')
   })
 
-  it.skip('should create a ordered list', () => {
+  it('should create a ordered list', () => {
     cy.get('.ProseMirror')
       .type('1. foobar')
       .find('ol')
       .should('contain', 'foobar')
   })
 
-  it.skip('should create a blockquote', () => {
+  it('should create a blockquote', () => {
     cy.get('.ProseMirror')
       .type('> foobar')
       .find('blockquote')

--- a/docs/src/demos/Extensions/History/index.spec.js
+++ b/docs/src/demos/Extensions/History/index.spec.js
@@ -1,9 +1,6 @@
 context('/demos/Extensions/History', () => {
-  before(() => {
-    cy.visit('/demos/Extensions/History')
-  })
-
   beforeEach(() => {
+    cy.visit('/demos/Extensions/History')
     cy.get('.ProseMirror').then(([{ editor }]) => {
       editor.commands.setContent('<p>Mistake</p>')
     })
@@ -20,10 +17,52 @@ context('/demos/Extensions/History', () => {
       .should('not.contain', 'Mistake')
   })
 
-  it('the keyboard shortcut should make the last change undone', () => {
+  it('should make the last change undone with the keyboard shortcut', () => {
     cy.get('.ProseMirror')
-      .trigger('keydown', { modKey: true, key: 'z' })
+      .trigger('keydown', {modKey: true, key: 'z' })
+
+
+    cy.get('.ProseMirror')
       .should('not.contain', 'Mistake')
+  })
+
+  it('should make the last change undone with the keyboard shortcut (russian)', () => {
+    cy.get('.ProseMirror')
+      .should('contain', 'Mistake')
+
+    cy.get('.ProseMirror')
+      .trigger('keydown', {modKey: true, key: 'я' })
+
+    cy.get('.ProseMirror')
+      .should('not.contain', 'Mistake')
+  })
+
+  it('should apply the last undone change again with the keyboard shortcut', () => {
+    cy.get('.ProseMirror')
+      .trigger('keydown', {modKey: true, key: 'z' })
+
+    cy.get('.ProseMirror')
+      .should('not.contain', 'Mistake')
+
+    cy.get('.ProseMirror')
+      .trigger('keydown', {modKey: true, shiftKey: true, key: 'z' })
+
+    cy.get('.ProseMirror')
+      .should('contain', 'Mistake')
+  })
+
+  it('should apply the last undone change again with the keyboard shortcut (russian)', () => {
+    cy.get('.ProseMirror')
+      .trigger('keydown', {modKey: true, key: 'я' })
+
+    cy.get('.ProseMirror')
+      .should('not.contain', 'Mistake')
+
+    cy.get('.ProseMirror')
+      .trigger('keydown', {modKey: true, shiftKey: true, key: 'я' })
+
+    cy.get('.ProseMirror')
+      .should('contain', 'Mistake')
   })
 
   it('should apply the last undone change again', () => {
@@ -40,14 +79,6 @@ context('/demos/Extensions/History', () => {
       .click()
 
     cy.get('.ProseMirror')
-      .should('contain', 'Mistake')
-  })
-
-  it.skip('the keyboard shortcut should apply the last undone change again', () => {
-    cy.get('.ProseMirror')
-      .trigger('keydown', { modKey: true, key: 'z' })
-      .should('not.contain', 'Mistake')
-      .trigger('keydown', { modKey: true, shiftKey: true, key: 'z' })
       .should('contain', 'Mistake')
   })
 })

--- a/docs/src/demos/Extensions/History/index.spec.js
+++ b/docs/src/demos/Extensions/History/index.spec.js
@@ -19,8 +19,7 @@ context('/demos/Extensions/History', () => {
 
   it('should make the last change undone with the keyboard shortcut', () => {
     cy.get('.ProseMirror')
-      .trigger('keydown', {modKey: true, key: 'z' })
-
+      .trigger('keydown', { modKey: true, key: 'z' })
 
     cy.get('.ProseMirror')
       .should('not.contain', 'Mistake')
@@ -31,7 +30,7 @@ context('/demos/Extensions/History', () => {
       .should('contain', 'Mistake')
 
     cy.get('.ProseMirror')
-      .trigger('keydown', {modKey: true, key: 'я' })
+      .trigger('keydown', { modKey: true, key: 'я' })
 
     cy.get('.ProseMirror')
       .should('not.contain', 'Mistake')
@@ -39,13 +38,13 @@ context('/demos/Extensions/History', () => {
 
   it('should apply the last undone change again with the keyboard shortcut', () => {
     cy.get('.ProseMirror')
-      .trigger('keydown', {modKey: true, key: 'z' })
+      .trigger('keydown', { modKey: true, key: 'z' })
 
     cy.get('.ProseMirror')
       .should('not.contain', 'Mistake')
 
     cy.get('.ProseMirror')
-      .trigger('keydown', {modKey: true, shiftKey: true, key: 'z' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 'z' })
 
     cy.get('.ProseMirror')
       .should('contain', 'Mistake')
@@ -53,13 +52,13 @@ context('/demos/Extensions/History', () => {
 
   it('should apply the last undone change again with the keyboard shortcut (russian)', () => {
     cy.get('.ProseMirror')
-      .trigger('keydown', {modKey: true, key: 'я' })
+      .trigger('keydown', { modKey: true, key: 'я' })
 
     cy.get('.ProseMirror')
       .should('not.contain', 'Mistake')
 
     cy.get('.ProseMirror')
-      .trigger('keydown', {modKey: true, shiftKey: true, key: 'я' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 'я' })
 
     cy.get('.ProseMirror')
       .should('contain', 'Mistake')

--- a/docs/src/demos/Nodes/HardBreak/index.spec.js
+++ b/docs/src/demos/Nodes/HardBreak/index.spec.js
@@ -34,7 +34,7 @@ context('/demos/Nodes/HardBreak', () => {
       .should('exist')
   })
 
-  it.skip('the default keyboard shortcut should add a line break', () => {
+  it('the default keyboard shortcut should add a line break', () => {
     cy.get('.ProseMirror br')
       .should('not.exist')
 

--- a/packages/extension-history/src/history.ts
+++ b/packages/extension-history/src/history.ts
@@ -49,8 +49,10 @@ export const History = Extension.create<HistoryOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-z': () => this.editor.commands.undo(),
+      'Mod-я': () => this.editor.commands.undo(),
       'Mod-y': () => this.editor.commands.redo(),
       'Shift-Mod-z': () => this.editor.commands.redo(),
+      'Shift-Mod-я': () => this.editor.commands.redo(),
     }
   },
 })


### PR DESCRIPTION
This readds the shortcuts introduced in Tiptap v1 and fixes the history tests.

+ this removes the skipped flags of all remaining tests