### PR TITLE
Remove `element.current` from `useEffect` in `BubbleMenu` and `FloatingMenu`

### DIFF
--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect, useState, RefCallback,
+  useEffect, useState
 } from 'react'
 import { BubbleMenuPlugin, BubbleMenuPluginProps } from '@tiptap/extension-bubble-menu'
 
@@ -11,10 +11,13 @@ export type BubbleMenuProps = Omit<Optional<BubbleMenuPluginProps, 'pluginKey'>,
 
 export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
   const [element, setElement] = useState<HTMLDivElement | null>(null)
-  const elementRef = useCallback<RefCallback<HTMLDivElement>>(node => setElement(node), [])
 
   useEffect(() => {
     if (!element) {
+      return
+    }
+
+    if (props.editor.isDestroyed) {
       return
     }
 
@@ -41,7 +44,7 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
   ])
 
   return (
-    <div ref={elementRef} className={props.className} style={{ visibility: 'hidden' }}>
+    <div ref={setElement} className={props.className} style={{ visibility: 'hidden' }}>
       {props.children}
     </div>
   )

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -33,10 +33,7 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
     return () => {
       editor.unregisterPlugin(pluginKey)
     }
-  }, [
-    props.editor,
-    element.current,
-  ])
+  }, [props.editor])
 
   return (
     <div ref={element} className={props.className} style={{ visibility: 'hidden' }}>

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useState
+  useEffect, useState,
 } from 'react'
 import { BubbleMenuPlugin, BubbleMenuPluginProps } from '@tiptap/extension-bubble-menu'
 

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useState, RefCallback } from 'react'
 import { BubbleMenuPlugin, BubbleMenuPluginProps } from '@tiptap/extension-bubble-menu'
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
@@ -8,12 +8,11 @@ export type BubbleMenuProps = Omit<Optional<BubbleMenuPluginProps, 'pluginKey'>,
 }
 
 export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
