### PR TITLE
Added toggle to react editable content demo

### DIFF
--- a/docs/src/demos/Guide/NodeViews/ReactComponentContent/Extension.js
+++ b/docs/src/demos/Guide/NodeViews/ReactComponentContent/Extension.js
@@ -7,7 +7,9 @@ export default Node.create({
 
   group: 'block',
 
-  content: 'inline*',
+  content: 'block*',
+
+  defining: true,
 
   parseHTML() {
     return [
@@ -19,6 +21,20 @@ export default Node.create({
 
   renderHTML({ HTMLAttributes }) {
     return ['react-component', mergeAttributes(HTMLAttributes), 0]
+  },
+
+  addCommands() {
+    return {
+      setReactComponent: () => ({ commands }) => {
+        return commands.wrapIn('reactComponent')
+      },
+      toggleReactComponent: () => ({ commands }) => {
+        return commands.toggleWrap('reactComponent')
+      },
+      unsetReactComponent: () => ({ commands }) => {
+        return commands.lift('reactComponent')
+      },
+    }
   },
 
   addNodeView() {

--- a/docs/src/demos/Guide/NodeViews/ReactComponentContent/index.jsx
+++ b/docs/src/demos/Guide/NodeViews/ReactComponentContent/index.jsx
@@ -24,6 +24,22 @@ export default () => {
   })
 
   return (
-    <EditorContent editor={editor} />
+    <>
+      {editor && (
+        <div>
+          <button
+            className={[
+              editor.isActive('reactComponent') && 'is-active'
+            ].filter(Boolean).join(' ')}
+            onClick={() => {
+              editor.chain().focus().toggleReactComponent().run()
+            }}
+          >
+            React Component
+          </button>
+        </div>
+      )}
+      <EditorContent editor={editor} />
+    </>
   )
 }


### PR DESCRIPTION
I slightly altered the React content editable example to be a defining block, which I _think_ would be closer to a real world example. I added a toggle button to allow users to toggle the wrap, like the blockquote demo. The reason I did all of this was to highlight a selection issue that I'm running into. When I `wrapIn` the reactComponent, the cursor is jumping to the end of the reactComponent, but the selection state looks to modified correctly by the `wrapIn` (see attached video). Any ideas what could be causing this/how to fix it? 

https://user-images.githubusercontent.com/498226/129076954-2fccc449-b013-4277-a1dd-f68517946c04.mov

Also, I wasn't able to reproduce this issue when I did a vanilla javascript NodeView.
