### PR TITLE
Make sure editor is available on first render

### DIFF
--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -9,13 +9,18 @@ function useForceUpdate() {
 }
 
 export const useEditor = (options: Partial<EditorOptions> = {}, deps: DependencyList = []) => {
-  const [editor, setEditor] = useState<Editor | null>(null)
+  const [editor, setEditor] = useState<Editor>(() => new Editor(options))
   const forceUpdate = useForceUpdate()
 
   useEffect(() => {
-    const instance = new Editor(options)
+    let instance: Editor
 
-    setEditor(instance)
+    if (editor.isDestroyed) {
+      instance = new Editor(options)
+      setEditor(instance)
+    } else {
+      instance = editor
+    }
 
     instance.on('transaction', () => {
       requestAnimationFrame(() => {


### PR DESCRIPTION
This is a fix for #2182 - it makes sure that the editor is available on the first render of `useEditor` in the react package.

The reason for this fix is that the first render never has an editor and that causes the page's content to jump and flash. First render has no editor, so nothing is rendered. Then the second render has the editor and the WYSIWYG editor is rendered causing all the content on the page to shift down.

The effect will also re-create the editor if anything in the deps list changes.

cc @philippkuehn 