### PR TITLE
feat(ReactNodeViewRenderer): Add `as` option and pass through to ReactRenderer

### DIFF
--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -20,7 +20,7 @@ export interface ReactNodeViewRendererOptions extends NodeViewRendererOptions {
     newDecorations: Decoration[],
     updateProps: () => void,
   }) => boolean) | null,
-  as?: React.Element,
+  as?: React.ElementType,
 }
 
 class ReactNodeView extends NodeView<React.FunctionComponent, Editor, ReactNodeViewRendererOptions> {

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -20,7 +20,7 @@ export interface ReactNodeViewRendererOptions extends NodeViewRendererOptions {
     newDecorations: Decoration[],
     updateProps: () => void,
   }) => boolean) | null,
-  as?: React.ElementType,
+  as?: string,
 }
 
 class ReactNodeView extends NodeView<React.FunctionComponent, Editor, ReactNodeViewRendererOptions> {

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -20,6 +20,7 @@ export interface ReactNodeViewRendererOptions extends NodeViewRendererOptions {
     newDecorations: Decoration[],
     updateProps: () => void,
   }) => boolean) | null,
+  as?: React.Element,
 }
 
 class ReactNodeView extends NodeView<React.FunctionComponent, Editor, ReactNodeViewRendererOptions> {
@@ -81,12 +82,15 @@ class ReactNodeView extends NodeView<React.FunctionComponent, Editor, ReactNodeV
       this.contentDOMElement.style.whiteSpace = 'inherit'
     }
 
+    let as = this.node.isInline ? 'span' : 'div'
+    if (this.options.as) {
+      as = this.options.as
+    }
+
     this.renderer = new ReactRenderer(ReactNodeViewProvider, {
       editor: this.editor,
       props,
-      as: this.node.isInline
-        ? 'span'
-        : 'div',
+      as,
       className: `node-${this.node.type.name}`,
     })
   }


### PR DESCRIPTION
Right now, `ReactNodeViewRenderer` renders as a `<div class="react-renderer">` wrapper. We'd like to be able to pass an `as` prop to specify what kind of top-level HTMLElement corresponds with our node content. This could give people are a more granular control over how their elements get added (i.e. instead of just `div` or `span`, we could let people render an `img` or `li` directly).

At Gamma, our main use case is to allow us to have `li` elements adjacent to each other (rather than nested inside the div produced by ReactNodeViewRenderer). 

Additionally, (and for a separate PR), we like being able to pass the top-level `<li>` an `indent` attribute to dynamically do counter-resets. Right now there's no flexibility to add arbitrary attributes to the outermost wrapper when you use `ReactNodeViewRenderer`, so we're working on a way to do this in our own fork. We'll probably attempt this in a separate PR.