### PR TITLE
fix code-block language attribute value

### DIFF
--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -47,17 +47,22 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
       language: {
         default: null,
         parseHTML: element => {
-          const classAttribute = element.firstElementChild?.getAttribute('class')
-
-          if (!classAttribute) {
-            return null
-          }
-
+          const classAttributes = element.firstElementChild?.classList
           const regexLanguageClassPrefix = new RegExp(`^(${this.options.languageClassPrefix})`)
 
-          return {
-            language: classAttribute.replace(regexLanguageClassPrefix, ''),
+          let language = null
+          for (const attribute of classAttributes) {
+            if (attribute.startsWith(this.options.languageClassPrefix)) {
+              language = attribute.replace(regexLanguageClassPrefix, '')
+              break
+            }
           }
+          if (!language) {
+            return null
+          }
+          return {
+            language
+          };
         },
         renderHTML: attributes => {
           if (!attributes.language) {


### PR DESCRIPTION
If paste a piece of html with highlight, the HTML may be like this:

```html
<pre><code class="hljs language-javascript">
...
</code></pre>
```

Then, this extension will try to get the language from className, which results in `hljs language-javascript`, but actually it should be `javascript`.

And then, when render this code block, the className becomes `language-hljs language-javascript`, which leads to a very strange result.

This PR get class list via DOM API `.classList`, and see if a className starts with `languageClassPrefix`, if it is, then try to get the language value.