### PR TITLE
Svelte Example: remove wrong `type="context"` tag

### DIFF
--- a/docs/installation/svelte.md
+++ b/docs/installation/svelte.md
@@ -43,7 +43,7 @@ To actually start using Tiptap, you’ll need to add a new component to your app
 This is the fastest way to get Tiptap up and running with SvelteKit. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
 
 ```html
-<script type="module">
+<script>
   import { onMount, onDestroy } from 'svelte'
   import { Editor } from '@tiptap/core'
   import StarterKit from '@tiptap/starter-kit'


### PR DESCRIPTION
This example doesn't compile because in Svelte 3 there is no `type="context"`, there is only `context="module"`. Even if you use `context="module"` it is supposed to give an error because there is no `onMount` and `onDestroy` in module context.  Removing this tag from the Script element will fix the issue.