### PR TITLE
fix: override schema text serializers if provided in getText options

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -440,8 +440,8 @@ export class Editor extends EventEmitter<EditorEvents> {
     return getText(this.state.doc, {
       blockSeparator,
       textSerializers: {
-        ...textSerializers,
         ...getTextSerializersFromSchema(this.schema),
+        ...textSerializers,
       },
     })
   }


### PR DESCRIPTION
Fixes https://github.com/ueberdosis/tiptap/issues/3670