### PR TITLE
fix(extension-code-block-lowlight): Bump lowlight to 2.7.0, remove outdated @types

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -11,6 +11,7 @@
     "@hocuspocus/provider": "^1.0.0-alpha.29",
     "d3": "^7.3.0",
     "fast-glob": "^3.2.11",
+    "highlight.js": "^11.6.0",
     "lowlight": "^2.7.0",
     "remixicon": "^2.5.0",
     "shiki": "^0.10.0",

--- a/demos/package.json
+++ b/demos/package.json
@@ -11,7 +11,7 @@
     "@hocuspocus/provider": "^1.0.0-alpha.29",
     "d3": "^7.3.0",
     "fast-glob": "^3.2.11",
-    "lowlight": "^1.20.0",
+    "lowlight": "^2.7.0",
     "remixicon": "^2.5.0",
     "shiki": "^0.10.0",
     "simplify-js": "^1.2.4",

--- a/demos/src/Examples/CodeBlockLanguage/React/index.jsx
+++ b/demos/src/Examples/CodeBlockLanguage/React/index.jsx
@@ -9,11 +9,20 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { EditorContent, ReactNodeViewRenderer, useEditor } from '@tiptap/react'
+import css from 'highlight.js/lib/languages/css'
+import js from 'highlight.js/lib/languages/javascript'
+import ts from 'highlight.js/lib/languages/typescript'
+import html from 'highlight.js/lib/languages/xml'
 // load all highlight.js languages
 import { lowlight } from 'lowlight'
 import React from 'react'
 
 import CodeBlockComponent from './CodeBlockComponent'
