### PR TITLE
feat(extensions): add text-direction extension

### DIFF
--- a/demos/src/Extensions/TextDirection/React/index.jsx
+++ b/demos/src/Extensions/TextDirection/React/index.jsx
@@ -1,0 +1,51 @@
+import './styles.scss'
+
+import Document from '@tiptap/extension-document'
+import Heading from '@tiptap/extension-heading'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import TextDirection from '@tiptap/extension-text-direction'
+import { EditorContent, useEditor } from '@tiptap/react'
+import React from 'react'
+
+export default () => {
+  const editor = useEditor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      Heading,
+      TextDirection.configure({
+        types: ['heading', 'paragraph'],
+      }),
+    ],
+    content: `
+        <h2 dir="ltr">Heading</h2>
+        <h2 dir="rtl">عنوان</h2>
+        <p id="ltr-text" dir="ltr">first paragraph</p>
+        <p id="rtl-text" dir="rtl">پاراگراف دوم</p>
+      `,
+  })
+
+  if (!editor) {
+    return null
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => editor.chain().focus().setTextDirection('ltr').run()}
+        className={editor.isActive({ dir: 'ltr' }) ? 'is-active' : ''}
+      >
+        ltr
+      </button>
+      <button
+        onClick={() => editor.chain().focus().setTextDirection('rtl').run()}
+        className={editor.isActive({ dir: 'rtl' }) ? 'is-active' : ''}
+      >
+        rtl
+      </button>
+      <EditorContent editor={editor} />
+    </div>
+  )
+}

--- a/demos/src/Extensions/TextDirection/React/index.spec.js
+++ b/demos/src/Extensions/TextDirection/React/index.spec.js
@@ -1,0 +1,51 @@
+context('/src/Extensions/TextDirection/React/', () => {
+  before(() => {
+    cy.visit('/src/Extensions/TextDirection/React/')
+  })
+
+  beforeEach(() => {
+    cy.get('.ProseMirror').then(([{ editor }]) => {
+      editor.commands.setContent('<p>LTR Example Text</p>\n<p>متن راست به چپ</p>')
+    })
+  })
+
+  it('should parse RTL text correctly', () => {
+    cy.get('.ProseMirror').then(([{ editor }]) => {
+      editor.commands.setContent('<p dir="rtl">متن راست به چپ</p>')
+      expect(editor.getHTML()).to.eq('<p dir="rtl">متن راست به چپ</p>')
+    })
+  })
+
+  it('should parse LTR text correctly', () => {
+    cy.get('.ProseMirror').then(([{ editor }]) => {
+      editor.commands.setContent('<p dir="ltr">LTR Example Text</p>')
+      expect(editor.getHTML()).to.eq('<p dir="ltr">LTR Example Text</p>')
+    })
+  })
+
+  it('should remove the dir attribute if node is empty', () => {
+    cy.get('.ProseMirror').then(([{ editor }]) => {
+      editor.commands.setContent('<p dir="ltr"></p>')
+      expect(editor.getHTML()).to.eq('<p></p>')
+    })
+  })
+
+  it('shouldn\'t change the dir attribute if it already has one', () => {
+    cy.get('.ProseMirror').then(([{ editor }]) => {
+      editor.commands.setContent('<p dir="rtl">LTR Example Text</p>')
+      expect(editor.getHTML()).to.eq('<p dir="rtl">LTR Example Text</p>')
+    })
+  })
+
+  it('should set the text direction to ltr on the 1st button', () => {
+    cy.get('button:nth-child(1)').click()
+
+    cy.get('.ProseMirror').find('#rtl-text').invoke('attr', 'dir').should('eq', 'ltr')
+  })
+
+  it('should set the text direction to rtl on the 2st button', () => {
+    cy.get('button:nth-child(2)').click()
+
+    cy.get('.ProseMirror').find('#ltr-text').invoke('attr', 'dir').should('eq', 'rtl')
+  })
+})

