### PR TITLE
fix: use prose-base class for sm screens 

### DIFF
--- a/demos/src/Experiments/Tailwind/JS/index.html
+++ b/demos/src/Experiments/Tailwind/JS/index.html
@@ -16,7 +16,7 @@ const editor = new Editor({
   ],
   editorProps: {
     attributes: {
-      class: 'prose dark:prose-invert prose-sm sm:prose lg:prose-lg xl:prose-2xl m-5 focus:outline-none',
+      class: 'prose dark:prose-invert prose-sm sm:prose-base lg:prose-lg xl:prose-2xl m-5 focus:outline-none',
     },
   },
   content: `


### PR DESCRIPTION
Heya,

I figured that using `sm:prose-base` makes more sense since the `prose` class is already set beforehand