### PR TITLE
Draft: Moves all prosemirror deps to peerDependencies & devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6714,6 +6714,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@tiptap/prosemirror-tables/-/prosemirror-tables-1.1.3.tgz",
       "integrity": "sha512-Pp7Iyup+kxniDGEvFHX+BRw3et9vys83NVqk6B+PbVAztq64QyX/mY+vzcpFmOsF9/th+Po981igbGUG7C/8hw==",
+      "dev": true,
       "dependencies": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -13612,8 +13613,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -16129,6 +16129,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.3.1.tgz",
       "integrity": "sha512-XTporPgoECkOQACVw0JTe3RZGi+fls3/byqt+tXwGTkD7qLuB4KdVrJamDMJf4kfKga3uB8hZ+kUUyZ5oWpnfg==",
+      "dev": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -16137,6 +16138,7 @@
     },
     "node_modules/prosemirror-dropcursor": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -16148,6 +16150,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.1.tgz",
       "integrity": "sha512-GKTeE7ZoMsx5uVfc51/ouwMFPq0o8YrZ7Hx4jTF4EeGbXxBveUV8CGv46mSHuBBeXGmvu50guoV2kSnOeZZnUA==",
+      "dev": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -16157,6 +16160,7 @@
     },
     "node_modules/prosemirror-history": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.2.2",
@@ -16166,6 +16170,7 @@
     },
     "node_modules/prosemirror-keymap": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -16183,6 +16188,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.2.2.tgz",
       "integrity": "sha512-rd0pqSDp86p0MUMKG903g3I9VmElFkQpkZ2iOd3EOVg1vo5Cst51rAsoE+5IPy0LPXq64eGcCYlW1+JPNxOj2w==",
+      "dev": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -16991,6 +16997,7 @@
     },
     "node_modules/rope-sequence": {
       "version": "1.3.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/run-async": {
@@ -18778,6 +18785,7 @@
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/walk-up-path": {
@@ -19318,7 +19326,7 @@
       "name": "@tiptap/core",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "prosemirror-commands": "^1.3.1",
         "prosemirror-keymap": "^1.2.0",
         "prosemirror-model": "^1.18.1",
@@ -19330,12 +19338,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "prosemirror-commands": "^1.3.1",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-schema-list": "^1.2.2",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-transform": "^1.7.0",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "packages/extension-blockquote": {
       "name": "@tiptap/extension-blockquote",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.1"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19348,6 +19368,9 @@
       "name": "@tiptap/extension-bold",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19361,26 +19384,32 @@
       "version": "2.0.0-beta.204",
       "license": "MIT",
       "dependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "lodash": "^4.17.21",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@types/lodash": "^4.14.187",
-        "lodash": "^4.17.21"
+        "@types/lodash": "^4.14.187"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "packages/extension-bullet-list": {
       "name": "@tiptap/extension-bullet-list",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19393,7 +19422,8 @@
       "name": "@tiptap/extension-character-count",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       },
@@ -19402,13 +19432,18 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "packages/extension-code": {
       "name": "@tiptap/extension-code",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19421,7 +19456,8 @@
       "name": "@tiptap/extension-code-block",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1"
       },
       "funding": {
@@ -19429,14 +19465,17 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "packages/extension-code-block-lowlight": {
       "name": "@tiptap/extension-code-block-lowlight",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/extension-code-block": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -19447,14 +19486,18 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0-beta.193",
-        "@tiptap/extension-code-block": "^2.0.0-beta.193"
+        "@tiptap/extension-code-block": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "packages/extension-collaboration": {
       "name": "@tiptap/extension-collaboration",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1",
         "y-prosemirror": "1.0.20"
       },
@@ -19463,14 +19506,17 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1",
+        "y-prosemirror": "1.0.20"
       }
     },
     "packages/extension-collaboration-cursor": {
       "name": "@tiptap/extension-collaboration-cursor",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "y-prosemirror": "1.0.20"
       },
       "funding": {
@@ -19478,13 +19524,18 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "y-prosemirror": "1.0.20"
       }
     },
     "packages/extension-color": {
       "name": "@tiptap/extension-color",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/extension-text-style": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19498,6 +19549,9 @@
       "name": "@tiptap/extension-document",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19510,7 +19564,8 @@
       "name": "@tiptap/extension-dropcursor",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-dropcursor": "1.5.0"
       },
       "funding": {
@@ -19518,7 +19573,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-dropcursor": "1.5.0"
       }
     },
     "packages/extension-floating-menu": {
@@ -19526,23 +19582,10 @@
       "version": "2.0.0-beta.204",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-state": "^1.4.1",
-        "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
-      }
-    },
-    "packages/extension-focus": {
-      "name": "@tiptap/extension-focus",
-      "version": "2.0.0-beta.204",
-      "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
       },