--- a/demos/src/Extensions/TextDirection/React/styles.scss
+++ b/demos/src/Extensions/TextDirection/React/styles.scss
@@ -1,0 +1,7 @@
+.ProseMirror li[dir="rtl"] {
+  text-align: right;
+}
+
+.ProseMirror li[dir="ltr"] {
+  text-align: left;
+}

--- a/docs/api/extensions/text-direction.md
+++ b/docs/api/extensions/text-direction.md
@@ -1,0 +1,77 @@
+---
+description: Left, right, center, whatever! Align the text however you like.
+icon: align-left
+---
+
+# TextDirection
+
+[![Version](https://img.shields.io/npm/v/@tiptap/extension-text-direction.svg?label=version)](https://www.npmjs.com/package/@tiptap/extension-text-direction)
+[![Downloads](https://img.shields.io/npm/dm/@tiptap/extension-text-direction.svg)](https://npmcharts.com/compare/@tiptap/extension-text-direction?minimal=true)
+
+This plugin automatically adds the `dir` attribute to a specified list of nodes. The direction is automatically detected based on the node's content.
+
+## Installation
+
+```bash
+npm install @tiptap/extension-text-direction
+```
+
+## Settings
+
+### types
+
+A list of nodes where the `dir` attribute should be added to. Usually something like `['heading', 'paragraph']`.
+
+Default: `[]`
+
+```js
+TextDirection.configure({
+  types: ["heading", "paragraph"],
+});
+```
+
+### directions
+
+A list of available options for the 'dir' attribute.
+
+Default: `['ltr', 'rtl']`
+
+```js
+TextDirection.configure({
+  directions: ["ltr", "rtl"],
+});
+```
+
+### defaultDirection
+
+The default direction.
+
+:::warning
+If you specify a defaultDirection, the `dir` attribute will be excluded in nodes that have the same direction as the defaultDirection.
+:::
+
+Default: `null`
+
+```js
+TextDirection.configure({
+  defaultDirection: "rtl",
+});
+```
+
+## Commands
+
+### setTextDirection()
+
+Set the text direction to the specified value.
+
+```js
+editor.commands.setTextDirection("rtl");
+```
+
+## Source code
+
+[packages/extension-text-direction/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-text-direction/)
+
+## Usage
+
+https://embed.tiptap.dev/preview/Extensions/TextDirection

--- a/package-lock.json
+++ b/package-lock.json
@@ -4694,6 +4694,10 @@
       "resolved": "packages/extension-text-align",
       "link": true
     },
+    "node_modules/@tiptap/extension-text-direction": {
+      "resolved": "packages/extension-text-direction",
+      "link": true
+    },
     "node_modules/@tiptap/extension-text-style": {
       "resolved": "packages/extension-text-style",
       "link": true
@@ -17187,7 +17191,7 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.0.0-beta.180",
+      "version": "2.0.0-beta.181",
       "license": "MIT",
       "dependencies": {
         "prosemirror-commands": "1.3.0",
@@ -17229,7 +17233,7 @@
     },
     "packages/extension-bubble-menu": {
       "name": "@tiptap/extension-bubble-menu",
-      "version": "2.0.0-beta.60",
+      "version": "2.0.0-beta.61",
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "1.4.1",
@@ -17258,7 +17262,7 @@
     },
     "packages/extension-character-count": {
       "name": "@tiptap/extension-character-count",
-      "version": "2.0.0-beta.30",
+      "version": "2.0.0-beta.31",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "1.18.1",
@@ -17286,7 +17290,7 @@
     },
     "packages/extension-code-block": {
       "name": "@tiptap/extension-code-block",
-      "version": "2.0.0-beta.41",
+      "version": "2.0.0-beta.42",
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "1.4.1"
@@ -17301,10 +17305,10 @@
     },
     "packages/extension-code-block-lowlight": {
       "name": "@tiptap/extension-code-block-lowlight",
-      "version": "2.0.0-beta.72",
+      "version": "2.0.0-beta.73",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-code-block": "^2.0.0-beta.41",
+        "@tiptap/extension-code-block": "^2.0.0-beta.42",
         "@types/lowlight": "^0.0.3",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1",
@@ -17321,7 +17325,7 @@
     },
     "packages/extension-collaboration": {
       "name": "@tiptap/extension-collaboration",
-      "version": "2.0.0-beta.37",
+      "version": "2.0.0-beta.38",
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "1.4.1",
@@ -17377,7 +17381,7 @@
     },
     "packages/extension-dropcursor": {
       "name": "@tiptap/extension-dropcursor",
-      "version": "2.0.0-beta.28",
+      "version": "2.0.0-beta.29",
       "license": "MIT",
       "dependencies": {
         "prosemirror-dropcursor": "1.5.0"
@@ -17392,7 +17396,7 @@
     },
     "packages/extension-floating-menu": {
       "name": "@tiptap/extension-floating-menu",
-      "version": "2.0.0-beta.55",
+      "version": "2.0.0-beta.56",
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "1.4.1",
@@ -17409,7 +17413,7 @@
     },
     "packages/extension-focus": {
       "name": "@tiptap/extension-focus",
-      "version": "2.0.0-beta.44",
+      "version": "2.0.0-beta.45",
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "1.4.1",
@@ -17438,7 +17442,7 @@
     },
     "packages/extension-gapcursor": {
       "name": "@tiptap/extension-gapcursor",
-      "version": "2.0.0-beta.38",
+      "version": "2.0.0-beta.39",
       "license": "MIT",
       "dependencies": {
         "prosemirror-gapcursor": "1.3.0"
@@ -17489,7 +17493,7 @@
     },
     "packages/extension-history": {
       "name": "@tiptap/extension-history",
-      "version": "2.0.0-beta.25",
+      "version": "2.0.0-beta.26",
       "license": "MIT",
       "dependencies": {
         "prosemirror-history": "1.3.0"
@@ -17504,7 +17508,7 @@
     },
     "packages/extension-horizontal-rule": {
       "name": "@tiptap/extension-horizontal-rule",
-      "version": "2.0.0-beta.35",
+      "version": "2.0.0-beta.36",
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "1.4.1"
@@ -17543,7 +17547,7 @@
     },
     "packages/extension-link": {
       "name": "@tiptap/extension-link",
-      "version": "2.0.0-beta.42",
+      "version": "2.0.0-beta.43",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^3.0.5",
@@ -17572,10 +17576,10 @@
     },
     "packages/extension-mention": {
       "name": "@tiptap/extension-mention",
-      "version": "2.0.0-beta.101",
+      "version": "2.0.0-beta.102",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/suggestion": "^2.0.0-beta.96",
+        "@tiptap/suggestion": "^2.0.0-beta.97",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1"
       },
@@ -17613,7 +17617,7 @@
     },
     "packages/extension-placeholder": {
       "name": "@tiptap/extension-placeholder",
-      "version": "2.0.0-beta.52",
+      "version": "2.0.0-beta.53",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "1.18.1",
@@ -17666,7 +17670,7 @@
     },
     "packages/extension-table": {
       "name": "@tiptap/extension-table",
-      "version": "2.0.0-beta.53",
+      "version": "2.0.0-beta.54",
       "license": "MIT",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "1.1.3",
@@ -17720,7 +17724,7 @@
     },
     "packages/extension-task-item": {
       "name": "@tiptap/extension-task-item",
-      "version": "2.0.0-beta.36",
+      "version": "2.0.0-beta.37",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -17767,6 +17771,21 @@
         "@tiptap/core": "^2.0.0-beta.1"
       }
     },
+    "packages/extension-text-direction": {
+      "name": "@tiptap/extension-text-direction",
+      "version": "2.0.0-beta.29",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0-beta.1"
+      }
+    },
     "packages/extension-text-style": {
       "name": "@tiptap/extension-text-style",
       "version": "2.0.0-beta.26",
@@ -17805,7 +17824,7 @@
     },
     "packages/extension-youtube": {
       "name": "@tiptap/extension-youtube",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.6",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -17817,10 +17836,10 @@
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.0.0-beta.179",
+      "version": "2.0.0-beta.180",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.180",
+        "@tiptap/core": "^2.0.0-beta.181",
         "prosemirror-model": "1.18.1",
         "zeed-dom": "^0.9.19"
       },
@@ -17831,11 +17850,11 @@
     },
     "packages/react": {
       "name": "@tiptap/react",
-      "version": "2.0.0-beta.113",
+      "version": "2.0.0-beta.114",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.60",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.55",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.61",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.56",
         "prosemirror-view": "1.26.2"
       },
       "devDependencies": {
@@ -17856,22 +17875,22 @@
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.0.0-beta.189",
+      "version": "2.0.0-beta.190",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.180",
+        "@tiptap/core": "^2.0.0-beta.181",
         "@tiptap/extension-blockquote": "^2.0.0-beta.29",
         "@tiptap/extension-bold": "^2.0.0-beta.28",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.29",
         "@tiptap/extension-code": "^2.0.0-beta.28",
-        "@tiptap/extension-code-block": "^2.0.0-beta.41",
+        "@tiptap/extension-code-block": "^2.0.0-beta.42",
         "@tiptap/extension-document": "^2.0.0-beta.17",
-        "@tiptap/extension-dropcursor": "^2.0.0-beta.28",
-        "@tiptap/extension-gapcursor": "^2.0.0-beta.38",
+        "@tiptap/extension-dropcursor": "^2.0.0-beta.29",
+        "@tiptap/extension-gapcursor": "^2.0.0-beta.39",
         "@tiptap/extension-hard-break": "^2.0.0-beta.33",
         "@tiptap/extension-heading": "^2.0.0-beta.29",
-        "@tiptap/extension-history": "^2.0.0-beta.25",
-        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.35",
+        "@tiptap/extension-history": "^2.0.0-beta.26",
+        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.36",
         "@tiptap/extension-italic": "^2.0.0-beta.28",
         "@tiptap/extension-list-item": "^2.0.0-beta.23",
         "@tiptap/extension-ordered-list": "^2.0.0-beta.30",
@@ -17886,7 +17905,7 @@
     },
     "packages/suggestion": {
       "name": "@tiptap/suggestion",
-      "version": "2.0.0-beta.96",
+      "version": "2.0.0-beta.97",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "1.18.1",
@@ -17903,11 +17922,11 @@
     },
     "packages/vue-2": {
       "name": "@tiptap/vue-2",
-      "version": "2.0.0-beta.83",
+      "version": "2.0.0-beta.84",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.60",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.55",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.61",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.56",
         "prosemirror-view": "1.26.2"
       },
       "devDependencies": {
@@ -17930,11 +17949,11 @@
     },
     "packages/vue-3": {
       "name": "@tiptap/vue-3",
-      "version": "2.0.0-beta.95",
+      "version": "2.0.0-beta.96",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.60",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.55",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.61",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.56",
         "prosemirror-state": "1.4.1",
         "prosemirror-view": "1.26.2"
       },
@@ -21333,7 +21352,7 @@
     "@tiptap/extension-code-block-lowlight": {
       "version": "file:packages/extension-code-block-lowlight",
       "requires": {
-        "@tiptap/extension-code-block": "^2.0.0-beta.41",
+        "@tiptap/extension-code-block": "^2.0.0-beta.42",
         "@types/lowlight": "^0.0.3",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1",
@@ -21439,7 +21458,7 @@
     "@tiptap/extension-mention": {
       "version": "file:packages/extension-mention",
       "requires": {
-        "@tiptap/suggestion": "^2.0.0-beta.96",
+        "@tiptap/suggestion": "^2.0.0-beta.97",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1"
       }
@@ -21509,6 +21528,12 @@
       "version": "file:packages/extension-text-align",
       "requires": {}
     },
+    "@tiptap/extension-text-direction": {
+      "version": "file:packages/extension-text-direction",
+      "requires": {
+        "prosemirror-state": "^1.4.1"
+      }
+    },
     "@tiptap/extension-text-style": {
       "version": "file:packages/extension-text-style",
       "requires": {}
@@ -21528,7 +21553,7 @@
     "@tiptap/html": {
       "version": "file:packages/html",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.180",
+        "@tiptap/core": "^2.0.0-beta.181",
         "prosemirror-model": "1.18.1",
         "zeed-dom": "^0.9.19"
       }
@@ -21536,8 +21561,8 @@
     "@tiptap/react": {
       "version": "file:packages/react",
       "requires": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.60",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.55",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.61",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.56",
         "@types/react": "^18.0.1",
         "@types/react-dom": "^18.0.0",
         "prosemirror-view": "1.26.2",
@@ -21548,19 +21573,19 @@
     "@tiptap/starter-kit": {
       "version": "file:packages/starter-kit",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.180",
+        "@tiptap/core": "^2.0.0-beta.181",
         "@tiptap/extension-blockquote": "^2.0.0-beta.29",
         "@tiptap/extension-bold": "^2.0.0-beta.28",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.29",
         "@tiptap/extension-code": "^2.0.0-beta.28",
-        "@tiptap/extension-code-block": "^2.0.0-beta.41",
+        "@tiptap/extension-code-block": "^2.0.0-beta.42",
         "@tiptap/extension-document": "^2.0.0-beta.17",
-        "@tiptap/extension-dropcursor": "^2.0.0-beta.28",
-        "@tiptap/extension-gapcursor": "^2.0.0-beta.38",
+        "@tiptap/extension-dropcursor": "^2.0.0-beta.29",
+        "@tiptap/extension-gapcursor": "^2.0.0-beta.39",
         "@tiptap/extension-hard-break": "^2.0.0-beta.33",
         "@tiptap/extension-heading": "^2.0.0-beta.29",
-        "@tiptap/extension-history": "^2.0.0-beta.25",
-        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.35",
+        "@tiptap/extension-history": "^2.0.0-beta.26",
+        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.36",
         "@tiptap/extension-italic": "^2.0.0-beta.28",
         "@tiptap/extension-list-item": "^2.0.0-beta.23",
         "@tiptap/extension-ordered-list": "^2.0.0-beta.30",
@@ -21580,8 +21605,8 @@
     "@tiptap/vue-2": {
       "version": "file:packages/vue-2",
       "requires": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.60",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.55",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.61",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.56",
         "prosemirror-view": "1.26.2",
         "vue": "^2.6.0"
       },
@@ -21597,8 +21622,8 @@
     "@tiptap/vue-3": {
       "version": "file:packages/vue-3",
       "requires": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.60",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.55",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.61",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.56",
         "prosemirror-state": "1.4.1",
         "prosemirror-view": "1.26.2",
         "vue": "^3.0.0"

--- a/packages/extension-text-direction/README.md
+++ b/packages/extension-text-direction/README.md
@@ -1,0 +1,18 @@
+# @tiptap/extension-text-direction
+
+[![Version](https://img.shields.io/npm/v/@tiptap/extension-text-direction.svg?label=version)](https://www.npmjs.com/package/@tiptap/extension-text-direction)
+[![Downloads](https://img.shields.io/npm/dm/@tiptap/extension-text-direction.svg)](https://npmcharts.com/compare/tiptap?minimal=true)
+[![License](https://img.shields.io/npm/l/@tiptap/extension-text-direction.svg)](https://www.npmjs.com/package/@tiptap/extension-text-direction)
+[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ueberdosis)
+
+## Introduction
+
+tiptap is a headless wrapper around [ProseMirror](https://ProseMirror.net) – a toolkit for building rich text WYSIWYG editors, which is already in use at many well-known companies such as _New York Times_, _The Guardian_ or _Atlassian_.
+
+## Official Documentation
+
+Documentation can be found on the [tiptap website](https://tiptap.dev).
+
+## License
+
+tiptap is open sourced software licensed under the [MIT license](https://github.com/ueberdosis/tiptap/blob/main/LICENSE.md).

--- a/packages/extension-text-direction/package.json
+++ b/packages/extension-text-direction/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@tiptap/extension-text-direction",
+  "description": "text direction extension for tiptap",
+  "version": "2.0.0-beta.29",
+  "homepage": "https://tiptap.dev",
+  "keywords": [
+    "tiptap",
+    "tiptap extension"
+  ],
+  "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/ueberdosis"
+  },
+  "main": "dist/tiptap-extension-text-direction.cjs.js",
+  "umd": "dist/tiptap-extension-text-direction.umd.js",
+  "module": "dist/tiptap-extension-text-direction.esm.js",
+  "types": "dist/packages/extension-text-direction/src/index.d.ts",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "peerDependencies": {
+    "@tiptap/core": "^2.0.0-beta.1"
+  },
+  "dependencies": {
+    "prosemirror-state": "^1.4.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ueberdosis/tiptap",
+    "directory": "packages/extension-text-direction"
+  }
+}

--- a/packages/extension-text-direction/src/index.ts
+++ b/packages/extension-text-direction/src/index.ts
@@ -1,0 +1,5 @@
+import { TextDirection } from './text-direction'
+
+export * from './text-direction'
+
+export default TextDirection

--- a/packages/extension-text-direction/src/text-direction-plugin.ts
+++ b/packages/extension-text-direction/src/text-direction-plugin.ts
@@ -1,0 +1,69 @@
+import { findChildren } from '@tiptap/core'
+import { Plugin, PluginKey } from 'prosemirror-state'
+
+export type Direction = 'ltr' | 'rtl';
+
+const RTL = '\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC'
+
+const LTR = 'A-Za-z\u00C0-\u00D6\u00D8-\u00F6'
+  + '\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C'
+  + '\uFE00-\uFE6F\uFEFD-\uFFFF'
+
+// eslint-disable-next-line no-misleading-character-class
+export const RTL_REGEX = new RegExp(`^[^${LTR}]*[${RTL}]`)
+
+// eslint-disable-next-line no-misleading-character-class
+export const LTR_REGEX = new RegExp(`^[^${RTL}]*[${LTR}]`)
+
+export function getTextDirection(text: string): Direction | null {
+  if (RTL_REGEX.test(text)) {
+    return 'rtl'
+  }
+  if (LTR_REGEX.test(text)) {
+    return 'ltr'
+  }
+  return null
+}
+
+export function DirectionPlugin({
+  types,
+  defaultDirection,
+}: {
+  types: string[];
+  defaultDirection?: Direction | null;
+}) {
+  return new Plugin({
+    key: new PluginKey('textDirection'),
+    appendTransaction: (transactions, _oldState, newState) => {
+      const tr = newState.tr
+      let modified = false
+
+      if (transactions.some(transaction => transaction.docChanged)) {
+        const nodes = findChildren(newState.doc, node => types.includes(node.type.name))
+
+        nodes.forEach(block => {
+          const { node, pos } = block
+          const { attrs, textContent } = node
+
+          // don't add the `dir` attribute for nodes that already have one
+          // so we can change/force the direction of a node without automatic
+          // direction detection being involved.
+          if (Boolean(attrs && attrs.dir) && textContent.length !== 0) {
+            return
+          }
+
+          const dir = getTextDirection(textContent)
+
+          tr.setNodeMarkup(pos, undefined, {
+            ...attrs,
+            dir: dir === defaultDirection ? null : dir,
+          })
+
+          modified = true
+        })
+      }
+
+      return modified ? tr : null
+    },
+  })
+}

--- a/packages/extension-text-direction/src/text-direction.ts
+++ b/packages/extension-text-direction/src/text-direction.ts
@@ -1,0 +1,70 @@
+import { Extension } from '@tiptap/core'
+
+import { Direction, DirectionPlugin } from './text-direction-plugin'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    textDirection: {
+      setTextDirection: (direction: Direction) => ReturnType;
+    };
+  }
+}
+
+export interface TextDirectionOptions {
+  types: string[];
+  directions: string[];
+  defaultDirection: Direction | null;
+}
+
+export const TextDirection = Extension.create<TextDirectionOptions>({
+  name: 'textDirection',
+
+  addOptions() {
+    return {
+      types: [],
+      directions: ['ltr', 'rtl'],
+      defaultDirection: null,
+    }
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          dir: {
+            default: this.options.defaultDirection,
+            parseHTML: element => {
+              return element.dir
+            },
+            renderHTML: attributes => {
+              return { dir: attributes.dir }
+            },
+          },
+        },
+      },
+    ]
+  },
+
+  addCommands() {
+    return {
+      setTextDirection:
+        direction => ({ commands }) => {
+          if (!this.options.directions || !this.options.directions.includes(direction)) {
+            return false
+          }
+
+          return this.options.types.every(type => commands.updateAttributes(type, { dir: direction }))
+        },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      DirectionPlugin({
+        types: this.options.types,
+        defaultDirection: this.options.defaultDirection,
+      }),
+    ]
+  },
+})


### PR DESCRIPTION
This plugin automatically adds `dir="ltr"` or `dir="rtl"` to a specified list of nodes based on their content. Forcing a direction is also possible through the `setTextDirection` command. The direction detection logic comes from [lexical](https://github.com/facebook/lexical).

### Why?
Why not? tiptap is one of the most popular rich text editors and it has been adopted for very large-scale applications. IMO it should have first-class support for RTL content. This plugin may not solve all of the issues with supporting both RTL and LTR content but definitely makes it easier.

### Demo

https://user-images.githubusercontent.com/87268103/178113964-db7e21e4-05d9-4339-9efc-84421c0b3b3f.mp4

Example configuration:
```ts
  TextDirection.configure({
    types: [
      "paragraph",
      "heading",
      "blockquote",
      "listItem",
    ],
  }),
```
`editor.getHTML()` result:
```html
<p dir="ltr">Hello</p>
<p dir="ltr">سلام fsdlfksjodfiwer hello</p>
<ul>
    <li dir="ltr">
        <p dir="ltr">hello</p>
    </li>
    <li dir="rtl">
        <p dir="rtl">سلام</p>
    </li>
    <li dir="ltr">
        <p dir="ltr">sghl</p>
    </li>
</ul>
<h2 dir="rtl">سلام</h2>
<h2 dir="ltr">hello</h2>
```

The `dir` attribute must be rendered instead of being a decorator (like text-align extention) because it's not just an in-editor thing. displaying and especially styling RTL content could be different than LTR content so `dir` must be in the HTML output to clarify the direction for both browsers and developers. 

### Why not `dir="auto"`?
Mainly for more control. With `dir="auto"` we can't change the direction later and also styling would be harder (if RTL and LTR content have different styles). 
"Where to add `dir=" auto"`" is another challenging question. if we add it to an element that wraps the editor, the direction of the whole document would be determined by the first node. We can add it to each node but, again, we don't have any control over the direction.

### Why not a custom paragraph node?
headings and other text nodes also need it

### Related issues  
https://github.com/ueberdosis/tiptap/issues/116
https://github.com/ueberdosis/tiptap/issues/1621