### PR TITLE
Add support for custom protocols in extension-link

### DIFF
--- a/docs/api/marks/link.md
+++ b/docs/api/marks/link.md
@@ -20,6 +20,17 @@ npm install @tiptap/extension-link
 
 ## Settings
 
+### protocols
+Additional custom protocols you would like to be recognized as links.
+
+Default: `[]`
+
+```js
+Link.configure({
+  protocols: ['ftp', 'mailto'],
+})
+```
+
 ### autolink
 If enabled, it adds links as you type.
 

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -1,4 +1,4 @@
-import { find } from 'linkifyjs'
+import { find, registerCustomProtocol } from 'linkifyjs'
 
 import { Mark, markPasteRule, mergeAttributes } from '@tiptap/core'
 
@@ -11,6 +11,10 @@ export interface LinkOptions {
    * If enabled, it adds links as you type.
    */
   autolink: boolean,
+  /**
+   * An array of custom protocols to be registered with linkifyjs.
+   */
+  protocols: Array<string>,
   /**
    * If enabled, links will be opened on click.
    */
@@ -57,6 +61,12 @@ export const Link = Mark.create<LinkOptions>({
 
   keepOnSplit: false,
 
+  onCreate() {
+    for (const protocol of this.options.protocols) {
+      registerCustomProtocol(protocol)
+    }
+  },
+
   inclusive() {
     return this.options.autolink
   },
@@ -66,6 +76,7 @@ export const Link = Mark.create<LinkOptions>({
       openOnClick: true,
       linkOnPaste: true,
       autolink: true,
+      protocols: [],
       HTMLAttributes: {
         target: '_blank',
         rel: 'noopener noreferrer nofollow',


### PR DESCRIPTION
This pull request adds custom protocols to extension-link. Previously, only urls beginning with http & https are recognized. Now it is possible to do the following:

```javascript
Link.configure({
    protocols: ['ftp']
})
```

And ftp:// links will be automatically recognized and turned into hyperlinks.

The registration of custom protocols uses the builtin function `registerCustomProtocol` of linkifyjs, which is already used by the extension. 

Docs are updated as well.