### PR TITLE
fix: fix React Node View render problem in React 18

### DIFF
--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -1,5 +1,6 @@
 import { Editor } from '@tiptap/core'
 import React from 'react'
+import { flushSync } from 'react-dom'
 
 import { Editor as ExtendedEditor } from './Editor'
 
@@ -77,14 +78,16 @@ export class ReactRenderer<R = unknown, P = unknown> {
 
     this.reactElement = <Component {...props } />
 
-    if (this.editor?.contentComponent) {
-      this.editor.contentComponent.setState({
-        renderers: this.editor.contentComponent.state.renderers.set(
-          this.id,
-          this,
-        ),
-      })
-    }
+    flushSync(() => {
+      if (this.editor?.contentComponent) {
+        this.editor.contentComponent.setState({
+          renderers: this.editor.contentComponent.state.renderers.set(
+            this.id,
+            this,
+          ),
+        })
+      }
+    })
   }
 
   updateProps(props: Record<string, any> = {}): void {
@@ -97,14 +100,16 @@ export class ReactRenderer<R = unknown, P = unknown> {
   }
 
   destroy(): void {
-    if (this.editor?.contentComponent) {
-      const { renderers } = this.editor.contentComponent.state
+    flushSync(() => {
+      if (this.editor?.contentComponent) {
+        const { renderers } = this.editor.contentComponent.state
 
-      renderers.delete(this.id)
+        renderers.delete(this.id)
 
-      this.editor.contentComponent.setState({
-        renderers,
-      })
-    }
+        this.editor.contentComponent.setState({
+          renderers,
+        })
+      }
+    })
   }
 }


### PR DESCRIPTION
After switching to `React 18 createRoot() API`, we met the selection bug for the block using react custom node view.

https://github.com/ProseMirror/prosemirror-view/blob/master/src/viewdesc.ts#L420
When prosemirror wants to update the dom selection, if the `anchorNode` points to a react portal dom, it is still not mounted (`anchorNode.isConnect` equals false). This will cause the selection to stay in the position before when create a new block with the react node view. 

For example, extending the paragraph with react node view and pressing Enter at the end of the document will reproduce this bug.

After digging the code, I think the bug comes from https://github.com/ueberdosis/tiptap/blob/main/packages/react/src/ReactRenderer.tsx#L80-L88

After React 18 updates inside of timeouts, promises, native event handlers, or any other event are batched.
https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#automatic-batching

That causes the node view portals to render in an async way.
https://github.com/ueberdosis/tiptap/blob/main/packages/react/src/EditorContent.tsx#L7-L19

So `flushSync` is necessary to opt-out of automatic batching
https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#automatic-batching