### PR TITLE
Use pasteRegex in addPasteRules

### DIFF
--- a/packages/extension-highlight/src/highlight.ts
+++ b/packages/extension-highlight/src/highlight.ts
@@ -103,7 +103,7 @@ export const Highlight = Mark.create<HighlightOptions>({
 
   addPasteRules() {
     return [
-      markPasteRule(inputRegex, this.type),
+      markPasteRule(pasteRegex, this.type),
     ]
   },
 })


### PR DESCRIPTION
Seems like inputRegex was used in addPasteRules by mistake (?)