### PR TITLE
Fix destroyed view causing errors on dispatchTransaction

### DIFF
--- a/demos/src/Experiments/DestroyingEditor/Vue/index.vue
+++ b/demos/src/Experiments/DestroyingEditor/Vue/index.vue
@@ -1,0 +1,49 @@
+<template>
+  <div v-if="editor">
+    <button @click="() => editor.chain().toggleBold().focus().run()">Make bold</button>
+    <button @click="() => editor.destroy()">Destroy editor</button>
+  </div>
+  <div v-if="editor">
+    <editor-content :editor="editor" />
+  </div>
+</template>
+
+<script>
+import StarterKit from '@tiptap/starter-kit'
+import { Editor, EditorContent } from '@tiptap/vue-3'
+
+export default {
+  components: {
+    EditorContent,
+  },
+
+  data() {
+    return {
+      editor: null,
+    }
+  },
+
+  mounted() {
+    this.editor = new Editor({
+      extensions: [
+        StarterKit,
+      ],
+      content: `
+        <p>Try destroying the editor</p>
+      `,
+    })
+  },
+
+  beforeUnmount() {
+    this.editor.destroy()
+  },
+}
+</script>
+
+<style lang="scss">
+.ProseMirror {
+  > * + * {
+    margin-top: 0.75em;
+  }
+}
+</style>

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -320,6 +320,12 @@ export class Editor extends EventEmitter<EditorEvents> {
    * @param transaction An editor state transaction
    */
   private dispatchTransaction(transaction: Transaction): void {
+    // if the editor / the view of the editor was destroyed
+    // the transaction should not be dispatched as there is no view anymore.
+    if (this.view.isDestroyed) {
+      return
+    }
+
     if (this.isCapturingTransaction) {
       if (!this.capturedTransaction) {
         this.capturedTransaction = transaction


### PR DESCRIPTION
This PR should fix the issue #3798 

There should be no errors anymore if the view is not existent anymore.

close #3798 