### PR TITLE
Fix addInputRules in figure.ts for Vue

### DIFF
--- a/demos/src/Experiments/Figure/Vue/figure.ts
+++ b/demos/src/Experiments/Figure/Vue/figure.ts
@@ -180,10 +180,14 @@ export const Figure = Node.create<FigureOptions>({
 
   addInputRules() {
     return [
-      nodeInputRule(inputRegex, this.type, match => {
-        const [, alt, src, title] = match
+      nodeInputRule({
+        find: inputRegex,
+        type: this.type,
+        getAttributes: match => {
+          const [,, alt, src, title] = match
 
-        return { src, alt, title }
+          return { src, alt, title }
+        },
       }),
     ]
   },


### PR DESCRIPTION
Hallöchen there :) 

Was just trying out the figure Node for Vue, under experiments. Needed a slight adjustment/alignment with other nodeInputRule-functions in order to work properly for me.

Tested it under http://localhost:3000/src/Experiments/Figure/Vue/