### PR TITLE
feat: trigger inputrule on enter for code block

### DIFF
--- a/packages/extension-code-block/package.json
+++ b/packages/extension-code-block/package.json
@@ -24,7 +24,10 @@
     "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
-    "prosemirror-inputrules": "^1.1.3"
+    "@types/prosemirror-view": "^1.19.1",
+    "@types/prosemirror-state": "^1.2.7",
+    "prosemirror-inputrules": "^1.1.3",
+    "prosemirror-state": "^1.3.4"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -1,5 +1,6 @@
 import { Node } from '@tiptap/core'
 import { textblockTypeInputRule } from 'prosemirror-inputrules'
+import enterRules from './plugin'
 
 export interface CodeBlockOptions {
   languageClassPrefix: string,
@@ -21,8 +22,8 @@ declare module '@tiptap/core' {
   }
 }
 
-export const backtickInputRegex = /^```(?<language>[a-z]*)? $/
-export const tildeInputRegex = /^~~~(?<language>[a-z]*)? $/
+export const backtickInputRegex = /^```(?<language>[a-z]*)?\s$/
+export const tildeInputRegex = /^~~~(?<language>[a-z]*)?\s$/
 
 export const CodeBlock = Node.create<CodeBlockOptions>({
   name: 'codeBlock',
@@ -123,6 +124,18 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
     return [
       textblockTypeInputRule(backtickInputRegex, this.type, ({ groups }: any) => groups),
       textblockTypeInputRule(tildeInputRegex, this.type, ({ groups }: any) => groups),
+    ]
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      ...((this.parent && this.parent()) || []),
+      enterRules({
+        rules: [
+          textblockTypeInputRule(backtickInputRegex, this.type, ({ groups }: any) => groups),
+          textblockTypeInputRule(tildeInputRegex, this.type, ({ groups }: any) => groups),
+        ],
+      }),
     ]
   },
 })

--- a/packages/extension-code-block/src/plugin.ts
+++ b/packages/extension-code-block/src/plugin.ts
@@ -1,0 +1,45 @@
+// Modified from
+// https://github.com/ProseMirror/prosemirror-inputrules/blob/master/src/inputrules.js
+// license: MIT
+
+import { InputRule } from 'prosemirror-inputrules'
+import { Plugin as ProseMirrorPlugin } from 'prosemirror-state'
+import type { Plugin, TextSelection } from 'prosemirror-state'
+import type { EditorView } from 'prosemirror-view'
+
+const MAX_MATCH = 500
+
+function run(view: EditorView, from: number, to: number, text: string, rules: any[], plugin: Plugin) {
+  if (view.composing) return false
+  const state = view.state; const
+    $from = state.doc.resolve(from)
+  if ($from.parent.type.spec.code) return false
+  const textBefore = $from.parent.textBetween(Math.max(0, $from.parentOffset - MAX_MATCH), $from.parentOffset,
+    undefined, '\ufffc') + text
+  for (let i = 0; i < rules.length; i += 1) {
+    const match = rules[i].match.exec(textBefore)
+    const tr = match && rules[i].handler(state, match, from - (match[0].length - text.length), to)
+    if (!tr) continue
+    view.dispatch(tr.setMeta(plugin, {
+      transform: tr, from, to, text,
+    }))
+    return true
+  }
+  return false
+}
+
+export default function (options: any = {}) {
+  const rules: InputRule[] = options.rules || []
+  const plugin: Plugin = new ProseMirrorPlugin({
+    props: {
+      handleKeyDown(view, event) {
+        if (event.key !== 'Enter') return false
+        const { $cursor } = view.state.selection as TextSelection
+        if ($cursor) return run(view, $cursor.pos, $cursor.pos, '\n', rules, plugin)
+        return false
+      },
+    },
+  })
+
+  return plugin
+}


### PR DESCRIPTION
```
```{space|enter}
```

Support using {space} or {enter} to trigger inputrule

related issue: https://github.com/ueberdosis/tiptap/issues/1107