### PR TITLE
fix(figure): insert the figure at the current cursor position

### DIFF
--- a/demos/src/Experiments/Figure/Vue/figure.ts
+++ b/demos/src/Experiments/Figure/Vue/figure.ts
@@ -105,7 +105,7 @@ export const Figure = Node.create<FigureOptions>({
           // set cursor at end of caption field
           .command(({ tr, commands }) => {
             const { doc, selection } = tr
-            const position = doc.resolve(selection.to - 2).end()
+            const position = doc.resolve(selection.to).end()
 
             return commands.setTextSelection(position)
           })


### PR DESCRIPTION
Two problems with the current implementation:
1. We get an error if we try to insert a figure at the beginning of the document
2. The figure gets inserted after the cursor