### PR TITLE
chore: add repository for all packages.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,5 +39,10 @@
     "prosemirror-state": "^1.3.4",
     "prosemirror-transform": "^1.3.2",
     "prosemirror-view": "^1.18.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/core"
   }
 }

--- a/packages/extension-blockquote/package.json
+++ b/packages/extension-blockquote/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-blockquote"
   }
 }

--- a/packages/extension-bold/package.json
+++ b/packages/extension-bold/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-bold"
   }
 }

--- a/packages/extension-bubble-menu/package.json
+++ b/packages/extension-bubble-menu/package.json
@@ -27,5 +27,10 @@
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.18.8",
     "tippy.js": "^6.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-bubble-menu"
   }
 }

--- a/packages/extension-bullet-list/package.json
+++ b/packages/extension-bullet-list/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-bullet-list"
   }
 }

--- a/packages/extension-character-count/package.json
+++ b/packages/extension-character-count/package.json
@@ -23,5 +23,10 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-text-style": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-character-count"
   }
 }

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -30,5 +30,10 @@
     "prosemirror-model": "^1.14.2",
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.18.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-code-block-lowlight"
   }
 }

--- a/packages/extension-code-block/package.json
+++ b/packages/extension-code-block/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-code-block"
   }
 }

--- a/packages/extension-code/package.json
+++ b/packages/extension-code/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-code"
   }
 }

--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "y-prosemirror": "^1.0.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-collaboration-cursor"
   }
 }

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "y-prosemirror": "^1.0.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-collaboration"
   }
 }

--- a/packages/extension-document/package.json
+++ b/packages/extension-document/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-document"
   }
 }

--- a/packages/extension-dropcursor/package.json
+++ b/packages/extension-dropcursor/package.json
@@ -26,5 +26,10 @@
   "dependencies": {
     "@types/prosemirror-dropcursor": "^1.0.2",
     "prosemirror-dropcursor": "^1.3.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-dropcursor"
   }
 }

--- a/packages/extension-floating-menu/package.json
+++ b/packages/extension-floating-menu/package.json
@@ -27,5 +27,10 @@
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.18.8",
     "tippy.js": "^6.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-floating-menu"
   }
 }

--- a/packages/extension-focus/package.json
+++ b/packages/extension-focus/package.json
@@ -26,5 +26,10 @@
   "dependencies": {
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.18.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-focus"
   }
 }

--- a/packages/extension-font-family/package.json
+++ b/packages/extension-font-family/package.json
@@ -23,5 +23,10 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-text-style": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-font-family"
   }
 }

--- a/packages/extension-gapcursor/package.json
+++ b/packages/extension-gapcursor/package.json
@@ -26,5 +26,10 @@
   "dependencies": {
     "@types/prosemirror-gapcursor": "^1.0.4",
     "prosemirror-gapcursor": "^1.1.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-gapcursor"
   }
 }

--- a/packages/extension-hard-break/package.json
+++ b/packages/extension-hard-break/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-hard-break"
   }
 }

--- a/packages/extension-heading/package.json
+++ b/packages/extension-heading/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-heading"
   }
 }

--- a/packages/extension-highlight/package.json
+++ b/packages/extension-highlight/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-highlight"
   }
 }

--- a/packages/extension-history/package.json
+++ b/packages/extension-history/package.json
@@ -26,5 +26,10 @@
   "dependencies": {
     "@types/prosemirror-history": "^1.0.3",
     "prosemirror-history": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-history"
   }
 }

--- a/packages/extension-horizontal-rule/package.json
+++ b/packages/extension-horizontal-rule/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-state": "^1.3.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-horizontal-rule"
   }
 }

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-image"
   }
 }

--- a/packages/extension-italic/package.json
+++ b/packages/extension-italic/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-italic"
   }
 }

--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-state": "^1.3.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-link"
   }
 }

--- a/packages/extension-list-item/package.json
+++ b/packages/extension-list-item/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-list-item"
   }
 }

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "@tiptap/suggestion": "^2.0.0-beta.59"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-mention"
   }
 }

--- a/packages/extension-ordered-list/package.json
+++ b/packages/extension-ordered-list/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-ordered-list"
   }
 }

--- a/packages/extension-paragraph/package.json
+++ b/packages/extension-paragraph/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-paragraph"
   }
 }

