### PR TITLE
Allow triggering suggestions without prefix space

### DIFF
--- a/packages/suggestion/src/findSuggestionMatch.ts
+++ b/packages/suggestion/src/findSuggestionMatch.ts
@@ -4,6 +4,7 @@ import { ResolvedPos } from 'prosemirror-model'
 export interface Trigger {
   char: string,
   allowSpaces: boolean,
+  prefixSpace: boolean,
   startOfLine: boolean,
   $position: ResolvedPos,
 }
@@ -18,6 +19,7 @@ export function findSuggestionMatch(config: Trigger): SuggestionMatch {
   const {
     char,
     allowSpaces,
+    prefixSpace,
     startOfLine,
     $position,
   } = config
@@ -49,7 +51,7 @@ export function findSuggestionMatch(config: Trigger): SuggestionMatch {
   // or the line beginning
   const matchPrefix = match.input.slice(Math.max(0, match.index - 1), match.index)
 
-  if (!/^[\s\0]?$/.test(matchPrefix)) {
+  if (prefixSpace && !/^[\s\0]?$/.test(matchPrefix)) {
     return null
   }
 

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -9,6 +9,7 @@ export interface SuggestionOptions {
   char?: string,
   allowSpaces?: boolean,
   startOfLine?: boolean,
+  prefixSpace?: boolean,
   decorationTag?: string,
   decorationClass?: string,
   command?: (props: {
@@ -53,6 +54,7 @@ export function Suggestion({
   editor,
   char = '@',
   allowSpaces = false,
+  prefixSpace = true,
   startOfLine = false,
   decorationTag = 'span',
   decorationClass = 'suggestion',
@@ -173,6 +175,7 @@ export function Suggestion({
           const match = findSuggestionMatch({
             char,
             allowSpaces,
+            prefixSpace,
             startOfLine,
             $position: selection.$from,
           })


### PR DESCRIPTION
Currently `suggestion` extension only allows triggering the suggestions dropdown if the suggestion character is prefixed by space. This of course makes sense for @mentions but for some other use cases it is desirable to also trigger suggestions dropdown if suggestions character is not prefixed by space (e.g. with variables inside the text).

Already requested in:
* https://github.com/ueberdosis/tiptap/issues/1384
* https://github.com/ueberdosis/tiptap/issues/329