### PR TITLE
fix: add "type": "module" and "exports" field to ESM dependencies

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -12,6 +12,14 @@
     "type": "github",
     "url": "https://github.com/sponsors/ueberdosis"
   },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/packages/html/src/index.d.ts",
+      "import": "./dist/tiptap-html.esm.js",
+      "require": "./dist/tiptap-html.cjs"
+    }
+  },
   "main": "dist/tiptap-html.cjs",
   "umd": "dist/tiptap-html.umd.js",
   "module": "dist/tiptap-html.esm.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,6 +12,14 @@
     "type": "github",
     "url": "https://github.com/sponsors/ueberdosis"
   },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/packages/react/src/index.d.ts",
+      "import": "./dist/tiptap-react.esm.js",
+      "require": "./dist/tiptap-react.cjs"
+    }
+  },
   "main": "dist/tiptap-react.cjs",
   "umd": "dist/tiptap-react.umd.js",
   "module": "dist/tiptap-react.esm.js",

--- a/packages/starter-kit/package.json
+++ b/packages/starter-kit/package.json
@@ -12,6 +12,14 @@
     "type": "github",
     "url": "https://github.com/sponsors/ueberdosis"
   },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/packages/starter-kit/src/index.d.ts",
+      "import": "./dist/tiptap-starter-kit.esm.js",
+      "require": "./dist/tiptap-starter-kit.cjs"
+    }
+  },
   "main": "dist/tiptap-starter-kit.cjs",
   "umd": "dist/tiptap-starter-kit.umd.js",
   "module": "dist/tiptap-starter-kit.esm.js",

--- a/packages/suggestion/package.json
+++ b/packages/suggestion/package.json
@@ -12,6 +12,14 @@
     "type": "github",
     "url": "https://github.com/sponsors/ueberdosis"
   },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/packages/suggestion/src/index.d.ts",
+      "import": "./dist/tiptap-suggestion.esm.js",
+      "require": "./dist/tiptap-suggestion.cjs"
+    }
+  },
   "main": "dist/tiptap-suggestion.cjs",
   "umd": "dist/tiptap-suggestion.umd.js",
   "module": "dist/tiptap-suggestion.esm.js",

--- a/packages/vue-2/package.json
+++ b/packages/vue-2/package.json
@@ -12,6 +12,14 @@
     "type": "github",
     "url": "https://github.com/sponsors/ueberdosis"
   },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/packages/vue-2/src/index.d.ts",
+      "import": "./dist/tiptap-vue-2.esm.js",
+      "require": "./dist/tiptap-vue-2.cjs"
+    }
+  },
   "main": "dist/tiptap-vue-2.cjs",
   "umd": "dist/tiptap-vue-2.umd.js",
   "module": "dist/tiptap-vue-2.esm.js",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -12,6 +12,14 @@
     "type": "github",
     "url": "https://github.com/sponsors/ueberdosis"
   },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/packages/vue-3/src/index.d.ts",
+      "import": "./dist/tiptap-vue-3.esm.js",
+      "require": "./dist/tiptap-vue-3.cjs"
+    }
+  },
   "main": "dist/tiptap-vue-3.cjs",
   "umd": "dist/tiptap-vue-3.umd.js",
   "module": "dist/tiptap-vue-3.esm.js",


### PR DESCRIPTION
After #3435 some dependencies are not treated as ESM, when they should be (since they have a separation with extensions)

For example, ESM `@tiptap-mention` imports CJS `@tiptap-suggestions`, because Node doesn't look at "module" field (this is bundlers convention, not Node's), and it's default is not a function, but a whole module (since this is how CJS works), so it fails with:

```
Suggestion is not a function
```