### PR TITLE
Apply the correct regex in markPasteRule

### DIFF
--- a/packages/extension-code/src/code.ts
+++ b/packages/extension-code/src/code.ts
@@ -78,7 +78,7 @@ export const Code = Mark.create<CodeOptions>({
 
   addPasteRules() {
     return [
-      markPasteRule(inputRegex, this.type),
+      markPasteRule(pasteRegex, this.type),
     ]
   },
 })


### PR DESCRIPTION
Bug fix 👍 

`markPasteRule` has been using the `inputRegex` which is terminated with $ so it's only being applied to when the pasted text is _only_ code, not when it _contains_ code.