### PR TITLE
chore: added visual studio code debugging launch options

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Tiptap demos in Google Chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds basic VSCode debugging options for Chrome. I wasn't able to figure out the correct options for Firefox debugging - will figure them out in a future PR.