+
+lowlight.registerLanguage('html', html)
+lowlight.registerLanguage('css', css)
+lowlight.registerLanguage('js', js)
+lowlight.registerLanguage('ts', ts)
 
 const MenuBar = ({ editor }) => {
   if (!editor) {

--- a/demos/src/Examples/CodeBlockLanguage/React/index.jsx
+++ b/demos/src/Examples/CodeBlockLanguage/React/index.jsx
@@ -1,5 +1,5 @@
 // load specific languages only
-// import lowlight from 'lowlight/lib/core'
+// import { lowlight } from 'lowlight/lib/core'
 // import javascript from 'highlight.js/lib/languages/javascript'
 // lowlight.registerLanguage('javascript', javascript)
 import './styles.scss'
@@ -10,7 +10,7 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { EditorContent, ReactNodeViewRenderer, useEditor } from '@tiptap/react'
 // load all highlight.js languages
-import lowlight from 'lowlight'
+import { lowlight } from 'lowlight'
 import React from 'react'
 
 import CodeBlockComponent from './CodeBlockComponent'

--- a/demos/src/Examples/CodeBlockLanguage/Vue/index.vue
+++ b/demos/src/Examples/CodeBlockLanguage/Vue/index.vue
@@ -13,10 +13,19 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
+import css from 'highlight.js/lib/languages/css'
+import js from 'highlight.js/lib/languages/javascript'
+import ts from 'highlight.js/lib/languages/typescript'
+import html from 'highlight.js/lib/languages/xml'
 // load all highlight.js languages
 import { lowlight } from 'lowlight'
 
 import CodeBlockComponent from './CodeBlockComponent.vue'
+
+lowlight.registerLanguage('html', html)
+lowlight.registerLanguage('css', css)
+lowlight.registerLanguage('js', js)
+lowlight.registerLanguage('ts', ts)
 
 // load specific languages only
 // import { lowlight } from 'lowlight/lib/core'

--- a/demos/src/Examples/CodeBlockLanguage/Vue/index.vue
+++ b/demos/src/Examples/CodeBlockLanguage/Vue/index.vue
@@ -14,12 +14,12 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
 // load all highlight.js languages
-import lowlight from 'lowlight'
+import { lowlight } from 'lowlight'
 
 import CodeBlockComponent from './CodeBlockComponent.vue'
 
 // load specific languages only
-// import lowlight from 'lowlight/lib/core'
+// import { lowlight } from 'lowlight/lib/core'
 // import javascript from 'highlight.js/lib/languages/javascript'
 // lowlight.registerLanguage('javascript', javascript)
 

--- a/demos/src/Experiments/All/Vue/index.vue
+++ b/demos/src/Experiments/All/Vue/index.vue
@@ -106,7 +106,7 @@ import TextAlign from '@tiptap/extension-text-align'
 import TextStyle from '@tiptap/extension-text-style'
 import Underline from '@tiptap/extension-underline'
 import { Editor, EditorContent } from '@tiptap/vue-3'
-import lowlight from 'lowlight'
+import { lowlight } from 'lowlight'
 
 export default {
   components: {

--- a/demos/src/Nodes/CodeBlockLowlight/React/index.jsx
+++ b/demos/src/Nodes/CodeBlockLowlight/React/index.jsx
@@ -1,5 +1,5 @@
 // load specific languages only
-// import lowlight from 'lowlight/lib/core'
+// import { lowlight } from 'lowlight/lib/core'
 // import javascript from 'highlight.js/lib/languages/javascript'
 // lowlight.registerLanguage('javascript', javascript)
 import './styles.scss'
@@ -10,7 +10,7 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { EditorContent, useEditor } from '@tiptap/react'
 // load all highlight.js languages
-import lowlight from 'lowlight'
+import { lowlight } from 'lowlight'
 import React from 'react'
 
 export default () => {

--- a/demos/src/Nodes/CodeBlockLowlight/React/index.jsx
+++ b/demos/src/Nodes/CodeBlockLowlight/React/index.jsx
@@ -9,9 +9,18 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { EditorContent, useEditor } from '@tiptap/react'
+import css from 'highlight.js/lib/languages/css'
+import js from 'highlight.js/lib/languages/javascript'
+import ts from 'highlight.js/lib/languages/typescript'
+import html from 'highlight.js/lib/languages/xml'
 // load all highlight.js languages
 import { lowlight } from 'lowlight'
 import React from 'react'
+
+lowlight.registerLanguage('html', html)
+lowlight.registerLanguage('css', css)
+lowlight.registerLanguage('js', js)
+lowlight.registerLanguage('ts', ts)
 
 export default () => {
   const editor = useEditor({

--- a/demos/src/Nodes/CodeBlockLowlight/Vue/index.vue
+++ b/demos/src/Nodes/CodeBlockLowlight/Vue/index.vue
@@ -17,13 +17,17 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Editor, EditorContent } from '@tiptap/vue-3'
+import css from 'highlight.js/lib/languages/css'
+import js from 'highlight.js/lib/languages/javascript'
+import ts from 'highlight.js/lib/languages/typescript'
+import html from 'highlight.js/lib/languages/xml'
 // load all highlight.js languages
 import { lowlight } from 'lowlight'
 
-// load specific languages only
-// import { lowlight } from 'lowlight/lib/core'
-// import javascript from 'highlight.js/lib/languages/javascript'
-// lowlight.registerLanguage('javascript', javascript)
+lowlight.registerLanguage('html', html)
+lowlight.registerLanguage('css', css)
+lowlight.registerLanguage('js', js)
+lowlight.registerLanguage('ts', ts)
 
 export default {
   components: {

--- a/demos/src/Nodes/CodeBlockLowlight/Vue/index.vue
+++ b/demos/src/Nodes/CodeBlockLowlight/Vue/index.vue
@@ -18,10 +18,10 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Editor, EditorContent } from '@tiptap/vue-3'
 // load all highlight.js languages
-import lowlight from 'lowlight'
+import { lowlight } from 'lowlight'
 
 // load specific languages only
-// import lowlight from 'lowlight/lib/core'
+// import { lowlight } from 'lowlight/lib/core'
 // import javascript from 'highlight.js/lib/languages/javascript'
 // lowlight.registerLanguage('javascript', javascript)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@hocuspocus/provider": "^1.0.0-alpha.29",
         "d3": "^7.3.0",
         "fast-glob": "^3.2.11",
+        "highlight.js": "^11.6.0",
         "lowlight": "^2.7.0",
         "remixicon": "^2.5.0",
         "shiki": "^0.10.0",
@@ -12007,6 +12008,14 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
+    "node_modules/highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -14155,14 +14164,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/lowlight/node_modules/highlight.js": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
-      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -29968,6 +29969,11 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
+    },
     "hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -31537,11 +31543,6 @@
           "requires": {
             "format": "^0.2.0"
           }
-        },
-        "highlight.js": {
-          "version": "11.6.0",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
-          "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
         }
       }
     },
@@ -34858,6 +34859,7 @@
         "autoprefixer": "^10.4.2",
         "d3": "^7.3.0",
         "fast-glob": "^3.2.11",
+        "highlight.js": "^11.6.0",
         "iframe-resizer": "^4.3.2",
         "lowlight": "^2.7.0",
         "postcss": "^8.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6759,11 +6759,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/lowlight": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/lowlight/-/lowlight-0.0.3.tgz",
-      "integrity": "sha512-R83q/yPX2nIlo9D3WtSjyUDd57t8s+GVLaL8YIv3k7zMMWpYpOXqjJgrWp80qXUJB/a1t76nTyBpxrv0JNYaEg=="
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -19929,7 +19924,7 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.0.0-beta.181",
+      "version": "2.0.0-beta.182",
       "license": "MIT",
       "dependencies": {
         "prosemirror-commands": "1.3.0",
@@ -20047,7 +20042,6 @@
       "license": "MIT",
       "dependencies": {
         "@tiptap/extension-code-block": "^2.0.0-beta.42",
-        "@types/lowlight": "^0.0.3",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1",
         "prosemirror-view": "1.26.2"
@@ -20057,8 +20051,7 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.1",
-        "lowlight": ">=1.20.0"
+        "@tiptap/core": "^2.0.0-beta.1"
       }
     },
     "packages/extension-collaboration": {
@@ -20559,10 +20552,10 @@
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.0.0-beta.180",
+      "version": "2.0.0-beta.181",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "prosemirror-model": "1.18.1",
         "zeed-dom": "^0.9.19"
       },
@@ -20598,10 +20591,10 @@
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.0.0-beta.190",
+      "version": "2.0.0-beta.191",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "@tiptap/extension-blockquote": "^2.0.0-beta.29",
         "@tiptap/extension-bold": "^2.0.0-beta.28",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.29",
@@ -25719,7 +25712,6 @@
       "version": "file:packages/extension-code-block-lowlight",
       "requires": {
         "@tiptap/extension-code-block": "^2.0.0-beta.42",
-        "@types/lowlight": "^0.0.3",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1",
         "prosemirror-view": "1.26.2"
@@ -25913,7 +25905,7 @@
     "@tiptap/html": {
       "version": "file:packages/html",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "prosemirror-model": "1.18.1",
         "zeed-dom": "^0.9.19"
       }
@@ -25933,7 +25925,7 @@
     "@tiptap/starter-kit": {
       "version": "file:packages/starter-kit",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "@tiptap/extension-blockquote": "^2.0.0-beta.29",
         "@tiptap/extension-bold": "^2.0.0-beta.28",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.29",
@@ -26032,11 +26024,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "@types/lowlight": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/lowlight/-/lowlight-0.0.3.tgz",
-      "integrity": "sha512-R83q/yPX2nIlo9D3WtSjyUDd57t8s+GVLaL8YIv3k7zMMWpYpOXqjJgrWp80qXUJB/a1t76nTyBpxrv0JNYaEg=="
     },
     "@types/minimatch": {
       "version": "3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20051,7 +20051,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.1"
+        "@tiptap/core": "^2.0.0-beta.1",
+        "lowlight": ">=1.20.0"
       }
     },
     "packages/extension-collaboration": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6751,7 +6751,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
       "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -6854,8 +6853,7 @@
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "peer": true
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
@@ -14137,7 +14135,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-2.7.0.tgz",
       "integrity": "sha512-RRdrHalFfjpxL91ITTX7KhJYH3QmX5bW9Uie2D2E5GPIR3XBYDYhScBjE291ewFZkStz/k2PN9KC+8deNLiI3Q==",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "fault": "^2.0.0",
@@ -14152,7 +14149,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
       "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "peer": true,
       "dependencies": {
         "format": "^0.2.0"
       },
@@ -14165,7 +14161,6 @@
       "version": "11.6.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
       "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -20070,8 +20065,7 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.1",
-        "lowlight": "^2.7.0"
+        "@tiptap/core": "^2.0.0-beta.1"
       }
     },
     "packages/extension-collaboration": {
@@ -26037,7 +26031,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
       "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
-      "peer": true,
       "requires": {
         "@types/unist": "*"
       }
@@ -26140,8 +26133,7 @@
     "@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "peer": true
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@types/uuid": {
       "version": "8.3.4",
@@ -31532,7 +31524,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-2.7.0.tgz",
       "integrity": "sha512-RRdrHalFfjpxL91ITTX7KhJYH3QmX5bW9Uie2D2E5GPIR3XBYDYhScBjE291ewFZkStz/k2PN9KC+8deNLiI3Q==",
-      "peer": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "fault": "^2.0.0",
@@ -31543,7 +31534,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
           "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-          "peer": true,
           "requires": {
             "format": "^0.2.0"
           }
@@ -31551,8 +31541,7 @@
         "highlight.js": {
           "version": "11.6.0",
           "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
-          "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
-          "peer": true
+          "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@hocuspocus/provider": "^1.0.0-alpha.29",
         "d3": "^7.3.0",
         "fast-glob": "^3.2.11",
-        "lowlight": "^1.20.0",
+        "lowlight": "^2.7.0",
         "remixicon": "^2.5.0",
         "shiki": "^0.10.0",
         "simplify-js": "^1.2.4",
@@ -6747,6 +6747,15 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -6841,6 +6850,12 @@
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "peer": true
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
@@ -11239,18 +11254,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fault": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-      "dependencies": {
-        "format": "^0.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -12005,14 +12008,6 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
@@ -14139,16 +14134,40 @@
       }
     },
     "node_modules/lowlight": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
-      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-2.7.0.tgz",
+      "integrity": "sha512-RRdrHalFfjpxL91ITTX7KhJYH3QmX5bW9Uie2D2E5GPIR3XBYDYhScBjE291ewFZkStz/k2PN9KC+8deNLiI3Q==",
+      "peer": true,
       "dependencies": {
-        "fault": "^1.0.0",
-        "highlight.js": "~10.7.0"
+        "@types/hast": "^2.0.0",
+        "fault": "^2.0.0",
+        "highlight.js": "~11.6.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lowlight/node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "peer": true,
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lowlight/node_modules/highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -20051,7 +20070,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.1"
+        "@tiptap/core": "^2.0.0-beta.1",
+        "lowlight": "^2.7.0"
       }
     },
     "packages/extension-collaboration": {
@@ -26013,6 +26033,15 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/hast": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "peer": true,
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -26107,6 +26136,12 @@
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "peer": true
     },
     "@types/uuid": {
       "version": "8.3.4",
@@ -29368,14 +29403,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "fault": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-      "requires": {
-        "format": "^0.2.0"
-      }
-    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -29948,11 +29975,6 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
-    },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "hosted-git-info": {
       "version": "4.1.0",
@@ -31507,12 +31529,31 @@
       }
     },
     "lowlight": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
