### PR TITLE
Fix peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     },
     "demos": {
       "name": "tiptap-demos",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "dependencies": {
         "@hocuspocus/provider": "^1.0.0-alpha.29",
         "d3": "^7.3.0",
@@ -6714,7 +6714,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@tiptap/prosemirror-tables/-/prosemirror-tables-1.1.3.tgz",
       "integrity": "sha512-Pp7Iyup+kxniDGEvFHX+BRw3et9vys83NVqk6B+PbVAztq64QyX/mY+vzcpFmOsF9/th+Po981igbGUG7C/8hw==",
-      "dev": true,
       "dependencies": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -16170,7 +16169,6 @@
     },
     "node_modules/prosemirror-keymap": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -18785,7 +18783,6 @@
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/walk-up-path": {
@@ -19324,7 +19321,7 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
         "prosemirror-commands": "^1.3.1",
@@ -19351,10 +19348,10 @@
     },
     "packages/extension-blockquote": {
       "name": "@tiptap/extension-blockquote",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19366,10 +19363,10 @@
     },
     "packages/extension-bold": {
       "name": "@tiptap/extension-bold",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19381,13 +19378,11 @@
     },
     "packages/extension-bubble-menu": {
       "name": "@tiptap/extension-bubble-menu",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "lodash": "^4.17.21",
-        "prosemirror-state": "^1.4.1",
-        "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
@@ -19405,10 +19400,10 @@
     },
     "packages/extension-bullet-list": {
       "name": "@tiptap/extension-bullet-list",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19420,10 +19415,10 @@
     },
     "packages/extension-character-count": {
       "name": "@tiptap/extension-character-count",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       },
@@ -19439,10 +19434,10 @@
     },
     "packages/extension-code": {
       "name": "@tiptap/extension-code",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19454,10 +19449,10 @@
     },
     "packages/extension-code-block": {
       "name": "@tiptap/extension-code-block",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1"
       },
       "funding": {
@@ -19471,11 +19466,11 @@
     },
     "packages/extension-code-block-lowlight": {
       "name": "@tiptap/extension-code-block-lowlight",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-code-block": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-code-block": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -19494,10 +19489,10 @@
     },
     "packages/extension-collaboration": {
       "name": "@tiptap/extension-collaboration",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "y-prosemirror": "1.0.20"
       },
@@ -19513,10 +19508,10 @@
     },
     "packages/extension-collaboration-cursor": {
       "name": "@tiptap/extension-collaboration-cursor",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "y-prosemirror": "1.0.20"
       },
       "funding": {
@@ -19530,11 +19525,11 @@
     },
     "packages/extension-color": {
       "name": "@tiptap/extension-color",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-text-style": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-text-style": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19547,10 +19542,10 @@
     },
     "packages/extension-document": {
       "name": "@tiptap/extension-document",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19562,10 +19557,10 @@
     },
     "packages/extension-dropcursor": {
       "name": "@tiptap/extension-dropcursor",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-dropcursor": "1.5.0"
       },
       "funding": {
@@ -19579,13 +19574,13 @@
     },
     "packages/extension-floating-menu": {
       "name": "@tiptap/extension-floating-menu",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
       },
@@ -19601,10 +19596,10 @@
     },
     "packages/extension-focus": {
       "name": "@tiptap/extension-focus",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
       },
@@ -19620,11 +19615,11 @@
     },
     "packages/extension-font-family": {
       "name": "@tiptap/extension-font-family",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-text-style": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-text-style": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19637,10 +19632,10 @@
     },
     "packages/extension-gapcursor": {
       "name": "@tiptap/extension-gapcursor",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-gapcursor": "^1.3.1"
       },
       "funding": {
@@ -19654,10 +19649,10 @@
     },
     "packages/extension-hard-break": {
       "name": "@tiptap/extension-hard-break",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19669,10 +19664,10 @@
     },
     "packages/extension-heading": {
       "name": "@tiptap/extension-heading",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19684,10 +19679,10 @@
     },
     "packages/extension-highlight": {
       "name": "@tiptap/extension-highlight",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19699,10 +19694,10 @@
     },
     "packages/extension-history": {
       "name": "@tiptap/extension-history",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-history": "^1.3.0"
       },
       "funding": {
@@ -19716,10 +19711,10 @@
     },
     "packages/extension-horizontal-rule": {
       "name": "@tiptap/extension-horizontal-rule",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1"
       },
       "funding": {
@@ -19733,10 +19728,10 @@
     },
     "packages/extension-image": {
       "name": "@tiptap/extension-image",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19748,10 +19743,10 @@
     },
     "packages/extension-italic": {
       "name": "@tiptap/extension-italic",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19763,13 +19758,13 @@
     },
     "packages/extension-link": {
       "name": "@tiptap/extension-link",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^3.0.5"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       },
@@ -19785,10 +19780,10 @@
     },
     "packages/extension-list-item": {
       "name": "@tiptap/extension-list-item",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19800,11 +19795,11 @@
     },
     "packages/extension-mention": {
       "name": "@tiptap/extension-mention",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/suggestion": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/suggestion": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       },
