### PR TITLE
chore(maintainment): :rocket: update prosemirror packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15784,8 +15784,9 @@
       }
     },
     "node_modules/prosemirror-commands": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.3.1.tgz",
+      "integrity": "sha512-XTporPgoECkOQACVw0JTe3RZGi+fls3/byqt+tXwGTkD7qLuB4KdVrJamDMJf4kfKga3uB8hZ+kUUyZ5oWpnfg==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -15802,8 +15803,9 @@
       }
     },
     "node_modules/prosemirror-gapcursor": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.1.tgz",
+      "integrity": "sha512-GKTeE7ZoMsx5uVfc51/ouwMFPq0o8YrZ7Hx4jTF4EeGbXxBveUV8CGv46mSHuBBeXGmvu50guoV2kSnOeZZnUA==",
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -15836,8 +15838,9 @@
       }
     },
     "node_modules/prosemirror-schema-list": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.2.2.tgz",
+      "integrity": "sha512-rd0pqSDp86p0MUMKG903g3I9VmElFkQpkZ2iOd3EOVg1vo5Cst51rAsoE+5IPy0LPXq64eGcCYlW1+JPNxOj2w==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -15853,15 +15856,17 @@
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.6.0",
-      "license": "MIT",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.7.0.tgz",
+      "integrity": "sha512-O4T697Cqilw06Zvc3Wm+e237R6eZtJL/xGMliCi+Uo8VL6qHk6afz1qq0zNjT3eZMuYwnP8ZS0+YxX/tfcE9TQ==",
       "dependencies": {
         "prosemirror-model": "^1.0.0"
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.26.2",
-      "license": "MIT",
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.28.2.tgz",
+      "integrity": "sha512-uK28mJbu0GI8Oz7Aclt6BKL4g+C59EBShBXDB0Y9Y71H25p4bQgmLQLfDWjsT1J9XOw0bR8QQajZmdK8RvXI9g==",
       "dependencies": {
         "prosemirror-model": "^1.16.0",
         "prosemirror-state": "^1.0.0",
@@ -18965,13 +18970,13 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-commands": "1.3.0",
-        "prosemirror-keymap": "1.2.0",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-schema-list": "1.2.0",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-transform": "1.6.0",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-commands": "^1.3.1",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-schema-list": "^1.2.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-transform": "^1.7.0",
+        "prosemirror-view": "^1.28.2"
       },
       "funding": {
         "type": "github",
@@ -19007,8 +19012,8 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       },
       "funding": {
@@ -19036,8 +19041,8 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       },
       "funding": {
         "type": "github",
@@ -19064,7 +19069,7 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-state": "1.4.1"
+        "prosemirror-state": "^1.4.1"
       },
       "funding": {
         "type": "github",
@@ -19079,9 +19084,9 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       },
       "funding": {
         "type": "github",
@@ -19097,7 +19102,7 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-state": "1.4.1",
+        "prosemirror-state": "^1.4.1",
         "y-prosemirror": "1.0.20"
       },
       "funding": {
@@ -19168,8 +19173,8 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       },
       "funding": {
@@ -19185,8 +19190,8 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       },
       "funding": {
         "type": "github",
@@ -19214,7 +19219,7 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-gapcursor": "1.3.0"
+        "prosemirror-gapcursor": "^1.3.1"
       },
       "funding": {
         "type": "github",
@@ -19265,7 +19270,7 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-history": "1.3.0"
+        "prosemirror-history": "^1.3.0"
       },
       "funding": {
         "type": "github",
@@ -19280,7 +19285,7 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-state": "1.4.1"
+        "prosemirror-state": "^1.4.1"
       },
       "funding": {
         "type": "github",
@@ -19320,8 +19325,8 @@
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^3.0.5",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       },
       "funding": {
         "type": "github",
@@ -19348,8 +19353,8 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       },
       "funding": {
         "type": "github",
@@ -19389,9 +19394,9 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       },
       "funding": {
         "type": "github",
@@ -19443,9 +19448,9 @@
       "license": "MIT",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "1.1.3",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       },
       "funding": {
         "type": "github",
@@ -19501,7 +19506,7 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0-beta.193",
-        "prosemirror-model": "1.18.1"
+        "prosemirror-model": "^1.18.1"
       }
     },
     "packages/extension-task-list": {
@@ -19594,7 +19599,7 @@
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^2.0.0-beta.196",
-        "prosemirror-model": "1.18.1",
+        "prosemirror-model": "^1.18.1",
         "zeed-dom": "^0.9.19"
       },
       "funding": {
@@ -19609,7 +19614,7 @@
       "dependencies": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-view": "^1.28.2"
       },
       "devDependencies": {
         "@types/react": "^18.0.1",
@@ -19662,9 +19667,9 @@
       "version": "2.0.0-beta.196",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       },
       "funding": {
         "type": "github",
@@ -19681,7 +19686,7 @@
       "dependencies": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-view": "^1.28.2"
       },
       "devDependencies": {
         "vue": "^2.6.0"
@@ -19707,8 +19712,8 @@
       "dependencies": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       },
       "devDependencies": {
         "vue": "^3.0.0"
@@ -24473,13 +24478,13 @@
     "@tiptap/core": {
       "version": "file:packages/core",
       "requires": {
-        "prosemirror-commands": "1.3.0",
-        "prosemirror-keymap": "1.2.0",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-schema-list": "1.2.0",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-transform": "1.6.0",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-commands": "^1.3.1",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-schema-list": "^1.2.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-transform": "^1.7.0",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "@tiptap/extension-blockquote": {
@@ -24493,8 +24498,8 @@
     "@tiptap/extension-bubble-menu": {
       "version": "file:packages/extension-bubble-menu",
       "requires": {
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       }
     },
@@ -24505,8 +24510,8 @@
     "@tiptap/extension-character-count": {
       "version": "file:packages/extension-character-count",
       "requires": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-code": {
@@ -24516,21 +24521,21 @@
     "@tiptap/extension-code-block": {
       "version": "file:packages/extension-code-block",
       "requires": {
-        "prosemirror-state": "1.4.1"
+        "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-code-block-lowlight": {
       "version": "file:packages/extension-code-block-lowlight",
       "requires": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "@tiptap/extension-collaboration": {
       "version": "file:packages/extension-collaboration",
       "requires": {
-        "prosemirror-state": "1.4.1",
+        "prosemirror-state": "^1.4.1",
         "y-prosemirror": "1.0.20"
       }
     },
@@ -24557,16 +24562,16 @@
     "@tiptap/extension-floating-menu": {
       "version": "file:packages/extension-floating-menu",
       "requires": {
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       }
     },
     "@tiptap/extension-focus": {
       "version": "file:packages/extension-focus",
       "requires": {
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "@tiptap/extension-font-family": {
@@ -24576,7 +24581,7 @@
     "@tiptap/extension-gapcursor": {
       "version": "file:packages/extension-gapcursor",
       "requires": {
-        "prosemirror-gapcursor": "1.3.0"
+        "prosemirror-gapcursor": "^1.3.1"
       }
     },
     "@tiptap/extension-hard-break": {
@@ -24594,13 +24599,13 @@
     "@tiptap/extension-history": {
       "version": "file:packages/extension-history",
       "requires": {
-        "prosemirror-history": "1.3.0"
+        "prosemirror-history": "^1.3.0"
       }
     },
     "@tiptap/extension-horizontal-rule": {
       "version": "file:packages/extension-horizontal-rule",
       "requires": {
-        "prosemirror-state": "1.4.1"
+        "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-image": {
@@ -24615,8 +24620,8 @@
       "version": "file:packages/extension-link",
       "requires": {
         "linkifyjs": "^3.0.5",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-list-item": {
@@ -24626,8 +24631,8 @@
     "@tiptap/extension-mention": {
       "version": "file:packages/extension-mention",
       "requires": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-ordered-list": {
@@ -24641,9 +24646,9 @@
     "@tiptap/extension-placeholder": {
       "version": "file:packages/extension-placeholder",
       "requires": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "@tiptap/extension-strike": {
@@ -24662,9 +24667,9 @@
       "version": "file:packages/extension-table",
       "requires": {
         "@_ueberdosis/prosemirror-tables": "1.1.3",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "@tiptap/extension-table-cell": {
@@ -24715,7 +24720,7 @@
       "version": "file:packages/html",
       "requires": {
         "@tiptap/core": "^2.0.0-beta.196",
-        "prosemirror-model": "1.18.1",
+        "prosemirror-model": "^1.18.1",
         "zeed-dom": "^0.9.19"
       }
     },
@@ -24726,7 +24731,7 @@
         "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
         "@types/react": "^18.0.1",
         "@types/react-dom": "^18.0.0",
-        "prosemirror-view": "1.26.2",
+        "prosemirror-view": "^1.28.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
@@ -24758,9 +24763,9 @@
     "@tiptap/suggestion": {
       "version": "file:packages/suggestion",
       "requires": {
-        "prosemirror-model": "1.18.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2"
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "@tiptap/vue-2": {
@@ -24768,7 +24773,7 @@
       "requires": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-        "prosemirror-view": "1.26.2",
+        "prosemirror-view": "^1.28.2",
         "vue": "^2.6.0"
       },
       "dependencies": {
@@ -24783,8 +24788,8 @@
       "requires": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-view": "1.26.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2",
         "vue": "^3.0.0"
       }
     },
@@ -30923,7 +30928,9 @@
       }
     },
     "prosemirror-commands": {
-      "version": "1.3.0",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.3.1.tgz",
+      "integrity": "sha512-XTporPgoECkOQACVw0JTe3RZGi+fls3/byqt+tXwGTkD7qLuB4KdVrJamDMJf4kfKga3uB8hZ+kUUyZ5oWpnfg==",
       "requires": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -30939,7 +30946,9 @@
       }
     },
     "prosemirror-gapcursor": {
-      "version": "1.3.0",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.1.tgz",
+      "integrity": "sha512-GKTeE7ZoMsx5uVfc51/ouwMFPq0o8YrZ7Hx4jTF4EeGbXxBveUV8CGv46mSHuBBeXGmvu50guoV2kSnOeZZnUA==",
       "requires": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -30969,7 +30978,9 @@
       }
     },
     "prosemirror-schema-list": {
-      "version": "1.2.0",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.2.2.tgz",
+      "integrity": "sha512-rd0pqSDp86p0MUMKG903g3I9VmElFkQpkZ2iOd3EOVg1vo5Cst51rAsoE+5IPy0LPXq64eGcCYlW1+JPNxOj2w==",
       "requires": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -30984,13 +30995,17 @@
       }
     },
     "prosemirror-transform": {
-      "version": "1.6.0",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.7.0.tgz",
+      "integrity": "sha512-O4T697Cqilw06Zvc3Wm+e237R6eZtJL/xGMliCi+Uo8VL6qHk6afz1qq0zNjT3eZMuYwnP8ZS0+YxX/tfcE9TQ==",
       "requires": {
         "prosemirror-model": "^1.0.0"
       }
     },
     "prosemirror-view": {
-      "version": "1.26.2",
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.28.2.tgz",
+      "integrity": "sha512-uK28mJbu0GI8Oz7Aclt6BKL4g+C59EBShBXDB0Y9Y71H25p4bQgmLQLfDWjsT1J9XOw0bR8QQajZmdK8RvXI9g==",
       "requires": {
         "prosemirror-model": "^1.16.0",
         "prosemirror-state": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,13 +24,13 @@
     "dist"
   ],
   "dependencies": {
-    "prosemirror-commands": "1.3.0",
-    "prosemirror-keymap": "1.2.0",
-    "prosemirror-model": "1.18.1",
-    "prosemirror-schema-list": "1.2.0",
-    "prosemirror-state": "1.4.1",
-    "prosemirror-transform": "1.6.0",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-commands": "^1.3.1",
+    "prosemirror-keymap": "^1.2.0",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-schema-list": "^1.2.2",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-transform": "^1.7.0",
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-bubble-menu/package.json
+++ b/packages/extension-bubble-menu/package.json
@@ -24,8 +24,8 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2",
     "tippy.js": "^6.3.7"
   },
   "repository": {

--- a/packages/extension-character-count/package.json
+++ b/packages/extension-character-count/package.json
@@ -24,8 +24,8 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-model": "1.18.1",
-    "prosemirror-state": "1.4.1"
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -25,9 +25,9 @@
     "@tiptap/extension-code-block": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-model": "1.18.1",
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-code-block/package.json
+++ b/packages/extension-code-block/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-state": "1.4.1"
+    "prosemirror-state": "^1.4.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-state": "1.4.1",
+    "prosemirror-state": "^1.4.1",
     "y-prosemirror": "1.0.20"
   },
   "repository": {

--- a/packages/extension-floating-menu/package.json
+++ b/packages/extension-floating-menu/package.json
@@ -24,8 +24,8 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2",
     "tippy.js": "^6.3.7"
   },
   "repository": {

--- a/packages/extension-focus/package.json
+++ b/packages/extension-focus/package.json
@@ -24,8 +24,8 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-gapcursor/package.json
+++ b/packages/extension-gapcursor/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-gapcursor": "1.3.0"
+    "prosemirror-gapcursor": "^1.3.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-history/package.json
+++ b/packages/extension-history/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-history": "1.3.0"
+    "prosemirror-history": "^1.3.0"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-horizontal-rule/package.json
+++ b/packages/extension-horizontal-rule/package.json
@@ -24,7 +24,7 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-state": "1.4.1"
+    "prosemirror-state": "^1.4.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "linkifyjs": "^3.0.5",
-    "prosemirror-model": "1.18.1",
-    "prosemirror-state": "1.4.1"
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -25,8 +25,8 @@
     "@tiptap/suggestion": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-model": "1.18.1",
-    "prosemirror-state": "1.4.1"
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-placeholder/package.json
+++ b/packages/extension-placeholder/package.json
@@ -24,9 +24,9 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-model": "1.18.1",
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@_ueberdosis/prosemirror-tables": "1.1.3",
-    "prosemirror-model": "1.18.1",
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-task-item/package.json
+++ b/packages/extension-task-item/package.json
@@ -22,7 +22,7 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193",
-    "prosemirror-model": "1.18.1"
+    "prosemirror-model": "^1.18.1"
   },
   "repository": {
     "type": "git",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "@tiptap/core": "^2.0.0-beta.196",
-    "prosemirror-model": "1.18.1",
+    "prosemirror-model": "^1.18.1",
     "zeed-dom": "^0.9.19"
   },
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
     "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/suggestion/package.json
+++ b/packages/suggestion/package.json
@@ -24,9 +24,9 @@
     "@tiptap/core": "^2.0.0-beta.193"
   },
   "dependencies": {
-    "prosemirror-model": "1.18.1",
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/vue-2/package.json
+++ b/packages/vue-2/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
     "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.196",
     "@tiptap/extension-floating-menu": "^2.0.0-beta.196",
-    "prosemirror-state": "1.4.1",
-    "prosemirror-view": "1.26.2"
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates all prosemirror packages to the most recent version + also brings back fixed versions at the minor level.

If we see increased problems with minor versions breaking Tiptap again - we'll consider to go more strict with the version fixing again.