### PR TITLE
fix: compatibility with lowlight v2

### DIFF
--- a/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
+++ b/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
@@ -34,8 +34,8 @@ function getDecorations({ doc, name, lowlight }: { doc: ProsemirrorNode, name: s
       const { language } = block.node.attrs
       const languages = lowlight.listLanguages()
       const nodes = language && languages.includes(language)
-        ? lowlight.highlight(language, block.node.textContent).value
-        : lowlight.highlightAuto(block.node.textContent).value
+        ? getHighlightNodes(lowlight.highlight(language, block.node.textContent))
+        : getHighlightNodes(lowlight.highlightAuto(block.node.textContent))
 
       parseNodes(nodes).forEach(node => {
         const to = from + node.text.length
@@ -51,6 +51,11 @@ function getDecorations({ doc, name, lowlight }: { doc: ProsemirrorNode, name: s
         from = to
       })
     })
+  
+  function getHighlightNodes(result) {
+    // `.value` for lowlight v1, `.children` for lowlight v2
+    return result.value || result.children || []
+  }
 
   return DecorationSet.create(doc, decorations)
 }


### PR DESCRIPTION
`.value` is changed to `.children` in lowlight v2