### PR TITLE
Only getting empty mark range if forced for link on unsetMark

### DIFF
--- a/packages/core/src/commands/toggleMark.ts
+++ b/packages/core/src/commands/toggleMark.ts
@@ -9,17 +9,17 @@ declare module '@tiptap/core' {
       /**
        * Toggle a mark on and off.
        */
-      toggleMark: (typeOrName: string | MarkType, attributes?: Record<string, any>) => ReturnType,
+      toggleMark: (typeOrName: string | MarkType, attributes?: Record<string, any>, toggleEmptyRange?: boolean) => ReturnType,
     }
   }
 }
 
-export const toggleMark: RawCommands['toggleMark'] = (typeOrName, attributes = {}) => ({ state, commands }) => {
+export const toggleMark: RawCommands['toggleMark'] = (typeOrName, attributes = {}, toggleEmptyRange = false) => ({ state, commands }) => {
   const type = getMarkType(typeOrName, state.schema)
   const isActive = isMarkActive(state, type, attributes)
 
   if (isActive) {
-    return commands.unsetMark(type)
+    return commands.unsetMark(type, toggleEmptyRange)
   }
 
   return commands.setMark(type, attributes)

--- a/packages/core/src/commands/unsetMark.ts
+++ b/packages/core/src/commands/unsetMark.ts
@@ -9,18 +9,22 @@ declare module '@tiptap/core' {
       /**
        * Remove all marks in the current selection.
        */
-      unsetMark: (typeOrName: string | MarkType) => ReturnType,
+      unsetMark: (typeOrName: string | MarkType, unsetEmptyRange?: boolean) => ReturnType,
     }
   }
 }
 
-export const unsetMark: RawCommands['unsetMark'] = typeOrName => ({ tr, state, dispatch }) => {
+export const unsetMark: RawCommands['unsetMark'] = (typeOrName, unsetEmptyRange = false) => ({ tr, state, dispatch }) => {
   const { selection } = tr
   const type = getMarkType(typeOrName, state.schema)
   const { $from, empty, ranges } = selection
 
   if (dispatch) {
-    if (empty) {
+    if (!empty) {
+      ranges.forEach(range => {
+        tr.removeMark(range.$from.pos, range.$to.pos, type)
+      })
+    } else if (unsetEmptyRange) {
       let { from, to } = selection
       const range = getMarkRange($from, type)
 
@@ -30,10 +34,6 @@ export const unsetMark: RawCommands['unsetMark'] = typeOrName => ({ tr, state, d
       }
 
       tr.removeMark(from, to, type)
-    } else {
-      ranges.forEach(range => {
-        tr.removeMark(range.$from.pos, range.$to.pos, type)
-      })
     }
 
     tr.removeStoredMark(type)

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -92,10 +92,10 @@ export const Link = Mark.create<LinkOptions>({
         return commands.setMark('link', attributes)
       },
       toggleLink: attributes => ({ commands }) => {
-        return commands.toggleMark('link', attributes)
+        return commands.toggleMark('link', attributes, true)
       },
       unsetLink: () => ({ commands }) => {
-        return commands.unsetMark('link')
+        return commands.unsetMark('link', true)
       },
     }
   },


### PR DESCRIPTION
Toggling mark around an empty selection makes sense for things like links. But it kinda has an unexpected behaviour for formatting marks like bold, strikethrough and others of the same kind. This PR adds a way to differentiate between the two types of marks