### PR TITLE
Added setup script syntax to Vue 3 install docs

### DIFF
--- a/docs/installation/vue3.md
+++ b/docs/installation/vue3.md
@@ -106,6 +106,26 @@ export default {
 </script>
 ```
 
+Or feel free to use the new [`<script setup>` syntax](https://v3.vuejs.org/api/sfc-script-setup.html).
+
+```html
+<template>
+  <editor-content :editor="editor" />
+</template>
+
+<script setup>
+import { useEditor, EditorContent } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
+
+const editor = useEditor({
+  content: '<p>I’m running Tiptap with Vue.js. 🎉</p>',
+  extensions: [
+    StarterKit,
+  ],
+})
+</script>
+```
+
 ## 4. Add it to your app
 Now, let’s replace the content of `src/App.vue` with the following example code to use our new `Tiptap` component in our app.
 


### PR DESCRIPTION
## What

Another newly added feature to Vue 3 has been the addition of the [setup script syntax](https://v3.vuejs.org/api/sfc-script-setup.html). Feels like it might be good to add this as another possible installation method.