### PR TITLE
change reactrenderer component type definition

### DIFF
--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -24,12 +24,12 @@ export interface ReactRendererOptions {
   className?: string,
 }
 
-type ComponentType<R> =
-  | React.ComponentClass
-  | React.FunctionComponent
-  | React.ForwardRefExoticComponent<{ items: any[], command: any } & React.RefAttributes<R>>
+type ComponentType<R, P> =
+  React.ComponentClass<P> |
+  React.FunctionComponent<P> |
+  React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<R>>;
 
-export class ReactRenderer<R = unknown> {
+export class ReactRenderer<R = unknown,P = unknown> {
   id: string
 
   editor: ExtendedEditor
@@ -44,7 +44,7 @@ export class ReactRenderer<R = unknown> {
 
   ref: R | null = null
 
-  constructor(component: ComponentType<R>, {
+  constructor(component: ComponentType<R, P>, {
     editor,
     props = {},
     as = 'div',


### PR DESCRIPTION
This PR modifies the ReactRenderer types so that they are no longer tied to the `mention` example.

#2011 makes the `ComponentType` require `items[]` and a `command` in the props, but the ReactRenderer does not make the same assumption. 

I think this should also make it possible to change the type of `props` in the `ReactRenderer` class to `P`, and similarly in the function definition for `ReactRenderer.updateProps`. But I wanted this to be a minimal change so I just fixed the issue in the `ComponentType` type definition.

