### PR TITLE
chore: allow new ReactComponentContent components to be created

### DIFF
--- a/demos/src/GuideNodeViews/ReactComponentContent/React/Extension.js
+++ b/demos/src/GuideNodeViews/ReactComponentContent/React/Extension.js
@@ -18,6 +18,14 @@ export default Node.create({
     ]
   },
 
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Enter': () => {
+        return this.editor.chain().insertContentAt(this.editor.state.selection.head, { type: this.type.name }).focus().run()
+      },
+    }
+  },
+
   renderHTML({ HTMLAttributes }) {
     return ['react-component', mergeAttributes(HTMLAttributes), 0]
   },

--- a/demos/src/GuideNodeViews/ReactComponentContent/React/index.jsx
+++ b/demos/src/GuideNodeViews/ReactComponentContent/React/index.jsx
@@ -17,7 +17,7 @@ export default () => {
       This is still the text editor you’re used to, but enriched with node views.
     </p>
     <react-component>
-      <p>This is editable.</p>
+      <p>This is editable. You can create a new component by pressing Mod+Enter.</p>
     </react-component>
     <p>
       Did you see that? That’s a React component. We are really living in the future.

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -80,7 +80,7 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
     // a lifecycle method.
     if (this.initialized) {
       queueMicrotask(() => {
-        flushSync(fn)        
+        flushSync(fn)
       })
     } else {
       fn()


### PR DESCRIPTION
Inside the `ReactComponentContent` node view demo there was no way to add new components to test cursor behavior. This adds this functionality by using `Mod+Enter`.

This is related to #3781 as it was used to test the functionality this way.