### PR TITLE
Fix Editor Reactivity

### DIFF
--- a/packages/vue-3/src/useEditor.ts
+++ b/packages/vue-3/src/useEditor.ts
@@ -1,9 +1,9 @@
-import { onMounted, onBeforeUnmount, ref } from 'vue'
+import { onMounted, onBeforeUnmount, shallowRef } from 'vue'
 import { EditorOptions } from '@tiptap/core'
 import { Editor } from './Editor'
 
 export const useEditor = (options: Partial<EditorOptions> = {}) => {
-  const editor = ref<Editor>()
+  const editor = shallowRef<Editor>()
 
   onMounted(() => {
     editor.value = new Editor(options)


### PR DESCRIPTION
When using the `useEditor` composable, the `Ref` that is returned observes changes on the Editor's own properties, causing any effects that reference `editor` to trigger unnecessarily.

Even though the Editor's constructor uses `markRaw`, using `ref` wraps your value in an object and makes it reactive internally. You can see this happening here: https://github.com/vuejs/composition-api/blob/main/src/reactivity/ref.ts#L82
The check for `isRaw` only happens on the parent, which in this case is the wrapper object.

Using `shallowRef` instead allows us to create effects that trigger when the Editor is instantiated (in the `onMounted`) while preventing reactivity of the Editor's properties. From the Vue docs:
> Creates a ref that tracks its own .value mutation but doesn't make its value reactive.