### PR TITLE
[PROPOSAL] dynamic default attributes

### DIFF
--- a/packages/core/src/helpers/getAttributesFromExtensions.ts
+++ b/packages/core/src/helpers/getAttributesFromExtensions.ts
@@ -93,7 +93,11 @@ export function getAttributesFromExtensions(extensions: Extensions): ExtensionAt
           ...attribute,
         }
 
-        if (attribute?.isRequired && attribute?.default === undefined) {
+        if(typeof mergedAttr?.default === 'function') {
+          mergedAttr.default = mergedAttr.default()
+        }
+
+        if (mergedAttr?.isRequired && mergedAttr?.default === undefined) {
           delete mergedAttr.default
         }
 


### PR DESCRIPTION
> Sorry if you'd really prefer that I raise this as an issue first - it just seemed like a simple enough idea to demonstrate in a PR. If I've missed something in the public API that would otherwise solve the same problem, I'd appreciate some input. 

## Description

Resolve a `default` attribute thunk once when a node is created, in order to compute a default value dynamically.

## Use-case

I'd like to be able assign an attribute to a node that uniquely identifies it. 

### Example usage

```javascript
Node.create({
    // ...
    addAttributes() {
        return {
            id: {
                default: () => generate_uuid(),
                parseHTML: element => element.getAttribute('id')
            }
        }
    }
})
```
