### PR TITLE
extension-link: add support for title attribute

### DIFF
--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -27,11 +27,11 @@ declare module '@tiptap/core' {
       /**
        * Set a link mark
        */
-      setLink: (attributes: { href: string, target?: string }) => ReturnType,
+      setLink: (attributes: { href: string, target?: string, title?: string }) => ReturnType,
       /**
        * Toggle a link mark
        */
-      toggleLink: (attributes: { href: string, target?: string }) => ReturnType,
+      toggleLink: (attributes: { href: string, target?: string, title?: string }) => ReturnType,
       /**
        * Unset a link mark
        */
@@ -65,6 +65,9 @@ export const Link = Mark.create<LinkOptions>({
       },
       target: {
         default: this.options.HTMLAttributes.target,
+      },
+      title: {
+        default: null,
       },
     }
   },


### PR DESCRIPTION
In some use cases, it could be useful to specify the `title` of the link, for accessibility or SEO purposes.

This PR add support for this attribute.