### PR TITLE
Fix 'Edit on Github' link url for examples in docs

### DIFF
--- a/demos/preview/Demo.vue
+++ b/demos/preview/Demo.vue
@@ -154,7 +154,7 @@ export default {
     },
 
     githubUrl() {
-      return `https://github.com/ueberdosis/tiptap-pro-extensions/tree/main/demos/src/${this.name}`
+      return `https://github.com/ueberdosis/tiptap/tree/main/demos/src/${this.name}`
     },
 
     source() {


### PR DESCRIPTION
Fixes the link to vie the examle directly on Github

![grafik](https://user-images.githubusercontent.com/10237069/134350646-ac11824c-8da1-4ace-9b2e-30e0cc629528.png)
