### PR TITLE
Retain existing config when calling `configure` on Marks and Extensions

### DIFF
--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -340,7 +340,7 @@ export class Extension<Options = any, Storage = any> {
   configure(options: Partial<Options> = {}) {
     // return a new instance so we can use the same extension
     // with different calls of `configure`
-    const extension = this.extend()
+    const extension = this.extend(this.config)
 
     extension.options = mergeDeep(this.options as Record<string, any>, options) as Options
 

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -464,7 +464,7 @@ export class Mark<Options = any, Storage = any> {
   configure(options: Partial<Options> = {}) {
     // return a new instance so we can use the same extension
     // with different calls of `configure`
-    const extension = this.extend()
+    const extension = this.extend(this.config)
 
     extension.options = mergeDeep(this.options as Record<string, any>, options) as Options
 

--- a/tests/cypress/integration/core/configureExtensions.spec.ts
+++ b/tests/cypress/integration/core/configureExtensions.spec.ts
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+
+import { Extension } from '@tiptap/core'
+
+describe('configure extensions', () => {
+  it('should inherit config', () => {
+    const name = 'my-extension'
+    const extension = Extension.create({ name })
+
+    expect(extension.configure().config.name).to.eq(name)
+  })
+})

--- a/tests/cypress/integration/core/configureMarks.spec.ts
+++ b/tests/cypress/integration/core/configureMarks.spec.ts
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+
+import { Mark } from '@tiptap/core'
+
+describe('configure marks', () => {
+  it('should inherit config', () => {
+    const exitable = true
+    const mark = Mark.create({ exitable })
+
+    expect(mark.configure().config.exitable).to.eq(true)
+  })
+})


### PR DESCRIPTION
Currently, when you call `.configure()` on a `Mark` or `Extension`, the `Mark` or `Extension` that's returned doesn't retain the config from the original.

This is a problem for StarterKit. When `Code` is added to an editor added as a standalone extension, [an inline code block is `exitable`](https://github.com/ueberdosis/tiptap/blob/43970fd496ffa22eae73ce95a11ed71d6efa4c03/packages/extension-code/src/code.ts#L47). When added as part of StarterKit, [an inline code block is not `exitable`](https://github.com/ueberdosis/tiptap/issues/3813) because [StarterKit calls `Code.configure()`](https://github.com/ueberdosis/tiptap/blob/43970fd496ffa22eae73ce95a11ed71d6efa4c03/packages/starter-kit/src/starter-kit.ts#L61), blowing away the default config.

This PR ensures that when you call `.configure()` on a `Mark` or `Extension`, the `Mark` or `Extension` that's returned retains the config from the original.

closes https://github.com/ueberdosis/tiptap/issues/3813