--- a/packages/extension-placeholder/package.json
+++ b/packages/extension-placeholder/package.json
@@ -27,5 +27,10 @@
     "prosemirror-model": "^1.14.2",
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.18.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-placeholder"
   }
 }

--- a/packages/extension-strike/package.json
+++ b/packages/extension-strike/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-strike"
   }
 }

--- a/packages/extension-subscript/package.json
+++ b/packages/extension-subscript/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-subscript"
   }
 }

--- a/packages/extension-superscript/package.json
+++ b/packages/extension-superscript/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-superscript"
   }
 }

--- a/packages/extension-table-cell/package.json
+++ b/packages/extension-table-cell/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-table-cell"
   }
 }

--- a/packages/extension-table-header/package.json
+++ b/packages/extension-table-header/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-table-header"
   }
 }

--- a/packages/extension-table-row/package.json
+++ b/packages/extension-table-row/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-table-row"
   }
 }

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -26,5 +26,10 @@
   "dependencies": {
     "prosemirror-tables": "^1.1.1",
     "prosemirror-view": "^1.18.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-table"
   }
 }

--- a/packages/extension-task-item/package.json
+++ b/packages/extension-task-item/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-task-item"
   }
 }

--- a/packages/extension-task-list/package.json
+++ b/packages/extension-task-list/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-task-list"
   }
 }

--- a/packages/extension-text-align/package.json
+++ b/packages/extension-text-align/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-text-align"
   }
 }

--- a/packages/extension-text-style/package.json
+++ b/packages/extension-text-style/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-text-style"
   }
 }

--- a/packages/extension-text/package.json
+++ b/packages/extension-text/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-text"
   }
 }

--- a/packages/extension-typography/package.json
+++ b/packages/extension-typography/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^1.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-typography"
   }
 }

--- a/packages/extension-underline/package.json
+++ b/packages/extension-underline/package.json
@@ -22,5 +22,10 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-underline"
   }
 }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -24,5 +24,10 @@
     "@tiptap/core": "^2.0.0-beta.86",
     "hostic-dom": "^0.8.7",
     "prosemirror-model": "^1.14.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/html"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,5 +33,10 @@
   "devDependencies": {
     "@types/react": "^17.0.11",
     "@types/react-dom": "^17.0.7"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/react"
   }
 }

--- a/packages/starter-kit/package.json
+++ b/packages/starter-kit/package.json
@@ -40,5 +40,10 @@
     "@tiptap/extension-paragraph": "^2.0.0-beta.15",
     "@tiptap/extension-strike": "^2.0.0-beta.16",
     "@tiptap/extension-text": "^2.0.0-beta.12"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/starter-kit"
   }
 }

--- a/packages/suggestion/package.json
+++ b/packages/suggestion/package.json
@@ -27,5 +27,10 @@
     "prosemirror-model": "^1.14.2",
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.18.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/suggestion"
   }
 }

--- a/packages/vue-2/package.json
+++ b/packages/vue-2/package.json
@@ -28,5 +28,10 @@
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.24",
     "@tiptap/extension-floating-menu": "^2.0.0-beta.18",
     "prosemirror-view": "^1.18.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/vue-2"
   }
 }

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -29,5 +29,10 @@
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.18.8",
     "vue": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/vue-3"
   }
 }


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives


<details>
<summary>made the changes with a script to make my life easier 🙂 </summary>


```js
const { readdirSync, readFileSync, writeFileSync } = require("fs");
const { resolve } = require("path");

// CHANGE THESE
const folders = ["packages"];
const defaulUrl = "https://github.com/ueberdosis/tiptap"
const homepage = "https://www.tiptap.dev/"

folders.forEach((folder) => {
  readdirSync(folder).forEach((dir) => {
    const path = resolve(process.cwd(), folder, dir, "package.json");
    const directory = `${folder}/${dir}`
    console.log(directory)
    try {
      const package = require(path);

      package.homepage = package.homepage || homepage

      const repoInfo = typeof package.repository === 'string'
        ? { url: package.repository }
        : (package.repository || {})
      
      package.repository = {
        ...repoInfo,
        type: "git",
        url: repoInfo.url || defaulUrl,
        directory
      },

      writeFileSync(path, JSON.stringify(package, null, 2) + "\n");
    } catch (e) {
      console.log(e)
    }
  });
});
```

</details>
