### PR TITLE
add way to cancel inputrules and pasterules

### DIFF
--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -306,7 +306,7 @@ export class ExtensionManager {
         editor,
         rules: inputRules,
       }),
-      pasteRulesPlugin({
+      ...pasteRulesPlugin({
         editor,
         rules: pasteRules,
       }),

--- a/packages/core/src/InputRule.ts
+++ b/packages/core/src/InputRule.ts
@@ -1,4 +1,9 @@
-import { EditorState, Plugin, TextSelection } from 'prosemirror-state'
+import {
+  EditorState,
+  Plugin,
+  TextSelection,
+  Transaction,
+} from 'prosemirror-state'
 import { Editor } from './Editor'
 import { CommandManager } from './CommandManager'
 import { createChainableState } from './helpers/createChainableState'
@@ -33,7 +38,7 @@ export class InputRule {
     commands: SingleCommands,
     chain: () => ChainedCommands,
     can: () => CanCommands,
-  }) => void
+  }) => Transaction | null
 
   constructor(config: {
     find: InputRuleFinder,
@@ -44,7 +49,7 @@ export class InputRule {
       commands: SingleCommands,
       chain: () => ChainedCommands,
       can: () => CanCommands,
-    }) => void,
+    }) => Transaction | null,
   }) {
     this.find = config.find
     this.handler = config.handler
@@ -87,7 +92,7 @@ function run(config: {
   text: string,
   rules: InputRule[],
   plugin: Plugin,
-}): any {
+}): boolean {
   const {
     editor,
     from,
@@ -148,7 +153,7 @@ function run(config: {
       state,
     })
 
-    rule.handler({
+    const handler = rule.handler({
       state,
       range,
       match,
@@ -158,7 +163,7 @@ function run(config: {
     })
 
     // stop if there are no changes
-    if (!tr.steps.length) {
+    if (!handler || !tr.steps.length) {
       return
     }
 

--- a/packages/core/src/inputRules/markInputRule.ts
+++ b/packages/core/src/inputRules/markInputRule.ts
@@ -24,7 +24,7 @@ export function markInputRule(config: {
       const attributes = callOrReturn(config.getAttributes, undefined, match)
 
       if (attributes === false || attributes === null) {
-        return
+        return null
       }
 
       const { tr } = state
@@ -64,6 +64,8 @@ export function markInputRule(config: {
 
         tr.removeStoredMark(config.type)
       }
+
+      return tr
     },
   })
 }

--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -45,6 +45,8 @@ export function nodeInputRule(config: {
       } else if (match[0]) {
         tr.replaceWith(start, end, config.type.create(attributes))
       }
+
+      return tr
     },
   })
 }

--- a/packages/core/src/inputRules/textInputRule.ts
+++ b/packages/core/src/inputRules/textInputRule.ts
@@ -29,7 +29,11 @@ export function textInputRule(config: {
         }
       }
 
-      state.tr.insertText(insert, start, end)
+      const { tr } = state
+
+      tr.insertText(insert, start, end)
+
+      return tr
     },
   })
 }

--- a/packages/core/src/inputRules/textblockTypeInputRule.ts
+++ b/packages/core/src/inputRules/textblockTypeInputRule.ts
@@ -29,9 +29,12 @@ export function textblockTypeInputRule(config: {
         return null
       }
 
-      state.tr
-        .delete(range.from, range.to)
+      const { tr } = state
+
+      tr.delete(range.from, range.to)
         .setBlockType(range.from, range.from, config.type, attributes)
+
+      return tr
     },
   })
 }

--- a/packages/core/src/inputRules/wrappingInputRule.ts
+++ b/packages/core/src/inputRules/wrappingInputRule.ts
@@ -54,6 +54,8 @@ export function wrappingInputRule(config: {
       ) {
         tr.join(range.from - 1)
       }
+
+      return tr
     },
   })
 }

--- a/packages/core/src/pasteRules/markPasteRule.ts
+++ b/packages/core/src/pasteRules/markPasteRule.ts
@@ -24,7 +24,7 @@ export function markPasteRule(config: {
       const attributes = callOrReturn(config.getAttributes, undefined, match)
 
       if (attributes === false || attributes === null) {
-        return
+        return null
       }
 
       const { tr } = state
@@ -64,6 +64,8 @@ export function markPasteRule(config: {
 
         tr.removeStoredMark(config.type)
       }
+
+      return tr
     },
   })
 }

--- a/packages/core/src/pasteRules/textPasteRule.ts
+++ b/packages/core/src/pasteRules/textPasteRule.ts
@@ -29,7 +29,11 @@ export function textPasteRule(config: {
         }
       }
 
-      state.tr.insertText(insert, start, end)
+      const { tr } = state
+
+      tr.insertText(insert, start, end)
+
+      return tr
     },
   })
 }


### PR DESCRIPTION
With this PR it’s possible to cancel inputRules and pasteRules. The issue is also described in #2225.

```js
new InputRule({
  handler: ({ state, range, match }) => {
    // cancel input rule when returning `null`
    if (true) {
      return null
    }

    const tr = state.tr
    
    // otherwise always return a transaction
    return tr
  }
})
```

### Caveat
Pasterules work slightly differently because a match can appear in several nodes at the same time. When returning `null`, the rule for all occurrences is not applied.


fixes #2348