### PR TITLE
fix(extension/placeholder): Resolve placeholder performance issues

### DIFF
--- a/packages/extension-placeholder/src/placeholder.ts
+++ b/packages/extension-placeholder/src/placeholder.ts
@@ -44,6 +44,10 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
               return null
             }
 
+            // only calculate isEmpty once due to its performance impacts (see issue #3360)
+            const emptyDocInstance = doc.type.createAndFill()
+            const isEditorEmpty = emptyDocInstance?.sameMarkup(doc) && emptyDocInstance.content.findDiffStart(doc.content) === null
+
             doc.descendants((node, pos) => {
               const hasAnchor = anchor >= pos && anchor <= (pos + node.nodeSize)
               const isEmpty = !node.isLeaf && !node.childCount
@@ -51,7 +55,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
               if ((hasAnchor || !this.options.showOnlyCurrent) && isEmpty) {
                 const classes = [this.options.emptyNodeClass]
 
-                if (this.editor.isEmpty) {
+                if (isEditorEmpty) {
                   classes.push(this.options.emptyEditorClass)
                 }
 


### PR DESCRIPTION
Fix #3360

The issue seems to be caused by this line in `placeholder.ts`:
https://github.com/ueberdosis/tiptap/blob/2b69f344c713befecd4ec606df5e9ba680aa2ce8/packages/extension-placeholder/src/placeholder.ts#L54

`isEmpty` is NOT a simple operation, but uses JSON stringify on the entire document to verify emptiness compared to the default of the given node type.

This wouldn't be too bad on it's own, but it's called for every descendent, causing noticeable performance issues if more than a few empty paragraphs exist on a large document (even on the Moby Dick large text example).

The issue was actually fixed with https://github.com/ueberdosis/tiptap/pull/2665 but was then reverted by https://github.com/ueberdosis/tiptap/commit/10248924541d7b9414087a7369dad24b24fe9b11 for an unknown reason

Credit to @BrianHung for the more efficient empty editor check