@@ -19551,13 +19594,38 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
+      }
+    },
+    "packages/extension-focus": {
+      "name": "@tiptap/extension-focus",
+      "version": "2.0.0-beta.204",
+      "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "packages/extension-font-family": {
       "name": "@tiptap/extension-font-family",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/extension-text-style": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19571,7 +19639,8 @@
       "name": "@tiptap/extension-gapcursor",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-gapcursor": "^1.3.1"
       },
       "funding": {
@@ -19579,13 +19648,17 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-gapcursor": "^1.3.1"
       }
     },
     "packages/extension-hard-break": {
       "name": "@tiptap/extension-hard-break",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19598,6 +19671,9 @@
       "name": "@tiptap/extension-heading",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19610,6 +19686,9 @@
       "name": "@tiptap/extension-highlight",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19622,7 +19701,8 @@
       "name": "@tiptap/extension-history",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-history": "^1.3.0"
       },
       "funding": {
@@ -19630,14 +19710,16 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-history": "^1.3.0"
       }
     },
     "packages/extension-horizontal-rule": {
       "name": "@tiptap/extension-horizontal-rule",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1"
       },
       "funding": {
@@ -19645,13 +19727,17 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "packages/extension-image": {
       "name": "@tiptap/extension-image",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19664,6 +19750,9 @@
       "name": "@tiptap/extension-italic",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19677,7 +19766,10 @@
       "version": "2.0.0-beta.204",
       "license": "MIT",
       "dependencies": {
-        "linkifyjs": "^3.0.5",
+        "linkifyjs": "^3.0.5"
+      },
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       },
@@ -19686,13 +19778,18 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "packages/extension-list-item": {
       "name": "@tiptap/extension-list-item",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19705,7 +19802,9 @@
       "name": "@tiptap/extension-mention",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/suggestion": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       },
@@ -19715,13 +19814,18 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0-beta.193",
-        "@tiptap/suggestion": "^2.0.0-beta.193"
+        "@tiptap/suggestion": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1"
       }
     },
     "packages/extension-ordered-list": {
       "name": "@tiptap/extension-ordered-list",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19734,6 +19838,9 @@
       "name": "@tiptap/extension-paragraph",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19746,7 +19853,8 @@
       "name": "@tiptap/extension-placeholder",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -19756,13 +19864,19 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "packages/extension-strike": {
       "name": "@tiptap/extension-strike",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19775,6 +19889,9 @@
       "name": "@tiptap/extension-subscript",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19787,6 +19904,9 @@
       "name": "@tiptap/extension-superscript",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19799,7 +19919,8 @@
       "name": "@tiptap/extension-table",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "@tiptap/prosemirror-tables": "^1.1.3",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
@@ -19810,13 +19931,19 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "packages/extension-table-cell": {
       "name": "@tiptap/extension-table-cell",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19829,6 +19956,9 @@
       "name": "@tiptap/extension-table-header",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19841,6 +19971,9 @@
       "name": "@tiptap/extension-table-row",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19853,6 +19986,10 @@
       "name": "@tiptap/extension-task-item",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19866,6 +20003,9 @@
       "name": "@tiptap/extension-task-list",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19878,6 +20018,9 @@
       "name": "@tiptap/extension-text",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19890,6 +20033,9 @@
       "name": "@tiptap/extension-text-align",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19902,6 +20048,9 @@
       "name": "@tiptap/extension-text-style",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19914,6 +20063,9 @@
       "name": "@tiptap/extension-typography",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19926,6 +20078,9 @@
       "name": "@tiptap/extension-underline",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19938,6 +20093,9 @@
       "name": "@tiptap/extension-youtube",
       "version": "2.0.0-beta.204",
       "license": "MIT",
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -19951,13 +20109,19 @@
       "version": "2.0.0-beta.204",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.204",
-        "prosemirror-model": "^1.18.1",
         "zeed-dom": "^0.9.19"
+      },
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.204",
+        "prosemirror-model": "^1.18.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0-beta.204",
+        "prosemirror-model": "^1.18.1"
       }
     },
     "packages/react": {
@@ -19970,6 +20134,7 @@
         "prosemirror-view": "^1.28.2"
       },
       "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "@types/react": "^18.0.1",
         "@types/react-dom": "^18.0.0",
         "react": "^18.0.0",
