### PR TITLE
Fixed typo in React installation guide

### DIFF
--- a/docs/installation/react.md
+++ b/docs/installation/react.md
@@ -13,7 +13,7 @@ The following guide describes how to integrate tiptap with your [React](https://
 * Experience with [React](https://reactjs.org/docs/getting-started.html)
 
 ## Using a template
-If you just want to get up and running with tiptap you can use the [tiptap Create React App template](https://github.com/alb/cra-template-tiptap) by [@alb](https://github.com/alb) to automatically create a new project with all the steps below alreay completed.
+If you just want to get up and running with tiptap you can use the [tiptap Create React App template](https://github.com/alb/cra-template-tiptap) by [@alb](https://github.com/alb) to automatically create a new project with all the steps below already completed.
 
 ```bash
 # create a project based on the tiptap template


### PR DESCRIPTION
Fixes a typo that snuck in with commit 2be975ff1f3f93b9eaf2e50d7775ac6154440f28