### PR TITLE
normalize text pasted from VSCode

### DIFF
--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -1,5 +1,5 @@
 import { Node, textblockTypeInputRule } from '@tiptap/core'
-import { Plugin, PluginKey, TextSelection } from 'prosemirror-state'
+import { Plugin, PluginKey } from 'prosemirror-state'
 
 export interface CodeBlockOptions {
   languageClassPrefix: string,


### PR DESCRIPTION
Because we're using raw clipboard data, it isn't processed by ProseMirror directly. Default ProseMirror behavior is to strip carriage returns when pasting into a codeblock.

https://github.com/ProseMirror/prosemirror-view/commit/a50a6bcceb4ce52ac8fcc6162488d8875613aacd