### PR TITLE
fix(extension-link): Click handler opens selected link instead of clicked link

### DIFF
--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -14,8 +14,11 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
         const attrs = getAttributes(view.state, options.type.name)
         const link = (event.target as HTMLElement)?.closest('a')
 
-        if (link && attrs.href) {
-          window.open(attrs.href, attrs.target)
+        const href = link?.href ?? attrs.href
+        const target = link?.target ?? attrs.target
+
+        if (link && href) {
+          window.open(href, target)
 
           return true
         }


### PR DESCRIPTION
# Description
Fixes a bug in which under certain conditions where multiple links are present, clicking one link will instead open a different link. Specifically, when the editor state shows one link as selected, clicking a different link will open the "selected" link instead.

See also https://github.com/ParabolInc/parabol/issues/7524 where this issue was initially reported for our web app.

# Repro
The specific conditions in which editor state does not reflect the clicked link are:
* `openOnClick` is true
* Content is read-only - `editable` is false

As such, I recommend reviewers test with the following patch applied:
```
diff --git a/demos/src/Marks/Link/React/index.jsx b/demos/src/Marks/Link/React/index.jsx
index 53b3134a9..4cfb9b4f3 100644
--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -16,7 +16,7 @@ export default () => {
       Text,
       Code,
       Link.configure({
-        openOnClick: false,
+        openOnClick: true,
       }),
     ],
     content: `
@@ -27,6 +27,8 @@ export default () => {
           By default every link will get a <code>rel="noopener noreferrer nofollow"</code> attribute. It’s configurable though.
         </p>
       `,
+
+    editable: false,
   })
 
   const setLink = useCallback(() => {

```

With this patch applied, you can reproduce locally with the following steps:
* Navigate to `/preview/Marks/Link`
* Cmd+click "world wide web" (opens https://en.wikipedia.org/wiki/World_Wide_Web)
* Cmd+click "another one" (also opens https://en.wikipedia.org/wiki/World_Wide_Web instead of https://statamic.com/)

After applying the changes in this PR, the Cmd+click on "another one" will open the correct link, https://statamic.com/