### PR TITLE
fix: don't override behaviour of Home / End in pc keymap

### DIFF
--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -60,8 +60,6 @@ export const Keymap = Extension.create({
 
     const pcKeymap = {
       ...baseKeymap,
-      Home: () => this.editor.commands.selectTextblockStart(),
-      End: () => this.editor.commands.selectTextblockEnd(),
     }
 
     const macKeymap = {


### PR DESCRIPTION
# Description
Fixes https://github.com/ueberdosis/tiptap/issues/2685 by removing the Home/End keybindings in the PC keymap.

This was similarly removed in Prosemirror at https://github.com/ProseMirror/prosemirror-commands/commit/20371c58, to favour default browser / OS behaviour.

Note: This behaviour continues to be preserved on Mac under the `Ctrl-a` and `Ctrl-e` keys

For users who wish to preserve this behaviour, they can achieve this via a custom extension:

```javascript
const CustomKeyboardBehaviour = Extension.create({
  addKeyboardShortcuts() {
    return {
      ['Home']: () => this.editor.commands.selectTextblockStart(),
      ['End']: () => this.editor.commands.selectTextblockEnd(),
    }
  }
})

const editor = new Editor({
  extensions: [
    // Register your custom extension with the editor.
    CustomKeyboardBehaviour,
  ]
});
```

If we haven't reached consensus on this change, then feel free to ignore. Just raising the PR in case this is all that's missing to resolve the issue.