### PR TITLE
fix(core): insert PasteRule Node at matched position (#2942)

### DIFF
--- a/packages/core/src/pasteRules/nodePasteRule.ts
+++ b/packages/core/src/pasteRules/nodePasteRule.ts
@@ -29,7 +29,7 @@ export function nodePasteRule(config: {
       if (match.input) {
         chain()
           .deleteRange(range)
-          .insertContent({
+          .insertContentAt(range.from, {
             type: config.type.name,
             attrs: attributes,
           })


### PR DESCRIPTION
This PR is meant to fix #2942

Using `nodePasteRule` the Node would be added at the end of the editor.
This PR replaces `insertContent` with `insertContentAt` to insert the Node at the matched position instead.