### PR TITLE
fix: Allow tippyOptions.getReferenceClientRect in bubble menu to be overridden

### DIFF
--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -180,7 +180,7 @@ export class BubbleMenuView {
     }
 
     this.tippy?.setProps({
-      getReferenceClientRect: () => {
+      getReferenceClientRect: this.tippyOptions.getReferenceClientRect || () => {
         if (isNodeSelection(state.selection)) {
           const node = view.nodeDOM(from) as HTMLElement
 

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -180,7 +180,7 @@ export class BubbleMenuView {
     }
 
     this.tippy?.setProps({
-      getReferenceClientRect: this.tippyOptions.getReferenceClientRect || () => {
+      getReferenceClientRect: this.tippyOptions?.getReferenceClientRect || (() => {
         if (isNodeSelection(state.selection)) {
           const node = view.nodeDOM(from) as HTMLElement
 
@@ -190,7 +190,7 @@ export class BubbleMenuView {
         }
 
         return posToDOMRect(view, from, to)
-      },
+      }),
     })
 
     this.show()

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -156,7 +156,7 @@ export class FloatingMenuView {
     }
 
     this.tippy?.setProps({
-      getReferenceClientRect: this.tippyOptions.getReferenceClientRect || () => posToDOMRect(view, from, to),
+      getReferenceClientRect: this.tippyOptions?.getReferenceClientRect || (() => posToDOMRect(view, from, to)),
     })
 
     this.show()

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -156,7 +156,7 @@ export class FloatingMenuView {
     }
 
     this.tippy?.setProps({
-      getReferenceClientRect: () => posToDOMRect(view, from, to),
+      getReferenceClientRect: this.tippyOptions.getReferenceClientRect || () => posToDOMRect(view, from, to),
     })
 
     this.show()


### PR DESCRIPTION
Problem: The bubble menu's position currently depends on prosemirror selection, which works well for inline elements. But for block level elements, like code blocks, if we want to show a bubble menu to do things like change the language of the code block or to delete the code block, it would be ideal to have the bubble menu stick to the top left of the code block, for example. 

Solution: Allowing overriding `getReferenceClientRect` along with other `tippyOptions` solves this problem and allows customizing the position of tippy outside of the plugin. 