-      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-2.7.0.tgz",
+      "integrity": "sha512-RRdrHalFfjpxL91ITTX7KhJYH3QmX5bW9Uie2D2E5GPIR3XBYDYhScBjE291ewFZkStz/k2PN9KC+8deNLiI3Q==",
+      "peer": true,
       "requires": {
-        "fault": "^1.0.0",
-        "highlight.js": "~10.7.0"
+        "@types/hast": "^2.0.0",
+        "fault": "^2.0.0",
+        "highlight.js": "~11.6.0"
+      },
+      "dependencies": {
+        "fault": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+          "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+          "peer": true,
+          "requires": {
+            "format": "^0.2.0"
+          }
+        },
+        "highlight.js": {
+          "version": "11.6.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+          "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+          "peer": true
+        }
       }
     },
     "lru-cache": {
@@ -34829,7 +34870,7 @@
         "d3": "^7.3.0",
         "fast-glob": "^3.2.11",
         "iframe-resizer": "^4.3.2",
-        "lowlight": "^1.20.0",
+        "lowlight": "^2.7.0",
         "postcss": "^8.4.6",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20051,8 +20051,7 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.1",
-        "lowlight": ">=1.20.0"
+        "@tiptap/core": "^2.0.0-beta.1"
       }
     },
     "packages/extension-collaboration": {

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -21,7 +21,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.1"
+    "@tiptap/core": "^2.0.0-beta.1",
+    "lowlight": "^2.7.0"
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.42",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -22,7 +22,7 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1",
-    "lowlight": ">=1.20.0"
+    "lowlight": "^2.7.0"
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.42",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -21,8 +21,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.1",
-    "lowlight": ">=1.20.0"
+    "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.42",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -21,8 +21,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.1",
-    "lowlight": "^2.7.0"
+    "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.42",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -22,7 +22,7 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1",
-    "lowlight": "^2.7.0"
+    "lowlight": ">=1.20.0"
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.42",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@tiptap/extension-code-block": "^2.0.0-beta.42",
-    "@types/lowlight": "^0.0.3",
     "prosemirror-model": "1.18.1",
     "prosemirror-state": "1.4.1",
     "prosemirror-view": "1.26.2"


### PR DESCRIPTION
Closes https://github.com/ueberdosis/tiptap/issues/2880

Lowlight now has TS types in the package itself. This PR bumps to latest 2.7.0, and removes the @types package which is very out of date and actively prevents developers from using current version of lowlight (because @types always takes precedence over built in types, causing TS to throw errors, see https://github.com/ueberdosis/tiptap/issues/2880

We may also choose to leave lowlight at 1.2.0, but without @types built-in, it would add friction to devs who want to plug-and-play the CodeBlockLowlight extension. IMO updating to 2.7.0 preserves this single npm install experience.

FWIW the docs are a little confusing, the currently claim that:

> You should provide the lowlight module to this extension. Decoupling the lowlight package from the extension allows the client application to control which version of lowlight it uses and which programming language packages it needs to load.

which I would personally love, but the extension currently provides an out of date lowlight with types that prevent client apps from using the latest lowlight.

happy to also put up a version with that change (just removing lowlight from the extension)