### PR TITLE
feat: Add alias condition to code-block-lowlight

### DIFF
--- a/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
+++ b/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
@@ -1,4 +1,6 @@
 import { findChildren } from '@tiptap/core'
+// @ts-ignore
+import highlight from 'highlight.js/lib/core'
 import { Node as ProsemirrorNode } from 'prosemirror-model'
 import { Plugin, PluginKey } from 'prosemirror-state'
 import { Decoration, DecorationSet } from 'prosemirror-view'
@@ -30,6 +32,10 @@ function getHighlightNodes(result: any) {
   return result.value || result.children || []
 }
 
+function registered(aliasOrLanguage: string) {
+  return Boolean(highlight.getLanguage(aliasOrLanguage))
+}
+
 function getDecorations({
   doc,
   name,
@@ -43,7 +49,8 @@ function getDecorations({
       let from = block.pos + 1
       const language = block.node.attrs.language || defaultLanguage
       const languages = lowlight.listLanguages()
-      const nodes = language && languages.includes(language)
+
+      const nodes = language && (languages.includes(language) || registered(language))
         ? getHighlightNodes(lowlight.highlight(language, block.node.textContent))
         : getHighlightNodes(lowlight.highlightAuto(block.node.textContent))
 


### PR DESCRIPTION
Lowlight's `lowlight.listLanguages` does not support `alias`.

So, for example, if you use `alias` called `js`, it is not parsed properly.

Currently, a method called `registered` exists in the lowlight 2 version, but it does not exist in the 1 version, so this part is directly implemented.

Please check and merge.