### PR TITLE
fix(typography): dont create fractions in the middle of a string

### DIFF
--- a/packages/extension-typography/src/typography.ts
+++ b/packages/extension-typography/src/typography.ts
@@ -86,7 +86,7 @@ export const registeredTrademark = textInputRule({
 })
 
 export const oneHalf = textInputRule({
-  find: /1\/2$/,
+  find: /(?:^|\s)(1\/2)$/,
   replace: '½',
 })
 
@@ -126,12 +126,12 @@ export const superscriptThree = textInputRule({
 })
 
 export const oneQuarter = textInputRule({
-  find: /1\/4$/,
+  find: /(?:^|\s)(1\/4)$/,
   replace: '¼',
 })
 
 export const threeQuarters = textInputRule({
-  find: /3\/4$/,
+  find: /(?:^|\s)(3\/4)$/,
   replace: '¾',
 })
 


### PR DESCRIPTION
This PR should fix #3674 by implementing more strict regex expressions to catch only fractions with a whitespace char or the start of a newline.

closes #3674 