### PR TITLE
Fix selection with autofocus when editor content is empty on startup

### DIFF
--- a/packages/core/src/commands/focus.ts
+++ b/packages/core/src/commands/focus.ts
@@ -59,8 +59,8 @@ export const focus: RawCommands['focus'] = (position = null) => ({
 
   const { from, to } = resolveSelection(editor.state, position) || editor.state.selection
   const { doc, storedMarks } = tr
-  const resolvedFrom = minMax(from, 0, doc.content.size)
-  const resolvedEnd = minMax(to, 0, doc.content.size)
+  const resolvedFrom = minMax(from, 1, doc.content.size)
+  const resolvedEnd = minMax(to, 1, doc.content.size)
   const selection = TextSelection.create(doc, resolvedFrom, resolvedEnd)
   const isSameSelection = editor.state.selection.eq(selection)
 


### PR DESCRIPTION
Fixes https://github.com/ueberdosis/tiptap/issues/1588

It seams that the selection of the anchor and head is not zero based.

When initializing an empty editor and setting the focus by clicking into the editor. The `editor.state.selection` will have:

```
selection: Object
- type: "text"
- anchor: 1
- head: 1
```

![image](https://user-images.githubusercontent.com/10237069/125775341-cac7e036-b9d9-4cf0-8dee-c4f440fa0a7d.png)
