### PR TITLE
extension/link: adds 'whenNotEditable' as option for openOnClick

### DIFF
--- a/docs/api/marks/link.md
+++ b/docs/api/marks/link.md
@@ -53,6 +53,14 @@ Link.configure({
 })
 ```
 
+If set to `'whenNotEditable'`, links will be opened on click only when editor is not editable.
+
+```js
+Link.configure({
+  openOnClick: 'whenNotEditable',
+})
+```
+
 ### linkOnPaste
 Adds a link to the current selection if the pasted content only contains an url.
 

--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -4,6 +4,7 @@ import { Plugin, PluginKey } from 'prosemirror-state'
 
 type ClickHandlerOptions = {
   type: MarkType,
+  whenNotEditable: boolean
 }
 
 export function clickHandler(options: ClickHandlerOptions): Plugin {
@@ -11,6 +12,10 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
     key: new PluginKey('handleClickLink'),
     props: {
       handleClick: (view, pos, event) => {
+        if (options.whenNotEditable && view.editable) {
+          return false
+        }
+
         const attrs = getAttributes(view.state, options.type.name)
         const link = (event.target as HTMLElement)?.closest('a')
 

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -18,7 +18,7 @@ export interface LinkOptions {
   /**
    * If enabled, links will be opened on click.
    */
-  openOnClick: boolean,
+  openOnClick: boolean | 'whenNotEditable',
   /**
    * Adds a link to the current selection if the pasted content only contains an url.
    */
@@ -175,6 +175,7 @@ export const Link = Mark.create<LinkOptions>({
     if (this.options.openOnClick) {
       plugins.push(clickHandler({
         type: this.type,
+        whenNotEditable: this.options.openOnClick === 'whenNotEditable',
       }))
     }
 


### PR DESCRIPTION
Allows 'openOnClick' configuration to be set to 'whenNotEditable' so that links are not clickable while editing the content.
I have noticed that the editing experience is a little bumpy when you click on a 'link' marked text e.g. to modify the text - but then the link opens.