### PR TITLE
Ensure VueNodeViewRenderer will use Editor's Global Vue Instance

### DIFF
--- a/packages/vue-2/src/VueNodeViewRenderer.ts
+++ b/packages/vue-2/src/VueNodeViewRenderer.ts
@@ -83,7 +83,10 @@ class VueNodeView extends NodeView<(Vue | VueConstructor), Editor, VueNodeViewRe
       value: this.getDecorationClasses(),
     })
 
-    const Component = Vue
+    // @ts-ignore
+    const vue = this.editor.contentComponent?.$options._base ?? Vue
+
+    const Component = vue
       .extend(this.component)
       .extend({
         props: Object.keys(props),


### PR DESCRIPTION
Currently, if you attempt to register a component via `Vue.component()` with a different global instance of Vue (this can happen if you are building plugins for an existing application and the plugin and application exist in separate bundles) the component will not be found via the `Vue` imported into VueNodeViewRenderer.

In an ideal world, when attempting to `Vue.extend()` a component via the VueNodeViewRenderer.. (for example):

```
Node.create({
  addNodeView() {
    return VueNodeViewRenderer(uiForNodeComponent)
  }
})
```

then the provided `uiForNodeComponent` will be `Vue.extend()`ed by a Global Vue that has access to any previously registered (`Vue.component(...)`) components.  The only way to ensure this in a situation where there might be multiple Global views (multiple bundles with Vue), is to use the one that is inside the actual editor's `contentComponent`.

There are probably a few more places where tiptap should favor the editor Vue, but this at least solves the problem of using the right Vue from within a Node creation, as per how the documentation describes building custom Vue backed components.

Without this particular fix, one would get the message below when attempting to use a Globally registered Vue component inside a Node's View.

```
vue.esm.js?4b29:628 [Vue warn]: Unknown custom element: <component-globally-registered> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
```