### PR TITLE
Fix cursor not following to new node when using a react node view

### DIFF
--- a/packages/react/src/Editor.ts
+++ b/packages/react/src/Editor.ts
@@ -2,7 +2,13 @@ import { Editor as CoreEditor } from '@tiptap/core'
 import React from 'react'
 
 import { EditorContentProps, EditorContentState } from './EditorContent'
+import { ReactRenderer } from './ReactRenderer'
+
+type ContentComponent = React.Component<EditorContentProps, EditorContentState> & {
+  setRenderer(id: string, renderer: ReactRenderer): void;
+  removeRenderer(id: string): void;
+}
 
 export class Editor extends CoreEditor {
-  public contentComponent: React.Component<EditorContentProps, EditorContentState> | null = null
+  public contentComponent: ContentComponent | null = null
 }

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLProps } from 'react'
-import ReactDOM from 'react-dom'
+import ReactDOM, { flushSync } from 'react-dom'
 
 import { Editor } from './Editor'
 import { ReactRenderer } from './ReactRenderer'
@@ -66,6 +66,30 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
 
       editor.createNodeViews()
     }
+  }
+
+  setRenderer(id: string, renderer: ReactRenderer) {
+    queueMicrotask(() => {
+      flushSync(() => {
+        const { renderers } = this.state
+
+        renderers.set(id, renderer)
+
+        this.setState({ renderers })
+      })
+    })
+  }
+
+  removeRenderer(id: string) {
+    queueMicrotask(() => {
+      flushSync(() => {
+        const { renderers } = this.state
+
+        renderers.delete(id)
+
+        this.setState({ renderers })
+      })
+    })
   }
 
   componentWillUnmount() {

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -1,6 +1,5 @@
 import { Editor } from '@tiptap/core'
 import React from 'react'
-import { flushSync } from 'react-dom'
 
 import { Editor as ExtendedEditor } from './Editor'
 
@@ -78,18 +77,7 @@ export class ReactRenderer<R = unknown, P = unknown> {
 
     this.reactElement = <Component {...props } />
 
-    queueMicrotask(() => {
-      flushSync(() => {
-        if (this.editor?.contentComponent) {
-          this.editor.contentComponent.setState({
-            renderers: this.editor.contentComponent.state.renderers.set(
-              this.id,
-              this,
-            ),
-          })
-        }
-      })
-    })
+    this.editor?.contentComponent?.setRenderer(this.id, this)
   }
 
   updateProps(props: Record<string, any> = {}): void {
@@ -102,18 +90,6 @@ export class ReactRenderer<R = unknown, P = unknown> {
   }
 
   destroy(): void {
-    queueMicrotask(() => {
-      flushSync(() => {
-        if (this.editor?.contentComponent) {
-          const { renderers } = this.editor.contentComponent.state
-
-          renderers.delete(this.id)
-
-          this.editor.contentComponent.setState({
-            renderers,
-          })
-        }
-      })
-    })
+    this.editor?.contentComponent?.removeRenderer(this.id)
   }
 }


### PR DESCRIPTION
This fixes the cursor problem described in #3200.

Node views need to be rendered immediately when they're created so that the editor can correctly position the cursor inside them. That's achieved using `flushSync` whenever a new node view renderer is added.

However, `flushSync` cannot be used from inside a React component lifecycle method. Thus #3188 moved the `flushSync` call into a microtask. This delays the `flushSync`, and so the editor can't correctly position the cursor inside the new node view, because it doesn't exist in the DOM yet.

By keeping an instance variable to determine if initialization has happened, we can avoid using `flushSync` from inside the `componentDidMount` and `componentDidUpdate` methods, and still call it whenever a new node view is created afterwards.

### How I tested this

I added the following code to the `ReactComponentContent` demo (but I didn't commit this):

```diff
diff --git a/demos/src/GuideNodeViews/ReactComponentContent/React/Extension.js b/demos/src/GuideNodeViews/ReactComponentContent/React/Extension.js
index b3cde8328..6d70f3c61 100644
--- a/demos/src/GuideNodeViews/ReactComponentContent/React/Extension.js
+++ b/demos/src/GuideNodeViews/ReactComponentContent/React/Extension.js
@@ -10,6 +10,18 @@ export default Node.create({
 
   content: 'inline*',
 
+  addKeyboardShortcuts() {
+    return {
+      Enter: ({ editor }) => {
+        if (editor.state.selection.$from.parent.type.name === this.name) {
+          return this.editor.chain().splitBlock().setNode(this.name).run()
+        }
+
+        return false
+      }
+    }
+  },
+
   parseHTML() {
     return [
       {

``` 

Then I tested hitting enter at the end of the react node:

| Before | After
| - | - |
| <video src="https://user-images.githubusercontent.com/3883777/196845068-ae4f3809-804d-4164-a342-177578b34c53.mov" /> |  <video src="https://user-images.githubusercontent.com/3883777/196845197-aa76dd82-1025-43a2-b8d5-33f00377f28a.mov" /> |

### Additional changes in this PR

* Moved the code that was updating `EditorContent`'s state in `ReactRenderer` into instance methods in `EditorContent`.
* Updated `EditorContent` to keep the renderers in a JS object instead of an ES6 Map. ES6 Maps are mutable, and React discourages mutating state.

---

Fixes #3200