### PR TITLE
docs: add extension cli note to contributing docs

### DIFF
--- a/docs/overview/contributing.md
+++ b/docs/overview/contributing.md
@@ -34,5 +34,14 @@ There is an eslint config that ensures a consistent code style. To check for err
 ## Testing for errors
 Your pull request will automatically execute all our existing tests. Make sure that they all pass, before sending a pull request. Run all tests locally with `$ npm run test` or run single tests (e. g. when writing new ones) with `$ npm run test:open`.
 
+## Creating your own extensions
+If you want to create and maintain your own extensions, you can use your `create-tiptap-extension` CLI tool. It will create a new extension boilerplate with all necessary files and the build process. It's as easy as running
+
+```bash
+npm init tiptap-extension
+```
+
+If you want to let us know about your extension you can give us a hint on [Twitter](https://twitter.com/tiptap_editor) or [Discord](https://discord.gg/WtJ49jGshW).
+
 ## Further questions
 Any further questions? Create a new issue or discussion in the repository. We’ll get back to you.


### PR DESCRIPTION
Adds a note about our new `create-tiptap-extension` CLI to the contribution documentation.