### PR TITLE
Optimize empty document detection in `documentClear` plugin

### DIFF
--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -99,9 +99,13 @@ export const Keymap = Extension.create({
           const allFrom = Selection.atStart(oldState.doc).from
           const allEnd = Selection.atEnd(oldState.doc).to
           const allWasSelected = from === allFrom && to === allEnd
-          const isEmpty = newState.doc.textBetween(0, newState.doc.content.size, ' ', ' ').length === 0
 
-          if (empty || !allWasSelected || !isEmpty) {
+          if (empty || !allWasSelected) {
+            return
+          }
+
+          const isEmpty = newState.doc.textBetween(0, newState.doc.content.size, ' ', ' ').length === 0
+          if (!isEmpty) {
             return
           }
 


### PR DESCRIPTION
Currently Tiptap checks if the document is empty on almost every transaction using `doc.textBetween` which is quite expensive. This is not required most of the time because Select all + delete is a rare case. This PR moves the `doc.textBetween` based check after the other checks to it only runs when it is 100% that user has actually selected all the text.