### PR TITLE
Reduce bundle size of @tiptap/extension-table package

### DIFF
--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -24,8 +24,12 @@
     "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
+    "@types/prosemirror-model": "^1.16.0",
+    "@types/prosemirror-state": "^1.2.8",
     "prosemirror-tables": "^1.1.1",
-    "prosemirror-view": "^1.23.6"
+    "prosemirror-view": "^1.23.6",
+    "prosemirror-model": "^1.16.1",
+    "prosemirror-state": "^1.3.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR declares the `prosemirror-model`, and `prosemirror-state` packages as dependencies of the `@tiptap/extension-table` package. Doing this indicates to rollup that it should not build these dependencies into the distribution files of the `@tiptap/extension-table` package.

In turn, this change dramatically reduces the build size of the `@tiptap/extension-table` package. 

### How did I find this problem?

I noticed that the esm build of the table extension is 214kb, and most of the code is contributed by the prosemirror dependencies. You can see here: https://unpkg.com/browse/@tiptap/extension-table@2.0.0-beta.48/dist/tiptap-extension-table.esm.js

After applying this change, the esm build is only 11kb 🎉 