### PR TITLE
Allow class attribute through setLink()

### DIFF
--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -61,6 +61,7 @@ export const Link = Mark.create<LinkOptions>({
       HTMLAttributes: {
         target: '_blank',
         rel: 'noopener noreferrer nofollow',
+        class: null,
       },
     }
   },
@@ -72,6 +73,9 @@ export const Link = Mark.create<LinkOptions>({
       },
       target: {
         default: this.options.HTMLAttributes.target,
+      },
+      class: {
+        default: this.options.HTMLAttributes.class,
       },
     }
   },


### PR DESCRIPTION
While you can set a default value for the Link extensions class attribute using 
```javascript
Link.configure({
  HTMLAttributes: {
    class: 'my-custom-class',
  },
})
```
It is currently not possible to dynamically set the class attribute when calling setLink() e.g. 
```javascript
this.editor.chain().focus().extendMarkRange('link').setLink({href: url, class: 'this class should be added'}).run();
```

This change allows for that by default, without needing to extend the Link extension. E.g. https://github.com/ueberdosis/tiptap/issues/72#issuecomment-1118287785