### PR TITLE
feat: add extendEmptyMarkRange option to mark commands

### DIFF
--- a/packages/core/src/commands/toggleMark.ts
+++ b/packages/core/src/commands/toggleMark.ts
@@ -9,17 +9,27 @@ declare module '@tiptap/core' {
       /**
        * Toggle a mark on and off.
        */
-      toggleMark: (typeOrName: string | MarkType, attributes?: Record<string, any>) => ReturnType,
+      toggleMark: (
+        typeOrName: string | MarkType,
+        attributes?: Record<string, any>,
+        options?: {
+          /**
+           * Removes the mark even across the current selection. Defaults to `false`.
+           */
+          extendEmptyMarkRange?: boolean,
+        },
+      ) => ReturnType,
     }
   }
 }
 
-export const toggleMark: RawCommands['toggleMark'] = (typeOrName, attributes = {}) => ({ state, commands }) => {
+export const toggleMark: RawCommands['toggleMark'] = (typeOrName, attributes = {}, options = {}) => ({ state, commands }) => {
+  const { extendEmptyMarkRange = false } = options
   const type = getMarkType(typeOrName, state.schema)
   const isActive = isMarkActive(state, type, attributes)
 
   if (isActive) {
-    return commands.unsetMark(type)
+    return commands.unsetMark(type, { extendEmptyMarkRange })
   }
 
   return commands.setMark(type, attributes)

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -92,10 +92,10 @@ export const Link = Mark.create<LinkOptions>({
         return commands.setMark('link', attributes)
       },
       toggleLink: attributes => ({ commands }) => {
-        return commands.toggleMark('link', attributes)
+        return commands.toggleMark('link', attributes, { extendEmptyMarkRange: true })
       },
       unsetLink: () => ({ commands }) => {
-        return commands.unsetMark('link')
+        return commands.unsetMark('link', { extendEmptyMarkRange: true })
       },
     }
   },


### PR DESCRIPTION
This PR adds an option `extendEmptyMarkRange` to the `unsetMark` and `toggleMark` commands. This defaults to `false` now (until now it was `true`). This options is useful for the link mark, to remove a link even if there is an empty selection but it’s rather confusing for other marks.

Thanks for @isubasti for the main idea (#1650).