### PR TITLE
Add `setEditable` to the Editor documentation

### DIFF
--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -124,6 +124,18 @@ editor.setOptions({
   },
 })
 ```
+  
+### setEditable()
+Update editable state of the editor.
+  
+| Parameter | Type    | Description                                                   |
+| --------- | ------- | ------------------------------------------------------------- |
+| editable  | boolean | `true` when the user should be able to write into the editor. |
+  
+```js
+// Make the editor read-only
+editor.setEditable(false)
+```
 
 ### unregisterPlugin()
 Unregister a ProseMirror plugin.


### PR DESCRIPTION
I was looking for an option to toggle edit ability on the editor and only found `setOptions` in the docs. Was surprised by code completion with the option of setting `editable` directly this way.