### PR TITLE
Syntax Error

### DIFF
--- a/demos/src/Examples/CodeBlockLanguage/Vue/index.vue
+++ b/demos/src/Examples/CodeBlockLanguage/Vue/index.vue
@@ -14,7 +14,7 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
 // load all highlight.js languages
-import lowlight from 'lowlight'
+import { lowlight } from 'lowlight'
 
 import CodeBlockComponent from './CodeBlockComponent.vue'
 


### PR DESCRIPTION
1. SyntaxError: The requested module '/node_modules/.vite/deps/lowlight.js?v=539bea66' does not provide an export named 'default' ;
2. Uncaught (in promise) Error: You should provide an instance of lowlight to use the code-block-lowlight extension;