### PR TITLE
Update schema.md

### DIFF
--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -18,7 +18,7 @@ When you’ll work with the provided extensions only, you don’t have to care t
 // the underlying ProseMirror schema
 {
   nodes: {
-    document: {
+    doc: {
       content: 'block+',
     },
     paragraph: {


### PR DESCRIPTION
The schema definition example uses the node name `document` while the explaining text says that the node name is `doc`.