### PR TITLE
fix: update zeed-dom from 0.9.16 to 0.9.17 to fix #2217

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@tiptap/core": "^2.0.0-beta.143",
     "prosemirror-model": "^1.15.0",
-    "zeed-dom": "^0.9.16"
+    "zeed-dom": "^0.9.17"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,11 +3506,6 @@ css-unit-converter@^1.1.1:
   resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.2.tgz#4c77f5a1954e6dbff60695ecb214e3270436ab21"
   integrity sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==
 
-css-what@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
-  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
-
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -5097,11 +5092,6 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
-
-he@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -9151,11 +9141,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zeed-dom@^0.9.16:
-  version "0.9.16"
-  resolved "https://registry.yarnpkg.com/zeed-dom/-/zeed-dom-0.9.16.tgz#a743d876e6023c3c7c920fc7602a98e7fb83eda2"
-  integrity sha512-Rimrya1g5DhFYslHsaq93b/wRcbuynOKAGPfeZMLJChRfhR90NXZuC49qGpstdna9L503WecErLppm5DTl5LBA==
-  dependencies:
-    css-what "^5.1.0"
-  optionalDependencies:
-    he "^1.2.0"
+zeed-dom@^0.9.17:
+  version "0.9.17"
+  resolved "https://registry.yarnpkg.com/zeed-dom/-/zeed-dom-0.9.17.tgz#6983e294153318dd9c5dc18ce4591d2882fdd698"
+  integrity sha512-z/e1NBlpwGj6o/g0dYKzr/2BkbNYSnmJPCFlwx+bSS7ut04BskOUxN2mnehQhqRhOBal5aMrKQreklBZKat3PQ==


### PR DESCRIPTION
`zeed-dom@0.9.16` has issue that doesn't escape html perperly (see #2217), which has been fix in 0.9.17.