### PR TITLE
Fix "destory" method in view plugins.

### DIFF
--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -190,7 +190,7 @@ export class BubbleMenuView {
 
   destroy() {
     this.tippy?.destroy()
-    this.element.removeEventListener('mousedown', this.mousedownHandler)
+    this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.view.dom.removeEventListener('dragstart', this.dragstartHandler)
     this.editor.off('focus', this.focusHandler)
     this.editor.off('blur', this.blurHandler)

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -160,7 +160,7 @@ export class FloatingMenuView {
 
   destroy() {
     this.tippy?.destroy()
-    this.element.removeEventListener('mousedown', this.mousedownHandler)
+    this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.editor.off('focus', this.focusHandler)
     this.editor.off('blur', this.blurHandler)
   }


### PR DESCRIPTION
Update `destory` methods on BubbleMenu and FloatingMenu plugins to correctly remove event listeners.