### PR TITLE
Fix extension-code-block-lowlight lowlight compatibility

### DIFF
--- a/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
+++ b/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
@@ -33,11 +33,11 @@ function getDecorations({ doc, name, lowlight }: { doc: ProsemirrorNode, name: s
       let from = block.pos + 1
       const { language } = block.node.attrs
       const languages = lowlight.listLanguages()
-      const nodes = language && languages.includes(language)
-        ? lowlight.highlight(language, block.node.textContent).value
-        : lowlight.highlightAuto(block.node.textContent).value
+      const rootNode = language && languages.includes(language)
+        ? lowlight.highlight(language, block.node.textContent)
+        : lowlight.highlightAuto(block.node.textContent)
 
-      parseNodes(nodes).forEach(node => {
+      parseNodes(rootNode.children || rootNode.value).forEach(node => {
         const to = from + node.text.length
 
         if (node.classes.length) {


### PR DESCRIPTION
With the latest version of lowlight, `lowlight.highlight()` returns a root node with the following structure:
```js
{
  children: Node[]
  data: {language: string, relevance: number}
  type: string
}
```
The extension-code-block-lowlight block crashes when used with the latest version of lowlight. `getDecorations` tries to access `.value` on the root node which returns `undefined` and causes an error when passed in to `parseNodes`. 

The issue is due to a change in the lowlight API, the root node previously returned an array of nodes as `.value` this is now `.children`. This PR fixes the issue and also retains backwards compatibility. 
Reference to change: https://github.com/wooorm/lowlight/commit/ff252f9d5c59022ec80aca617c71531c4ab4b327#diff-826e5ed9069c92baa50ec46dde8074a6789b4c90837c5ede0e6b0438e3c34309R86

These changes are working on my end. Hope this is helpful, looks like there was some work done in the past to upgrade lowlight compatibility that was later reverted.
