### PR TITLE
fix: export text align extension options

### DIFF
--- a/packages/extension-text-align/src/text-align.ts
+++ b/packages/extension-text-align/src/text-align.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
 
-type TextAlignOptions = {
+export type TextAlignOptions = {
   types: string[],
   alignments: string[],
   defaultAlignment: string,


### PR DESCRIPTION
Text align extension`s options were not exported as for other extensions.