### PR TITLE
Ignore iOS mutations when unfocused

### DIFF
--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -202,7 +202,7 @@ export class NodeView<
     // this is because ProseMirror can’t preventDispatch on enter
     // this will lead to a re-render of the node view on enter
     // see: https://github.com/ueberdosis/tiptap/issues/1214
-    if (this.dom.contains(mutation.target) && mutation.type === 'childList' && isiOS()) {
+    if (this.dom.contains(mutation.target) && mutation.type === 'childList' && isiOS() && this.editor.isFocused) {
       const changedNodes = [
         ...Array.from(mutation.addedNodes),
         ...Array.from(mutation.removedNodes),


### PR DESCRIPTION
We're running into a weird bug where NodeViews get stuck an infinite loop of mounting and unmounting when they contain an iframe. This causes a React [maximum update depth exceeded](https://reactjs.org/docs/error-decoder.html/?invariant=185) crash, and also causes the content of some of those nodeviews to be wiped out. 

To reproduce, try visiting https://9hgxv.csb.app/ on an iPhone. The same code works fine on a desktop.

We believe the issue is related to the default `ignoreMutation` method, which returns false when contenteditable nodes are added on iOS. I don't understand all the context of this function, but we found that patching this function to add a check for `this.editor.isFocused` (to narrow the if statement to only apply when triggered by the user's keyboard) fixed it in our fork.

We previously raised this issue in https://github.com/ueberdosis/tiptap/issues/1971 but thought it was fixed. It turns out it was only partially fixed. Instead of happening with all nodeviews in iOS, it now only seems to happen in the narrower case when the iframe is present. But the fix described in #1971 still works.

Related issues: https://github.com/ueberdosis/tiptap/issues/1214, https://github.com/ProseMirror/prosemirror/issues/1162#issuecomment-827681792