@@ -19821,10 +19816,10 @@
     },
     "packages/extension-ordered-list": {
       "name": "@tiptap/extension-ordered-list",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19836,10 +19831,10 @@
     },
     "packages/extension-paragraph": {
       "name": "@tiptap/extension-paragraph",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19851,10 +19846,10 @@
     },
     "packages/extension-placeholder": {
       "name": "@tiptap/extension-placeholder",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -19872,10 +19867,10 @@
     },
     "packages/extension-strike": {
       "name": "@tiptap/extension-strike",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19887,10 +19882,10 @@
     },
     "packages/extension-subscript": {
       "name": "@tiptap/extension-subscript",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19902,10 +19897,10 @@
     },
     "packages/extension-superscript": {
       "name": "@tiptap/extension-superscript",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19917,11 +19912,13 @@
     },
     "packages/extension-table": {
       "name": "@tiptap/extension-table",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
+      "dependencies": {
+        "@tiptap/prosemirror-tables": "^1.1.3"
+      },
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/prosemirror-tables": "^1.1.3",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -19939,10 +19936,10 @@
     },
     "packages/extension-table-cell": {
       "name": "@tiptap/extension-table-cell",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19954,10 +19951,10 @@
     },
     "packages/extension-table-header": {
       "name": "@tiptap/extension-table-header",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19969,10 +19966,10 @@
     },
     "packages/extension-table-row": {
       "name": "@tiptap/extension-table-row",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -19984,10 +19981,10 @@
     },
     "packages/extension-task-item": {
       "name": "@tiptap/extension-task-item",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1"
       },
       "funding": {
@@ -20001,10 +19998,10 @@
     },
     "packages/extension-task-list": {
       "name": "@tiptap/extension-task-list",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20016,10 +20013,10 @@
     },
     "packages/extension-text": {
       "name": "@tiptap/extension-text",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20031,10 +20028,10 @@
     },
     "packages/extension-text-align": {
       "name": "@tiptap/extension-text-align",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20046,10 +20043,10 @@
     },
     "packages/extension-text-style": {
       "name": "@tiptap/extension-text-style",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20061,10 +20058,10 @@
     },
     "packages/extension-typography": {
       "name": "@tiptap/extension-typography",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20076,10 +20073,10 @@
     },
     "packages/extension-underline": {
       "name": "@tiptap/extension-underline",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20091,10 +20088,10 @@
     },
     "packages/extension-youtube": {
       "name": "@tiptap/extension-youtube",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20106,13 +20103,13 @@
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
         "zeed-dom": "^0.9.19"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1"
       },
       "funding": {
@@ -20126,15 +20123,14 @@
     },
     "packages/react": {
       "name": "@tiptap/react",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.206",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.206",
-        "prosemirror-view": "^1.28.2"
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.209"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "@types/react": "^18.0.1",
         "@types/react-dom": "^18.0.0",
         "react": "^18.0.0",
@@ -20146,34 +20142,35 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0-beta.193",
+        "prosemirror-view": "^1.28.2",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-blockquote": "^2.0.0-beta.206",
-        "@tiptap/extension-bold": "^2.0.0-beta.206",
-        "@tiptap/extension-bullet-list": "^2.0.0-beta.206",
-        "@tiptap/extension-code": "^2.0.0-beta.206",
-        "@tiptap/extension-code-block": "^2.0.0-beta.206",
-        "@tiptap/extension-document": "^2.0.0-beta.206",
-        "@tiptap/extension-dropcursor": "^2.0.0-beta.206",
-        "@tiptap/extension-gapcursor": "^2.0.0-beta.206",
-        "@tiptap/extension-hard-break": "^2.0.0-beta.206",
-        "@tiptap/extension-heading": "^2.0.0-beta.206",
-        "@tiptap/extension-history": "^2.0.0-beta.206",
-        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.206",
-        "@tiptap/extension-italic": "^2.0.0-beta.206",
-        "@tiptap/extension-list-item": "^2.0.0-beta.206",
-        "@tiptap/extension-ordered-list": "^2.0.0-beta.206",
-        "@tiptap/extension-paragraph": "^2.0.0-beta.206",
-        "@tiptap/extension-strike": "^2.0.0-beta.206",
-        "@tiptap/extension-text": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-blockquote": "^2.0.0-beta.209",
+        "@tiptap/extension-bold": "^2.0.0-beta.209",
+        "@tiptap/extension-bullet-list": "^2.0.0-beta.209",
+        "@tiptap/extension-code": "^2.0.0-beta.209",
+        "@tiptap/extension-code-block": "^2.0.0-beta.209",
+        "@tiptap/extension-document": "^2.0.0-beta.209",
+        "@tiptap/extension-dropcursor": "^2.0.0-beta.209",
+        "@tiptap/extension-gapcursor": "^2.0.0-beta.209",
+        "@tiptap/extension-hard-break": "^2.0.0-beta.209",
+        "@tiptap/extension-heading": "^2.0.0-beta.209",
+        "@tiptap/extension-history": "^2.0.0-beta.209",
+        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.209",
+        "@tiptap/extension-italic": "^2.0.0-beta.209",
+        "@tiptap/extension-list-item": "^2.0.0-beta.209",
+        "@tiptap/extension-ordered-list": "^2.0.0-beta.209",
+        "@tiptap/extension-paragraph": "^2.0.0-beta.209",
+        "@tiptap/extension-strike": "^2.0.0-beta.209",
+        "@tiptap/extension-text": "^2.0.0-beta.209"
       },
       "funding": {
         "type": "github",
@@ -20182,10 +20179,10 @@
     },
     "packages/suggestion": {
       "name": "@tiptap/suggestion",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -20203,14 +20200,14 @@
     },
     "packages/vue-2": {
       "name": "@tiptap/vue-2",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.206",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.206"
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.209"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-view": "^1.28.2",
         "vue": "^2.6.0"
       },
