### PR TITLE
Extend the character-counter extension for more reasonable counting counter

### DIFF
--- a/demos/src/Extensions/CharacterCount/React/index.jsx
+++ b/demos/src/Extensions/CharacterCount/React/index.jsx
@@ -16,6 +16,7 @@ export default () => {
       Text,
       CharacterCount.configure({
         limit,
+        countThroughSerializer: true,
       }),
     ],
     content: `
@@ -34,7 +35,7 @@ export default () => {
       <EditorContent editor={editor} />
 
       <div className="character-count">
-        {editor.getCharacterCount()}/{limit} characters
+        {editor.storage?.characterCount?.currentCharacterCount ?? 0}/{limit} characters
       </div>
     </div>
   )

--- a/demos/src/Extensions/CharacterCount/React/index.jsx
+++ b/demos/src/Extensions/CharacterCount/React/index.jsx
@@ -35,7 +35,7 @@ export default () => {
       <EditorContent editor={editor} />
 
       <div className="character-count">
-        {editor.storage?.characterCount?.currentCharacterCount ?? 0}/{limit} characters
+        {editor.storage.characterCount.currentCharacterCount}/{limit} characters
       </div>
     </div>
   )

--- a/demos/src/Extensions/CharacterCount/Vue/index.vue
+++ b/demos/src/Extensions/CharacterCount/Vue/index.vue
@@ -3,7 +3,7 @@
     <editor-content :editor="editor" />
 
     <div class="character-count" v-if="editor">
-      {{ editor.getCharacterCount() }}/{{ limit }} characters
+      {{ editor.storage?.characterCount?.currentCharacterCount ?? 0 }}/{{ limit }} characters
     </div>
   </div>
 </template>
@@ -35,6 +35,7 @@ export default {
         Text,
         CharacterCount.configure({
           limit: this.limit,
+          countThroughSerializer: true,
         }),
       ],
       content: `

--- a/demos/src/Extensions/CharacterCount/Vue/index.vue
+++ b/demos/src/Extensions/CharacterCount/Vue/index.vue
@@ -3,7 +3,7 @@
     <editor-content :editor="editor" />
 
     <div class="character-count" v-if="editor">
-      {{ editor.storage?.characterCount?.currentCharacterCount ?? 0 }}/{{ limit }} characters
+      {{ editor.storage.characterCount.currentCharacterCount }}/{{ limit }} characters
     </div>
   </div>
 </template>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export { default as isNodeEmpty } from './helpers/isNodeEmpty'
 export { default as isNodeSelection } from './helpers/isNodeSelection'
 export { default as isTextSelection } from './helpers/isTextSelection'
 export { default as posToDOMRect } from './helpers/posToDOMRect'
+export { default as getTextSeralizersFromSchema } from './helpers/getTextSeralizersFromSchema'
 
 // eslint-disable-next-line
 export interface Commands<ReturnType = any> {}

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -1,10 +1,16 @@
-import { Extension } from '@tiptap/core'
+import {
+  Extension,
+  getTextBetween,
+  getTextSeralizersFromSchema,
+} from '@tiptap/core'
+
 import { Plugin, PluginKey } from 'prosemirror-state'
 
 export const pluginKey = new PluginKey('characterLimit')
 
 export interface CharacterCountOptions {
   limit?: number,
+  countThroughSerializer?: boolean
 }
 
 export const CharacterCount = Extension.create<CharacterCountOptions>({
@@ -18,15 +24,21 @@ export const CharacterCount = Extension.create<CharacterCountOptions>({
 
   addProseMirrorPlugins() {
     const { options } = this
-
+    const { storage } = this.editor
     return [
       new Plugin({
 
         key: pluginKey,
 
         appendTransaction: (transactions, oldState, newState) => {
-          const length = newState.doc.content.size
-
+          const length = !options.countThroughSerializer
+            ? newState.doc.content.size
+            : getTextBetween(
+              newState.doc,
+              { from: 0, to: newState.doc.content.size },
+              { textSerializers: getTextSeralizersFromSchema(newState.schema) },
+            ).length
+          storage.characterCount = { currentCharacterCount: length }
           if (options.limit && length > options.limit) {
             return newState.tr.insertText('', options.limit + 1, length)
           }

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -22,6 +22,12 @@ export const CharacterCount = Extension.create<CharacterCountOptions>({
     }
   },
 
+  addStorage() {
+    return {
+      currentCharacterCount: 0,
+    }
+  },
+
   addProseMirrorPlugins() {
     const { options } = this
     const { storage } = this.editor
@@ -38,7 +44,9 @@ export const CharacterCount = Extension.create<CharacterCountOptions>({
               { from: 0, to: newState.doc.content.size },
               { textSerializers: getTextSeralizersFromSchema(newState.schema) },
             ).length
-          storage.characterCount = { currentCharacterCount: length }
+
+          storage.characterCount.currentCharacterCount = length
+
           if (options.limit && length > options.limit) {
             return newState.tr.insertText('', options.limit + 1, length)
           }


### PR DESCRIPTION
It is for fixing this #1839.
It adds a new option `countThroughSerializer` to the `character-counter`.
If `countThroughSerializer` is true, the character-counter counts through the return value from the similar `editor.getText`.
Actually, it calls the `getTextBetween` and uses the `newState.doc` for the first argument, the whole content range for the second, the `getTextSeralizersFromSchema` for the third, then get the return value length to compare with the `limit`.

It also adds a `storage` for the character count that counts through the serializer.
You can get the current number of characters by this `editor.storage.characterCount.currentCharacterCount`.