@@ -20019,7 +20184,8 @@
       "name": "@tiptap/suggestion",
       "version": "2.0.0-beta.204",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -20029,7 +20195,10 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0-beta.193"
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2"
       }
     },
     "packages/vue-2": {
@@ -20038,10 +20207,11 @@
       "license": "MIT",
       "dependencies": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.204",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.204",
-        "prosemirror-view": "^1.28.2"
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.204"
       },
       "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-view": "^1.28.2",
         "vue": "^2.6.0"
       },
       "funding": {
@@ -20050,6 +20220,7 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-view": "^1.28.2",
         "vue": "^2.6.0"
       }
     },
@@ -20064,11 +20235,12 @@
       "license": "MIT",
       "dependencies": {
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.204",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.204",
-        "prosemirror-state": "^1.4.1",
-        "prosemirror-view": "^1.28.2"
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.204"
       },
       "devDependencies": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2",
         "vue": "^3.0.0"
       },
       "funding": {
@@ -20077,6 +20249,8 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-view": "^1.28.2",
         "vue": "^3.0.0"
       }
     }
@@ -24866,15 +25040,20 @@
     },
     "@tiptap/extension-blockquote": {
       "version": "file:packages/extension-blockquote",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.1"
+      }
     },
     "@tiptap/extension-bold": {
       "version": "file:packages/extension-bold",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-bubble-menu": {
       "version": "file:packages/extension-bubble-menu",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "@types/lodash": "^4.14.187",
         "lodash": "^4.17.21",
         "prosemirror-state": "^1.4.1",
@@ -24884,28 +25063,36 @@
     },
     "@tiptap/extension-bullet-list": {
       "version": "file:packages/extension-bullet-list",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-character-count": {
       "version": "file:packages/extension-character-count",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-code": {
       "version": "file:packages/extension-code",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-code-block": {
       "version": "file:packages/extension-code-block",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-code-block-lowlight": {
       "version": "file:packages/extension-code-block-lowlight",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/extension-code-block": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -24914,6 +25101,7 @@
     "@tiptap/extension-collaboration": {
       "version": "file:packages/extension-collaboration",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1",
         "y-prosemirror": "1.0.20"
       }
@@ -24921,26 +25109,34 @@
     "@tiptap/extension-collaboration-cursor": {
       "version": "file:packages/extension-collaboration-cursor",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "y-prosemirror": "1.0.20"
       }
     },
     "@tiptap/extension-color": {
       "version": "file:packages/extension-color",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/extension-text-style": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-document": {
       "version": "file:packages/extension-document",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-dropcursor": {
       "version": "file:packages/extension-dropcursor",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-dropcursor": "1.5.0"
       }
     },
     "@tiptap/extension-floating-menu": {
       "version": "file:packages/extension-floating-menu",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
@@ -24949,55 +25145,73 @@
     "@tiptap/extension-focus": {
       "version": "file:packages/extension-focus",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
       }
     },
     "@tiptap/extension-font-family": {
       "version": "file:packages/extension-font-family",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/extension-text-style": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-gapcursor": {
       "version": "file:packages/extension-gapcursor",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-gapcursor": "^1.3.1"
       }
     },
     "@tiptap/extension-hard-break": {
       "version": "file:packages/extension-hard-break",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-heading": {
       "version": "file:packages/extension-heading",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-highlight": {
       "version": "file:packages/extension-highlight",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-history": {
       "version": "file:packages/extension-history",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-history": "^1.3.0"
       }
     },
     "@tiptap/extension-horizontal-rule": {
       "version": "file:packages/extension-horizontal-rule",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-image": {
       "version": "file:packages/extension-image",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-italic": {
       "version": "file:packages/extension-italic",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-link": {
       "version": "file:packages/extension-link",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "linkifyjs": "^3.0.5",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
@@ -25005,26 +25219,35 @@
     },
     "@tiptap/extension-list-item": {
       "version": "file:packages/extension-list-item",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-mention": {
       "version": "file:packages/extension-mention",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "@tiptap/suggestion": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-ordered-list": {
       "version": "file:packages/extension-ordered-list",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-paragraph": {
       "version": "file:packages/extension-paragraph",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-placeholder": {
       "version": "file:packages/extension-placeholder",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -25032,19 +25255,26 @@
     },
     "@tiptap/extension-strike": {
       "version": "file:packages/extension-strike",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-subscript": {
       "version": "file:packages/extension-subscript",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-superscript": {
       "version": "file:packages/extension-superscript",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-table": {
       "version": "file:packages/extension-table",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "@tiptap/prosemirror-tables": "^1.1.3",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
@@ -25053,47 +25283,70 @@
     },
     "@tiptap/extension-table-cell": {
       "version": "file:packages/extension-table-cell",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-table-header": {
       "version": "file:packages/extension-table-header",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-table-row": {
       "version": "file:packages/extension-table-row",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-task-item": {
       "version": "file:packages/extension-task-item",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-model": "^1.18.1"
+      }
     },
     "@tiptap/extension-task-list": {
       "version": "file:packages/extension-task-list",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-text": {
       "version": "file:packages/extension-text",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-text-align": {
       "version": "file:packages/extension-text-align",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-text-style": {
       "version": "file:packages/extension-text-style",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-typography": {
       "version": "file:packages/extension-typography",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-underline": {
       "version": "file:packages/extension-underline",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/extension-youtube": {
       "version": "file:packages/extension-youtube",
-      "requires": {}
+      "requires": {
+        "@tiptap/core": "^2.0.0-beta.193"
+      }
     },
     "@tiptap/html": {
       "version": "file:packages/html",
@@ -25107,6 +25360,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@tiptap/prosemirror-tables/-/prosemirror-tables-1.1.3.tgz",
       "integrity": "sha512-Pp7Iyup+kxniDGEvFHX+BRw3et9vys83NVqk6B+PbVAztq64QyX/mY+vzcpFmOsF9/th+Po981igbGUG7C/8hw==",
+      "dev": true,
       "requires": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -25118,6 +25372,7 @@
     "@tiptap/react": {
       "version": "file:packages/react",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.204",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.204",
         "@types/react": "^18.0.1",
@@ -25154,6 +25409,7 @@
     "@tiptap/suggestion": {
       "version": "file:packages/suggestion",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -25162,6 +25418,7 @@
     "@tiptap/vue-2": {
       "version": "file:packages/vue-2",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.204",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.204",
         "prosemirror-view": "^1.28.2",
@@ -25177,6 +25434,7 @@
     "@tiptap/vue-3": {
       "version": "file:packages/vue-3",
       "requires": {
+        "@tiptap/core": "^2.0.0-beta.193",
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.204",
         "@tiptap/extension-floating-menu": "^2.0.0-beta.204",
         "prosemirror-state": "^1.4.1",
@@ -29796,8 +30054,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -31550,6 +31807,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.3.1.tgz",
       "integrity": "sha512-XTporPgoECkOQACVw0JTe3RZGi+fls3/byqt+tXwGTkD7qLuB4KdVrJamDMJf4kfKga3uB8hZ+kUUyZ5oWpnfg==",
+      "dev": true,
       "requires": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -31558,6 +31816,7 @@
     },
     "prosemirror-dropcursor": {
       "version": "1.5.0",
+      "dev": true,
       "requires": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -31568,6 +31827,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.1.tgz",
       "integrity": "sha512-GKTeE7ZoMsx5uVfc51/ouwMFPq0o8YrZ7Hx4jTF4EeGbXxBveUV8CGv46mSHuBBeXGmvu50guoV2kSnOeZZnUA==",
+      "dev": true,
       "requires": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -31577,6 +31837,7 @@
     },
     "prosemirror-history": {
       "version": "1.3.0",
+      "dev": true,
       "requires": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -31585,6 +31846,7 @@
     },
     "prosemirror-keymap": {
       "version": "1.2.0",
+      "dev": true,
       "requires": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -31600,6 +31862,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.2.2.tgz",
       "integrity": "sha512-rd0pqSDp86p0MUMKG903g3I9VmElFkQpkZ2iOd3EOVg1vo5Cst51rAsoE+5IPy0LPXq64eGcCYlW1+JPNxOj2w==",
+      "dev": true,
       "requires": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -32162,7 +32425,8 @@
       }
     },
     "rope-sequence": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "dev": true
     },
     "run-async": {
       "version": "2.4.1",
@@ -33342,7 +33606,8 @@
       }
     },
     "w3c-keyname": {
-      "version": "2.2.4"
+      "version": "2.2.4",
+      "dev": true
     },
     "walk-up-path": {
       "version": "1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,16 @@
     "src",
     "dist"
   ],
-  "dependencies": {
+  "peerDependencies": {
+    "prosemirror-commands": "^1.3.1",
+    "prosemirror-keymap": "^1.2.0",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-schema-list": "^1.2.2",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-transform": "^1.7.0",
+    "prosemirror-view": "^1.28.2"
+  },
+  "devDependencies": {
     "prosemirror-commands": "^1.3.1",
     "prosemirror-keymap": "^1.2.0",
     "prosemirror-model": "^1.18.1",

--- a/packages/extension-blockquote/package.json
+++ b/packages/extension-blockquote/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.1"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-bold/package.json
+++ b/packages/extension-bold/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-bubble-menu/package.json
+++ b/packages/extension-bubble-menu/package.json
@@ -29,12 +29,16 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "dependencies": {
+    "tippy.js": "^6.3.7",
+    "lodash": "^4.17.21",
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-state": "^1.4.1",
-    "prosemirror-view": "^1.28.2",
-    "tippy.js": "^6.3.7"
+    "prosemirror-view": "^1.28.2"
   },
   "repository": {
     "type": "git",
@@ -43,7 +47,6 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@types/lodash": "^4.14.187",
-    "lodash": "^4.17.21"
+    "@types/lodash": "^4.14.187"
   }
 }

--- a/packages/extension-bullet-list/package.json
+++ b/packages/extension-bullet-list/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-character-count/package.json
+++ b/packages/extension-character-count/package.json
@@ -29,9 +29,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1"
   },

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -30,9 +30,14 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193",
-    "@tiptap/extension-code-block": "^2.0.0-beta.193"
+    "@tiptap/extension-code-block": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
+    "@tiptap/extension-code-block": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
     "prosemirror-view": "^1.28.2"

--- a/packages/extension-code-block/package.json
+++ b/packages/extension-code-block/package.json
@@ -29,9 +29,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-state": "^1.4.1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-state": "^1.4.1"
   },
   "repository": {

--- a/packages/extension-code/package.json
+++ b/packages/extension-code/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -29,9 +29,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "y-prosemirror": "1.0.20"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "y-prosemirror": "1.0.20"
   },
   "repository": {

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -29,9 +29,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-state": "^1.4.1",
+    "y-prosemirror": "1.0.20"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-state": "^1.4.1",
     "y-prosemirror": "1.0.20"
   },

--- a/packages/extension-color/package.json
+++ b/packages/extension-color/package.json
@@ -32,6 +32,10 @@
     "@tiptap/core": "^2.0.0-beta.193",
     "@tiptap/extension-text-style": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
+    "@tiptap/extension-text-style": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-document/package.json
+++ b/packages/extension-document/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-dropcursor/package.json
+++ b/packages/extension-dropcursor/package.json
@@ -29,9 +29,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-dropcursor": "1.5.0"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-dropcursor": "1.5.0"
   },
   "repository": {

--- a/packages/extension-floating-menu/package.json
+++ b/packages/extension-floating-menu/package.json
@@ -29,11 +29,16 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
+  },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "dependencies": {
-    "prosemirror-state": "^1.4.1",
-    "prosemirror-view": "^1.28.2",
     "tippy.js": "^6.3.7"
   },
   "repository": {

--- a/packages/extension-focus/package.json
+++ b/packages/extension-focus/package.json
@@ -29,9 +29,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-state": "^1.4.1",
     "prosemirror-view": "^1.28.2"
   },

