### PR TITLE
fix: Support inline nodes with content in @tiptap/suggestion

### DIFF
--- a/packages/suggestion/src/findSuggestionMatch.ts
+++ b/packages/suggestion/src/findSuggestionMatch.ts
@@ -32,7 +32,11 @@ export function findSuggestionMatch(config: Trigger): SuggestionMatch {
     : new RegExp(`${prefix}(?:^)?${escapedChar}[^\\s${escapedChar}]*`, 'gm')
 
   const text = $position.nodeBefore?.isText && $position.nodeBefore.text
-  if (!text) return null
+
+  if (!text) {
+    return null
+  }
+  
   const textFrom = $position.pos - text.length
   const match = Array.from(text.matchAll(regexp)).pop()
 

--- a/packages/suggestion/src/findSuggestionMatch.ts
+++ b/packages/suggestion/src/findSuggestionMatch.ts
@@ -31,12 +31,9 @@ export function findSuggestionMatch(config: Trigger): SuggestionMatch {
     ? new RegExp(`${prefix}${escapedChar}.*?(?=\\s${escapedChar}|$)`, 'gm')
     : new RegExp(`${prefix}(?:^)?${escapedChar}[^\\s${escapedChar}]*`, 'gm')
 
-  const isTopLevelNode = $position.depth <= 0
-  const textFrom = isTopLevelNode
-    ? 0
-    : $position.before()
-  const textTo = $position.pos
-  const text = $position.doc.textBetween(textFrom, textTo, '\0', '\0')
+  const text = $position.nodeBefore?.isText && $position.nodeBefore.text
+  if (!text) return null
+  const textFrom = $position.pos - text.length
   const match = Array.from(text.matchAll(regexp)).pop()
 
   if (!match || match.input === undefined || match.index === undefined) {
@@ -53,7 +50,7 @@ export function findSuggestionMatch(config: Trigger): SuggestionMatch {
   }
 
   // The absolute position of the match in the document
-  const from = match.index + $position.start()
+  const from = textFrom + match.index
   let to = from + match[0].length
 
   // Edge case handling; if spaces are allowed and we're directly in between

--- a/packages/suggestion/src/findSuggestionMatch.ts
+++ b/packages/suggestion/src/findSuggestionMatch.ts
@@ -36,7 +36,7 @@ export function findSuggestionMatch(config: Trigger): SuggestionMatch {
   if (!text) {
     return null
   }
-  
+
   const textFrom = $position.pos - text.length
   const match = Array.from(text.matchAll(regexp)).pop()
 


### PR DESCRIPTION
Problem: @tiptap/suggestion's `findSuggestionMatch` only works when inline nodes are leaves. When you have an inline node with content, in our case a footnote modeled off of https://prosemirror.net/examples/footnote/, suggestions after that node are broken.

This happens because the current logic relies on `textBetween` returning a string whose length exactly matches the absolute position range of the node. This is true with text nodes, as well as leaf nodes like a mention, but not a content node like footnote because its opening/close take up position spaces.

Solution: I don't think textBetween on the entire parent node is actually needed here. Just looking at the text node immediately before the suggestion fixes the problem and seems simpler as well.