### PR TITLE
feat(Suggestion): Pass additional props to suggestion render fns

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -35,6 +35,11 @@ export interface SuggestionProps {
   range: Range,
   query: string,
   text: string,
+  active: boolean,
+  moved: boolean,
+  started: boolean,
+  stopped: boolean,
+  changed: boolean,
   items: any[],
   command: (props: any) => void,
   decorationNode: Element | null,
@@ -98,6 +103,11 @@ export function Suggestion({
             range: state.range,
             query: state.query,
             text: state.text,
+            active: next.active,
+            moved,
+            started,
+            stopped,
+            changed,
             items: (handleChange || handleStart)
               ? await items(state.query)
               : [],

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -103,7 +103,7 @@ export function Suggestion({
             range: state.range,
             query: state.query,
             text: state.text,
-            active: next.active,
+            active: state.active,
             moved,
             started,
             stopped,


### PR DESCRIPTION
# Changes

- Pass the following additional props to the `@tiptap/suggestion` render fns:
  - `active: boolean`
  - `moved: boolean`
  - `started: boolean`
  - `stopped: boolean`
  - `changed: boolean`

This enables a higher fidelity of decision making in consumers' implementation of `onStart`, `onUpdate` and `onExit`

# Context

Fixes #1909 