### PR TITLE
fix: show FloatingMenu by default only if focused

### DIFF
--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -33,13 +33,17 @@ export class FloatingMenuView {
 
   public tippyOptions?: Partial<Props>
 
-  public shouldShow: Exclude<FloatingMenuPluginProps['shouldShow'], null> = ({ state }) => {
+  public shouldShow: Exclude<FloatingMenuPluginProps['shouldShow'], null> = ({ state, view }) => {
     const { selection } = state
     const { $anchor, empty } = selection
     const isRootDepth = $anchor.depth === 1
     const isEmptyTextBlock = $anchor.parent.isTextblock
       && !$anchor.parent.type.spec.code
       && !$anchor.parent.textContent
+
+    if (!view.hasFocus()) {
+      return false
+    }
 
     if (!empty || !isRootDepth || !isEmptyTextBlock) {
       return false


### PR DESCRIPTION
Right now, if any extension updates the editor state the `FloatingMenu` will become visible. In my opinion the `FloatingMenu` should only be visible when the user actually focuses the editor. I know that I can pass a custom `shouldShow` function to change the behaviour but I think it should also be the default behaviour.