### PR TITLE
In Vue 2 VueRenderer, only Vue.extend() non-VueConstructor arguments

### DIFF
--- a/packages/vue-2/src/VueRenderer.ts
+++ b/packages/vue-2/src/VueRenderer.ts
@@ -5,7 +5,7 @@ export class VueRenderer {
   ref!: Vue
 
   constructor(component: Vue | VueConstructor, props: any) {
-    const Component = Vue.extend(component)
+    const Component = (typeof component === 'function') ? component : Vue.extend(component)
 
     this.ref = new Component(props).$mount()
   }


### PR DESCRIPTION
Problem: Extending a VueConstructor / Vue constructor function in development will throw a Vue.warning of `Do not use built-in or reserved HTML elements as component id a`.

More details: This particular constructor is called via `VueNodeView.mount()`, this is the only place it is called from. That particular method ensures that a `VueComponent` function (constructor) is passed to the `VueRenderer`.

see: https://github.com/ueberdosis/tiptap/blob/main/packages/vue-2/src/VueNodeViewRenderer.ts#L103-L106