### PR TITLE
Allow a rule to be skipped from the getAttributes callback

### DIFF
--- a/packages/core/src/pasteRules/markPasteRule.ts
+++ b/packages/core/src/pasteRules/markPasteRule.ts
@@ -29,6 +29,10 @@ export default function (
             const attrs = getAttributes instanceof Function
               ? getAttributes(match)
               : getAttributes
+            
+            if (!attrs) {
+              continue;
+            }
 
             // adding text before markdown to nodes
             if (matchStart > 0) {


### PR DESCRIPTION
For example: you are matching URLs with a Regex but want to make additional checks on the match array before deciding if you want to apply the mark or not. Returning null or false won't attempt to apply the mark. 

Currently the return value of getAttributes is applied unconditionally. So this is somewhere between a feature request and a bug fix.