### PR TITLE
fix(core): setNodeSelection should not clamp pos by Selection.atStart/atEnd

### DIFF
--- a/packages/core/src/commands/setNodeSelection.ts
+++ b/packages/core/src/commands/setNodeSelection.ts
@@ -1,4 +1,4 @@
-import { NodeSelection, Selection } from 'prosemirror-state'
+import { NodeSelection } from 'prosemirror-state'
 
 import { RawCommands } from '../types'
 import { minMax } from '../utilities/minMax'
@@ -17,10 +17,8 @@ declare module '@tiptap/core' {
 export const setNodeSelection: RawCommands['setNodeSelection'] = position => ({ tr, dispatch }) => {
   if (dispatch) {
     const { doc } = tr
-    const minPos = Selection.atStart(doc).from
-    const maxPos = Selection.atEnd(doc).to
-    const resolvedPos = minMax(position, minPos, maxPos)
-    const selection = NodeSelection.create(doc, resolvedPos)
+    const from = minMax(position, 0, doc.content.size)
+    const selection = NodeSelection.create(doc, from)
 
     tr.setSelection(selection)
   }


### PR DESCRIPTION
Fixes #3090.

This doesn't regress #1588, as that bug was only in the `focus` command.