-  const element = useRef<HTMLDivElement>(null)
+  const [element, setElement] = useState<HTMLDivElement | null>(null)
+  const elementRef = useCallback<RefCallback<HTMLDivElement>>(node => setElement(node), [])
 
   useEffect(() => {
-    if (!element.current) {
-      return
-    }
+    if (!element) return
 
     const {
       pluginKey = 'bubbleMenu',
@@ -22,21 +21,23 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
       shouldShow = null,
     } = props
 
-    editor.registerPlugin(BubbleMenuPlugin({
+    const plugin = BubbleMenuPlugin({
       pluginKey,
       editor,
-      element: element.current as HTMLElement,
+      element,
       tippyOptions,
       shouldShow,
-    }))
+    })
 
-    return () => {
-      editor.unregisterPlugin(pluginKey)
-    }
-  }, [props.editor])
+    editor.registerPlugin(plugin)
+    return () => editor.unregisterPlugin(pluginKey)
+  }, [
+    props.editor,
+    element,
+  ])
 
   return (
-    <div ref={element} className={props.className} style={{ visibility: 'hidden' }}>
+    <div ref={elementRef} className={props.className} style={{ visibility: 'hidden' }}>
       {props.children}
     </div>
   )

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState, RefCallback } from 'react'
+import React, {
+  useCallback, useEffect, useState, RefCallback,
+} from 'react'
 import { BubbleMenuPlugin, BubbleMenuPluginProps } from '@tiptap/extension-bubble-menu'
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
@@ -12,7 +14,9 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = props => {
   const elementRef = useCallback<RefCallback<HTMLDivElement>>(node => setElement(node), [])
 
   useEffect(() => {
-    if (!element) return
+    if (!element) {
+      return
+    }
 
     const {
       pluginKey = 'bubbleMenu',

--- a/packages/react/src/FloatingMenu.tsx
+++ b/packages/react/src/FloatingMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useState, useCallback, RefCallback } from 'react'
 import { FloatingMenuPlugin, FloatingMenuPluginProps } from '@tiptap/extension-floating-menu'
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
@@ -8,12 +8,11 @@ export type FloatingMenuProps = Omit<Optional<FloatingMenuPluginProps, 'pluginKe
 }
 
 export const FloatingMenu: React.FC<FloatingMenuProps> = props => {
-  const element = useRef<HTMLDivElement>(null)
+  const [element, setElement] = useState<HTMLDivElement | null>(null)
+  const elementRef = useCallback<RefCallback<HTMLDivElement>>(node => setElement(node), [])
 
   useEffect(() => {
-    if (!element.current) {
-      return
-    }
+    if (!element) return
 
     const {
       pluginKey = 'floatingMenu',
@@ -22,24 +21,23 @@ export const FloatingMenu: React.FC<FloatingMenuProps> = props => {
       shouldShow = null,
     } = props
 
-    editor.registerPlugin(FloatingMenuPlugin({
+    const plugin = FloatingMenuPlugin({
       pluginKey,
       editor,
-      element: element.current as HTMLElement,
+      element,
       tippyOptions,
       shouldShow,
-    }))
+    })
 
-    return () => {
-      editor.unregisterPlugin(pluginKey)
-    }
+    editor.registerPlugin(plugin)
+    return () => editor.unregisterPlugin(pluginKey)
   }, [
     props.editor,
-    element.current,
+    element,
   ])
 
   return (
-    <div ref={element} className={props.className} style={{ visibility: 'hidden' }}>
+    <div ref={elementRef} className={props.className} style={{ visibility: 'hidden' }}>
       {props.children}
     </div>
   )

--- a/packages/react/src/FloatingMenu.tsx
+++ b/packages/react/src/FloatingMenu.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useState, useCallback, RefCallback,
+  useEffect, useState,
 } from 'react'
 import { FloatingMenuPlugin, FloatingMenuPluginProps } from '@tiptap/extension-floating-menu'
 
@@ -11,10 +11,13 @@ export type FloatingMenuProps = Omit<Optional<FloatingMenuPluginProps, 'pluginKe
 
 export const FloatingMenu: React.FC<FloatingMenuProps> = props => {
   const [element, setElement] = useState<HTMLDivElement | null>(null)
-  const elementRef = useCallback<RefCallback<HTMLDivElement>>(node => setElement(node), [])
 
   useEffect(() => {
     if (!element) {
+      return
+    }
+
+    if (props.editor.isDestroyed) {
       return
     }
 
@@ -41,7 +44,7 @@ export const FloatingMenu: React.FC<FloatingMenuProps> = props => {
   ])
 
   return (
-    <div ref={elementRef} className={props.className} style={{ visibility: 'hidden' }}>
+    <div ref={setElement} className={props.className} style={{ visibility: 'hidden' }}>
       {props.children}
     </div>
   )

--- a/packages/react/src/FloatingMenu.tsx
+++ b/packages/react/src/FloatingMenu.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useState, useCallback, RefCallback } from 'react'
+import React, {
+  useEffect, useState, useCallback, RefCallback,
+} from 'react'
 import { FloatingMenuPlugin, FloatingMenuPluginProps } from '@tiptap/extension-floating-menu'
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
@@ -12,7 +14,9 @@ export const FloatingMenu: React.FC<FloatingMenuProps> = props => {
   const elementRef = useCallback<RefCallback<HTMLDivElement>>(node => setElement(node), [])
 
   useEffect(() => {
-    if (!element) return
+    if (!element) {
+      return
+    }
 
     const {
       pluginKey = 'floatingMenu',


### PR DESCRIPTION
Changes to the `element.current` don't trigger `useEffect` rerender and shouldn't be used in the dependency array.
One discussion about this is for example here: https://stackoverflow.com/questions/60476155/is-it-safe-to-use-ref-current-as-useeffects-dependency-when-ref-points-to-a-dom

It's also causing some subtle bugs when mounting and unmounting editors.