### PR TITLE
fix: use toggleHeader from prosemirror-tables

### DIFF
--- a/packages/extension-table/src/table.ts
+++ b/packages/extension-table/src/table.ts
@@ -18,8 +18,7 @@ import {
   deleteTable,
   mergeCells,
   splitCell,
-  toggleHeaderColumn,
-  toggleHeaderRow,
+  toggleHeader,
   toggleHeaderCell,
   setCellAttr,
   fixTables,
@@ -157,10 +156,10 @@ export const Table = Node.create<TableOptions>({
         return splitCell(state, dispatch)
       },
       toggleHeaderColumn: () => ({ state, dispatch }) => {
-        return toggleHeaderColumn(state, dispatch)
+        return toggleHeader('column')(state, dispatch)
       },
       toggleHeaderRow: () => ({ state, dispatch }) => {
-        return toggleHeaderRow(state, dispatch)
+        return toggleHeader('row')(state, dispatch)
       },
       toggleHeaderCell: () => ({ state, dispatch }) => {
         return toggleHeaderCell(state, dispatch)


### PR DESCRIPTION
This PR will update the tables extension to use the `toggleHeader` command instead of the deprecated `toggleHeaderColumn` and `toggleHeaderRow` commands from `prosemirror-tables`. This is a **breaking change** because the commands will now only change the first column or row, respectively, instead of the row(s) or column(s) in the current selection. See the attached videos for examples.

The exception to the changes is `toggleHeaderCell`. I'm not sure what we'd like to be done with it and am looking for some feedback. Currently, it toggles any cell(s) in the selection to be "header cells". This is the deprecated behavior in `prosemirror-tables`. If we change it to use `toggleHeader`, then it will only toggle cells that are within the first row or column and, even then, it will only _remove_ a header cell, it doesn't put one back. This is confusing which is why I haven't included that change here.

### Old Behavior
https://user-images.githubusercontent.com/2583256/150428805-21660e4f-9a11-48f9-91ac-c34ba3a5bd65.mp4


### New Behavior
https://user-images.githubusercontent.com/2583256/150428804-6b54d70c-169e-47de-aa81-bea25737c4d9.mp4

