### PR TITLE
initialize autofocus selection in `createView`

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -12,6 +12,7 @@ import createDocument from './helpers/createDocument'
 import getHTMLFromFragment from './helpers/getHTMLFromFragment'
 import getText from './helpers/getText'
 import isNodeEmpty from './helpers/isNodeEmpty'
+import resolveFocusPosition from './helpers/resolveFocusPosition'
 import getTextSeralizersFromSchema from './helpers/getTextSeralizersFromSchema'
 import createStyleTag from './utilities/createStyleTag'
 import isFunction from './utilities/isFunction'
@@ -260,11 +261,14 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Creates a ProseMirror view.
    */
   private createView(): void {
+    const doc = createDocument(this.options.content, this.schema, this.options.parseOptions)
+    const selection = resolveFocusPosition(doc, this.options.autofocus)
     this.view = new EditorView(this.options.element, {
       ...this.options.editorProps,
       dispatchTransaction: this.dispatchTransaction.bind(this),
       state: EditorState.create({
-        doc: createDocument(this.options.content, this.schema, this.options.parseOptions),
+        doc,
+        selection,
       }),
     })
 

--- a/packages/core/src/commands/focus.ts
+++ b/packages/core/src/commands/focus.ts
@@ -1,6 +1,4 @@
-import { EditorState, Selection, TextSelection } from 'prosemirror-state'
 import { RawCommands, FocusPosition } from '../types'
-import minMax from '../utilities/minMax'
 import isTextSelection from '../helpers/isTextSelection'
 import isiOS from '../utilities/isiOS'
 import resolveFocusPosition from '../helpers/resolveFocusPosition'

--- a/packages/core/src/commands/focus.ts
+++ b/packages/core/src/commands/focus.ts
@@ -3,40 +3,7 @@ import { RawCommands, FocusPosition } from '../types'
 import minMax from '../utilities/minMax'
 import isTextSelection from '../helpers/isTextSelection'
 import isiOS from '../utilities/isiOS'
-
-function resolveSelection(state: EditorState, position: FocusPosition = null) {
-  if (!position) {
-    return null
-  }
-
-  if (position === 'start' || position === true) {
-    return {
-      from: 0,
-      to: 0,
-    }
-  }
-
-  const { size } = state.doc.content
-
-  if (position === 'end') {
-    return {
-      from: size,
-      to: size,
-    }
-  }
-
-  if (position === 'all') {
-    return {
-      from: 0,
-      to: size,
-    }
-  }
-
-  return {
-    from: position,
-    to: position,
-  }
-}
+import resolveFocusPosition from '../helpers/resolveFocusPosition'
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -95,13 +62,7 @@ export const focus: RawCommands['focus'] = (position = null, options) => ({
     return true
   }
 
-  const { from, to } = resolveSelection(editor.state, position) || editor.state.selection
-  const { doc, storedMarks } = tr
-  const minPos = Selection.atStart(doc).from
-  const maxPos = Selection.atEnd(doc).to
-  const resolvedFrom = minMax(from, minPos, maxPos)
-  const resolvedEnd = minMax(to, minPos, maxPos)
-  const selection = TextSelection.create(doc, resolvedFrom, resolvedEnd)
+  const selection = resolveFocusPosition(editor.state.doc, position)
   const isSameSelection = editor.state.selection.eq(selection)
 
   if (dispatch) {
@@ -111,8 +72,8 @@ export const focus: RawCommands['focus'] = (position = null, options) => ({
 
     // `tr.setSelection` resets the stored marks
     // so we’ll restore them if the selection is the same as before
-    if (isSameSelection && storedMarks) {
-      tr.setStoredMarks(storedMarks)
+    if (isSameSelection && tr.storedMarks) {
+      tr.setStoredMarks(tr.storedMarks)
     }
 
     delayedFocus()

--- a/packages/core/src/commands/focus.ts
+++ b/packages/core/src/commands/focus.ts
@@ -62,7 +62,7 @@ export const focus: RawCommands['focus'] = (position = null, options) => ({
     return true
   }
 
-  const selection = resolveFocusPosition(editor.state.doc, position)
+  const selection = resolveFocusPosition(editor.state.doc, position) || editor.state.selection
   const isSameSelection = editor.state.selection.eq(selection)
 
   if (dispatch) {

--- a/packages/core/src/helpers/resolveFocusPosition.ts
+++ b/packages/core/src/helpers/resolveFocusPosition.ts
@@ -1,0 +1,22 @@
+import { Node as ProseMirrorNode } from 'prosemirror-model'
+import { Selection, TextSelection } from 'prosemirror-state'
+import { FocusPosition } from '../types'
+import minMax from '../utilities/minMax'
+
+export default function resolveFocusPosition(
+  doc: ProseMirrorNode, 
+  position: FocusPosition = null
+): Selection | null {
+
+  if (!position) return null
+  if (position === 'start' || position === true) return Selection.atStart(doc)
+  if (position === 'end') return Selection.atEnd(doc)  
+  if (position === 'all') return TextSelection.create(doc, 0, state.doc.content.size)
+
+  // Check if `position` is in bounds of the doc if `position` is a number.
+  const minPos = Selection.atStart(doc).from
+  const maxPos = Selection.atEnd(doc).to
+  const resolvedFrom = minMax(position, minPos, maxPos)
+  const resolvedEnd = minMax(position, minPos, maxPos)  
+  return TextSelection.create(doc, resolvedFrom, resolvedEnd)
+}

--- a/packages/core/src/helpers/resolveFocusPosition.ts
+++ b/packages/core/src/helpers/resolveFocusPosition.ts
@@ -11,7 +11,7 @@ export default function resolveFocusPosition(
   if (!position) return null
   if (position === 'start' || position === true) return Selection.atStart(doc)
   if (position === 'end') return Selection.atEnd(doc)  
-  if (position === 'all') return TextSelection.create(doc, 0, state.doc.content.size)
+  if (position === 'all') return TextSelection.create(doc, 0, doc.content.size)
 
   // Check if `position` is in bounds of the doc if `position` is a number.
   const minPos = Selection.atStart(doc).from


### PR DESCRIPTION
Right now, the initial selection because it is undefined in `EditorState.create` is equal to [`Selection.atStart`](https://github.com/ProseMirror/prosemirror-state/blob/61bb964783b20800f6abc18dad855bd3bbf8cdd7/src/state.js#L25). 
Expected behavior is that if `autofocus` is defined, it is equal to the selection created on first focus. 

Example use-case is if `autofocus='end'`, then within a ProseMirror plugin `init` method: `state.doc.selection` should equal `Selection.atEnd` instead of `Selection.atStart`.