### PR TITLE
document removing or overriding link attributes

### DIFF
--- a/docs/api/marks/link.md
+++ b/docs/api/marks/link.md
@@ -75,6 +75,24 @@ Link.configure({
 })
 ```
 
+#### Removing and overriding existing html attributes
+
+You can add `rel: null` to HTMLAttributes to remove the default `rel="noopener noreferrer nofollow"`. You can also override the default by using `rel: "your-value"`.
+
+This can also be used to change the `target` from the default value of `_blank`.
+
+```js
+Link.configure({
+  HTMLAttributes: {
+    // Change rel to different value
+    // Allow search engines to follow links(remove nofollow)
+    rel: 'noopener noreferrer',
+    // Remove target entirely so links open in current tab
+    target: null,
+  },
+})
+```
+
 ### validate
 A function that validates every autolinked link. If it exists, it will be called with the link href as argument. If it returns `false`, the link will be removed.
 


### PR DESCRIPTION
The documentation mentions being able to override the `rel` on links but doesn't explain how. It also doesn't tell you how to remove the rel if needed(set to null).

Add an example of removing a default attribute and overriding one to a different value.