### PR TITLE
fix(core): make setEditable trigger all 'update' listeners

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -169,7 +169,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    */
   public setEditable(editable: boolean): void {
     this.setOptions({ editable })
-    this.options.onUpdate({ editor: this, transaction: this.state.tr })
+    this.emit('update', { editor: this, transaction: this.state.tr })
   }
 
   /**


### PR DESCRIPTION
Followup to https://github.com/ueberdosis/tiptap/pull/2935#issuecomment-1231009792. This makes `setEditable` fire an `update` event through the `EventEmitter` API, rather than calling `options.onUpdate` directly. This is more consistent with the rest of the code, and allows things like node views to use `.on('update', ...)` to start watching the status of `isEditable` after the editor has been created. 