### PR TITLE
fix(core): make setEditable trigger onUpdate function

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -169,6 +169,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    */
   public setEditable(editable: boolean): void {
     this.setOptions({ editable })
+    this.options.onUpdate({ editor: this, transaction: this.state.tr })
   }
 
   /**


### PR DESCRIPTION
This emits the onUpdate function when the editable state of the editor is changed via `setEditable`

should help with #2850