### PR TITLE
Change TextAlignOptions to interface (not type)

### DIFF
--- a/packages/extension-text-align/src/text-align.ts
+++ b/packages/extension-text-align/src/text-align.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
 
-export type TextAlignOptions = {
+export interface TextAlignOptions = {
   types: string[],
   alignments: string[],
   defaultAlignment: string,


### PR DESCRIPTION
TextAlignOptions is not being exported correctly. Other extensions have their options defined as an interface not a type, so I assume changing this to match will fix the problem.

eg

```ts
export interface BlockquoteOptions {
  HTMLAttributes: Record<string, any>,
}
```