### PR TITLE
fix: replace spread operator with `Array.from`

### DIFF
--- a/packages/core/src/utilities/findDuplicates.ts
+++ b/packages/core/src/utilities/findDuplicates.ts
@@ -1,5 +1,5 @@
 export default function findDuplicates(items: any[]): any[] {
   const filtered = items.filter((el, index) => items.indexOf(el) !== index)
 
-  return [...new Set(filtered)]
+  return Array.from(new Set(filtered))
 }


### PR DESCRIPTION
Hey there,

in our project (https://github.com/inovex/elements), we had trouble integrating the library into our setup.

The error occurred when creating the editor like the following:
```tsx
this.editor = new Editor({
  element: this.editorRef,
  extensions: [StarterKit],
});
```
The error:
```
RangeError: Invalid array length
    at __spreadArrays (elements_dist_esm-es5_ino-markdown-editor_entry_js.iframe.bundle.js:318)
    at findDuplicates (elements_dist_esm-es5_ino-markdown-editor_entry_js.iframe.bundle.js:18197)
    at Function.e.resolve (elements_dist_esm-es5_ino-markdown-editor_entry_js.iframe.bundle.js:18278)
    at new e (elements_dist_esm-es5_ino-markdown-editor_entry_js.iframe.bundle.js:18205)
    at t.createExtensionManager (elements_dist_esm-es5_ino-markdown-editor_entry_js.iframe.bundle.js:18701)
    at new t (elements_dist_esm-es5_ino-markdown-editor_entry_js.iframe.bundle.js:18575)
    at e.createEditor (elements_dist_esm-es5_ino-markdown-editor_entry_js.iframe.bundle.js:32564)
	// ...
```


We could trace the error to this piece of code:
https://github.com/ueberdosis/tiptap/blob/a55aa5fd172cf668c590200122bdca865a4e9189/packages/core/src/utilities/findDuplicates.ts#L4

It seems like our typescript setup could not interpret this line correctly and always would throw the error shown above. Typescript also provides the following error in our project when looking at the source files:
```
Type 'Set ' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators
```

I implemented this simple fix which resolves the error.