### PR TITLE
fix: remove extension-text-style from character-cout peer dependencies

### DIFF
--- a/packages/extension-character-count/package.json
+++ b/packages/extension-character-count/package.json
@@ -21,8 +21,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.1",
-    "@tiptap/extension-text-style": "^2.0.0-beta.1"
+    "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
     "prosemirror-model": "^1.16.1",


### PR DESCRIPTION
Remove the `@tiptap/extension-text-style` peer depencies from `@tiptap/extension-character-count`, the code of character-count does not seems to use it.

I noticed the issue when I added the `@tiptap/extension-character-count` to my project I saw the following log printed by pnpm:

```
├─┬ @tiptap/extension-character-count
│ └── ✕ missing peer @tiptap/extension-text-style@^2.0.0-beta.1
```