### PR TITLE
feat: Add a generic type for suggestion items

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -3,7 +3,7 @@ import { EditorState, Plugin, PluginKey } from 'prosemirror-state'
 import { Decoration, DecorationSet, EditorView } from 'prosemirror-view'
 import { findSuggestionMatch } from './findSuggestionMatch'
 
-export interface SuggestionOptions {
+export interface SuggestionOptions<I = any> {
   pluginKey?: PluginKey,
   editor: Editor,
   char?: string,
@@ -15,18 +15,18 @@ export interface SuggestionOptions {
   command?: (props: {
     editor: Editor,
     range: Range,
-    props: any,
+    props: I,
   }) => void,
   items?: (props: {
     query: string,
     editor: Editor,
-  }) => any[] | Promise<any[]>,
+  }) => I[] | Promise<I[]>,
   render?: () => {
-    onBeforeStart?: (props: SuggestionProps) => void
-    onStart?: (props: SuggestionProps) => void,
-    onBeforeUpdate?: (props: SuggestionProps) => void
-    onUpdate?: (props: SuggestionProps) => void,
-    onExit?: (props: SuggestionProps) => void,
+    onBeforeStart?: (props: SuggestionProps<I>) => void
+    onStart?: (props: SuggestionProps<I>) => void,
+    onBeforeUpdate?: (props: SuggestionProps<I>) => void
+    onUpdate?: (props: SuggestionProps<I>) => void,
+    onExit?: (props: SuggestionProps<I>) => void,
     onKeyDown?: (props: SuggestionKeyDownProps) => boolean,
   },
   allow?: (props: {
@@ -36,13 +36,13 @@ export interface SuggestionOptions {
   }) => boolean,
 }
 
-export interface SuggestionProps {
+export interface SuggestionProps<I = any> {
   editor: Editor,
   range: Range,
   query: string,
   text: string,
-  items: any[],
-  command: (props: any) => void,
+  items: I[],
+  command: (props: I) => void,
   decorationNode: Element | null,
   clientRect: (() => DOMRect) | null,
 }
@@ -55,7 +55,7 @@ export interface SuggestionKeyDownProps {
 
 export const SuggestionPluginKey = new PluginKey('suggestion')
 
-export function Suggestion({
+export function Suggestion<I = any>({
   pluginKey = SuggestionPluginKey,
   editor,
   char = '@',
@@ -68,9 +68,9 @@ export function Suggestion({
   items = () => [],
   render = () => ({}),
   allow = () => true,
-}: SuggestionOptions) {
+}: SuggestionOptions<I>) {
 
-  let props: SuggestionProps | undefined
+  let props: SuggestionProps<I> | undefined
   const renderer = render?.()
 
   return new Plugin({


### PR DESCRIPTION
Provides a generic type for suggestion items, defaulting to `any` as before (no breaking change).