### PR TITLE
fix(react): reset initialized when editorcontent is unmounting

### DIFF
--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -79,9 +79,7 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
     // lifecycle methods, and React doesn't allow calling flushSync from inside
     // a lifecycle method.
     if (this.initialized) {
-      queueMicrotask(() => {
-        flushSync(fn)        
-      })
+      flushSync(fn)
     } else {
       fn()
     }
@@ -115,6 +113,10 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
 
     if (!editor) {
       return
+    }
+
+    if (this.initialized) {
+      this.initialized = false
     }
 
     if (!editor.isDestroyed) {


### PR DESCRIPTION
This PR should resolve the flushSync issues (see #3331, #3580, #3764) and pr #3533 

From my local tests I didn't receive any error messages nor did my cursor stay in the old position after inserting a new React NodeView with an editor content.

closes #3331
closes #3580
closes #3764 