### PR TITLE
fix(extension/link): fix last word value being undefined

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -89,8 +89,17 @@ export function autolink(options: AutolinkOptions): Plugin {
 
         if (textBlock && textBeforeWhitespace) {
           const wordsBeforeWhitespace = textBeforeWhitespace.split(' ').filter(s => s !== '')
+
+          if (wordsBeforeWhitespace.length <= 0) {
+            return false
+          }
+
           const lastWordBeforeSpace = wordsBeforeWhitespace[wordsBeforeWhitespace.length - 1]
           const lastWordAndBlockOffset = textBlock.pos + textBeforeWhitespace.lastIndexOf(lastWordBeforeSpace)
+
+          if (!lastWordBeforeSpace) {
+            return false
+          }
 
           find(lastWordBeforeSpace)
             .filter(link => link.isLink)


### PR DESCRIPTION
This PR fixes the lastWordBeforeSpace value to not be passed through the autolink plugin when it is undefined. This can happen, when the filtered `wordBeforeWhitespace` array has a length of 0 since `lastWordBeforeSpace` is set to `wordsBeforeWhitespace.length - 1` which would result in an index of -1.