### PR TITLE
fix: remove blur event listener from tippy element (#3365)

### DIFF
--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -129,6 +129,10 @@ export class BubbleMenuView {
     this.hide()
   }
 
+  tippyBlurHandler = (event : FocusEvent) => {
+    this.blurHandler({ event })
+  }
+
   createTooltip() {
     const { element: editorElement } = this.editor.options
     const editorIsAttached = !!editorElement.parentElement
@@ -150,9 +154,7 @@ export class BubbleMenuView {
 
     // maybe we have to hide tippy on its own blur event as well
     if (this.tippy.popper.firstChild) {
-      (this.tippy.popper.firstChild as HTMLElement).addEventListener('blur', event => {
-        this.blurHandler({ event })
-      })
+      (this.tippy.popper.firstChild as HTMLElement).addEventListener('blur', this.tippyBlurHandler)
     }
   }
 
@@ -213,6 +215,9 @@ export class BubbleMenuView {
   }
 
   destroy() {
+    if (this.tippy?.popper.firstChild) {
+      (this.tippy.popper.firstChild as HTMLElement).removeEventListener('blur', this.tippyBlurHandler)
+    }
     this.tippy?.destroy()
     this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.view.dom.removeEventListener('dragstart', this.dragstartHandler)

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -104,6 +104,10 @@ export class FloatingMenuView {
     this.hide()
   }
 
+  tippyBlurHandler = (event : FocusEvent) => {
+    this.blurHandler({ event })
+  }
+
   createTooltip() {
     const { element: editorElement } = this.editor.options
     const editorIsAttached = !!editorElement.parentElement
@@ -125,9 +129,7 @@ export class FloatingMenuView {
 
     // maybe we have to hide tippy on its own blur event as well
     if (this.tippy.popper.firstChild) {
-      (this.tippy.popper.firstChild as HTMLElement).addEventListener('blur', event => {
-        this.blurHandler({ event })
-      })
+      (this.tippy.popper.firstChild as HTMLElement).addEventListener('blur', this.tippyBlurHandler)
     }
   }
 
@@ -172,6 +174,9 @@ export class FloatingMenuView {
   }
 
   destroy() {
+    if (this.tippy?.popper.firstChild) {
+      (this.tippy.popper.firstChild as HTMLElement).removeEventListener('blur', this.tippyBlurHandler)
+    }
     this.tippy?.destroy()
     this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.editor.off('focus', this.focusHandler)


### PR DESCRIPTION
Fixes: #3365 
We are adding event listener for blur on tippy element but we aren't removing it during `destroy`
This PR adds the invocation to remove the said event listener.