### PR TITLE
Floating menu - remove composition check

### DIFF
--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -119,12 +119,12 @@ export class FloatingMenuView {
   }
 
   update(view: EditorView, oldState?: EditorState) {
-    const { state, composing } = view
+    const { state } = view
     const { doc, selection } = state
     const { from, to } = selection
     const isSame = oldState && oldState.doc.eq(doc) && oldState.selection.eq(selection)
 
-    if (composing || isSame) {
+    if (isSame) {
       return
     }
 


### PR DESCRIPTION
I did some more debugging on #1994 and found out that the problem (floating menu does not hide when you type) happens when composition is true (https://firefox-source-docs.mozilla.org/editor/IMEHandlingGuide.html).

The common cases I found:
- Japanese keyboard on both IOS and Android (https://github.com/ueberdosis/tiptap/issues/1994#issuecomment-961598567)
- Typing on Android before you insert space as it uses autocomplete and autocorrect (https://github.com/ueberdosis/tiptap/issues/1994#issuecomment-957025857)
- Interestingly, I have autocomplete and autocorrect on IOS and it does not go to composition

This PR simply removes check if composition is true. I use floating menu for both menu on empty line (as Tiptap example does) and menu attached at the end of the current line as you type. In both cases, I want update position/hide menu on typing any character, even if it is in composition mode.

I think we don't care for composition and `shouldShow()` should handle it.

The question I have is **Was check for composition added for any specific reason?**

I don't have experience with composition so maybe I am missing something and the check is actually needed, in that case reject this PR please.

Fixes #1994 