### PR TITLE
Reduce bundle size of the `extension-code-block-lowlight` by declaring lowlight as a peerDependency

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -15,7 +15,8 @@
     "shiki": "^0.10.0",
     "simplify-js": "^1.2.4",
     "y-webrtc": "^10.2.2",
-    "yjs": "^13.5.26"
+    "yjs": "^13.5.26",
+    "lowlight": "^1.20.0"
   },
   "devDependencies": {
     "@types/uuid": "^8.3.4",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -21,12 +21,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.1"
+    "@tiptap/core": "^2.0.0-beta.1",
+    "lowlight": "^1.20.0"
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.37",
     "@types/lowlight": "^0.0.3",
-    "lowlight": "^1.20.0",
     "prosemirror-model": "^1.16.1",
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.23.6"


### PR DESCRIPTION
The lowlight package used by the extension-code-block-lowlight extension is a dependency that must be installed in the tiptap framework and the application using tiptap. If `lowlight` is not installed in the application, the application can’t load language packages 

Declaring lowlight as a peer dependency delegates the control of which version of lowlight is installed to the client application. This is necessary because the `@tiptap/extension-code-block-lowlight` esm build includes the `lowlight` source code as well. As a result, the client application ends up delivering two versions of lowlight which significantly increases the bundle size of the application.