### PR TITLE
fix: Only trigger image input rule at the start or with a preceding space

### DIFF
--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -21,7 +21,7 @@ declare module '@tiptap/core' {
   }
 }
 
-export const inputRegex = /(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/
+export const inputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/
 
 export const Image = Node.create<ImageOptions>({
   name: 'image',


### PR DESCRIPTION
This only allows the image input rule to be triggered:

* At the start of a paragraph/line
* If it has a preceding space

This prevents the rule from triggering when one is typing the image Markdown syntax inside an inline code mark.

### Before

https://user-images.githubusercontent.com/96476/170526204-0fb7681d-a416-484e-9d9b-69982cf6c39a.mp4

### After

https://user-images.githubusercontent.com/96476/170525738-02364be4-3823-4228-8ad5-52fe12b6b73d.mp4


