### PR TITLE
fix: prevent suggestions from being active when editor is readonly

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -169,6 +169,7 @@ export function Suggestion({
 
       // Apply changes to the plugin state from a view transaction.
       apply(transaction, prev, oldState, state) {
+        const { isEditable } = editor
         const { composing } = editor.view
         const { selection } = transaction
         const { empty, from } = selection
@@ -176,9 +177,10 @@ export function Suggestion({
 
         next.composing = composing
 
-        // We can only be suggesting if there is no selection
-        // or a composition is active (see: https://github.com/ueberdosis/tiptap/issues/1449)
-        if (empty || editor.view.composing) {
+        // We can only be suggesting if the view is editable, and:
+        //   * there is no selection, or
+        //   * a composition is active (see: https://github.com/ueberdosis/tiptap/issues/1449)
+        if (isEditable && (empty || editor.view.composing)) {
           // Reset active state if we just left the previous suggestion range
           if (
             (from < prev.range.from || from > prev.range.to)


### PR DESCRIPTION
# Problem
The suggestions extension will continue to react to selection changes even when the editable is "readonly", which can lead to it showing a pop-up for text that start with the trigger character. This was discovered in https://github.com/ueberdosis/tiptap/issues/2680.

See the demo below:

https://user-images.githubusercontent.com/38820281/162368119-7b98076b-af09-47e6-a301-fffdbbb11570.mov

# Fix
We need to ensure we don't attempt to detect a suggestion at the current selection when isEditable is false. The attached commit will fail-fast and cleanup any active suggestion state. Demo:

https://user-images.githubusercontent.com/38820281/162368748-50c49488-8749-485b-98e6-eab2ffe37da7.mov

