### PR TITLE
update ReactRenderer to include CSS class

### DIFF
--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -50,6 +50,9 @@ export class ReactRenderer<R = unknown> {
     this.props = props
     this.element = document.createElement(as)
     this.element.classList.add('react-renderer')
+    if (props.extension.name) {
+      this.element.classList.add(props.extension.name)
+    }
     this.render()
   }
 


### PR DESCRIPTION
Includes extension name to root `react-renderer` node so that styling can be done directly.