### PR TITLE
Use ref to move contentDOM

### DIFF
--- a/packages/react/src/NodeViewContent.tsx
+++ b/packages/react/src/NodeViewContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useReactNodeView } from './useReactNodeView'
 
 export interface NodeViewContentProps {
@@ -6,18 +6,14 @@ export interface NodeViewContentProps {
   as?: React.ElementType,
 }
 
-export const NodeViewContent: React.FC<NodeViewContentProps> = React.forwardRef((props, ref) => {
+export const NodeViewContent: React.FC<NodeViewContentProps> = props => {
   const Tag = props.as || 'div'
-  const { maybeMoveContentDOM } = useReactNodeView()
-
-  useEffect(() => {
-    maybeMoveContentDOM?.()
-  }, [])
+  const { nodeViewContentRef } = useReactNodeView()
 
   return (
     <Tag
       {...props}
-      ref={ref}
+      ref={nodeViewContentRef}
       data-node-view-content=""
       style={{
         ...props.style,
@@ -25,4 +21,4 @@ export const NodeViewContent: React.FC<NodeViewContentProps> = React.forwardRef(
       }}
     />
   )
-})
+}

--- a/packages/react/src/useReactNodeView.ts
+++ b/packages/react/src/useReactNodeView.ts
@@ -2,7 +2,7 @@ import { createContext, useContext } from 'react'
 
 export interface ReactNodeViewContextProps {
   onDragStart: (event: DragEvent) => void,
-  maybeMoveContentDOM: () => void,
+  nodeViewContentRef: (element: HTMLElement | null) => void,
 }
 
 export const ReactNodeViewContext = createContext<Partial<ReactNodeViewContextProps>>({


### PR DESCRIPTION
Instead of calling `maybeMoveContentDOM` manually, we are using a `ref`.

fixes #1942, which was broken because of[ this patch](https://github.com/ueberdosis/tiptap/commit/b15a8a8683bafbc9fd57dc64d60329f9ab08ecfd) (which was a fix for #1747). #1747 is still fixed with this PR.

@YousefED I had to remove `forwardRef` for `NodeViewContent` (which was a [merged PR from you](https://github.com/ueberdosis/tiptap/pull/1452)) for that so I would like to hear you thoughts about this change. I’m still not quite sure what you needed this ref for. Can you give me an example?