### PR TITLE
fix: properly calculate setDragImage position

### DIFF
--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -82,8 +82,12 @@ export class NodeView<
       const domBox = this.dom.getBoundingClientRect()
       const handleBox = dragHandle.getBoundingClientRect()
 
-      x = handleBox.x - domBox.x + event.offsetX
-      y = handleBox.y - domBox.y + event.offsetY
+      // In React, we have to go through nativeEvent to reach offsetX/offsetY.
+      const offsetX = event.offsetX ?? (event as any).nativeEvent?.offsetX
+      const offsetY = event.offsetY ?? (event as any).nativeEvent?.offsetY
+      
+      x = handleBox.x - domBox.x + offsetX
+      y = handleBox.y - domBox.y + offsetY
     }
 
     event.dataTransfer?.setDragImage(this.dom, x, y)

--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -85,7 +85,7 @@ export class NodeView<
       // In React, we have to go through nativeEvent to reach offsetX/offsetY.
       const offsetX = event.offsetX ?? (event as any).nativeEvent?.offsetX
       const offsetY = event.offsetY ?? (event as any).nativeEvent?.offsetY
-      
+
       x = handleBox.x - domBox.x + offsetX
       y = handleBox.y - domBox.y + offsetY
     }


### PR DESCRIPTION
NodeView's onDragStart assumes the event is a DragEvent.

In React, the event is usually a SyntheticBaseEvent, which doesn't have offsetX/offsetY properties.

To get the offsetX/offsetY properties, have to use event.nativeEvent, which is the DragEvent.

Without this fix, x and y become NaN in React.