### PR TITLE
fix: editor don't has contentComponent attribute when suggestion onUp…

### DIFF
--- a/packages/vue-2/src/VueRenderer.ts
+++ b/packages/vue-2/src/VueRenderer.ts
@@ -21,7 +21,7 @@ export class VueRenderer {
 
     // prevents `Avoid mutating a prop directly` error message
     // Fix: `VueNodeViewRenderer` change vue Constructor `config.silent` not working
-    const currentVueConstructor = this.ref.$props.editor.contentComponent?.$options._base ?? Vue // eslint-disable-line
+    const currentVueConstructor = this.ref.$props.editor?.contentComponent?.$options._base ?? Vue // eslint-disable-line
     const originalSilent = currentVueConstructor.config.silent
 
     currentVueConstructor.config.silent = true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16507306/175226959-30872ba0-0ece-478a-ba8b-79873191b85b.png)
![image](https://user-images.githubusercontent.com/16507306/175226985-3c8fb823-b952-4569-aa9f-3bac61d5e3d0.png)

when I use suggestion extension, I change the word that I inputed, it has this error in the console.
It's an error of VueRenderer for Vue2.
We should check whether $props has editor attribute.
