### PR TITLE
Fix: custom text serializers should override text serializers defined in the schema

### DIFF
--- a/packages/core/src/helpers/generateText.ts
+++ b/packages/core/src/helpers/generateText.ts
@@ -23,8 +23,8 @@ export function generateText(
   return getText(contentNode, {
     blockSeparator,
     textSerializers: {
-      ...textSerializers,
       ...getTextSerializersFromSchema(schema),
+      ...textSerializers,
     },
   })
 }


### PR DESCRIPTION
Fixes https://github.com/ueberdosis/tiptap/issues/3538