### PR TITLE
fix: improve Vue nodeViewProps typing

### DIFF
--- a/packages/vue-2/src/VueNodeViewRenderer.ts
+++ b/packages/vue-2/src/VueNodeViewRenderer.ts
@@ -15,35 +15,35 @@ import { VueRenderer } from './VueRenderer'
 export const nodeViewProps = {
   editor: {
     type: Object as PropType<NodeViewProps['editor']>,
-    required: true,
+    required: true as const,
   },
   node: {
     type: Object as PropType<NodeViewProps['node']>,
-    required: true,
+    required: true as const,
   },
   decorations: {
     type: Object as PropType<NodeViewProps['decorations']>,
-    required: true,
+    required: true as const,
   },
   selected: {
     type: Boolean as PropType<NodeViewProps['selected']>,
-    required: true,
+    required: true as const,
   },
   extension: {
     type: Object as PropType<NodeViewProps['extension']>,
-    required: true,
+    required: true as const,
   },
   getPos: {
     type: Function as PropType<NodeViewProps['getPos']>,
-    required: true,
+    required: true as const,
   },
   updateAttributes: {
     type: Function as PropType<NodeViewProps['updateAttributes']>,
-    required: true,
+    required: true as const,
   },
   deleteNode: {
     type: Function as PropType<NodeViewProps['deleteNode']>,
-    required: true,
+    required: true as const,
   },
 }
 

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -21,35 +21,35 @@ import { VueRenderer } from './VueRenderer'
 export const nodeViewProps = {
   editor: {
     type: Object as PropType<NodeViewProps['editor']>,
-    required: true,
+    required: true as const,
   },
   node: {
     type: Object as PropType<NodeViewProps['node']>,
-    required: true,
+    required: true as const,
   },
   decorations: {
     type: Object as PropType<NodeViewProps['decorations']>,
-    required: true,
+    required: true as const,
   },
   selected: {
     type: Boolean as PropType<NodeViewProps['selected']>,
-    required: true,
+    required: true as const,
   },
   extension: {
     type: Object as PropType<NodeViewProps['extension']>,
-    required: true,
+    required: true as const,
   },
   getPos: {
     type: Function as PropType<NodeViewProps['getPos']>,
-    required: true,
+    required: true as const,
   },
   updateAttributes: {
     type: Function as PropType<NodeViewProps['updateAttributes']>,
-    required: true,
+    required: true as const,
   },
   deleteNode: {
     type: Function as PropType<NodeViewProps['deleteNode']>,
-    required: true,
+    required: true as const,
   },
 }
 


### PR DESCRIPTION
## Description
This PR add `as const` to every `required` options in `nodeViewProps`.

Resolved #2654 

## Testing

1. run `yarn rollup -c --scope @tiptap/vue-2` and `yarn rollup -c --scope @tiptap/vue-3`
2. Then verify the typing is
```typescript
export declare const nodeViewProps: {
    editor: {
        type: PropType<import("@tiptap/core").Editor>;
        required: true;
    };
   // ...
}
```
instead of:
```typescript
export declare const nodeViewProps: {
    editor: {
        type: PropType<import("@tiptap/core").Editor>;
        required: boolean;
    };
   // ...
}
```