### PR TITLE
expose hasAnchor to custom placeholder function

### DIFF
--- a/packages/extension-placeholder/src/placeholder.ts
+++ b/packages/extension-placeholder/src/placeholder.ts
@@ -14,6 +14,7 @@ export interface PlaceholderOptions {
   showOnlyWhenEditable: boolean,
   showOnlyCurrent: boolean,
   includeChildren: boolean,
+  hasAnchor: boolean,
 }
 
 export const Placeholder = Extension.create<PlaceholderOptions>({
@@ -61,7 +62,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
                       editor: this.editor,
                       node,
                       pos,
-                      hasAnchor
+                      hasAnchor,
                     })
                     : this.options.placeholder,
                 })

--- a/packages/extension-placeholder/src/placeholder.ts
+++ b/packages/extension-placeholder/src/placeholder.ts
@@ -61,6 +61,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
                       editor: this.editor,
                       node,
                       pos,
+                      hasAnchor
                     })
                     : this.options.placeholder,
                 })


### PR DESCRIPTION
I propose passing hasAnchor to custom placeholder callbacks. In this way, custom placeholder functions can show placeholders for some nodes only when the cursor is in there, and for other nodes always show the placeholder