### PR TITLE
docs: fix naming

### DIFF
--- a/packages/extension-subscript/README.md
+++ b/packages/extension-subscript/README.md
@@ -1,7 +1,7 @@
-# @tiptap/extension-superscript
-[![Version](https://img.shields.io/npm/v/@tiptap/extension-superscript.svg?label=version)](https://www.npmjs.com/package/@tiptap/extension-superscript)
-[![Downloads](https://img.shields.io/npm/dm/@tiptap/extension-superscript.svg)](https://npmcharts.com/compare/tiptap?minimal=true)
-[![License](https://img.shields.io/npm/l/@tiptap/extension-superscript.svg)](https://www.npmjs.com/package/@tiptap/extension-superscript)
+# @tiptap/extension-subscript
+[![Version](https://img.shields.io/npm/v/@tiptap/extension-subscript.svg?label=version)](https://www.npmjs.com/package/@tiptap/extension-subscript)
+[![Downloads](https://img.shields.io/npm/dm/@tiptap/extension-subscript.svg)](https://npmcharts.com/compare/tiptap?minimal=true)
+[![License](https://img.shields.io/npm/l/@tiptap/extension-subscript.svg)](https://www.npmjs.com/package/@tiptap/extension-subscript)
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ueberdosis)
 
 ## Introduction


### PR DESCRIPTION
Adjustment of the subscript extension documentation from `superscript` to `subscript`.