### PR TITLE
Undo group node support in nodeInputRule()

### DIFF
--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -25,23 +25,7 @@ export default function nodeInputRule(config: {
       const start = range.from
       let end = range.to
 
-      if (match[1]) {
-        const offset = match[0].lastIndexOf(match[1])
-        let matchStart = start + offset
-
-        if (matchStart > end) {
-          matchStart = end
-        } else {
-          end = matchStart + match[1].length
-        }
-
-        // insert last typed character
-        const lastChar = match[0][match[0].length - 1]
-        tr.insertText(lastChar, start + match[0].length - 1)
-
-        // insert node from input rule
-        tr.replaceWith(matchStart, end, config.type.create(attributes))
-      } else if (match[0]) {
+      if (match[0]) {
         tr.replaceWith(start, end, config.type.create(attributes))
       }
     },


### PR DESCRIPTION
Fixes #2016

Note: this is not a complete revert of my previous PR #1574. I kept the piece of "start" instead of "start - 1" to make sure `#hashtags` replacements don't eat one leading space.