### PR TITLE
fix: Mark the bubble/floating menu extensions as side effect free

### DIFF
--- a/packages/extension-bubble-menu/package.json
+++ b/packages/extension-bubble-menu/package.json
@@ -32,5 +32,6 @@
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-bubble-menu"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/extension-floating-menu/package.json
+++ b/packages/extension-floating-menu/package.json
@@ -32,5 +32,6 @@
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-floating-menu"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
This is very similar to https://github.com/ueberdosis/tiptap/pull/2361, but also adds `sideEffects: false` to `@tiptap/extension-bubble-menu` and `@tiptap/extension-floating-menu`, which are `@tiptap/react` dependencies.

Without this change, importing anything from the `@tiptap/react` pulls and bundles the whole package, even if we are not using the `BubbleMenu` or the `FloatingMenu` components.

For reference: https://webpack.js.org/guides/tree-shaking