### PR TITLE
update getJSON return type to JSONContent

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -22,6 +22,7 @@ import {
   EditorOptions,
   CanCommands,
   ChainedCommands,
+  JSONContent,
   SingleCommands,
   TextSerializer,
   EditorEvents,
@@ -401,7 +402,7 @@ export class Editor extends EventEmitter<EditorEvents> {
   /**
    * Get the document as JSON.
    */
-  public getJSON(): Record<string, any> {
+  public getJSON(): JSONContent {
     return this.state.doc.toJSON()
   }
 


### PR DESCRIPTION
Just a small typescript tweak to the `getJSON` return type.
If there is a reason it wasn't this way, feel free to close and I'll know not to type my onUpdate handlers with it. 😄 

<img width="692" alt="Screen Shot 2021-11-10 at 8 38 26 am" src="https://user-images.githubusercontent.com/1168602/141016752-915c03fe-2fe9-4f99-8211-ccfbdce580f3.png">