--- a/packages/extension-font-family/package.json
+++ b/packages/extension-font-family/package.json
@@ -32,6 +32,10 @@
     "@tiptap/core": "^2.0.0-beta.193",
     "@tiptap/extension-text-style": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
+    "@tiptap/extension-text-style": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-gapcursor/package.json
+++ b/packages/extension-gapcursor/package.json
@@ -29,9 +29,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-gapcursor": "^1.3.1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-gapcursor": "^1.3.1"
   },
   "repository": {

--- a/packages/extension-hard-break/package.json
+++ b/packages/extension-hard-break/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-heading/package.json
+++ b/packages/extension-heading/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-highlight/package.json
+++ b/packages/extension-highlight/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-history/package.json
+++ b/packages/extension-history/package.json
@@ -29,9 +29,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-history": "^1.3.0"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-history": "^1.3.0"
   },
   "repository": {

--- a/packages/extension-horizontal-rule/package.json
+++ b/packages/extension-horizontal-rule/package.json
@@ -29,9 +29,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-state": "^1.4.1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-state": "^1.4.1"
   },
   "repository": {

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-italic/package.json
+++ b/packages/extension-italic/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -29,12 +29,17 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
-  },
-  "dependencies": {
-    "linkifyjs": "^3.0.5",
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1"
+  },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1"
+  },
+  "dependencies": {
+    "linkifyjs": "^3.0.5"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-list-item/package.json
+++ b/packages/extension-list-item/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -30,9 +30,13 @@
   ],
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193",
-    "@tiptap/suggestion": "^2.0.0-beta.193"
+    "@tiptap/suggestion": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
+    "@tiptap/suggestion": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1"
   },

