### PR TITLE
Add support to have multiple rules for the same text input

### DIFF
--- a/packages/core/src/InputRule.ts
+++ b/packages/core/src/InputRule.ts
@@ -1,4 +1,4 @@
-import { EditorState, Plugin, TextSelection } from 'prosemirror-state'
+import { EditorState, Plugin, TextSelection, Transaction } from 'prosemirror-state'
 import { Editor } from './Editor'
 import CommandManager from './CommandManager'
 import createChainableState from './helpers/createChainableState'
@@ -33,7 +33,7 @@ export class InputRule {
     commands: SingleCommands,
     chain: () => ChainedCommands,
     can: () => CanCommands,
-  }) => void
+  }) => Transaction<any> | null
 
   constructor(config: {
     find: InputRuleFinder,
@@ -44,7 +44,7 @@ export class InputRule {
       commands: SingleCommands,
       chain: () => ChainedCommands,
       can: () => CanCommands,
-    }) => void,
+    }) => Transaction<any> | null,
   }) {
     this.find = config.find
     this.handler = config.handler
@@ -148,7 +148,7 @@ function run(config: {
       state,
     })
 
-    rule.handler({
+    const handlerTr = rule.handler({
       state,
       range,
       match,
@@ -158,7 +158,7 @@ function run(config: {
     })
 
     // stop if there are no changes
-    if (!tr.steps.length) {
+    if (!handlerTr || !tr.steps.length) {
       return
     }
 

--- a/packages/core/src/InputRule.ts
+++ b/packages/core/src/InputRule.ts
@@ -1,4 +1,6 @@
-import { EditorState, Plugin, TextSelection, Transaction } from 'prosemirror-state'
+import {
+  EditorState, Plugin, TextSelection, Transaction,
+} from 'prosemirror-state'
 import { Editor } from './Editor'
 import CommandManager from './CommandManager'
 import createChainableState from './helpers/createChainableState'

--- a/packages/core/src/inputRules/markInputRule.ts
+++ b/packages/core/src/inputRules/markInputRule.ts
@@ -24,7 +24,7 @@ export default function markInputRule(config: {
       const attributes = callOrReturn(config.getAttributes, undefined, match)
 
       if (attributes === false || attributes === null) {
-        return
+        return null
       }
 
       const { tr } = state
@@ -64,6 +64,7 @@ export default function markInputRule(config: {
 
         tr.removeStoredMark(config.type)
       }
+      return tr
     },
   })
 }

--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -44,6 +44,7 @@ export default function nodeInputRule(config: {
       } else if (match[0]) {
         tr.replaceWith(start, end, config.type.create(attributes))
       }
+      return tr
     },
   })
 }

--- a/packages/core/src/inputRules/textInputRule.ts
+++ b/packages/core/src/inputRules/textInputRule.ts
@@ -30,6 +30,7 @@ export default function textInputRule(config: {
       }
 
       state.tr.insertText(insert, start, end)
+      return state.tr
     },
   })
 }

--- a/packages/core/src/inputRules/textblockTypeInputRule.ts
+++ b/packages/core/src/inputRules/textblockTypeInputRule.ts
@@ -32,6 +32,7 @@ export default function textblockTypeInputRule(config: {
       state.tr
         .delete(range.from, range.to)
         .setBlockType(range.from, range.from, config.type, attributes)
+      return state.tr
     },
   })
 }

--- a/packages/core/src/inputRules/wrappingInputRule.ts
+++ b/packages/core/src/inputRules/wrappingInputRule.ts
@@ -54,6 +54,7 @@ export default function wrappingInputRule(config: {
       ) {
         tr.join(range.from - 1)
       }
+      return tr
     },
   })
 }


### PR DESCRIPTION
Right now, it is assumed that input rules can only be skipped if it doesn't have any transaction step. This makes a few things harder to do as sometimes it is required to do some tr steps to figure out if all steps needed for the input rules can be done.
Prosemirror's official `prosemirror-inputrules` plugin does this by returning `null` if the input rules can't apply all the steps.

This changes introduce the same behaviour of `prosemirror-inputrules` to `@tiptap/core`'s InputRule plugin