### PR TITLE
Separate drags from drops in stopEvent

### DIFF
--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -115,10 +115,10 @@ export class NodeView<
 
     const isDropEvent = event.type === 'drop'
     const isInput = ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA'].includes(target.tagName)
-      || (target.isContentEditable && !isDropEvent)
+      || target.isContentEditable
 
     // any input event within node views should be ignored by ProseMirror
-    if (isInput) {
+    if (isInput && !isDropEvent) {
       return true
     }
 


### PR DESCRIPTION
# Problem
When you try to drop something on the edges of a NodeView, outside the contentDOM, it looks like it should be droppable because dropCursor shows a line in the correct place. But it doesn't actually go through, or it goes through as a copy instead of a move, because `stopEvent` triggers and prevents the drop event from propagating effectively.

More details: https://github.com/ProseMirror/prosemirror/issues/1208

# Solution
Separate the logic for handling drag events from drop events