### PR TITLE
Extend `nodePasteRule` `find` type to most generic `PasteRuleFinder`

### DIFF
--- a/packages/core/src/pasteRules/nodePasteRule.ts
+++ b/packages/core/src/pasteRules/nodePasteRule.ts
@@ -1,6 +1,6 @@
 import { NodeType } from '@tiptap/pm/model'
 
-import { PasteRule } from '../PasteRule'
+import { PasteRule, PasteRuleFinder } from '../PasteRule'
 import { ExtendedRegExpMatchArray } from '../types'
 import { callOrReturn } from '../utilities'
 
@@ -9,7 +9,7 @@ import { callOrReturn } from '../utilities'
  * matched text is pasted into it.
  */
 export function nodePasteRule(config: {
-  find: RegExp
+  find: PasteRuleFinder
   type: NodeType
   getAttributes?:
     | Record<string, any>


### PR DESCRIPTION
Hello team!
First off, thank you for building and maintaining `tiptap`, it is truly a pleasure to work with.

While working on our editor, we ran across `nodePasteRule` which we wanted to use with a non-regexp pattern.
The specs in `PasteRule.ts` doe also allow functions as argument for `find`, and functions actually work perfectly with `nodePasteRule` as well, but there will be a type error.

This PR changes the type of `nodePasteRule`'s `find` to the most general type it can accept.
I hope it's  OK to open a PR directly for this two-line change.