@@ -20231,14 +20228,14 @@
     },
     "packages/vue-3": {
       "name": "@tiptap/vue-3",
-      "version": "2.0.0-beta.206",
+      "version": "2.0.0-beta.209",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.206",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.206"
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.209"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2",
         "vue": "^3.0.0"
@@ -25041,36 +25038,34 @@
     "@tiptap/extension-blockquote": {
       "version": "file:packages/extension-blockquote",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-bold": {
       "version": "file:packages/extension-bold",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-bubble-menu": {
       "version": "file:packages/extension-bubble-menu",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "@types/lodash": "^4.14.187",
         "lodash": "^4.17.21",
-        "prosemirror-state": "^1.4.1",
-        "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
       }
     },
     "@tiptap/extension-bullet-list": {
       "version": "file:packages/extension-bullet-list",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-character-count": {
       "version": "file:packages/extension-character-count",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       }
@@ -25078,21 +25073,21 @@
     "@tiptap/extension-code": {
       "version": "file:packages/extension-code",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-code-block": {
       "version": "file:packages/extension-code-block",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-code-block-lowlight": {
       "version": "file:packages/extension-code-block-lowlight",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-code-block": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-code-block": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -25101,7 +25096,7 @@
     "@tiptap/extension-collaboration": {
       "version": "file:packages/extension-collaboration",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "y-prosemirror": "1.0.20"
       }
@@ -25109,34 +25104,34 @@
     "@tiptap/extension-collaboration-cursor": {
       "version": "file:packages/extension-collaboration-cursor",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "y-prosemirror": "1.0.20"
       }
     },
     "@tiptap/extension-color": {
       "version": "file:packages/extension-color",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-text-style": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-text-style": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-document": {
       "version": "file:packages/extension-document",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-dropcursor": {
       "version": "file:packages/extension-dropcursor",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-dropcursor": "1.5.0"
       }
     },
     "@tiptap/extension-floating-menu": {
       "version": "file:packages/extension-floating-menu",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2",
         "tippy.js": "^6.3.7"
@@ -25145,7 +25140,7 @@
     "@tiptap/extension-focus": {
       "version": "file:packages/extension-focus",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
       }
@@ -25153,65 +25148,65 @@
     "@tiptap/extension-font-family": {
       "version": "file:packages/extension-font-family",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-text-style": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-text-style": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-gapcursor": {
       "version": "file:packages/extension-gapcursor",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-gapcursor": "^1.3.1"
       }
     },
     "@tiptap/extension-hard-break": {
       "version": "file:packages/extension-hard-break",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-heading": {
       "version": "file:packages/extension-heading",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-highlight": {
       "version": "file:packages/extension-highlight",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-history": {
       "version": "file:packages/extension-history",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-history": "^1.3.0"
       }
     },
     "@tiptap/extension-horizontal-rule": {
       "version": "file:packages/extension-horizontal-rule",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1"
       }
     },
     "@tiptap/extension-image": {
       "version": "file:packages/extension-image",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-italic": {
       "version": "file:packages/extension-italic",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-link": {
       "version": "file:packages/extension-link",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "linkifyjs": "^3.0.5",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
@@ -25220,14 +25215,14 @@
     "@tiptap/extension-list-item": {
       "version": "file:packages/extension-list-item",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-mention": {
       "version": "file:packages/extension-mention",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/suggestion": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/suggestion": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1"
       }
@@ -25235,19 +25230,19 @@
     "@tiptap/extension-ordered-list": {
       "version": "file:packages/extension-ordered-list",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-paragraph": {
       "version": "file:packages/extension-paragraph",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-placeholder": {
       "version": "file:packages/extension-placeholder",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -25256,25 +25251,25 @@
     "@tiptap/extension-strike": {
       "version": "file:packages/extension-strike",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-subscript": {
       "version": "file:packages/extension-subscript",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-superscript": {
       "version": "file:packages/extension-superscript",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-table": {
       "version": "file:packages/extension-table",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "@tiptap/prosemirror-tables": "^1.1.3",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
@@ -25284,74 +25279,74 @@
     "@tiptap/extension-table-cell": {
       "version": "file:packages/extension-table-cell",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-table-header": {
       "version": "file:packages/extension-table-header",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-table-row": {
       "version": "file:packages/extension-table-row",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-task-item": {
       "version": "file:packages/extension-task-item",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1"
       }
     },
     "@tiptap/extension-task-list": {
       "version": "file:packages/extension-task-list",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-text": {
       "version": "file:packages/extension-text",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-text-align": {
       "version": "file:packages/extension-text-align",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-text-style": {
       "version": "file:packages/extension-text-style",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-typography": {
       "version": "file:packages/extension-typography",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-underline": {
       "version": "file:packages/extension-underline",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/extension-youtube": {
       "version": "file:packages/extension-youtube",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209"
       }
     },
     "@tiptap/html": {
       "version": "file:packages/html",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "zeed-dom": "^0.9.19"
       }
@@ -25360,7 +25355,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@tiptap/prosemirror-tables/-/prosemirror-tables-1.1.3.tgz",
       "integrity": "sha512-Pp7Iyup+kxniDGEvFHX+BRw3et9vys83NVqk6B+PbVAztq64QyX/mY+vzcpFmOsF9/th+Po981igbGUG7C/8hw==",
-      "dev": true,
       "requires": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -25372,12 +25366,11 @@
     "@tiptap/react": {
       "version": "file:packages/react",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.206",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.209",
         "@types/react": "^18.0.1",
         "@types/react-dom": "^18.0.0",
-        "prosemirror-view": "^1.28.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
@@ -25385,31 +25378,31 @@
     "@tiptap/starter-kit": {
       "version": "file:packages/starter-kit",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-blockquote": "^2.0.0-beta.206",
-        "@tiptap/extension-bold": "^2.0.0-beta.206",
-        "@tiptap/extension-bullet-list": "^2.0.0-beta.206",
-        "@tiptap/extension-code": "^2.0.0-beta.206",
-        "@tiptap/extension-code-block": "^2.0.0-beta.206",
-        "@tiptap/extension-document": "^2.0.0-beta.206",
-        "@tiptap/extension-dropcursor": "^2.0.0-beta.206",
-        "@tiptap/extension-gapcursor": "^2.0.0-beta.206",
-        "@tiptap/extension-hard-break": "^2.0.0-beta.206",
-        "@tiptap/extension-heading": "^2.0.0-beta.206",
-        "@tiptap/extension-history": "^2.0.0-beta.206",
-        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.206",
-        "@tiptap/extension-italic": "^2.0.0-beta.206",
-        "@tiptap/extension-list-item": "^2.0.0-beta.206",
-        "@tiptap/extension-ordered-list": "^2.0.0-beta.206",
-        "@tiptap/extension-paragraph": "^2.0.0-beta.206",
-        "@tiptap/extension-strike": "^2.0.0-beta.206",
-        "@tiptap/extension-text": "^2.0.0-beta.206"
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-blockquote": "^2.0.0-beta.209",
+        "@tiptap/extension-bold": "^2.0.0-beta.209",
+        "@tiptap/extension-bullet-list": "^2.0.0-beta.209",
+        "@tiptap/extension-code": "^2.0.0-beta.209",
+        "@tiptap/extension-code-block": "^2.0.0-beta.209",
+        "@tiptap/extension-document": "^2.0.0-beta.209",
+        "@tiptap/extension-dropcursor": "^2.0.0-beta.209",
+        "@tiptap/extension-gapcursor": "^2.0.0-beta.209",
+        "@tiptap/extension-hard-break": "^2.0.0-beta.209",
+        "@tiptap/extension-heading": "^2.0.0-beta.209",
+        "@tiptap/extension-history": "^2.0.0-beta.209",
+        "@tiptap/extension-horizontal-rule": "^2.0.0-beta.209",
+        "@tiptap/extension-italic": "^2.0.0-beta.209",
+        "@tiptap/extension-list-item": "^2.0.0-beta.209",
+        "@tiptap/extension-ordered-list": "^2.0.0-beta.209",
+        "@tiptap/extension-paragraph": "^2.0.0-beta.209",
+        "@tiptap/extension-strike": "^2.0.0-beta.209",
+        "@tiptap/extension-text": "^2.0.0-beta.209"
       }
     },
     "@tiptap/suggestion": {
       "version": "file:packages/suggestion",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
         "prosemirror-model": "^1.18.1",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2"
@@ -25418,9 +25411,9 @@
     "@tiptap/vue-2": {
       "version": "file:packages/vue-2",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.206",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.209",
         "prosemirror-view": "^1.28.2",
         "vue": "^2.6.0"
       },
@@ -25434,9 +25427,9 @@
     "@tiptap/vue-3": {
       "version": "file:packages/vue-3",
       "requires": {
-        "@tiptap/core": "^2.0.0-beta.206",
-        "@tiptap/extension-bubble-menu": "^2.0.0-beta.206",
-        "@tiptap/extension-floating-menu": "^2.0.0-beta.206",
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
+        "@tiptap/extension-floating-menu": "^2.0.0-beta.209",
         "prosemirror-state": "^1.4.1",
         "prosemirror-view": "^1.28.2",
         "vue": "^3.0.0"
@@ -31846,7 +31839,6 @@
     },
     "prosemirror-keymap": {
       "version": "1.2.0",
-      "dev": true,
       "requires": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -33606,8 +33598,7 @@
       }
     },
     "w3c-keyname": {
-      "version": "2.2.4",
-      "dev": true
+      "version": "2.2.4"
     },
     "walk-up-path": {
       "version": "1.0.0",

--- a/packages/extension-bubble-menu/package.json
+++ b/packages/extension-bubble-menu/package.json
@@ -36,8 +36,6 @@
   "dependencies": {
     "@tiptap/core": "^2.0.0-beta.209",
     "lodash": "^4.17.21",
-    "prosemirror-state": "^1.4.1",
-    "prosemirror-view": "^1.28.2",
     "tippy.js": "^6.3.7"
   },
   "repository": {

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -28,16 +28,17 @@
     "src",
     "dist"
   ],
+  "dependencies": {
+    "@tiptap/prosemirror-tables": "^1.1.3"
+  },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193",
-    "@tiptap/prosemirror-tables": "^1.1.3",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
     "prosemirror-view": "^1.28.2"
   },
   "devDependencies": {
     "@tiptap/core": "^2.0.0-beta.209",
-    "@tiptap/prosemirror-tables": "^1.1.3",
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
     "prosemirror-view": "^1.28.2"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,12 +30,12 @@
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.193",
     "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "prosemirror-view": "^1.28.2"
   },
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
-    "@tiptap/extension-floating-menu": "^2.0.0-beta.209",
-    "prosemirror-view": "^1.28.2"
+    "@tiptap/extension-floating-menu": "^2.0.0-beta.209"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- It seems there still have been some ProseMirror dependencies left in extension-bubble-menu. Removed them.
- @tiptap/prosemirror-tables became a dependency in extension-table since it has PM peer dependencies.
- React package still had prosemirror-view in dependencies. Outsourced to peer dependencies.