### PR TITLE
Fix #3392 - Unexpected renderText() for contentful nodes

### DIFF
--- a/packages/core/src/helpers/getTextBetween.ts
+++ b/packages/core/src/helpers/getTextBetween.ts
@@ -33,7 +33,11 @@ export function getTextBetween(
           range,
         })
       }
-    } else if (node.isText) {
+      // do not descend into child nodes when there exists a serializer
+      return false
+    }
+
+    if (node.isText) {
       text += node?.text?.slice(Math.max(from, pos) - pos, to - pos) // eslint-disable-line
       separated = false
     } else if (node.isBlock && !separated) {

--- a/tests/cypress/integration/core/generateText.spec.ts
+++ b/tests/cypress/integration/core/generateText.spec.ts
@@ -1,0 +1,66 @@
+/// <reference types="cypress" />
+
+import { generateText, Node, NodeConfig } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+
+describe(generateText.name, () => {
+  it('generates Text from JSON without an editor instance', () => {
+    const json = {
+      type: 'doc',
+      content: [{
+        type: 'paragraph',
+        content: [
+          {
+            type: 'custom-node-default-renderer',
+            content: [
+              {
+                type: 'text',
+                text: 'Example One',
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' ',
+          },
+          {
+            type: 'custom-node-custom-renderer',
+            content: [
+              {
+                type: 'text',
+                text: 'Example Two',
+              },
+            ],
+          },
+        ],
+      }],
+    }
+
+    const contentfulInlineNode = (name: string, config?: Partial<NodeConfig>) => Node.create({
+      name,
+      group: 'inline',
+      inline: true,
+      content: 'text*',
+      parseHTML() {
+        return [{ tag: name }]
+      },
+      ...config,
+    })
+
+    const text = generateText(json, [
+      Document,
+      Paragraph,
+      Text,
+      contentfulInlineNode('custom-node-default-renderer'),
+      contentfulInlineNode('custom-node-custom-renderer', {
+        renderText({ node }) {
+          return `~${node.textContent}~`
+        },
+      }),
+    ])
+
+    expect(text).to.eq('Example One ~Example Two~')
+  })
+})


### PR DESCRIPTION
 - resolves: #3392

This issue is causing a number of downstream problems for me as it impacts multiple touch points, namely:
  - `editor.getText()` state
  - clipboard copy-paste
  - reasoning about the selection state of the editor

I had a go at patching it myself and this appears to be the simplest solution - it might raise the question of how deeply nested nodes should be handled but I think it is reasonable to assert that: ***any nodes with a custom text renderer are solely responsible for how their children are rendered***.