### PR TITLE
build(vue3-deps): Moves extension deps to peerDependencies & devDependencies

### DIFF
--- a/packages/extension-floating-menu/package.json
+++ b/packages/extension-floating-menu/package.json
@@ -28,8 +28,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.209",
-    "@tiptap/pm": "^2.0.0-beta.209"
+    "@tiptap/core": "^2.0.0-beta.212",
+    "@tiptap/pm": "^2.0.0-beta.212"
   },
   "devDependencies": {
     "@tiptap/core": "^2.0.0-beta.212",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -30,16 +30,16 @@
   "devDependencies": {
     "@tiptap/core": "^2.0.0-beta.212",
     "@tiptap/pm": "^2.0.0-beta.212",
+    "@tiptap/extension-bubble-menu": "^2.0.0-beta.212",
+    "@tiptap/extension-floating-menu": "^2.0.0-beta.212",
     "vue": "^3.0.0"
   },
   "peerDependencies": {
-    "@tiptap/core": "^2.0.0-beta.209",
-    "@tiptap/pm": "^2.0.0-beta.209",
-    "vue": "^3.0.0"
-  },
-  "dependencies": {
+    "@tiptap/core": "^2.0.0-beta.212",
+    "@tiptap/pm": "^2.0.0-beta.212",
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.212",
-    "@tiptap/extension-floating-menu": "^2.0.0-beta.212"
+    "@tiptap/extension-floating-menu": "^2.0.0-beta.212",
+    "vue": "^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Do not affect when there is a new version