### PR TITLE
Using vue 2 and 3 when passing props to VueRenderer in Mention plugin

### DIFF
--- a/demos/src/Nodes/Mention/Vue/suggestion.js
+++ b/demos/src/Nodes/Mention/Vue/suggestion.js
@@ -19,6 +19,7 @@ export default {
           // using vue 2:
           // parent: this,
           // propsData: props,
+          // using vue 3:
           props,
           editor: props.editor,
         })


### PR DESCRIPTION
A comment clarifying the difference between using vue 2 and 3 when passing props to VueRenderer in Mention plugin
A reason - it tooks me hours to realize that I need not only use this:
```
parent: this,
propsData: props,
```
 for vue 2 but remove that as well:
```
props,
editor: props.editor,
```
It led to a performance issue - a tab freezed in my case when adding some mentions