### PR TITLE
Convenience extension - TableKit

### DIFF
--- a/demos/src/Examples/Tables/React/index.jsx
+++ b/demos/src/Examples/Tables/React/index.jsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import Table from '@tiptap/extension-table'
-import TableRow from '@tiptap/extension-table-row'
+import TableKit from '@tiptap/table-kit'
 import TableCell from '@tiptap/extension-table-cell'
-import TableHeader from '@tiptap/extension-table-header'
+
 import './styles.scss'
 
 const CustomTableCell = TableCell.extend({
@@ -129,13 +128,10 @@ export default () => {
   const editor = useEditor({
     extensions: [
       StarterKit,
-      Table.configure({
-        resizable: true,
+      TableKit.configure({
+        table: { resizable: true },
+        tableCell: false,
       }),
-      TableRow,
-      TableHeader,
-      // Default TableCell
-      // TableCell,
       // Custom TableCell with backgroundColor attribute
       CustomTableCell,
     ],

--- a/demos/src/Examples/Tables/Vue/index.vue
+++ b/demos/src/Examples/Tables/Vue/index.vue
@@ -61,10 +61,8 @@
 <script>
 import { Editor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
-import Table from '@tiptap/extension-table'
-import TableRow from '@tiptap/extension-table-row'
+import TableKit from '@tiptap/table-kit'
 import TableCell from '@tiptap/extension-table-cell'
-import TableHeader from '@tiptap/extension-table-header'
 
 const CustomTableCell = TableCell.extend({
   addAttributes() {
@@ -102,13 +100,10 @@ export default {
     this.editor = new Editor({
       extensions: [
         StarterKit,
-        Table.configure({
-          resizable: true,
+        TableKit.configure({
+          table: { resizable: true },
+          tableCell: false,
         }),
-        TableRow,
-        TableHeader,
-        // Default TableCell
-        // TableCell,
         // Custom TableCell with backgroundColor attribute
         CustomTableCell,
       ],

--- a/demos/src/Experiments/All/Vue/index.vue
+++ b/demos/src/Experiments/All/Vue/index.vue
@@ -94,10 +94,7 @@ import Superscript from '@tiptap/extension-superscript'
 import Subscript from '@tiptap/extension-subscript'
 import Link from '@tiptap/extension-link'
 import Mention from '@tiptap/extension-mention'
-import Table from '@tiptap/extension-table'
-import TableRow from '@tiptap/extension-table-row'
-import TableCell from '@tiptap/extension-table-cell'
-import TableHeader from '@tiptap/extension-table-header'
+import TableKit from '@tiptap/table-kit'
 import Image from '@tiptap/extension-image'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
@@ -152,12 +149,9 @@ export default {
             class: 'mention',
           },
         }),
-        Table.configure({
-          resizable: true,
+        TableKit.configure({
+          table: { resizable: true },
         }),
-        TableRow,
-        TableHeader,
-        TableCell,
         Image,
         TaskList,
         TaskItem,

--- a/demos/src/Experiments/GenericFigure/Vue/index.vue
+++ b/demos/src/Experiments/GenericFigure/Vue/index.vue
@@ -20,10 +20,7 @@
 import { Editor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Image from '@tiptap/extension-image'
-import Table from '@tiptap/extension-table'
-import TableRow from '@tiptap/extension-table-row'
-import TableCell from '@tiptap/extension-table-cell'
-import TableHeader from '@tiptap/extension-table-header'
+import TableKit from '@tiptap/table-kit'
 import { Figure } from './figure'
 import { Figcaption } from './figcaption'
 
@@ -156,10 +153,7 @@ export default {
     this.editor = new Editor({
       extensions: [
         StarterKit,
-        Table,
-        TableRow,
-        TableHeader,
-        TableCell,
+        TableKit,
         ImageFigure,
         TableFigure,
         Figcaption,

--- a/demos/src/Nodes/Table/React/index.jsx
+++ b/demos/src/Nodes/Table/React/index.jsx
@@ -3,10 +3,7 @@ import { useEditor, EditorContent } from '@tiptap/react'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
-import Table from '@tiptap/extension-table'
-import TableRow from '@tiptap/extension-table-row'
-import TableCell from '@tiptap/extension-table-cell'
-import TableHeader from '@tiptap/extension-table-header'
+import TableKit from '@tiptap/table-kit'
 import Gapcursor from '@tiptap/extension-gapcursor'
 import './styles.scss'
 
@@ -17,12 +14,9 @@ export default () => {
       Paragraph,
       Text,
       Gapcursor,
-      Table.configure({
-        resizable: true,
+      TableKit.configure({
+        table: { resizable: true },
       }),
-      TableRow,
-      TableHeader,
-      TableCell,
     ],
     content: `
         <table>

--- a/demos/src/Nodes/Table/Vue/index.vue
+++ b/demos/src/Nodes/Table/Vue/index.vue
@@ -63,10 +63,7 @@ import { Editor, EditorContent } from '@tiptap/vue-3'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
-import Table from '@tiptap/extension-table'
-import TableRow from '@tiptap/extension-table-row'
-import TableCell from '@tiptap/extension-table-cell'
-import TableHeader from '@tiptap/extension-table-header'
+import TableKit from '@tiptap/table-kit'
 import Gapcursor from '@tiptap/extension-gapcursor'
 
 export default {
@@ -87,12 +84,9 @@ export default {
         Paragraph,
         Text,
         Gapcursor,
-        Table.configure({
-          resizable: true,
+        TableKit.configure({
+          table: { resizable: true },
         }),
-        TableRow,
-        TableHeader,
-        TableCell,
       ],
       content: `
         <table>

--- a/packages/table-kit/CHANGELOG.md
+++ b/packages/table-kit/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+

--- a/packages/table-kit/README.md
+++ b/packages/table-kit/README.md
@@ -1,0 +1,18 @@
+# @tiptap/table-kit
+
+[![Version](https://img.shields.io/npm/v/@tiptap/table-kit.svg?label=version)](https://www.npmjs.com/package/@tiptap/table-kit)
+[![Downloads](https://img.shields.io/npm/dm/@tiptap/table-kit.svg)](https://npmcharts.com/compare/tiptap?minimal=true)
+[![License](https://img.shields.io/npm/l/@tiptap/table-kit.svg)](https://www.npmjs.com/package/@tiptap/table-kit)
+[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ueberdosis)
+
+## Introduction
+
+tiptap is a headless wrapper around [ProseMirror](https://ProseMirror.net) – a toolkit for building rich text WYSIWYG editors, which is already in use at many well-known companies such as *New York Times*, *The Guardian* or *Atlassian*.
+
+## Official Documentation
+
+Documentation can be found on the [tiptap website](https://tiptap.dev).
+
+## License
+
+tiptap is open sourced software licensed under the [MIT license](https://github.com/ueberdosis/tiptap/blob/main/LICENSE.md).

--- a/packages/table-kit/package.json
+++ b/packages/table-kit/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@tiptap/table-kit",
+  "description": "table kit for tiptap",
+  "version": "2.0.0-beta.184",
+  "homepage": "https://tiptap.dev",
+  "keywords": [
+    "tiptap",
+    "tiptap table kit"
+  ],
+  "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/ueberdosis"
+  },
+  "main": "dist/tiptap-table-kit.cjs.js",
+  "umd": "dist/tiptap-table-kit.umd.js",
+  "module": "dist/tiptap-table-kit.esm.js",
+  "types": "dist/packages/table-kit/src/index.d.ts",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "dependencies": {
+    "@tiptap/core": "^2.0.0-beta.175",
+    "@tiptap/extension-table": "^2.0.0-beta.48",
+    "@tiptap/extension-table-cell": "^2.0.0-beta.20",
+    "@tiptap/extension-table-header": "^2.0.0-beta.22",
+    "@tiptap/extension-table-row": "^2.0.0-beta.19"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/table-kit"
+  }
+}

--- a/packages/table-kit/src/index.ts
+++ b/packages/table-kit/src/index.ts
@@ -1,0 +1,3 @@
+import { TableKit } from './table-kit'
+
+export default TableKit

--- a/packages/table-kit/src/table-kit.ts
+++ b/packages/table-kit/src/table-kit.ts
@@ -1,0 +1,39 @@
+import { Extension } from '@tiptap/core'
+
+import Table, { TableOptions } from '@tiptap/extension-table'
+import TableRow, { TableRowOptions } from '@tiptap/extension-table-row'
+import TableCell, { TableCellOptions } from '@tiptap/extension-table-cell'
+import TableHeader, { TableHeaderOptions } from '@tiptap/extension-table-header'
+
+export interface TableKitOptions {
+  table: Partial<TableOptions> | false
+  tableRow: Partial<TableRowOptions> | false
+  tableCell: Partial<TableCellOptions> | false
+  tableHeader: Partial<TableHeaderOptions> | false
+}
+
+export const TableKit = Extension.create({
+  name: 'tableKit',
+
+  addExtensions() {
+    const extensions = []
+
+    if (this.options.table !== false) {
+      extensions.push(Table.configure(this.options?.table))
+    }
+
+    if (this.options.tableRow !== false) {
+      extensions.push(TableRow.configure(this.options?.tableRow))
+    }
+
+    if (this.options.tableCell !== false) {
+      extensions.push(TableCell.configure(this.options?.tableCell))
+    }
+
+    if (this.options.tableHeader !== false) {
+      extensions.push(TableHeader.configure(this.options?.tableHeader))
+    }
+
+    return extensions
+  },
+})


### PR DESCRIPTION
Akin to StarterKit, this extension TableKit imports all extensions to form a table:

```html
        <table>
          <tbody>
            <tr>
              <th>Name</th>
              <th colspan="3">Description</th>
            </tr>
            <tr>
              <td>Cyndi Lauper</td>
              <td>singer</td>
              <td>songwriter</td>
              <td>actress</td>
            </tr>
            <tr>
              <td>Philipp Kühn</td>
              <td>designer</td>
              <td>developer</td>
              <td>maker</td>
            </tr>
            <tr>
              <td>Hans Pagel</td>
              <td>wrote this</td>
              <td colspan="2">that’s it</td>
            </tr>
          </tbody>
        </table>
```

I've confirmed that linting passes and packages can be built.

I have not added any new documentation nor used it in any demos yet.

This is my first PR. I wanted to check that you wanted this convenience extension (that I'm on the right path to making tiptap more delightful for everyone).

If you'd like me to have a crack at adding some docs/demos, or updating the docs/demos to reference this `TableKit` instead of the underlying extensions, I will do that.

**Update:** you can configure each sub-extension, or out-out, using the same method as StarterKit.  The React/Vue demos have been updated to use TableKit:

```js
      TableKit.configure({
        table: { resizable: true },
      }),
```

