### PR TITLE
fix(core): only respect text of node before current position (#2937)

### DIFF
--- a/packages/core/src/helpers/getTextContentFromNodes.ts
+++ b/packages/core/src/helpers/getTextContentFromNodes.ts
@@ -9,7 +9,7 @@ export const getTextContentFromNodes = ($from: ResolvedPos, maxMatch = 500) => {
     (node, pos, parent, index) => {
       textBefore += node.type.spec.toText?.({
         node, pos, parent, index,
-      }) || node.textContent || '%leaf%'
+      }) || $from.nodeBefore?.text || '%leaf%'
     },
   )
 


### PR DESCRIPTION
Hopefully this PR fixes https://github.com/ueberdosis/tiptap/issues/2937

Since `node.textContent` always looks at the entire text of the node, the desired behavior worked out well at the end but not once the position is somewhere else within the text.

I replaced it with [nodeBefore](https://prosemirror.net/docs/ref/#model.ResolvedPos.nodeBefore) 

> Get the node directly before the position, if any. **If the position points into a text node, only the part of that node before the position is returned.**