### PR TITLE
fix(extension-link): prevent parsing `javascript:` pseudo-protocol

### DIFF
--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -78,7 +78,7 @@ export const Link = Mark.create<LinkOptions>({
 
   parseHTML() {
     return [
-      { tag: 'a[href]' },
+      { tag: 'a[href]:not([href *= "javascript:" i])' },
     ]
   },
 


### PR DESCRIPTION
Currently editors using the link extension are vulnerable to XSS using `insertContent` and `insertContentAt`. It allows attackers to run arbitrary javascript code on a victims machine when they click a given link.

```js
editor.commands.insertContent('<a href="javascript:alert(1)" target="_self" rel="">Malicious link</a>')
```

This issue can be avoided by not parsing `javascript:` pseudo-protocol.