### PR TITLE
Check node type above custom update fn

### DIFF
--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -114,6 +114,10 @@ class ReactNodeView extends NodeView<React.FunctionComponent, Editor, ReactNodeV
       this.renderer.updateProps(props)
     }
 
+    if (node.type !== this.node.type) {
+      return false
+    }
+
     if (typeof this.options.update === 'function') {
       const oldNode = this.node
       const oldDecorations = this.decorations
@@ -128,10 +132,6 @@ class ReactNodeView extends NodeView<React.FunctionComponent, Editor, ReactNodeV
         newDecorations: decorations,
         updateProps: () => updateProps({ node, decorations }),
       })
-    }
-
-    if (node.type !== this.node.type) {
-      return false
     }
 
     if (node === this.node && this.decorations === decorations) {


### PR DESCRIPTION
This is a pretty simple one - I was running into a bunch of issues with the wrong NodeView component rendering for a node after I dragged it. After reading this issue on the ProseMirror forums https://discuss.prosemirror.net/t/nodeview-dragging-results-in-duplicates-bug/3962/2 I realized the culprit was my custom `update` function, which wasn't checking for node type.

I couldn't think of any reason why somebody would want a different node type's component to render, so I think it would help people avoid this bug to move the node type check above the custom update function running. Let me know what you think.