### PR TITLE
docs: link YouTube node docs to proper GitHub url

### DIFF
--- a/docs/api/nodes.md
+++ b/docs/api/nodes.md
@@ -30,7 +30,7 @@ If you think of the document as a tree, then nodes are just a type of content in
 | [TaskList](/api/nodes/task-list)             | –                                                | [GitHub](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-task-list/)       |
 | [TaskItem](/api/nodes/task-item)             | –                                                | [GitHub](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-task-item/)       |
 | [Text](/api/nodes/text)                      | Included                                         | [GitHub](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-text/)            |
-| [YouTube](/api/nodes/youtube)                | Included                                         | [GitHub](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-text/)            |
+| [YouTube](/api/nodes/youtube)                | Included                                         | [GitHub](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-youtube/)            |
 
 ## Create a new node
 You’re free to create your own nodes for Tiptap. Here is the boilerplate code that’s need to create and register your own node:


### PR DESCRIPTION
The source code link of the YouTube node in the list of supported nodes linked to the wrong page.