--- a/packages/extension-ordered-list/package.json
+++ b/packages/extension-ordered-list/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-paragraph/package.json
+++ b/packages/extension-paragraph/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-placeholder/package.json
+++ b/packages/extension-placeholder/package.json
@@ -29,9 +29,13 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
     "prosemirror-view": "^1.28.2"

--- a/packages/extension-strike/package.json
+++ b/packages/extension-strike/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-subscript/package.json
+++ b/packages/extension-subscript/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-superscript/package.json
+++ b/packages/extension-superscript/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-table-cell/package.json
+++ b/packages/extension-table-cell/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-table-header/package.json
+++ b/packages/extension-table-header/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-table-row/package.json
+++ b/packages/extension-table-row/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -29,10 +29,14 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
-  "dependencies": {
+  "devDependencies": {
     "@tiptap/prosemirror-tables": "^1.1.3",
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
     "prosemirror-view": "^1.28.2"

--- a/packages/extension-task-item/package.json
+++ b/packages/extension-task-item/package.json
@@ -32,6 +32,10 @@
     "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-task-list/package.json
+++ b/packages/extension-task-list/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-text-align/package.json
+++ b/packages/extension-text-align/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-text-style/package.json
+++ b/packages/extension-text-style/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-text/package.json
+++ b/packages/extension-text/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-typography/package.json
+++ b/packages/extension-typography/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-underline/package.json
+++ b/packages/extension-underline/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/extension-youtube/package.json
+++ b/packages/extension-youtube/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193"
   },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -20,9 +20,15 @@
     "src",
     "dist"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.204",
-    "prosemirror-model": "^1.18.1",
+    "prosemirror-model": "^1.18.1"
+  },
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.204",
+    "prosemirror-model": "^1.18.1"
+  },
+  "dependencies": {
     "zeed-dom": "^0.9.19"
   },
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,6 +21,7 @@
     "dist"
   ],
   "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "@types/react": "^18.0.1",
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",

