### PR TITLE
fix: export starter kit extension options

### DIFF
--- a/packages/starter-kit/src/index.ts
+++ b/packages/starter-kit/src/index.ts
@@ -19,6 +19,8 @@ import ListItem, { ListItemOptions } from '@tiptap/extension-list-item'
 
 import { StarterKit } from './starter-kit'
 
+export { StarterKitOptions } from './starter-kit'
+
 export default StarterKit
 
 export function defaultExtensions(options?: Partial<{


### PR DESCRIPTION
Starter kit extension options were not exported.
Without this change, we have to import types from the dist directory:
```typescript
import { StarterKitOptions } from "@tiptap/starter-kit/dist/packages/starter-kit/src/starter-kit";
```