### PR TITLE
feat: Required attributes

### DIFF
--- a/packages/core/src/helpers/getAttributesFromExtensions.ts
+++ b/packages/core/src/helpers/getAttributesFromExtensions.ts
@@ -94,14 +94,14 @@ export function getAttributesFromExtensions(extensions: Extensions): ExtensionAt
         }
 
         if (attribute.isRequired && attribute.default === undefined) {
-          delete mergedAttr.default;
+          delete mergedAttr.default
         }
-  
+
         extensionAttributes.push({
           type: extension.name,
           name,
           attribute: mergedAttr,
-        });
+        })
       })
   })
 

--- a/packages/core/src/helpers/getAttributesFromExtensions.ts
+++ b/packages/core/src/helpers/getAttributesFromExtensions.ts
@@ -24,6 +24,7 @@ export function getAttributesFromExtensions(extensions: Extensions): ExtensionAt
     renderHTML: null,
     parseHTML: null,
     keepOnSplit: true,
+    isRequired: false,
   }
 
   extensions.forEach(extension => {
@@ -87,14 +88,20 @@ export function getAttributesFromExtensions(extensions: Extensions): ExtensionAt
     Object
       .entries(attributes)
       .forEach(([name, attribute]) => {
+        const mergedAttr = {
+          ...defaultAttribute,
+          ...attribute,
+        }
+
+        if (attribute.isRequired && attribute.default === undefined) {
+          delete mergedAttr.default;
+        }
+  
         extensionAttributes.push({
           type: extension.name,
           name,
-          attribute: {
-            ...defaultAttribute,
-            ...attribute,
-          },
-        })
+          attribute: mergedAttr,
+        });
       })
   })
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,6 +127,7 @@ export type Attribute = {
   renderHTML?: ((attributes: Record<string, any>) => Record<string, any> | null) | null,
   parseHTML?: ((element: HTMLElement) => any | null) | null,
   keepOnSplit: boolean,
+  isRequired?: boolean,
 }
 
 export type Attributes = {


### PR DESCRIPTION
Problem: When using Tiptap, there's no way to mark a Node/Mark attribute as required. Tiptap sets `default: null` for every attribute, and there's no way to clear this if you want an attr to be required. This causes downstream issues - for example, ProseMirror's `joinBackward` command may try to create a wrapping with a node that has a required attribute, without knowing how to fill it in. ProseMirror tries to guard against this using the NodeType's [hasRequiredAttrs](https://prosemirror.net/docs/ref/#model.NodeType.hasRequiredAttrs) method, but when using Tiptap it will always return `false`.

Solution: Add a new, optional, `isRequired` option on attrs. If an attr is set up with this property, and no default, then the `default: null` will be deleted and then ProseMirror's `hasRequiredAttrs` will return true.

Alternatively, I also considered allowing users to pass `default: undefined`, but this seemed more explicit.

Impact: Without this fix in @tiptap/core, I'm currently using an extension to hack this behavior. It's pretty hacky:

```export const FixRequiredAttrs = Extension.create({
  onBeforeCreate() {
    Object.values(this.editor.schema.nodes).forEach((nodeType) => {
      // @ts-ignore - attrs is not a public method. But if it's ever changed, this won't crash.
      Object.values(nodeType.attrs || {}).forEach((attr: any) => {
        if (attr.default === undefined) {
          attr.hasDefault = false
        }
      })
    })
  },
})```