### PR TITLE
Fix export for CommandManager

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,8 +9,9 @@ export * from './NodeView'
 export * from './Tracker'
 export * from './InputRule'
 export * from './PasteRule'
-export * from './CommandManager'
 export * from './types'
+
+export { default as CommandManger } from './CommandManager'
 
 export { default as nodeInputRule } from './inputRules/nodeInputRule'
 export { default as markInputRule } from './inputRules/markInputRule'


### PR DESCRIPTION
`CommandManager` is exported but it only has export default on `CommandManager.ts` hence it is not properly exported.