### PR TITLE
Include bubble menu element when checking if the editor view still has focus

### DIFF
--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -55,8 +55,15 @@ export class BubbleMenuView {
     const isEmptyTextBlock = !doc.textBetween(from, to).length
       && isTextSelection(state.selection)
 
+    // When clicking on a element inside the bubble menu the editor "blur" event
+    // is called and the bubble menu item is focussed. In this case we should
+    // consider the menu as part of the ditor and keep showing the menu
+    const isChildOfMenu = this.element.contains(document.activeElement)
+
+    const hasEditorFocus = view.hasFocus() || isChildOfMenu
+
     if (
-      !view.hasFocus()
+      !hasEditorFocus
       || empty
       || isEmptyTextBlock
     ) {


### PR DESCRIPTION
Before the bubble menu would flicker when selecting styles

![Screen Recording 2022-09-02 at 16 06 06](https://user-images.githubusercontent.com/11800807/188195230-92a5c182-ae29-4db6-a1a9-f733d21c46b6.gif)

---------

Afterwards the bubble menu stays visible when selecting styles

![Screen Recording 2022-09-02 at 18 05 56](https://user-images.githubusercontent.com/11800807/188195166-5d5c856f-14ad-40f3-ae50-662fc213edb1.gif)


