### PR TITLE
Declare lowlight as a peerDependency in `@tiptap/extension-code-block-lowlight`

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -15,7 +15,8 @@
     "shiki": "^0.10.0",
     "simplify-js": "^1.2.4",
     "y-webrtc": "^10.2.2",
-    "yjs": "^13.5.26"
+    "yjs": "^13.5.26",
+    "lowlight": "^1.20.0"
   },
   "devDependencies": {
     "@types/uuid": "^8.3.4",

--- a/docs/api/nodes/code-block-lowlight.md
+++ b/docs/api/nodes/code-block-lowlight.md
@@ -7,16 +7,34 @@ icon: terminal-box-fill
 [![Version](https://img.shields.io/npm/v/@tiptap/extension-code-block-lowlight.svg?label=version)](https://www.npmjs.com/package/@tiptap/extension-code-block-lowlight)
 [![Downloads](https://img.shields.io/npm/dm/@tiptap/extension-code-block-lowlight.svg)](https://npmcharts.com/compare/@tiptap/extension-code-block-lowlight?minimal=true)
 
-With the CodeBlock extension you can add fenced code blocks to your documents. It’ll wrap the code in `<pre>` and `<code>` HTML tags.
+With the CodeBlockLowlight extension you can add fenced code blocks to your documents. It’ll wrap the code in `<pre>` and `<code>` HTML tags.
+
+::: warning Syntax highlight dependency
+This extension relies on the [lowlight](https://github.com/wooorm/lowlight) library to apply syntax highlight to the code block’s content.
+:::
 
 Type <code>&grave;&grave;&grave;&nbsp;</code> (three backticks and a space) or <code>&Tilde;&Tilde;&Tilde;&nbsp;</code> (three tildes and a space) and a code block is instantly added for you. You can even specify the language, try writing <code>&grave;&grave;&grave;css&nbsp;</code>. That should add a `language-css` class to the `<code>`-tag.
 
 ## Installation
 ```bash
-npm install @tiptap/extension-code-block-lowlight
+npm install lowlight @tiptap/extension-code-block-lowlight
 ```
 
 ## Settings
+
+### lowlight
+
+You should provide the `lowlight` module to this extension. Decoupling the `lowlight`
+package from the extension allows the client application to control which
+version of lowlight it uses and which programming language packages it needs to load.
+
+```js
+import { lowlight } from 'lowlight/lib/core'
+
+CodeBlockLowlight.configure({
+  lowlight,
+})
+```
 
 ### HTMLAttributes
 Custom HTML attributes that should be added to the rendered HTML tag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@hocuspocus/provider": "^1.0.0-alpha.29",
         "d3": "^7.3.0",
         "fast-glob": "^3.2.11",
+        "lowlight": "^1.20.0",
         "remixicon": "^2.5.0",
         "shiki": "^0.10.0",
         "simplify-js": "^1.2.4",
@@ -17100,7 +17101,7 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.0.0-beta.175",
+      "version": "2.0.0-beta.176",
       "license": "MIT",
       "dependencies": {
         "@types/prosemirror-commands": "^1.0.4",
@@ -17226,7 +17227,6 @@
       "dependencies": {
         "@tiptap/extension-code-block": "^2.0.0-beta.37",
         "@types/lowlight": "^0.0.3",
-        "lowlight": "^1.20.0",
         "prosemirror-model": "^1.16.1",
         "prosemirror-state": "^1.3.4",
         "prosemirror-view": "^1.23.6"
@@ -17236,7 +17236,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.1"
+        "@tiptap/core": "^2.0.0-beta.1",
+        "lowlight": ">=1.20.0"
       }
     },
     "packages/extension-collaboration": {
@@ -17466,7 +17467,7 @@
     },
     "packages/extension-link": {
       "name": "@tiptap/extension-link",
-      "version": "2.0.0-beta.37",
+      "version": "2.0.0-beta.38",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^3.0.5",
@@ -17495,10 +17496,10 @@
     },
     "packages/extension-mention": {
       "name": "@tiptap/extension-mention",
-      "version": "2.0.0-beta.96",
+      "version": "2.0.0-beta.97",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/suggestion": "^2.0.0-beta.91",
+        "@tiptap/suggestion": "^2.0.0-beta.92",
         "prosemirror-model": "^1.16.1",
         "prosemirror-state": "^1.3.4"
       },
@@ -17589,7 +17590,7 @@
     },
     "packages/extension-table": {
       "name": "@tiptap/extension-table",
-      "version": "2.0.0-beta.48",
+      "version": "2.0.0-beta.49",
       "license": "MIT",
       "dependencies": {
         "@types/prosemirror-model": "^1.16.0",
@@ -17652,7 +17653,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.1"
+        "@tiptap/core": "^2.0.0-beta.1",
+        "prosemirror-model": "^1.16.1"
       }
     },
     "packages/extension-task-list": {
@@ -17729,10 +17731,10 @@
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.0.0-beta.174",
+      "version": "2.0.0-beta.175",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.175",
+        "@tiptap/core": "^2.0.0-beta.176",
         "prosemirror-model": "^1.16.1",
         "zeed-dom": "^0.9.19"
       },
@@ -17768,10 +17770,10 @@
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.0.0-beta.184",
+      "version": "2.0.0-beta.185",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.175",
+        "@tiptap/core": "^2.0.0-beta.176",
         "@tiptap/extension-blockquote": "^2.0.0-beta.26",
         "@tiptap/extension-bold": "^2.0.0-beta.26",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.26",
@@ -17798,7 +17800,7 @@
     },
     "packages/suggestion": {
       "name": "@tiptap/suggestion",
-      "version": "2.0.0-beta.91",
+      "version": "2.0.0-beta.92",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.16.1",
@@ -17820,7 +17822,7 @@
     },
     "packages/vue-2": {
       "name": "@tiptap/vue-2",
-      "version": "2.0.0-beta.78",
+      "version": "2.0.0-beta.79",
       "license": "MIT",
       "dependencies": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.56",
@@ -21170,7 +21172,6 @@
       "requires": {
         "@tiptap/extension-code-block": "^2.0.0-beta.37",
         "@types/lowlight": "^0.0.3",
-        "lowlight": "^1.20.0",
         "prosemirror-model": "^1.16.1",
         "prosemirror-state": "^1.3.4",
         "prosemirror-view": "^1.23.6"
@@ -21278,7 +21279,7 @@
     "@tiptap/extension-mention": {
       "version": "file:packages/extension-mention",
       "requires": {
-        "@tiptap/suggestion": "^2.0.0-beta.91",
+        "@tiptap/suggestion": "^2.0.0-beta.92",
         "prosemirror-model": "^1.16.1",
         "prosemirror-state": "^1.3.4"
       }
@@ -21365,7 +21366,7 @@
     "@tiptap/html": {
       "version": "file:packages/html",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.175",
+        "@tiptap/core": "^2.0.0-beta.176",
         "prosemirror-model": "^1.16.1",
         "zeed-dom": "^0.9.19"
       }
@@ -21385,7 +21386,7 @@
     "@tiptap/starter-kit": {
       "version": "file:packages/starter-kit",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.175",
+        "@tiptap/core": "^2.0.0-beta.176",
         "@tiptap/extension-blockquote": "^2.0.0-beta.26",
         "@tiptap/extension-bold": "^2.0.0-beta.26",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.26",
@@ -29841,6 +29842,7 @@
         "d3": "^7.3.0",
         "fast-glob": "^3.2.11",
         "iframe-resizer": "^4.3.2",
+        "lowlight": "^1.20.0",
         "postcss": "^8.4.6",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -21,12 +21,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.1"
+    "@tiptap/core": "^2.0.0-beta.1",
+    "lowlight": ">=1.20.0"
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.37",
     "@types/lowlight": "^0.0.3",
-    "lowlight": "^1.20.0",
     "prosemirror-model": "^1.16.1",
     "prosemirror-state": "^1.3.4",
     "prosemirror-view": "^1.23.6"

--- a/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
+++ b/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
@@ -1,4 +1,3 @@
-import lowlight from 'lowlight/lib/core'
 import CodeBlock, { CodeBlockOptions } from '@tiptap/extension-code-block'
 import { LowlightPlugin } from './lowlight-plugin'
 
@@ -11,7 +10,7 @@ export const CodeBlockLowlight = CodeBlock.extend<CodeBlockLowlightOptions>({
   addOptions() {
     return {
       ...this.parent?.(),
-      lowlight,
+      lowlight: {},
       defaultLanguage: null,
     }
   },

--- a/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
+++ b/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
@@ -65,7 +65,15 @@ function getDecorations({
   return DecorationSet.create(doc, decorations)
 }
 
+function isFunction(param: Function) {
+  return typeof param === 'function'
+}
+
 export function LowlightPlugin({ name, lowlight, defaultLanguage }: { name: string, lowlight: any, defaultLanguage: string | null | undefined }) {
+  if (!['highlight', 'highlightAuto', 'listLanguages'].every(api => isFunction(lowlight[api]))) {
+    throw Error('You should provide an instance of lowlight to use the code-block-lowlight extension')
+  }
+
   return new Plugin({
     key: new PluginKey('lowlight'),
 

--- a/tests/cypress/integration/extensions/codeBlockLowlight.spec.ts
+++ b/tests/cypress/integration/extensions/codeBlockLowlight.spec.ts
@@ -25,10 +25,10 @@ describe('code block highlight', () => {
 
   beforeEach(() => {
     Frontmatter = CodeBlockLowlight
-      .configure({ lowlight })
       .extend({
         name: 'frontmatter',
       })
+      .configure({ lowlight })
 
     editor = new Editor({
       element: createEditorEl(),
@@ -36,7 +36,7 @@ describe('code block highlight', () => {
         Document,
         Text,
         Paragraph,
-        CodeBlockLowlight,
+        CodeBlockLowlight.configure({ lowlight }),
         Frontmatter,
       ],
       content: {


### PR DESCRIPTION
This PR declares the `lowlight` package as a peerDependency and removes the direct import statement in the `@tiptap/extension-code-block-lowlight` package. 

### Why is this change necessary? 

The client application can’t control which version of `lowlight` is bundled into the final product even when the client application provides its own lowlight instance. A consequence of this situation is that using a newer major version of lowlight ends up forcing the client application to bundle two versions of lowlight/highlight.js/fault in the final distribution build. That‘s a lot of dead JavaScript code. 

The main purpose of this change is reducing the bundle size of this extension by removing the duplication of lowlight versions in the codebase. 