### PR TITLE
Fix #3084 - remove old newline-fix for ios that freezes safari on ios

### DIFF
--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -203,28 +203,6 @@ export class NodeView<
       return false
     }
 
-    // try to prevent a bug on iOS that will break node views on enter
-    // this is because ProseMirror can’t preventDispatch on enter
-    // this will lead to a re-render of the node view on enter
-    // see: https://github.com/ueberdosis/tiptap/issues/1214
-    if (
-      this.dom.contains(mutation.target)
-      && mutation.type === 'childList'
-      && isiOS()
-      && this.editor.isFocused
-    ) {
-      const changedNodes = [
-        ...Array.from(mutation.addedNodes),
-        ...Array.from(mutation.removedNodes),
-      ] as HTMLElement[]
-
-      // we’ll check if every changed node is contentEditable
-      // to make sure it’s probably mutated by ProseMirror
-      if (changedNodes.every(node => node.isContentEditable)) {
-        return false
-      }
-    }
-
     // we will allow mutation contentDOM with attributes
     // so we can for example adding classes within our node view
     if (this.contentDOM === mutation.target && mutation.type === 'attributes') {

--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -5,7 +5,6 @@ import { Decoration, NodeView as ProseMirrorNodeView } from 'prosemirror-view'
 import { Editor as CoreEditor } from './Editor'
 import { Node } from './Node'
 import { NodeViewRendererOptions, NodeViewRendererProps } from './types'
-import { isiOS } from './utilities/isiOS'
 
 export class NodeView<
   Component,


### PR DESCRIPTION
Started experiencing this issue (#3084) after updating to the latest versions of TipTap. Also confirmed it's present on the official TipTap website. It took a while to triage, and I finally solved it by completely removing a fix/patch that had been previously added to avoid double new lines.

I tried the editor after removing this fix, and it now 1) doesn't freeze anymore 2) doesn't add multiple lines on a single Enter key press.

I might be missing some context on issue #1214 (the one that the patch I'm removing originally fixed), but if it was due to a now outdated versions of TipTap/ProseMirror we might be good with removing it.