### PR TITLE
Mark `@tiptap/react` and `@tiptap/core` as side effect free

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,5 +43,6 @@
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/core"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,5 +40,6 @@
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/react"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Hi Tiptap people! 👋

I created a PR directly instead of an issue because the diff is quite small. Feel free to close this if undesired. 😊

As far as I understand, Tiptap doesn't rely on global side effects anywhere within the packages `@tiptap/core` and `@tiptap/react` (I didn't check the other packages). I added `sideEffects: false` to both package.jsons to indicate to app bundlers (primarily webpack and rollup) that unused exports within those packages can be removed safely from the final bundle. That's especially useful for large packages like `@tiptap/react` and `@tiptap/core`.

More info: https://webpack.js.org/guides/tree-shaking