### PR TITLE
Docs: Clear up Prosemirror EditorProps usage

### DIFF
--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -187,7 +187,7 @@ new Editor({
 ```
 
 ### Editor props
-For advanced use cases, you can pass `editorProps` which will be handled by [ProseMirror](https://prosemirror.net/docs/ref/#view.EditorProps). Here is an example how you can pass a few [Tailwind](https://tailwindcss.com/) classes to the editor container, but there is a lot more you can do.
+For advanced use cases, you can pass `editorProps` which will be handled by [ProseMirror](https://prosemirror.net/docs/ref/#view.EditorProps). Here is an example how you can pass a few [Tailwind](https://tailwindcss.com/) classes to the editor container, and transform pasted text, but there is a lot more you can do.
 
 ```js
 new Editor({
@@ -196,8 +196,11 @@ new Editor({
     attributes: {
       class: 'prose prose-sm sm:prose lg:prose-lg xl:prose-2xl mx-auto focus:outline-none',
     },
-  },
-})
+    transformPastedText(text) {
+      return text.toUpperCase();
+    }
+  }
+});
 ```
 
 You can use that to hook into event handlers and pass - for example - a custom paste handler, too.

--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -187,7 +187,7 @@ new Editor({
 ```
 
 ### Editor props
-For advanced use cases, you can pass `editorProps` which will be handled by [ProseMirror](https://prosemirror.net/docs/ref/#view.EditorProps). Here is an example how you can pass a few [Tailwind](https://tailwindcss.com/) classes to the editor container, and transform pasted text, but there is a lot more you can do.
+For advanced use cases, you can pass `editorProps` which will be handled by [ProseMirror](https://prosemirror.net/docs/ref/#view.EditorProps). You can use it to override various editor events or change editor DOM element attributes. Here is an example:
 
 ```js
 new Editor({

--- a/docs/guide/custom-extensions.md
+++ b/docs/guide/custom-extensions.md
@@ -499,7 +499,9 @@ const History = Extension.create({
 ```
 
 #### Access the ProseMirror API
-To hook into events, for example a click, double click or when content is pasted, you can pass event handlers as `editorProps` to the [editor](/api/editor). Or you can add them to a tiptap extension like shown in the below example.
+To hook into events, for example a click, double click or when content is pasted, you can pass [event handlers](https://prosemirror.net/docs/ref/#view.EditorProps) to `editorProps` on the [editor](/api/editor).
+
+Or you can add them to a tiptap extension like shown in the below example.
 
 ```js
 import { Extension } from '@tiptap/core'

--- a/docs/guide/custom-extensions.md
+++ b/docs/guide/custom-extensions.md
@@ -499,7 +499,7 @@ const History = Extension.create({
 ```
 
 #### Access the ProseMirror API
-To hook into events, for example a click, double click or when content is pasted, you can pass [event handlers](https://prosemirror.net/docs/ref/#view.EditorProps) to `editorProps` on the [editor](/api/editor).
+To hook into events, for example a click, double click or when content is pasted, you can pass [event handlers](https://prosemirror.net/docs/ref/#view.EditorProps) to `editorProps` on the [editor](/api/editor#editor-props).
 
 Or you can add them to a tiptap extension like shown in the below example.
 


### PR DESCRIPTION
Related: https://github.com/ueberdosis/tiptap/issues/943

It was difficult to find and understand Editor props, I tried to make docs more easy to unederstand