### PR TITLE
Docs: Fixing onUpdate example

### DIFF
--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -100,8 +100,8 @@ const editor = new Editor({
   content: `<p>Example Content</p>`,
 
   // triggered on every change
-  onUpdate: () => {
-    const json = this.getJSON()
+  onUpdate: ({ editor }) => {
+    const json = editor.getJSON()
     // send the content to an API here
   },
 })


### PR DESCRIPTION
Just got an error by this following the docs.

`this.getJSON()` isn't available in the `onUpdate`. We have to pull out the `editor` instance.

Matches the docs here: <https://tiptap.dev/api/events#option-1-configuration>