### PR TITLE
fix(core): dont use selection for setContent replacement

### DIFF
--- a/packages/core/src/commands/setContent.ts
+++ b/packages/core/src/commands/setContent.ts
@@ -1,5 +1,4 @@
 import { ParseOptions } from 'prosemirror-model'
-import { TextSelection } from 'prosemirror-state'
 
 import { createDocument } from '../helpers/createDocument'
 import { Content, RawCommands } from '../types'
@@ -22,11 +21,9 @@ declare module '@tiptap/core' {
 export const setContent: RawCommands['setContent'] = (content, emitUpdate = false, parseOptions = {}) => ({ tr, editor, dispatch }) => {
   const { doc } = tr
   const document = createDocument(content, editor.schema, parseOptions)
-  const selection = TextSelection.create(doc, 0, doc.content.size)
 
   if (dispatch) {
-    tr.setSelection(selection)
-      .replaceSelectionWith(document, false)
+    tr.replaceWith(0, doc.content.size, document)
       .setMeta('preventUpdate', !emitUpdate)
   }
 


### PR DESCRIPTION
closes #2846

prosemirror added a new warning when a selection is created that is not pointing into an inline node. This PR is fixing that warning on `commands.setContent` via not using a new Selection replacement but just replacing the current documents content from `0` to `document.content.size` with the new Document created.