### PR TITLE
Export NodeViewRendererOptions

### DIFF
--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -4,12 +4,7 @@ import { Node as ProseMirrorNode } from 'prosemirror-model'
 import { Editor as CoreEditor } from './Editor'
 import { Node } from './Node'
 import isiOS from './utilities/isiOS'
-import { NodeViewRendererProps } from './types'
-
-interface NodeViewRendererOptions {
-  stopEvent: ((event: Event) => boolean) | null,
-  update: ((node: ProseMirrorNode, decorations: Decoration[]) => boolean) | null,
-}
+import { NodeViewRendererProps, NodeViewRendererOptions } from './types'
 
 export class NodeView<Component, Editor extends CoreEditor = CoreEditor> implements ProseMirrorNodeView {
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -145,6 +145,11 @@ export type NodeViewProps = {
   deleteNode: () => void,
 }
 
+export interface NodeViewRendererOptions {
+  stopEvent: ((event: Event) => boolean) | null,
+  update: ((node: ProseMirrorNode, decorations: Decoration[]) => boolean) | null,
+}
+
 export type NodeViewRendererProps = {
   editor: Editor,
   node: ProseMirrorNode,


### PR DESCRIPTION
Export NodeViewRendererOptions. This avoids adding a dependency/peerDependency for `promsemirror/{view,model}` for packages like `svelte-tiptap` and `ngx-tiptap`.

Core packages can make use of this as well.