### PR TITLE
Option to make editor available during initial render of hook.

### DIFF
--- a/demos/src/Examples/Default/React/index.jsx
+++ b/demos/src/Examples/Default/React/index.jsx
@@ -120,6 +120,7 @@ const MenuBar = ({ editor }) => {
 
 export default () => {
   const editor = useEditor({
+    availableOnFirstRender: true,
     extensions: [
       StarterKit,
     ],

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -2,20 +2,28 @@ import { useState, useEffect, DependencyList } from 'react'
 import { EditorOptions } from '@tiptap/core'
 import { Editor } from './Editor'
 
+type UseEditorOptions = EditorOptions & {
+  availableOnFirstRender: boolean
+}
+
 function useForceUpdate() {
   const [, setValue] = useState(0)
 
   return () => setValue(value => value + 1)
 }
 
-export const useEditor = (options: Partial<EditorOptions> = {}, deps: DependencyList = []) => {
-  const [editor, setEditor] = useState<Editor>(() => new Editor(options))
+export const useEditor = (options: Partial<UseEditorOptions> = {}, deps: DependencyList = []): Editor | null => {
+  const { availableOnFirstRender, ...editorOptions } = options
+  const [editor, setEditor] = useState<Editor | null>(() => {
+    return availableOnFirstRender ? new Editor(editorOptions) : null
+  })
+
   const forceUpdate = useForceUpdate()
 
   useEffect(() => {
     let instance: Editor
 
-    if (editor.isDestroyed) {
+    if (!editor || editor.isDestroyed) {
       instance = new Editor(options)
       setEditor(instance)
     } else {


### PR DESCRIPTION
This PR is a fix for #2282 that allows the user to opt into having the editor available during the first render. We're making it opt in because the Editor doesn't render on the server (it expects `document` to exist), so enabling this by default would crash server rendered apps.

