### PR TITLE
fix(core) - support attributes being null/undefined 

### DIFF
--- a/packages/core/src/helpers/getAttributesFromExtensions.ts
+++ b/packages/core/src/helpers/getAttributesFromExtensions.ts
@@ -93,7 +93,7 @@ export function getAttributesFromExtensions(extensions: Extensions): ExtensionAt
           ...attribute,
         }
 
-        if (attribute.isRequired && attribute.default === undefined) {
+        if (attribute?.isRequired && attribute?.default === undefined) {
           delete mergedAttr.default
         }
 


### PR DESCRIPTION
This PR avoids a runtime error that happened when an attribute was set as undefined or null, as highlighted in issue #3032 .