### PR TITLE
Update Suggestion package.json

### DIFF
--- a/packages/suggestion/package.json
+++ b/packages/suggestion/package.json
@@ -20,6 +20,11 @@
     "src",
     "dist"
   ],
+  "devDependencies": {
+    "@types/prosemirror-model": "^1.16.1",
+    "@types/prosemirror-state": "^1.2.8",
+    "@types/prosemirror-view": "^1.23.1",
+  },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
   },


### PR DESCRIPTION
Fixes usage with Yarn v3

Currently getting the following error with Yarn v3:

```
../../.yarn/__virtual__/@tiptap-suggestion-virtual-e0732a477f/0/cache/@tiptap-suggestion-npm-2.0.0-beta.91-99c28c4aaa-cc6919a224.zip/node_modules/@tiptap/suggestion/dist/packages/suggestion/src/findSuggestionMatch.d.ts:2:29 - error TS7016: Could not find a declaration file for module 'prosemirror-model'. '/Users/dylanhuang/Git/beatthemarket/.yarn/cache/prosemirror-model-npm-1.16.1-61853f0125-76718aafbf.zip/node_modules/prosemirror-model/dist/index.js' implicitly has an 'any' type.
  If the 'prosemirror-model' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prosemirror-model'

2 import { ResolvedPos } from 'prosemirror-model';
                              ~~~~~~~~~~~~~~~~~~~

../../.yarn/__virtual__/@tiptap-suggestion-virtual-e0732a477f/0/cache/@tiptap-suggestion-npm-2.0.0-beta.91-99c28c4aaa-cc6919a224.zip/node_modules/@tiptap/suggestion/dist/packages/suggestion/src/suggestion.d.ts:2:48 - error TS7016: Could not find a declaration file for module 'prosemirror-state'. '/Users/dylanhuang/Git/beatthemarket/.yarn/cache/prosemirror-state-npm-1.3.4-c4b4427e53-088748bca0.zip/node_modules/prosemirror-state/dist/index.js' implicitly has an 'any' type.
  If the 'prosemirror-state' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prosemirror-state'

2 import { EditorState, Plugin, PluginKey } from 'prosemirror-state';
                                                 ~~~~~~~~~~~~~~~~~~~

../../.yarn/__virtual__/@tiptap-suggestion-virtual-e0732a477f/0/cache/@tiptap-suggestion-npm-2.0.0-beta.91-99c28c4aaa-cc6919a224.zip/node_modules/@tiptap/suggestion/dist/packages/suggestion/src/suggestion.d.ts:3:28 - error TS7016: Could not find a declaration file for module 'prosemirror-view'. '/Users/dylanhuang/Git/beatthemarket/.yarn/cache/prosemirror-view-npm-1.23.13-b86b902049-12bb3b1858.zip/node_modules/prosemirror-view/dist/index.js' implicitly has an 'any' type.
  If the 'prosemirror-view' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prosemirror-view'

3 import { EditorView } from 'prosemirror-view';
                             ~~~~~~~~~~~~~~~~~~


Found 3 errors in 2 files.

Errors  Files
     1  ../../.yarn/__virtual__/@tiptap-suggestion-virtual-e0732a477f/0/cache/@tiptap-suggestion-npm-2.0.0-beta.91-99c28c4aaa-cc6919a224.zip/node_modules/@tiptap/suggestion/dist/packages/suggestion/src/findSuggestionMatch.d.ts:2
     2  ../../.yarn/__virtual__/@tiptap-suggestion-virtual-e0732a477f/0/cache/@tiptap-suggestion-npm-2.0.0-beta.91-99c28c4aaa-cc6919a224.zip/node_modules/@tiptap/suggestion/dist/packages/suggestion/src/suggestion.d.ts:2
```