### PR TITLE
Vue3 CLI doesn't have "npm run dev"

### DIFF
--- a/docs/installation/vue3.md
+++ b/docs/installation/vue3.md
@@ -33,7 +33,7 @@ Okay, enough of the boring boilerplate work. Let’s finally install Tiptap! For
 npm install @tiptap/vue-3 @tiptap/starter-kit
 ```
 
-If you followed step 1 and 2, you can now start your project with `npm run dev`, and open [http://localhost:8080](http://localhost:8080) in your favorite browser. This might be different, if you’re working with an existing project.
+If you followed step 1 and 2, you can now start your project with `npm run serve`, and open [http://localhost:8080](http://localhost:8080) in your favorite browser. This might be different, if you’re working with an existing project.
 
 ## 3. Create a new component
 To actually start using Tiptap, you’ll need to add a new component to your app. Let’s call it `Tiptap` and put the following example code in `components/Tiptap.vue`.


### PR DESCRIPTION
npm run dev --> npm run serve

"dev" used to be in the CLI for Vue 2 but has since been removed with Vue 3

see: https://stackoverflow.com/questions/51664680/how-to-solve-npm-err-missing-script-dev/52694160 