### PR TITLE
Fix pasteRulesPlugin always adding one extra character to text range

### DIFF
--- a/packages/core/src/PasteRule.ts
+++ b/packages/core/src/PasteRule.ts
@@ -229,7 +229,7 @@ export function pasteRulesPlugin(props: { editor: Editor, rules: PasteRule[] }):
           editor,
           state: chainableState,
           from: Math.max(from - 1, 0),
-          to: to.b,
+          to: to.b - 1,
           rule,
         })
 


### PR DESCRIPTION
This is a fix for #2939

PasteRule's appendTransaction plugin method looks for a changed range by comparing the before/after state using `findDiffStart` and `findDiffEnd`.

The range is passed to `state.doc.nodesBetween` and then `node.textBetween`. findDiffStart/end appear to handle node positions differently.

This is already accounted for in the `from` argument (using `Math.max(from - 1, 0)`), but there was no such offset for `to`, so all paste rules receive one extra character at the end, unless the content was pasted at the end of a node (so this also can't be solved in userspace easily).