### PR TITLE
A brand new `CharacterCount` extension

### DIFF
--- a/demos/src/Examples/Community/React/index.jsx
+++ b/demos/src/Examples/Community/React/index.jsx
@@ -34,14 +34,14 @@ export default () => {
   })
 
   const percentage = editor
-    ? Math.round((100 / limit) * editor.getCharacterCount())
+    ? Math.round((100 / limit) * editor.storage.characterCount.characters())
     : 0
 
   return (
     <div>
       <EditorContent editor={editor} />
       {editor
-        && <div className={`character-count ${editor.getCharacterCount() === limit ? 'character-count--warning' : ''}`}>
+        && <div className={`character-count ${editor.storage.characterCount.characters() === limit ? 'character-count--warning' : ''}`}>
           <svg
             height="20"
             width="20"
@@ -73,7 +73,7 @@ export default () => {
           </svg>
 
           <div className="character-count__text">
-            {editor.getCharacterCount()}/{limit} characters
+            {editor.storage.characterCount.characters()}/{limit} characters
           </div>
         </div>
       }

--- a/demos/src/Examples/Community/Vue/index.vue
+++ b/demos/src/Examples/Community/Vue/index.vue
@@ -2,7 +2,7 @@
   <div>
     <editor-content :editor="editor" />
 
-    <div v-if="editor" :class="{'character-count': true, 'character-count--warning': editor.getCharacterCount() === limit}">
+    <div v-if="editor" :class="{'character-count': true, 'character-count--warning': editor.storage.characterCount.characters() === limit}">
       <svg
         height="20"
         width="20"
@@ -34,7 +34,7 @@
       </svg>
 
       <div class="character-count__text">
-        {{ editor.getCharacterCount() }}/{{ limit }} characters
+        {{ editor.storage.characterCount.characters() }}/{{ limit }} characters
       </div>
     </div>
   </div>
@@ -87,7 +87,7 @@ export default {
 
   computed: {
     percentage() {
-      return Math.round((100 / this.limit) * this.editor.getCharacterCount())
+      return Math.round((100 / this.limit) * this.editor.storage.characterCount.characters())
     },
   },
 

--- a/demos/src/Extensions/CharacterCount/React/index.jsx
+++ b/demos/src/Extensions/CharacterCount/React/index.jsx
@@ -35,6 +35,8 @@ export default () => {
 
       <div className="character-count">
         {editor.storage.characterCount.characters()}/{limit} characters
+        <br />
+        {editor.storage.characterCount.words()} words
       </div>
     </div>
   )

--- a/demos/src/Extensions/CharacterCount/React/index.jsx
+++ b/demos/src/Extensions/CharacterCount/React/index.jsx
@@ -34,7 +34,7 @@ export default () => {
       <EditorContent editor={editor} />
 
       <div className="character-count">
-        {editor.getCharacterCount()}/{limit} characters
+        {editor.storage.characterCount.characters()}/{limit} characters
       </div>
     </div>
   )

--- a/demos/src/Extensions/CharacterCount/Vue/index.vue
+++ b/demos/src/Extensions/CharacterCount/Vue/index.vue
@@ -3,7 +3,7 @@
     <editor-content :editor="editor" />
 
     <div class="character-count" v-if="editor">
-      {{ editor.getCharacterCount() }}/{{ limit }} characters
+      {{ editor.storage.characterCount.characters() }}/{{ limit }} characters
     </div>
   </div>
 </template>

--- a/demos/src/Extensions/CharacterCount/Vue/index.vue
+++ b/demos/src/Extensions/CharacterCount/Vue/index.vue
@@ -4,6 +4,8 @@
 
     <div class="character-count" v-if="editor">
       {{ editor.storage.characterCount.characters() }}/{{ limit }} characters
+      <br>
+      {{ editor.storage.characterCount.words() }} words
     </div>
   </div>
 </template>

--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -92,13 +92,6 @@ editor.isActive('heading', { level: 2 })
 editor.isActive({ textAlign: 'justify' })
 ```
 
-### getCharacterCount()
-Get the number of characters for the current document.
-
-```js
-editor.getCharacterCount()
-```
-
 ### registerPlugin()
 Register a ProseMirror plugin.
 
@@ -124,14 +117,14 @@ editor.setOptions({
   },
 })
 ```
-  
+
 ### setEditable()
 Update editable state of the editor.
-  
+
 | Parameter | Type    | Description                                                   |
 | --------- | ------- | ------------------------------------------------------------- |
 | editable  | boolean | `true` when the user should be able to write into the editor. |
-  
+
 ```js
 // Make the editor read-only
 editor.setEditable(false)

--- a/docs/api/extensions/character-count.md
+++ b/docs/api/extensions/character-count.md
@@ -18,7 +18,7 @@ npm install @tiptap/extension-character-count
 
 ### limit
 
-The maximum number of characters that should be allowed. |
+The maximum number of characters that should be allowed.
 
 Default: `0`
 
@@ -26,6 +26,33 @@ Default: `0`
 CharacterCount.configure({
   limit: 240,
 })
+```
+
+### mode
+
+The mode by which the size is calculated.
+
+Default: `'textSize'`
+
+```js
+CharacterCount.configure({
+  mode: 'nodeSize',
+})
+```
+
+## Storage
+
+### characters()
+Get the number of characters for the current document.
+
+```js
+editor.storage.characterCount.characters()
+
+// Get the size of a specific node.
+editor.storage.characterCount.characters({ node: someCustomNode })
+
+// Overwrite the default `mode`.
+editor.storage.characterCount.characters({ mode: 'nodeSize' })
 ```
 
 ## Source code

--- a/docs/api/extensions/character-count.md
+++ b/docs/api/extensions/character-count.md
@@ -55,21 +55,18 @@ editor.storage.characterCount.characters({ node: someCustomNode })
 editor.storage.characterCount.characters({ mode: 'nodeSize' })
 ```
 
+### words()
+Get the number of words for the current document.
+
+```js
+editor.storage.characterCount.words()
+
+// Get the number of words for a specific node.
+editor.storage.characterCount.words({ node: someCustomNode })
+```
+
 ## Source code
 [packages/extension-character-count/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-character-count/)
 
 ## Usage
 https://embed.tiptap.dev/preview/Extensions/CharacterCount
-
-## Count words, emojis, letters …
-Want to count words instead? Or emojis? Or the letter *a*? Sure, no problem. You can access the `textContent` directly and count whatever you’re into.
-
-```js
-new Editor({
-  onUpdate({ editor }) {
-    const wordCount = editor.state.doc.textContent.split(' ').length
-
-    console.log(wordCount)
-  },
-})
-```

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -449,8 +449,12 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   /**
    * Get the number of characters for the current document.
+   *
+   * @deprecated
    */
   public getCharacterCount(): number {
+    console.warn('[tiptap warn]: "editor.getCharacterCount()" is deprecated. Please use "editor.storage.characterCount.characters()" instead.')
+
     return this.state.doc.content.size - 2
   }
 

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -43,6 +43,14 @@ export const CharacterCount = Extension.create<CharacterCountOptions>({
             return false
           }
 
+          const isPaste = transaction.getMeta('paste')
+
+          // Block all exceeding transactions that were not pasted.
+          if (!isPaste) {
+            return false
+          }
+
+          // For pasted content, we try to remove the exceeding content.
           const pos = transaction.selection.$head.pos
           const over = newSize - limit
           const from = pos - over

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -10,7 +10,7 @@ export interface CharacterCountOptions {
   /**
    * The mode by which the size is calculated. Defaults to 'textSize'.
    */
-  mode: 'nodeSize' | 'textSize',
+  mode: 'textSize' | 'nodeSize',
 }
 
 export interface CharacterCountStorage {
@@ -19,7 +19,7 @@ export interface CharacterCountStorage {
    */
   characters?: (options: {
     node?: ProseMirrorNode,
-    mode?: 'nodeSize' | 'textSize',
+    mode?: 'textSize' | 'nodeSize',
   }) => number,
 }
 
@@ -44,11 +44,14 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
       const node = options?.node || this.editor.state.doc
       const mode = options?.mode || this.options.mode
 
-      if (mode === 'nodeSize') {
-        return node.nodeSize
+      if (mode === 'textSize') {
+        // TODO: maybe count blockSeparator and leaf nodes?
+        // return node.textBetween(0, node.content.size, ' ', ' ').length
+
+        return node.textContent.length
       }
 
-      return node.textContent.length
+      return node.nodeSize
     }
   },
 

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -21,6 +21,13 @@ export interface CharacterCountStorage {
     node?: ProseMirrorNode,
     mode?: 'textSize' | 'nodeSize',
   }) => number,
+
+  /**
+   * Get the number of words for the current document.
+   */
+  words?: (options: {
+    node?: ProseMirrorNode,
+  }) => number,
 }
 
 export const CharacterCount = Extension.create<CharacterCountOptions, CharacterCountStorage>({
@@ -36,6 +43,7 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
   addStorage() {
     return {
       characters: undefined,
+      words: undefined,
     }
   },
 
@@ -51,6 +59,16 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
       }
 
       return node.nodeSize
+    }
+
+    this.storage.words = options => {
+      const node = options?.node || this.editor.state.doc
+      const text = node.textBetween(0, node.content.size, undefined, ' ')
+      const words = text
+        .split(' ')
+        .filter(word => word !== '')
+
+      return words.length
     }
   },
 

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -59,12 +59,13 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
       new Plugin({
         key: new PluginKey('characterCount'),
         filterTransaction: (transaction, state) => {
-          // Nothing has changed. Ignore it.
-          if (!transaction.docChanged) {
+          const limit = this.options.limit
+
+          // Nothing has changed or no limit is defined. Ignore it.
+          if (!transaction.docChanged || limit === 0) {
             return true
           }
 
-          const limit = this.options.limit
           const oldSize = this.storage.characters?.({ node: state.doc }) || 0
           const newSize = this.storage.characters?.({ node: transaction.doc }) || 0
 

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -45,10 +45,9 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
       const mode = options?.mode || this.options.mode
 
       if (mode === 'textSize') {
-        // TODO: maybe count blockSeparator and leaf nodes?
-        // return node.textBetween(0, node.content.size, ' ', ' ').length
+        const text = node.textBetween(0, node.content.size, undefined, ' ')
 
-        return node.textContent.length
+        return text.length
       }
 
       return node.nodeSize

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -1,10 +1,8 @@
 import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from 'prosemirror-state'
 
-export const pluginKey = new PluginKey('characterLimit')
-
 export interface CharacterCountOptions {
-  limit?: number,
+  limit: number,
 }
 
 export const CharacterCount = Extension.create<CharacterCountOptions>({
@@ -17,19 +15,25 @@ export const CharacterCount = Extension.create<CharacterCountOptions>({
   },
 
   addProseMirrorPlugins() {
-    const { options } = this
-
     return [
       new Plugin({
-
-        key: pluginKey,
-
+        key: new PluginKey('characterCount'),
         appendTransaction: (transactions, oldState, newState) => {
-          const length = newState.doc.content.size
+          const limit = this.options.limit + 2
+          const oldSize = oldState.doc.content.size
+          const newSize = newState.doc.content.size
 
-          if (options.limit && length > options.limit) {
-            return newState.tr.insertText('', options.limit + 1, length)
+          if (newSize <= oldSize || newSize <= limit) {
+            return
           }
+
+          const pos = newState.selection.$head.pos
+          const over = newSize - limit
+          const from = pos - over
+          const to = pos
+          const tr = newState.tr.delete(from, to)
+
+          return tr
         },
       }),
     ]


### PR DESCRIPTION
With this PR we introduce the redesigned `CharacterCount` extension. It’s a full re-write and fixes some bugs.

## New features

### Add `mode` option
You can now choose between `textSize` and `nodeSize` for calculating the character size. Defaults to `textSize`.

```js
CharacterCount.configure({
  mode: 'nodeSize',
})
```

### Add `characters()` storage method

Get the number of characters for the current document with this new storage method. This deprecates `editor.getCharacterCount()`.

```js
editor.storage.characterCount.characters()

// Get the size of a specific node.
editor.storage.characterCount.characters({ node: someCustomNode })

// Overwrite the default `mode`.
editor.storage.characterCount.characters({ mode: 'nodeSize' })
```

### Add `words()` storage method

Get the number of words for the current document with this new storage method.

```js
editor.storage.characterCount.words()

// Get the number of words for a specific node.
editor.storage.characterCount.words({ node: someCustomNode })
```

## Preview

https://deploy-preview-2256--tiptap-embed.netlify.app/preview/Extensions/CharacterCount

Fixes #1049
Fixes #1550
Fixes #1839
Fixes #2245