### PR TITLE
add support for CSP nonces in createStyleTag

### DIFF
--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -349,6 +349,22 @@ new Editor({
 })
 ```
 
+### injectNonce
+When you use a [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) with `nonce`, you can specify a `nonce` to be added to dynamically created elements. Here is an example:
+
+```js
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+new Editor({
+  extensions: [
+    StarterKit,
+  ],
+  injectCSS: true,
+  injectNonce: "your-nonce-here"
+})
+```
+
 ### editorProps
 For advanced use cases, you can pass `editorProps` which will be handled by [ProseMirror](https://prosemirror.net/docs/ref/#view.EditorProps). You can use it to override various editor events or change editor DOM element attributes, for example to add some Tailwind classes. Here is an example:
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -57,6 +57,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     element: document.createElement('div'),
     content: '',
     injectCSS: true,
+    injectNonce: undefined,
     extensions: [],
     autofocus: false,
     editable: true,
@@ -136,7 +137,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    */
   private injectCSS(): void {
     if (this.options.injectCSS && document) {
-      this.css = createStyleTag(style)
+      this.css = createStyleTag(style, this.options.injectNonce)
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,6 +70,7 @@ export interface EditorOptions {
   content: Content,
   extensions: Extensions,
   injectCSS: boolean,
+  injectNonce: string | undefined,
   autofocus: FocusPosition,
   editable: boolean,
   editorProps: EditorProps,

--- a/packages/core/src/utilities/createStyleTag.ts
+++ b/packages/core/src/utilities/createStyleTag.ts
@@ -1,4 +1,4 @@
-export function createStyleTag(style: string): HTMLStyleElement {
+export function createStyleTag(style: string, nonce?: string): HTMLStyleElement {
   const tipTapStyleTag = (<HTMLStyleElement>document.querySelector('style[data-tiptap-style]'))
 
   if (tipTapStyleTag !== null) {
@@ -6,6 +6,10 @@ export function createStyleTag(style: string): HTMLStyleElement {
   }
 
   const styleNode = document.createElement('style')
+
+  if (nonce) {
+    styleNode.setAttribute('nonce', nonce)
+  }
 
   styleNode.setAttribute('data-tiptap-style', '')
   styleNode.innerHTML = style


### PR DESCRIPTION
Hi,

I noticed that tiptap injects a style element into the page's `head`. This breaks when using a Content Security Policy that disallows `unsafe-inline`, as there is currently no way to add a `nonce` to the dynamic style element.
As the injected CSS is in a typescript file and not a CSS file, there is no easy way to include it in the application bundle, and it differs from the default `prosemirror.css`. 

To resolve this, I added an option called `injectNonce` to tiptap which, when set, adds a `nonce` attribute to the dynamic style element.
Another solution would of course be to refactor the style into a CSS file which can be imported alongside tiptap, avoiding the dynamic element entirely, but that would probably require more code changes. 
Additionally, the `injectNonce` option could be handy if any other dynamic injection of styles or scripts is required in the future.

I'm open to discussion, but it would be great if we could use this amazing editor with a CSP!