### PR TITLE
Fix: code-block-lowlight child extensions do not highlight code

### DIFF
--- a/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
+++ b/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
@@ -16,7 +16,7 @@ export const CodeBlockLowlight = CodeBlock.extend<CodeBlockLowlightOptions>({
     return [
       ...this.parent?.() || [],
       LowlightPlugin({
-        name: 'codeBlock',
+        name: this.name,
         lowlight: this.options.lowlight,
       }),
     ]

--- a/tests/cypress/integration/extensions/codeBlockLowlight.spec.ts
+++ b/tests/cypress/integration/extensions/codeBlockLowlight.spec.ts
@@ -1,0 +1,80 @@
+/// <reference types="cypress" />
+
+import {
+  CodeBlockLowlight,
+} from '@tiptap/extension-code-block-lowlight'
+import { Text } from '@tiptap/extension-text'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Document } from '@tiptap/extension-document'
+import { Editor } from '@tiptap/core'
+import * as lowlight from 'lowlight'
+
+describe('code block highlight', () => {
+  let Frontmatter
+  const editorElClass = 'tiptap'
+  let editor: Editor
+
+  const createEditorEl = () => {
+    const editorEl = document.createElement('div')
+    editorEl.classList.add(editorElClass)
+
+    document.body.appendChild(editorEl)
+
+    return editorEl
+  }
+  const getEditorEl = () => document.querySelector(`.${editorElClass}`)
+
+  beforeEach(() => {
+    Frontmatter = CodeBlockLowlight
+      .configure({ lowlight })
+      .extend({
+        name: 'frontmatter',
+      })
+
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        CodeBlockLowlight,
+        Frontmatter,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'codeBlock',
+            attrs: {
+              language: 'javascript',
+            },
+            content: [{
+              type: 'text',
+              text: 'alert("Hello world");',
+            }],
+          },
+          {
+            type: 'frontmatter',
+            attrs: {
+              language: 'yaml',
+            },
+            content: [{
+              type: 'text',
+              text: '---\ntitle: Page title\n---',
+            }],
+          },
+        ],
+      },
+    })
+  })
+
+  afterEach(() => {
+    editor.destroy()
+    getEditorEl()?.remove()
+  })
+
+  it('executes lowlight plugin in extensions that inherit from code-block-lowlight', () => {
+    expect(getEditorEl()?.querySelector('.language-javascript .hljs-string')).not.to.eq(null)
+    expect(getEditorEl()?.querySelector('.language-yaml .hljs-string')).not.to.eq(null)
+  })
+})


### PR DESCRIPTION
This MR fixes a bug in the Code Block Lowlight extension that doesn’t allow extending the extension further. When we extend `CodeBlockLowlight`, the code in the child extension is not highlighted. We discovered that the root cause of this problem is a hard coded extension named provided to the `LowlightPlugin`. Passing the extension name fixes this problem. 

This PR also contains a failing test. 