### PR TITLE
feat(extension/bubble-menu): allow bubble menu to show up even on empty selections

### DIFF
--- a/docs/api/extensions/bubble-menu.md
+++ b/docs/api/extensions/bubble-menu.md
@@ -33,6 +33,15 @@ Type: `Number`
 
 Default: `undefined`
 
+
+### allowEmptySelection
+The `BubbleMenu` is shown even on empty selections (no character is selected and the bubble menu is displayed above the cursor).
+
+Type: `Boolean`
+
+Default: `false`
+
+
 ### tippyOptions
 Under the hood, the `BubbleMenu` uses [tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/). You can directly pass options to it.
 

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -23,6 +23,7 @@ export interface BubbleMenuPluginProps {
     from: number,
     to: number,
   }) => boolean) | null,
+  allowEmptySelection: boolean,
 }
 
 export type BubbleMenuViewProps = BubbleMenuPluginProps & {
@@ -43,6 +44,8 @@ export class BubbleMenuView {
   public tippyOptions?: Partial<Props>
 
   public updateDelay: number
+
+  public allowEmptySelection: boolean
 
   public shouldShow: Exclude<BubbleMenuPluginProps['shouldShow'], null> = ({
     view,
@@ -68,8 +71,7 @@ export class BubbleMenuView {
 
     if (
       !hasEditorFocus
-      || empty
-      || isEmptyTextBlock
+      || (!this.allowEmptySelection && (empty || isEmptyTextBlock))
       || !this.editor.isEditable
     ) {
       return false
@@ -85,11 +87,13 @@ export class BubbleMenuView {
     tippyOptions = {},
     updateDelay = 250,
     shouldShow,
+    allowEmptySelection = false,
   }: BubbleMenuViewProps) {
     this.editor = editor
     this.element = element
     this.view = view
     this.updateDelay = updateDelay
+    this.allowEmptySelection = allowEmptySelection
 
     if (shouldShow) {
       this.shouldShow = shouldShow
@@ -166,7 +170,9 @@ export class BubbleMenuView {
 
   update(view: EditorView, oldState?: EditorState) {
     const { state } = view
-    const hasValidSelection = state.selection.$from.pos !== state.selection.$to.pos
+    const hasValidSelection = this.allowEmptySelection
+      ? true
+      : state.selection.$from.pos !== state.selection.$to.pos
 
     if (this.updateDelay > 0 && hasValidSelection) {
       debounce(this.updateHandler, this.updateDelay)(view, oldState)

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -16,6 +16,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
       pluginKey: 'bubbleMenu',
       updateDelay: undefined,
       shouldShow: null,
+      allowEmptySelection: false,
     }
   },
 
@@ -32,6 +33,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
         tippyOptions: this.options.tippyOptions,
         updateDelay: this.options.updateDelay,
         shouldShow: this.options.shouldShow,
+        allowEmptySelection: this.options.allowEmptySelection,
       }),
     ]
   },

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -7,6 +7,7 @@ export type BubbleMenuProps = Omit<Optional<BubbleMenuPluginProps, 'pluginKey'>,
   className?: string;
   children: React.ReactNode;
   updateDelay?: number;
+  allowEmptySelection?: boolean;
 };
 
 export const BubbleMenu = (props: BubbleMenuProps) => {
@@ -22,7 +23,12 @@ export const BubbleMenu = (props: BubbleMenuProps) => {
     }
 
     const {
-      pluginKey = 'bubbleMenu', editor, tippyOptions = {}, updateDelay, shouldShow = null,
+      pluginKey = 'bubbleMenu',
+      editor,
+      tippyOptions = {},
+      updateDelay,
+      shouldShow = null,
+      allowEmptySelection = false,
     } = props
 
     const plugin = BubbleMenuPlugin({
@@ -32,6 +38,7 @@ export const BubbleMenu = (props: BubbleMenuProps) => {
       pluginKey,
       shouldShow,
       tippyOptions,
+      allowEmptySelection,
     })
 
     editor.registerPlugin(plugin)

--- a/packages/vue-2/src/BubbleMenu.ts
+++ b/packages/vue-2/src/BubbleMenu.ts
@@ -7,6 +7,7 @@ export interface BubbleMenuInterface extends Vue {
   tippyOptions: BubbleMenuPluginProps['tippyOptions'],
   updateDelay: BubbleMenuPluginProps['updateDelay'],
   shouldShow: BubbleMenuPluginProps['shouldShow'],
+  allowEmptySelection: BubbleMenuPluginProps['allowEmptySelection']
 }
 
 export const BubbleMenu: Component = {
@@ -36,6 +37,11 @@ export const BubbleMenu: Component = {
       type: Function as PropType<Exclude<BubbleMenuPluginProps['shouldShow'], null>>,
       default: null,
     },
+
+    allowEmptySelection: {
+      type: Boolean as PropType<BubbleMenuPluginProps['allowEmptySelection']>,
+      default: false,
+    },
   },
 
   watch: {
@@ -54,6 +60,7 @@ export const BubbleMenu: Component = {
             pluginKey: this.pluginKey,
             shouldShow: this.shouldShow,
             tippyOptions: this.tippyOptions,
+            allowEmptySelection: this.allowEmptySelection,
           }))
         })
       },

--- a/packages/vue-3/src/BubbleMenu.ts
+++ b/packages/vue-3/src/BubbleMenu.ts
@@ -38,6 +38,11 @@ export const BubbleMenu = defineComponent({
       type: Function as PropType<Exclude<Required<BubbleMenuPluginProps>['shouldShow'], null>>,
       default: null,
     },
+
+    allowEmptySelection: {
+      type: Boolean as PropType<BubbleMenuPluginProps['allowEmptySelection']>,
+      default: false,
+    },
   },
 
   setup(props, { slots }) {
@@ -50,6 +55,7 @@ export const BubbleMenu = defineComponent({
         pluginKey,
         shouldShow,
         tippyOptions,
+        allowEmptySelection,
       } = props
 
       editor.registerPlugin(BubbleMenuPlugin({
@@ -59,6 +65,7 @@ export const BubbleMenu = defineComponent({
         pluginKey,
         shouldShow,
         tippyOptions,
+        allowEmptySelection,
       }))
     })
 


### PR DESCRIPTION
This adds a prop that enables displaying bubble menus even with empty selections.
See https://github.com/ueberdosis/tiptap/issues/3633 for context.