### PR TITLE
feat: Allow array of extensions for `enableInputRules` and `enablePasteRules`

### DIFF
--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -13,6 +13,7 @@ import getNodeType from './helpers/getNodeType'
 import splitExtensions from './helpers/splitExtensions'
 import getAttributesFromExtensions from './helpers/getAttributesFromExtensions'
 import getRenderedAttributes from './helpers/getRenderedAttributes'
+import isExtensionRulesEnabled from './helpers/isExtensionRulesEnabled'
 import callOrReturn from './utilities/callOrReturn'
 import findDuplicates from './utilities/findDuplicates'
 import { NodeConfig } from '.'
@@ -270,7 +271,7 @@ export default class ExtensionManager {
           context,
         )
 
-        if (editor.options.enableInputRules && addInputRules) {
+        if (isExtensionRulesEnabled(extension, editor.options.enableInputRules) && addInputRules) {
           inputRules.push(...addInputRules())
         }
 
@@ -280,7 +281,7 @@ export default class ExtensionManager {
           context,
         )
 
-        if (editor.options.enablePasteRules && addPasteRules) {
+        if (isExtensionRulesEnabled(extension, editor.options.enablePasteRules) && addPasteRules) {
           pasteRules.push(...addPasteRules())
         }
 

--- a/packages/core/src/helpers/isExtensionRulesEnabled.ts
+++ b/packages/core/src/helpers/isExtensionRulesEnabled.ts
@@ -1,0 +1,15 @@
+import { AnyExtension, EnableRules } from '@tiptap/core'
+
+export default function isExtensionRulesEnabled(extension: AnyExtension, enabled: EnableRules): boolean {
+  if (Array.isArray(enabled)) {
+    return enabled.some(enabledExtension => {
+      const name = typeof enabledExtension === 'string'
+        ? enabledExtension
+        : enabledExtension.name
+
+      return name === extension.name
+    })
+  }
+
+  return enabled
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,6 +63,8 @@ export interface EditorEvents {
   destroy: void,
 }
 
+export type EnableRules = (AnyExtension | string)[] | boolean
+
 export interface EditorOptions {
   element: Element,
   content: Content,
@@ -72,8 +74,8 @@ export interface EditorOptions {
   editable: boolean,
   editorProps: EditorProps,
   parseOptions: ParseOptions,
-  enableInputRules: boolean,
-  enablePasteRules: boolean,
+  enableInputRules: EnableRules,
+  enablePasteRules: EnableRules,
   enableCoreExtensions: boolean,
   onBeforeCreate: (props: EditorEvents['beforeCreate']) => void,
   onCreate: (props: EditorEvents['create']) => void,


### PR DESCRIPTION
### Context
In multiple project I wan't to enable only input / paste rules I need but there is no easy way to do it. (e.g I only want to paste links)

### Feature
Allow to pass an array of extension or extension name for `enableInputRules` and `enablePasteRules` editor options:

```js
new Editor({
  extensions: [
    StarterKit,
    Link,
  ],
  enablePasteRules: [Link],
  enableInputRules: ['horizontalRule'],
})
```

### Comment
I will update docs if it's ok for you 👍 