### PR TITLE
docs: fix livewire attribute

### DIFF
--- a/docs/installation/php.md
+++ b/docs/installation/php.md
@@ -29,7 +29,7 @@ We provide [an official PHP package to work with Tiptap content](/api/utilities/
 ```html
 <div
   x-data="setupEditor(
-    $wire.entangle('{{ $attributes->wire('model') }}').defer
+    $wire.entangle('{{ $attributes->wire('model')->value() }}').defer
   )"
   x-init="() => init($refs.editor)"
   wire:ignore


### PR DESCRIPTION
The `->wire('...')` alone will output the entire attribute string. We only want
the `->value()` portion.