### PR TITLE
Fixed using both color and highlight

### DIFF
--- a/packages/extension-highlight/src/highlight.ts
+++ b/packages/extension-highlight/src/highlight.ts
@@ -58,7 +58,7 @@ export const Highlight = Mark.create<HighlightOptions>({
 
           return {
             'data-color': attributes.color,
-            style: `background-color: ${attributes.color}`,
+            style: `background-color: ${attributes.color}; color: inherit`,
           }
         },
       },


### PR DESCRIPTION
Prior this commit if we apply both color and highlight the color won't be applied.

Before:
![Screenshot from 2022-10-14 13-57-39](https://user-images.githubusercontent.com/3160384/195820393-b76a652e-8238-4036-b4e6-3643324ce0ab.png)

After (I added it in styles editor)
![Screenshot from 2022-10-14 13-58-11](https://user-images.githubusercontent.com/3160384/195820494-f621a64b-97f3-4ca7-b26e-2501c54d9d73.png)
