### PR TITLE
Improve backspace handling

### DIFF
--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -1,3 +1,6 @@
+import { Plugin, PluginKey, Selection } from 'prosemirror-state'
+import { createChainableState } from '../helpers/createChainableState'
+import { CommandManager } from '../CommandManager'
 import { Extension } from '../Extension'
 
 export const Keymap = Extension.create({
@@ -5,6 +8,24 @@ export const Keymap = Extension.create({
 
   addKeyboardShortcuts() {
     const handleBackspace = () => this.editor.commands.first(({ commands }) => [
+      // maybe convert first text block node to default node
+      () => commands.command(({ tr }) => {
+        const { selection, doc } = tr
+        const { empty, $anchor } = selection
+        const { pos, parent } = $anchor
+        const isAtStart = Selection.atStart(doc).from === pos
+
+        if (
+          !empty
+          || !isAtStart
+          || !parent.type.isTextblock
+          || parent.textContent.length
+        ) {
+          return false
+        }
+
+        return commands.clearNodes()
+      }),
       () => commands.undoInputRule(),
       () => commands.deleteSelection(),
       () => commands.joinBackward(),
@@ -32,5 +53,54 @@ export const Keymap = Extension.create({
       'Mod-Delete': handleDelete,
       'Mod-a': () => this.editor.commands.selectAll(),
     }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      // With this plugin we check if the whole document was selected and deleted.
+      // In this case we will additionally call `clearNodes()` to convert e.g. a heading
+      // to a paragraph if necessary.
+      // This is an alternative to ProseMirror's `AllSelection`, which doesn’t work well
+      // with many other commands.
+      new Plugin({
+        key: new PluginKey('clearDocument'),
+        appendTransaction: (transactions, oldState, newState) => {
+          const docChanges = transactions.some(transaction => transaction.docChanged)
+            && !oldState.doc.eq(newState.doc)
+
+          if (!docChanges) {
+            return
+          }
+
+          const { empty, from, to } = oldState.selection
+          const allFrom = Selection.atStart(oldState.doc).from
+          const allEnd = Selection.atEnd(oldState.doc).to
+          const allWasSelected = from === allFrom && to === allEnd
+          const isEmpty = newState.doc.textBetween(0, newState.doc.content.size, ' ', ' ').length === 0
+
+          if (empty || !allWasSelected || !isEmpty) {
+            return
+          }
+
+          const tr = newState.tr
+          const state = createChainableState({
+            state: newState,
+            transaction: tr,
+          })
+          const { commands } = new CommandManager({
+            editor: this.editor,
+            state,
+          })
+
+          commands.clearNodes()
+
+          if (!tr.steps.length) {
+            return
+          }
+
+          return tr
+        },
+      }),
+    ]
   },
 })

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -8,6 +8,7 @@ export const Keymap = Extension.create({
 
   addKeyboardShortcuts() {
     const handleBackspace = () => this.editor.commands.first(({ commands }) => [
+      () => commands.undoInputRule(),
       // maybe convert first text block node to default node
       () => commands.command(({ tr }) => {
         const { selection, doc } = tr
@@ -26,7 +27,6 @@ export const Keymap = Extension.create({
 
         return commands.clearNodes()
       }),
-      () => commands.undoInputRule(),
       () => commands.deleteSelection(),
       () => commands.joinBackward(),
       () => commands.selectNodeBackward(),

--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -103,22 +103,6 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
     return {
       'Mod-Alt-c': () => this.editor.commands.toggleCodeBlock(),
 
-      // remove code block when at start of document or code block is empty
-      Backspace: () => {
-        const { empty, $anchor } = this.editor.state.selection
-        const isAtStart = $anchor.pos === 1
-
-        if (!empty || $anchor.parent.type.name !== this.name) {
-          return false
-        }
-
-        if (isAtStart || !$anchor.parent.textContent.length) {
-          return this.editor.commands.clearNodes()
-        }
-
-        return false
-      },
-
       // escape node on triple enter
       Enter: ({ editor }) => {
         const { state } = editor

--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -106,12 +106,13 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
       // remove code block when at start of document or code block is empty
       Backspace: () => {
         const { empty, $anchor } = this.editor.state.selection
+        const isAtStart = $anchor.pos === 1
 
         if (!empty || $anchor.parent.type.name !== this.name) {
           return false
         }
 
-        if ($anchor.parent.textContent.length) {
+        if (isAtStart || !$anchor.parent.textContent.length) {
           return this.editor.commands.clearNodes()
         }
 

--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -103,6 +103,21 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
     return {
       'Mod-Alt-c': () => this.editor.commands.toggleCodeBlock(),
 
+      // remove code block when at start of document or code block is empty
+      Backspace: () => {
+        const { empty, $anchor } = this.editor.state.selection
+
+        if (!empty || $anchor.parent.type.name !== this.name) {
+          return false
+        }
+
+        if ($anchor.parent.textContent.length) {
+          return this.editor.commands.clearNodes()
+        }
+
+        return false
+      },
+
       // escape node on triple enter
       Enter: ({ editor }) => {
         const { state } = editor


### PR DESCRIPTION
With this PR we try to improve backspace handling in two cases

1. Convert an empty node to the default node when pressing backspace at the start of the document.
2. After pressing `cmd+a` and `backspace` the node is converted to the default node

fixes #2281

preview: https://deploy-preview-2284--tiptap-embed.netlify.app/preview/Examples/Default