### PR TITLE
Cleanup linkifyjs when the editor is destroyed

### DIFF
--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -1,5 +1,5 @@
 import { Mark, markPasteRule, mergeAttributes } from '@tiptap/core'
-import { find, registerCustomProtocol } from 'linkifyjs'
+import { find, registerCustomProtocol, reset } from 'linkifyjs'
 import { Plugin } from 'prosemirror-state'
 
 import { autolink } from './helpers/autolink'
@@ -63,6 +63,10 @@ export const Link = Mark.create<LinkOptions>({
 
   onCreate() {
     this.options.protocols.forEach(registerCustomProtocol)
+  },
+
+  onDestroy() {
+    reset()
   },
 
   inclusive() {


### PR DESCRIPTION
I'm was getting these warnings after pasting links and then destroying and creating a new editor again:

```
linkifyjs: already initialized - will not register custom protocol "ftp" until you manually call linkify.init(). 
To avoid this warning, please register all custom protocols before invoking linkify the first time.
```

With the extension being called like this:

```
Link.configure({
  protocols: ['ftp', 'mailto']
})
```

Resetting linkifyjs when the editor is destroyed fixes this.

