### PR TITLE
Docs/toc undo fix

### DIFF
--- a/demos/src/GuideNodeViews/TableOfContents/React/Component.jsx
+++ b/demos/src/GuideNodeViews/TableOfContents/React/Component.jsx
@@ -28,6 +28,7 @@ export default ({ editor }) => {
       }
     })
 
+    transaction.setMeta("addToHistory", false)
     transaction.setMeta('preventUpdate', true)
 
     editor.view.dispatch(transaction)

--- a/demos/src/GuideNodeViews/TableOfContents/Vue/Component.vue
+++ b/demos/src/GuideNodeViews/TableOfContents/Vue/Component.vue
@@ -55,6 +55,7 @@ export default {
         }
       })
 
+      transaction.setMeta("addToHistory", false)
       transaction.setMeta('preventUpdate', true)
 
       this.editor.view.dispatch(transaction)


### PR DESCRIPTION
As discussed fixes #2483 where undo wasn't working if you deleted a header when using the table of contents component.