--- a/packages/suggestion/package.json
+++ b/packages/suggestion/package.json
@@ -21,9 +21,13 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.193"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "prosemirror-model": "^1.18.1",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@tiptap/core": "^2.0.0-beta.193",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
     "prosemirror-view": "^1.28.2"

--- a/packages/vue-2/package.json
+++ b/packages/vue-2/package.json
@@ -21,16 +21,18 @@
     "dist"
   ],
   "devDependencies": {
-    "vue": "^2.6.0"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "vue": "^2.6.0",
+    "prosemirror-view": "^1.28.2"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193",
-    "vue": "^2.6.0"
+    "vue": "^2.6.0",
+    "prosemirror-view": "^1.28.2"
   },
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.204",
-    "@tiptap/extension-floating-menu": "^2.0.0-beta.204",
-    "prosemirror-view": "^1.28.2"
+    "@tiptap/extension-floating-menu": "^2.0.0-beta.204"
   },
   "repository": {
     "type": "git",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -21,17 +21,20 @@
     "dist"
   ],
   "devDependencies": {
-    "vue": "^3.0.0"
+    "@tiptap/core": "^2.0.0-beta.193",
+    "vue": "^3.0.0",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193",
-    "vue": "^3.0.0"
+    "vue": "^3.0.0",
+    "prosemirror-state": "^1.4.1",
+    "prosemirror-view": "^1.28.2"
   },
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.204",
-    "@tiptap/extension-floating-menu": "^2.0.0-beta.204",
-    "prosemirror-state": "^1.4.1",
-    "prosemirror-view": "^1.28.2"
+    "@tiptap/extension-floating-menu": "^2.0.0-beta.204"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
refs  #3209, https://github.com/ueberdosis/hocuspocus/issues/445