### PR TITLE
Add key bindings for uppercase letters for bold, italic and underline

### DIFF
--- a/packages/extension-bold/src/bold.ts
+++ b/packages/extension-bold/src/bold.ts
@@ -79,6 +79,7 @@ export const Bold = Mark.create<BoldOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-b': () => this.editor.commands.toggleBold(),
+      'Mod-B': () => this.editor.commands.toggleBold(),
     }
   },
 

--- a/packages/extension-italic/src/italic.ts
+++ b/packages/extension-italic/src/italic.ts
@@ -78,6 +78,7 @@ export const Italic = Mark.create<ItalicOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-i': () => this.editor.commands.toggleItalic(),
+      'Mod-I': () => this.editor.commands.toggleItalic(),
     }
   },
 

--- a/packages/extension-underline/src/underline.ts
+++ b/packages/extension-underline/src/underline.ts
@@ -66,6 +66,7 @@ export const Underline = Mark.create<UnderlineOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-u': () => this.editor.commands.toggleUnderline(),
+      'Mod-U': () => this.editor.commands.toggleUnderline(),
     }
   },
 })


### PR DESCRIPTION
This way, key bindings 'Mod-B', 'Mod-I' and 'Mod-U' with active caps
lock have the same effect as their lowercase siblings.

Prosemirror examples did the same, see ProseMirror/prosemirror#895

Fixes: #2426

Signed-off-by: Jonas <jonas@freesources.org>