### PR TITLE
Update ProseMirror-Tables to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,18 +82,6 @@
         "vue-router": "^4.0.11"
       }
     },
-    "node_modules/@_ueberdosis/prosemirror-tables": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@_ueberdosis/prosemirror-tables/-/prosemirror-tables-1.1.3.tgz",
-      "integrity": "sha512-su3pbFi1DT89g6Cuh72TE0MWWKHmWgHcQJ3ODRkm6XfIppWaGpU49t02ur3sgJc7hUhfQXjB93aSkDgOmIii2w==",
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -16648,6 +16636,18 @@
         "prosemirror-transform": "^1.0.0"
       }
     },
+    "node_modules/prosemirror-tables": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.2.2.tgz",
+      "integrity": "sha512-dKIuvsNMNnKjR6KNEdbeOneRuio/OyYUyfhlcnI4YQjXNnsiwE3xDAM7NzbJ/HFHM6keNnoZYhTqczZaULVANg==",
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
     "node_modules/prosemirror-transform": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.6.0.tgz",
@@ -19929,7 +19929,7 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.0.0-beta.181",
+      "version": "2.0.0-beta.182",
       "license": "MIT",
       "dependencies": {
         "prosemirror-commands": "1.3.0",
@@ -20411,9 +20411,9 @@
       "version": "2.0.0-beta.54",
       "license": "MIT",
       "dependencies": {
-        "@_ueberdosis/prosemirror-tables": "1.1.3",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1",
+        "prosemirror-tables": "1.2.2",
         "prosemirror-view": "1.26.2"
       },
       "funding": {
@@ -20559,10 +20559,10 @@
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.0.0-beta.180",
+      "version": "2.0.0-beta.181",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "prosemirror-model": "1.18.1",
         "zeed-dom": "^0.9.19"
       },
@@ -20598,10 +20598,10 @@
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.0.0-beta.190",
+      "version": "2.0.0-beta.191",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "@tiptap/extension-blockquote": "^2.0.0-beta.29",
         "@tiptap/extension-bold": "^2.0.0-beta.28",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.29",
@@ -20694,18 +20694,6 @@
     }
   },
   "dependencies": {
-    "@_ueberdosis/prosemirror-tables": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@_ueberdosis/prosemirror-tables/-/prosemirror-tables-1.1.3.tgz",
-      "integrity": "sha512-su3pbFi1DT89g6Cuh72TE0MWWKHmWgHcQJ3ODRkm6XfIppWaGpU49t02ur3sgJc7hUhfQXjB93aSkDgOmIii2w==",
-      "requires": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -25860,9 +25848,9 @@
     "@tiptap/extension-table": {
       "version": "file:packages/extension-table",
       "requires": {
-        "@_ueberdosis/prosemirror-tables": "1.1.3",
         "prosemirror-model": "1.18.1",
         "prosemirror-state": "1.4.1",
+        "prosemirror-tables": "1.2.2",
         "prosemirror-view": "1.26.2"
       }
     },
@@ -25913,7 +25901,7 @@
     "@tiptap/html": {
       "version": "file:packages/html",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "prosemirror-model": "1.18.1",
         "zeed-dom": "^0.9.19"
       }
@@ -25933,7 +25921,7 @@
     "@tiptap/starter-kit": {
       "version": "file:packages/starter-kit",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.181",
+        "@tiptap/core": "^2.0.0-beta.182",
         "@tiptap/extension-blockquote": "^2.0.0-beta.29",
         "@tiptap/extension-bold": "^2.0.0-beta.28",
         "@tiptap/extension-bullet-list": "^2.0.0-beta.29",
@@ -33441,6 +33429,18 @@
       "requires": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "prosemirror-tables": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.2.2.tgz",
+      "integrity": "sha512-dKIuvsNMNnKjR6KNEdbeOneRuio/OyYUyfhlcnI4YQjXNnsiwE3xDAM7NzbJ/HFHM6keNnoZYhTqczZaULVANg==",
+      "requires": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
       }
     },
     "prosemirror-transform": {

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
-    "@_ueberdosis/prosemirror-tables": "1.1.3",
+    "@_ueberdosis/prosemirror-tables": "1.2.2",
     "prosemirror-model": "1.18.1",
     "prosemirror-state": "1.4.1",
     "prosemirror-view": "1.26.2"

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.1"
   },
   "dependencies": {
-    "@_ueberdosis/prosemirror-tables": "1.2.2",
+    "prosemirror-tables": "1.2.2",
     "prosemirror-model": "1.18.1",
     "prosemirror-state": "1.4.1",
     "prosemirror-view": "1.26.2"

--- a/packages/extension-table/src/table.ts
+++ b/packages/extension-table/src/table.ts
@@ -1,4 +1,12 @@
 import {
+  callOrReturn,
+  getExtensionField,
+  mergeAttributes,
+  Node,
+  ParentConfig,
+} from '@tiptap/core'
+import { TextSelection } from 'prosemirror-state'
+import {
   addColumnAfter,
   addColumnBefore,
   addRowAfter,
@@ -16,15 +24,7 @@ import {
   tableEditing,
   toggleHeader,
   toggleHeaderCell,
-} from '@_ueberdosis/prosemirror-tables'
-import {
-  callOrReturn,
-  getExtensionField,
-  mergeAttributes,
-  Node,
-  ParentConfig,
-} from '@tiptap/core'
-import { TextSelection } from 'prosemirror-state'
+} from 'prosemirror-tables'
 import { NodeView } from 'prosemirror-view'
 
 import { TableView } from './TableView'

--- a/packages/extension-table/src/utilities/isCellSelection.ts
+++ b/packages/extension-table/src/utilities/isCellSelection.ts
@@ -1,4 +1,4 @@
-import { CellSelection } from '@_ueberdosis/prosemirror-tables'
+import { CellSelection } from 'prosemirror-tables'
 
 export function isCellSelection(value: unknown): value is CellSelection {
   return value instanceof CellSelection


### PR DESCRIPTION
I am struggling with a bug when resizing tables in TipTap. This exact bug seems to be fixed in ProseMirror-Tables: https://github.com/ProseMirror/prosemirror-tables/commit/23c79aeb323ba5f5498142b4a438f9b3a4729844

The first version of ProseMirror-table to include this fix is 1.2.2