### PR TITLE
Only allow left mouse button to open links

### DIFF
--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -11,6 +11,8 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
     key: new PluginKey('handleClickLink'),
     props: {
       handleClick: (view, pos, event) => {
+        if (event.button !== 1) return;
+
         const attrs = getAttributes(view.state, options.type.name)
         const link = (event.target as HTMLElement)?.closest('a')
 


### PR DESCRIPTION
Currently links inside the editor can be opened by pressing any of the mouse buttons. This changes fixes that by allowing only the left mouse button to open links (as is the behavior every where).