### PR TITLE
fix: use correct state when doc changed externally

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -83,7 +83,7 @@ export function Suggestion({
             return
           }
 
-          const state = handleExit ? prev : next
+          const state = handleExit && !handleStart ? prev : next
           const decorationNode = document.querySelector(`[data-decoration-id="${state.decorationId}"]`)
           const props: SuggestionProps = {
             editor,


### PR DESCRIPTION
There is a bug in suggestion plugin since Tiptap v1 when you use Collaboration and Mention together. It is bit edge case, but we actually ran into it in prod.

Open 2 editors (using collab)
Editor1 (user1): type some text and then enter Mention
Editor2 (user2): type/paste text anywhere before user1’s position
Editor1 (user1): confirms mention
Mention is at wrong position (replaces text at wrong position)

Reason: 
When you use mention locally, from variables “handleStart, handleChange, handleExit“ only 1 is true (as it goes: start->change->...->change->exit).

When text in front of mention is changed in collab, it is not considered change (handleChange==false) as query is the same. Instead of it handleExit==true, handleStart==true and handleChange==false which cause that onStart is called with props from “prev” state instead of “next”.

When typing, the position is wrong by 1:
![typing](https://user-images.githubusercontent.com/9148471/127121578-7f1ebc21-78ce-4fe7-bd90-0283e3b5ca4e.gif)

When pasting text, it is wrong by the length of pasted text:
![typing2](https://user-images.githubusercontent.com/9148471/127121354-a8efd7fa-ce15-4cbf-8a2e-bb082223c208.gif)

