### PR TITLE
fix: allow [] as a prefix for task items

### DIFF
--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -5,7 +5,7 @@ export interface TaskItemOptions {
   HTMLAttributes: Record<string, any>,
 }
 
-export const inputRegex = /^\s*(\[([ |x])\])\s$/
+export const inputRegex = /^\s*(\[([( |x])?\])\s$/
 
 export const TaskItem = Node.create<TaskItemOptions>({
   name: 'taskItem',


### PR DESCRIPTION
This PR fixes #2688 by updating the input rule for task items.