### PR TITLE
add-empty-editor-class-to-root-div

### DIFF
--- a/packages/extension-placeholder/src/placeholder.ts
+++ b/packages/extension-placeholder/src/placeholder.ts
@@ -45,8 +45,8 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
               return
             }
 
-            cachedEmptyTopNode = cachedEmptyTopNode || state.doc.type.createAndFill()
-            let isEditorEmpty = cachedEmptyTopNode.content.findDiffStart(state.doc.content) === null
+            cachedEmptyTopNode = cachedEmptyTopNode || doc.type.createAndFill()
+            let isEditorEmpty = cachedEmptyTopNode.sameMarkup(doc) && cachedEmptyTopNode.content.findDiffStart(doc.content) === null
 
             doc.descendants((node, pos) => {
               const hasAnchor = anchor >= pos && anchor <= (pos + node.nodeSize)
@@ -80,16 +80,28 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
 
             return DecorationSet.create(doc, decorations)
           },
-        },
 
-        attributes(state) {
-          cachedEmptyTopNode = cachedEmptyTopNode || state.doc.type.createAndFill()
-          let isEditorEmpty = cachedEmptyTopNode.content.findDiffStart(state.doc.content) === null
-          if (isEditorEmpty) {
-            return {class: this.options.emptyEditorClass} 
+          attributes: ({ doc }) => {
+            cachedEmptyTopNode = cachedEmptyTopNode || doc.type.createAndFill()
+            let isEditorEmpty = cachedEmptyTopNode.sameMarkup(doc) && cachedEmptyTopNode.content.findDiffStart(doc.content) === null
+            if (isEditorEmpty) {
+              return {
+                class: this.options.emptyEditorClass,
+                'data-placeholder': typeof this.options.placeholder === 'function'
+                  ? this.options.placeholder({
+                    editor: this.editor,
+                    node: doc,
+                    pos: 0,
+                    hasAnchor: true,
+                  })
+                  : this.options.placeholder,
+              } 
+            }
           }
-        }
+        },
       }),
     ]
   },
 })
+
+export default Placeholder

--- a/packages/extension-placeholder/src/placeholder.ts
+++ b/packages/extension-placeholder/src/placeholder.ts
@@ -32,6 +32,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
   },
 
   addProseMirrorPlugins() {
+    let cachedEmptyTopNode: ProsemirrorNode;
     return [
       new Plugin({
         props: {
@@ -44,14 +45,18 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
               return
             }
 
+            cachedEmptyTopNode = cachedEmptyTopNode || state.doc.type.createAndFill()
+            let isEditorEmpty = cachedEmptyTopNode.content.findDiffStart(state.doc.content) === null
+
             doc.descendants((node, pos) => {
               const hasAnchor = anchor >= pos && anchor <= (pos + node.nodeSize)
               const isEmpty = !node.isLeaf && !node.childCount
+              
 
               if ((hasAnchor || !this.options.showOnlyCurrent) && isEmpty) {
                 const classes = [this.options.emptyNodeClass]
 
-                if (this.editor.isEmpty) {
+                if (isEditorEmpty) {
                   classes.push(this.options.emptyEditorClass)
                 }
 
@@ -76,6 +81,14 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
             return DecorationSet.create(doc, decorations)
           },
         },
+
+        attributes(state) {
+          cachedEmptyTopNode = cachedEmptyTopNode || state.doc.type.createAndFill()
+          let isEditorEmpty = cachedEmptyTopNode.content.findDiffStart(state.doc.content) === null
+          if (isEditorEmpty) {
+            return {class: this.options.emptyEditorClass} 
+          }
+        }
       }),
     ]
   },


### PR DESCRIPTION
Cover case where doc is empty but no descendants (custom doc that mimics an input). Add `emptyEditorClass` to the ProseMirror dom element instead.

Also not required to call `this.editor.isEmpty` repeatedly in descendants, or call it multiple times. Instead, cache empty top node and use ProseMirror `diffStart` to do a quick compare.