### PR TITLE
fix: export type `Level` for external use

### DIFF
--- a/packages/extension-heading/src/heading.ts
+++ b/packages/extension-heading/src/heading.ts
@@ -1,6 +1,6 @@
 import { Node, mergeAttributes, textblockTypeInputRule } from '@tiptap/core'
 
-type Level = 1 | 2 | 3 | 4 | 5 | 6
+export type Level = 1 | 2 | 3 | 4 | 5 | 6
 
 export interface HeadingOptions {
   levels: Level[],


### PR DESCRIPTION
Export type `Level` to externally work with levels that are passed to the `setHeading` and `toggleHeading` commands, instead of only being able to pass literal numbers.

Example:
```
// where `selectedHeadingLevel` shall be of type `Level` and changes as part of other logic
this.editor.commands.toggleHeading({ level: this.selectedHeadingLevel })
```