### PR TITLE
Expose "range" to textSerializer. Used in "getTextBetween"

### DIFF
--- a/packages/core/src/helpers/getTextBetween.ts
+++ b/packages/core/src/helpers/getTextBetween.ts
@@ -31,6 +31,7 @@ export function getTextBetween(
         pos,
         parent,
         index,
+        range,
       })
     } else if (node.isText) {
       text += node?.text?.slice(Math.max(from, pos) - pos, to - pos)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -243,6 +243,7 @@ export type TextSerializer = (props: {
   pos: number,
   parent: ProseMirrorNode,
   index: number,
+  range: Range,
 }) => string
 
 export type ExtendedRegExpMatchArray = RegExpMatchArray & {


### PR DESCRIPTION
This PR gives `TextSerializer` access to the range that is being serialized.

Rationale: Without it, custom text nodes can't serialize partial content (based on selection).