### PR TITLE
fix: typo in docs

### DIFF
--- a/docs/examples/drawing.md
+++ b/docs/examples/drawing.md
@@ -1,4 +1,4 @@
 # Drawing
-Did you ever wanted to draw in a text editor? Me neither. Anyway, here is an example how that could work with Tiptap. If you want to build something like that, [learn more about node views](/guide/node-views).
+Did you ever want to draw in a text editor? Me neither. Anyway, here is an example how that could work with Tiptap. If you want to build something like that, [learn more about node views](/guide/node-views).
 
 https://embed.tiptap.dev/preview/Examples/Drawing


### PR DESCRIPTION
Fixed typo in drawing.md docs, want -> wanted