### PR TITLE
fix: Queue flushSync call

### DIFF
--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -79,7 +79,9 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
     // lifecycle methods, and React doesn't allow calling flushSync from inside
     // a lifecycle method.
     if (this.initialized) {
-      flushSync(fn)
+      queueMicrotask(() => {
+        flushSync(fn)        
+      })
     } else {
       fn()
     }


### PR DESCRIPTION
Do the same thing as https://github.com/ueberdosis/tiptap/pull/3188 - confirmed this got rid of the warning locally