### PR TITLE
Remove console.log statement from codeblock-lowlight-plugin file

### DIFF
--- a/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
+++ b/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
@@ -42,7 +42,6 @@ function getDecorations({
     .forEach(block => {
       let from = block.pos + 1
       const language = block.node.attrs.language || defaultLanguage
-      console.log({ language, defaultLanguage })
       const languages = lowlight.listLanguages()
       const nodes = language && languages.includes(language)
         ? getHighlightNodes(lowlight.highlight(language, block.node.textContent))


### PR DESCRIPTION
This MR removes a console.log statement from the `lowlight-plugin.ts` file that appears in testing and production environments. 