### PR TITLE
Fix #2016 Image input rule

### DIFF
--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -20,7 +20,7 @@ declare module '@tiptap/core' {
   }
 }
 
-export const inputRegex = /!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\)/
+export const inputRegex = /(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))/
 
 export const Image = Node.create<ImageOptions>({
   name: 'image',
@@ -83,7 +83,7 @@ export const Image = Node.create<ImageOptions>({
         find: inputRegex,
         type: this.type,
         getAttributes: match => {
-          const [, alt, src, title] = match
+          const [,, alt, src, title] = match
 
           return { src, alt, title }
         },


### PR DESCRIPTION
Image input rule leaves erroneous text behind due to my previous change to add group matching in #1574. Fixes #2016 

This change adds a `( ... )` regex group around the image input rule to have it work with the new code.