### PR TITLE
fix: linkifyjs upgrade for module resolve

### DIFF
--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
-    "linkifyjs": "^3.0.3",
+    "linkifyjs": "^3.0.4",
     "prosemirror-state": "^1.3.4"
   },
   "repository": {


### PR DESCRIPTION
Upgrading linkifyjs to resolve using 'module' key in package.json of linkifyjs

fix for https://github.com/ueberdosis/tiptap/issues/2086