### PR TITLE
Add shouldShow callback to bubble menu

### DIFF
--- a/docs/src/docPages/api/extensions/bubble-menu.md
+++ b/docs/src/docPages/api/extensions/bubble-menu.md
@@ -35,9 +35,9 @@ new Editor({
   extensions: [
     BubbleMenu.configure({
       element: document.querySelector('.menu'),
-      shouldShow: (view) => {
-        // your logic to control whether the menu should show
-        return true
+      shouldShow: ({ editor }) => {
+        // only show the buble menu for images and links
+        return editor.isActive('image') || editor.isActive('link')
       }
     }),
   ],

--- a/docs/src/docPages/api/extensions/bubble-menu.md
+++ b/docs/src/docPages/api/extensions/bubble-menu.md
@@ -15,10 +15,11 @@ yarn add @tiptap/extension-bubble-menu
 ```
 
 ## Settings
-| Option       | Type          | Default | Description                                                             |
-| ------------ | ------------- | ------- | ----------------------------------------------------------------------- |
-| element      | `HTMLElement` | `null`  | The DOM element that contains your menu.                                |
-| tippyOptions | `Object`      | `{}`    | [Options for tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/) |
+| Option       | Type          | Default      | Description                                                             |
+| ------------ | ------------- | ------------ | ----------------------------------------------------------------------- |
+| element      | `HTMLElement` | `null`       | The DOM element that contains your menu.                                |
+| tippyOptions | `Object`      | `{}`         | [Options for tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/) |
+| shouldShow   | `Function`    | `() => true` | A callback to control whether the menu should show                      |
 
 ## Source code
 [packages/extension-bubble-menu/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bubble-menu/)
@@ -34,6 +35,10 @@ new Editor({
   extensions: [
     BubbleMenu.configure({
       element: document.querySelector('.menu'),
+      shouldShow: (view, state) => {
+        // your logic to control whether the menu should show
+        return true
+      }
     }),
   ],
 })

--- a/docs/src/docPages/api/extensions/bubble-menu.md
+++ b/docs/src/docPages/api/extensions/bubble-menu.md
@@ -35,7 +35,7 @@ new Editor({
   extensions: [
     BubbleMenu.configure({
       element: document.querySelector('.menu'),
-      shouldShow: (view, state) => {
+      shouldShow: (view) => {
         // your logic to control whether the menu should show
         return true
       }

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -7,15 +7,18 @@ import {
 import { EditorState, Plugin, PluginKey } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import tippy, { Instance, Props } from 'tippy.js'
+import { ShouldShow } from './bubble-menu'
 
 export interface BubbleMenuPluginProps {
   editor: Editor,
   element: HTMLElement,
   tippyOptions?: Partial<Props>,
+  shouldShow: ShouldShow,
 }
 
 export type BubbleMenuViewProps = BubbleMenuPluginProps & {
   view: EditorView,
+  shouldShow: ShouldShow,
 }
 
 export class BubbleMenuView {
@@ -29,15 +32,19 @@ export class BubbleMenuView {
 
   public tippy!: Instance
 
+  public shouldShow: ShouldShow
+
   constructor({
     editor,
     element,
     view,
     tippyOptions,
+    shouldShow,
   }: BubbleMenuViewProps) {
     this.editor = editor
     this.element = element
     this.view = view
+    this.shouldShow = shouldShow
     this.element.addEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.view.dom.addEventListener('dragstart', this.dragstartHandler)
     this.editor.on('focus', this.focusHandler)
@@ -95,6 +102,12 @@ export class BubbleMenuView {
     const isSame = oldState && oldState.doc.eq(doc) && oldState.selection.eq(selection)
 
     if (composing || isSame) {
+      return
+    }
+
+    if (!this.shouldShow(view, oldState)) {
+      this.hide()
+
       return
     }
 

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -105,7 +105,7 @@ export class BubbleMenuView {
       return
     }
 
-    if (!this.shouldShow(view)) {
+    if (!this.shouldShow({ editor: this.editor, view: this.view })) {
       this.hide()
 
       return

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -105,7 +105,7 @@ export class BubbleMenuView {
       return
     }
 
-    if (!this.shouldShow(view, oldState)) {
+    if (!this.shouldShow(view)) {
       this.hide()
 
       return

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -7,7 +7,7 @@ export type BubbleMenuOptions = Omit<BubbleMenuPluginProps, 'editor' | 'element'
   element: HTMLElement | null,
 }
 
-export type ShouldShow = (view: EditorView, oldState?: EditorState) => boolean
+export type ShouldShow = (view?: EditorView, oldState?: EditorState) => boolean
 
 export const BubbleMenu = Extension.create<BubbleMenuOptions>({
   name: 'bubbleMenu',
@@ -15,7 +15,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
   defaultOptions: {
     element: null,
     tippyOptions: {},
-    shouldShow: (view: EditorView, oldState?: EditorState) => true,
+    shouldShow: () => true,
   },
 
   addProseMirrorPlugins() {

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -1,5 +1,4 @@
 import { Extension } from '@tiptap/core'
-import { EditorState } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import { BubbleMenuPlugin, BubbleMenuPluginProps } from './bubble-menu-plugin'
 
@@ -7,7 +6,7 @@ export type BubbleMenuOptions = Omit<BubbleMenuPluginProps, 'editor' | 'element'
   element: HTMLElement | null,
 }
 
-export type ShouldShow = (view?: EditorView, oldState?: EditorState) => boolean
+export type ShouldShow = (view?: EditorView) => boolean
 
 export const BubbleMenu = Extension.create<BubbleMenuOptions>({
   name: 'bubbleMenu',

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -1,9 +1,13 @@
 import { Extension } from '@tiptap/core'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
 import { BubbleMenuPlugin, BubbleMenuPluginProps } from './bubble-menu-plugin'
 
 export type BubbleMenuOptions = Omit<BubbleMenuPluginProps, 'editor' | 'element'> & {
   element: HTMLElement | null,
 }
+
+export type ShouldShow = (view: EditorView, oldState?: EditorState) => boolean
 
 export const BubbleMenu = Extension.create<BubbleMenuOptions>({
   name: 'bubbleMenu',
@@ -11,6 +15,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
   defaultOptions: {
     element: null,
     tippyOptions: {},
+    shouldShow: (view: EditorView, oldState?: EditorState) => true,
   },
 
   addProseMirrorPlugins() {
@@ -23,6 +28,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
         editor: this.editor,
         element: this.options.element,
         tippyOptions: this.options.tippyOptions,
+        shouldShow: this.options.shouldShow,
       }),
     ]
   },

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -1,4 +1,4 @@
-import { Extension } from '@tiptap/core'
+import { Editor, Extension } from '@tiptap/core'
 import { EditorView } from 'prosemirror-view'
 import { BubbleMenuPlugin, BubbleMenuPluginProps } from './bubble-menu-plugin'
 
@@ -6,7 +6,7 @@ export type BubbleMenuOptions = Omit<BubbleMenuPluginProps, 'editor' | 'element'
   element: HTMLElement | null,
 }
 
-export type ShouldShow = (view?: EditorView) => boolean
+export type ShouldShow = (props?: { editor: Editor, view: EditorView }) => boolean
 
 export const BubbleMenu = Extension.create<BubbleMenuOptions>({
   name: 'bubbleMenu',

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -9,12 +9,13 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
   const element = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const { editor, tippyOptions } = props
+    const { editor, tippyOptions, shouldShow } = props
 
     editor.registerPlugin(BubbleMenuPlugin({
       editor,
       element: element.current as HTMLElement,
       tippyOptions,
+      shouldShow,
     }))
 
     return () => {

--- a/packages/vue-2/src/BubbleMenu.ts
+++ b/packages/vue-2/src/BubbleMenu.ts
@@ -4,6 +4,7 @@ import { BubbleMenuPlugin, BubbleMenuPluginKey, BubbleMenuPluginProps } from '@t
 export interface BubbleMenuInterface extends Vue {
   tippyOptions: BubbleMenuPluginProps['tippyOptions'],
   editor: BubbleMenuPluginProps['editor'],
+  shouldShow: BubbleMenuPluginProps['shouldShow'],
 }
 
 export const BubbleMenu: Component = {
@@ -18,6 +19,11 @@ export const BubbleMenu: Component = {
     tippyOptions: {
       type: Object as PropType<BubbleMenuPluginProps['tippyOptions']>,
       default: () => ({}),
+    },
+
+    shouldShow: {
+      type: Function as PropType<BubbleMenuPluginProps['shouldShow']>,
+      default: () => true,
     },
   },
 
@@ -34,6 +40,7 @@ export const BubbleMenu: Component = {
             editor,
             element: this.$el as HTMLElement,
             tippyOptions: this.tippyOptions,
+            shouldShow: this.shouldShow,
           }))
         })
       },

--- a/packages/vue-3/src/BubbleMenu.ts
+++ b/packages/vue-3/src/BubbleMenu.ts
@@ -25,18 +25,24 @@ export const BubbleMenu = defineComponent({
       type: Object as PropType<BubbleMenuPluginProps['tippyOptions']>,
       default: () => ({}),
     },
+
+    shouldShow: {
+      type: Function as PropType<BubbleMenuPluginProps['shouldShow']>,
+      default: () => true,
+    },
   },
 
   setup(props, { slots }) {
     const root = ref<HTMLElement | null>(null)
 
     onMounted(() => {
-      const { editor, tippyOptions } = props
+      const { editor, tippyOptions, shouldShow } = props
 
       editor.registerPlugin(BubbleMenuPlugin({
         editor,
         element: root.value as HTMLElement,
         tippyOptions,
+        shouldShow,
       }))
     })
 


### PR DESCRIPTION
Relates to #1480 
Relates to #1313 (see https://github.com/ueberdosis/tiptap/issues/1313#issuecomment-842071420)

This PR adds a `shouldOpen` callback for the bubble menu. This allows users to control whether the bubbleMenu should open or not. By default, the new callback will always return `true` so there isn't an issue with bc.