### PR TITLE
Add extensions for settings font size and line height of spans.

### DIFF
--- a/packages/extension-font-size/CHANGELOG.md
+++ b/packages/extension-font-size/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.0.0-beta.1](https://github.com/ueberdosis/tiptap/compare/@tiptap/extension-font-size@2.0.0-beta.1...@tiptap/extension-font-size@2.0.0-beta.1) (2021-10-07)
+
+Initial version

--- a/packages/extension-font-size/README.md
+++ b/packages/extension-font-size/README.md
@@ -1,0 +1,14 @@
+# @tiptap/extension-font-size
+[![Version](https://img.shields.io/npm/v/@tiptap/extension-font-size.svg?label=version)](https://www.npmjs.com/package/@tiptap/extension-font-size)
+[![Downloads](https://img.shields.io/npm/dm/@tiptap/extension-font-size.svg)](https://npmcharts.com/compare/tiptap?minimal=true)
+[![License](https://img.shields.io/npm/l/@tiptap/extension-font-size.svg)](https://www.npmjs.com/package/@tiptap/extension-font-size)
+[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ueberdosis)
+
+## Introduction
+tiptap is a headless wrapper around [ProseMirror](https://ProseMirror.net) – a toolkit for building rich text WYSIWYG editors, which is already in use at many well-known companies such as *New York Times*, *The Guardian* or *Atlassian*.
+
+## Official Documentation
+Documentation can be found on the [tiptap website](https://tiptap.dev).
+
+## License
+tiptap is open sourced software licensed under the [MIT license](https://github.com/ueberdosis/tiptap/blob/main/LICENSE.md).

--- a/packages/extension-font-size/package.json
+++ b/packages/extension-font-size/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@tiptap/extension-font-size",
+  "description": "font size extension for tiptap",
+  "version": "2.0.0-beta.1",
+  "homepage": "https://tiptap.dev",
+  "keywords": [
+    "tiptap",
+    "tiptap extension"
+  ],
+  "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/ueberdosis"
+  },
+  "main": "dist/tiptap-extension-font-size.cjs.js",
+  "umd": "dist/tiptap-extension-font-size.umd.js",
+  "module": "dist/tiptap-extension-font-size.esm.js",
+  "types": "dist/packages/extension-font-size/src/index.d.ts",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "peerDependencies": {
+    "@tiptap/core": "^2.0.0-beta.1",
+    "@tiptap/extension-text-style": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-font-size"
+  }
+}

--- a/packages/extension-font-size/src/font-size.ts
+++ b/packages/extension-font-size/src/font-size.ts
@@ -1,0 +1,68 @@
+import { Extension } from '@tiptap/core'
+import '@tiptap/extension-text-style'
+
+type FontSizeOptions = {
+  types: string[],
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    fontSize: {
+      /**
+       * Set the font family
+       */
+      setFontSize: (fontSize: string) => ReturnType,
+      /**
+       * Unset the font family
+       */
+      unsetFontSize: () => ReturnType,
+    }
+  }
+}
+
+export const FontSize = Extension.create<FontSizeOptions>({
+  name: 'fontSize',
+
+  defaultOptions: {
+    types: ['textStyle'],
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          fontSize: {
+            default: null,
+            parseHTML: element => element.style.fontSize,
+            renderHTML: attributes => {
+              if (!attributes.fontSize) {
+                return {}
+              }
+
+              return {
+                style: `font-size: ${attributes.fontSize}`,
+              }
+            },
+          },
+        },
+      },
+    ]
+  },
+
+  addCommands() {
+    return {
+      setFontSize: fontSize => ({ chain }) => {
+        return chain()
+          .setMark('textStyle', { fontSize })
+          .run()
+      },
+      unsetFontSize: () => ({ chain }) => {
+        return chain()
+          .setMark('textStyle', { fontSize: null })
+          .removeEmptyTextStyle()
+          .run()
+      },
+    }
+  },
+})

--- a/packages/extension-font-size/src/index.ts
+++ b/packages/extension-font-size/src/index.ts
@@ -1,0 +1,5 @@
+import { FontSize } from './font-size'
+
+export * from './font-size'
+
+export default FontSize

--- a/packages/extension-line-height/CHANGELOG.md
+++ b/packages/extension-line-height/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.0.0-beta.1](https://github.com/ueberdosis/tiptap/compare/@tiptap/extension-line-height@2.0.0-beta.1...@tiptap/extension-line-height@2.0.0-beta.1) (2021-10-07)
+
+Initial version

--- a/packages/extension-line-height/README.md
+++ b/packages/extension-line-height/README.md
@@ -1,0 +1,14 @@
+# @tiptap/extension-line-height
+[![Version](https://img.shields.io/npm/v/@tiptap/extension-line-height.svg?label=version)](https://www.npmjs.com/package/@tiptap/extension-line-height)
+[![Downloads](https://img.shields.io/npm/dm/@tiptap/extension-line-height.svg)](https://npmcharts.com/compare/tiptap?minimal=true)
+[![License](https://img.shields.io/npm/l/@tiptap/extension-line-height.svg)](https://www.npmjs.com/package/@tiptap/extension-line-height)
+[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ueberdosis)
+
+## Introduction
+tiptap is a headless wrapper around [ProseMirror](https://ProseMirror.net) – a toolkit for building rich text WYSIWYG editors, which is already in use at many well-known companies such as *New York Times*, *The Guardian* or *Atlassian*.
+
+## Official Documentation
+Documentation can be found on the [tiptap website](https://tiptap.dev).
+
+## License
+tiptap is open sourced software licensed under the [MIT license](https://github.com/ueberdosis/tiptap/blob/main/LICENSE.md).

--- a/packages/extension-line-height/package.json
+++ b/packages/extension-line-height/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@tiptap/extension-line-height",
+  "description": "line height extension for tiptap",
+  "version": "2.0.0-beta.1",
+  "homepage": "https://tiptap.dev",
+  "keywords": [
+    "tiptap",
+    "tiptap extension"
+  ],
+  "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/ueberdosis"
+  },
+  "main": "dist/tiptap-extension-line-height.cjs.js",
+  "umd": "dist/tiptap-extension-line-height.umd.js",
+  "module": "dist/tiptap-extension-line-height.esm.js",
+  "types": "dist/packages/extension-line-height/src/index.d.ts",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "peerDependencies": {
+    "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-line-height"
+  }
+}

--- a/packages/extension-line-height/src/index.ts
+++ b/packages/extension-line-height/src/index.ts
@@ -1,0 +1,5 @@
+import { LineHeight } from './line-height'
+
+export * from './line-height'
+
+export default LineHeight

--- a/packages/extension-line-height/src/line-height.ts
+++ b/packages/extension-line-height/src/line-height.ts
@@ -1,0 +1,68 @@
+import { Extension } from '@tiptap/core'
+import '@tiptap/extension-text-style'
+
+type LineHeightOptions = {
+  types: string[],
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    lineHeight: {
+      /**
+       * Set the text line height
+       */
+      setLineHeight: (value: string) => ReturnType,
+      /**
+       * Unset the text line height
+       */
+      unsetLineHeight: () => ReturnType,
+    }
+  }
+}
+
+export const LineHeight = Extension.create<LineHeightOptions>({
+  name: 'lineHeight',
+
+  defaultOptions: {
+    types: ['textStyle'],
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          lineHeight: {
+            default: null,
+            parseHTML: element => element.style.lineHeight,
+            renderHTML: attributes => {
+              if (!attributes.lineHeight) {
+                return {}
+              }
+
+              return {
+                style: `line-height: ${attributes.lineHeight}`,
+              }
+            },
+          },
+        },
+      },
+    ]
+  },
+
+  addCommands() {
+    return {
+      setLineHeight: value => ({ chain }) => {
+        return chain()
+          .setMark('textStyle', { lineHeight: value })
+          .run()
+      },
+      unsetLineHeight: () => ({ chain }) => {
+        return chain()
+          .setMark('textStyle', { lineHeight: null })
+          .removeEmptyTextStyle()
+          .run()
+      },
+    }
+  },
+})


### PR DESCRIPTION
I've added two extensions - one for setting `font-size` and one for `line-height`. They're working in the same way as `extension-font-family` or `extension-text-align`.

```
  {
    "type": "text",
    "marks": [
      {
        "type": "textStyle",
        "attrs": {
          "fontFamily": "Constantia",
          "fontSize": "5px",
          "lineHeight": "1"
        }
      }
    ],
    "text": "k;k;l"
}
```

Resolves #388, resolves #887