### PR TITLE
fix: Allow `emit` to be accessed anywhere

### DIFF
--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -22,7 +22,7 @@ export class EventEmitter<T extends Record<string, any>> {
     return this
   }
 
-  protected emit<EventName extends StringKeyOf<T>>(event: EventName, ...args: CallbackType<T, EventName>): this {
+  public emit<EventName extends StringKeyOf<T>>(event: EventName, ...args: CallbackType<T, EventName>): this {
     const callbacks = this.callbacks[event]
 
     if (callbacks) {

--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -46,7 +46,7 @@ export class EventEmitter<T extends Record<string, any>> {
     return this
   }
 
-  protected removeAllListeners(): void {
+  public removeAllListeners(): void {
     this.callbacks = {}
   }
 }


### PR DESCRIPTION
replace the protected `emit` member in `EventEmitter` with public member. Originally posted by @fw6 in https://github.com/ueberdosis/tiptap/discussions/3845_