### PR TITLE
Docs: Update command names in upgrade guide

### DIFF
--- a/docs/overview/upgrade-guide.md
+++ b/docs/overview/upgrade-guide.md
@@ -136,13 +136,13 @@ All new extensions come with specific commands to set, unset and toggle styles. 
 | ~~`.bullet_list()`~~     | `.toggleBulletList()`           |
 | ~~`.code()`~~            | `.toggleCode()`                 |
 | ~~`.code_block()`~~      | `.toggleCodeBlock()`            |
-| ~~`.hard_break()`~~      | `.toggleHardBreak()`            |
+| ~~`.hard_break()`~~      | `.setHardBreak()`               |
 | ~~`.heading()`~~         | `.toggleHeading()`              |
-| ~~`.horizontal_rule()`~~ | `.toggleHorizontalRule()`       |
+| ~~`.horizontal_rule()`~~ | `.setHorizontalRule()`          |
 | ~~`.italic()`~~          | `.toggleItalic()`               |
 | ~~`.link()`~~            | `.toggleLink()`                 |
 | ~~`.ordered_list()`~~    | `.toggleOrderedList()`          |
-| ~~`.paragraph()`~~       | `.toggleParagraph()`            |
+| ~~`.paragraph()`~~       | `.setParagraph()`               |
 | ~~`.strike()`~~          | `.toggleStrike()`               |
 | ~~`.underline()`~~       | `.toggleUnderline()`            |
 | …                        | …                               |


### PR DESCRIPTION
The commands toggleHardBreak(), toggleHorizontalRule(), toggleParagraph() do not exist. 

Updating the documentation to reflect the existing commands setHardBreak(), setHorizontalRule(), setParagraph().