### PR TITLE
fix: replace the whole node in nodeInputRule

### DIFF
--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -43,7 +43,10 @@ export function nodeInputRule(config: {
         // insert node from input rule
         tr.replaceWith(matchStart, end, config.type.create(attributes))
       } else if (match[0]) {
-        tr.replaceWith(start, end, config.type.create(attributes))
+        tr.insert(start - 1, config.type.create(attributes)).delete(
+          tr.mapping.map(start),
+          tr.mapping.map(end),
+        )
       }
     },
   })


### PR DESCRIPTION
Hi,

This PR fixes some issues with the horizontal rule:

* https://github.com/ueberdosis/tiptap/issues/3809
* https://github.com/ueberdosis/tiptap/issues/1964
* https://github.com/ueberdosis/tiptap/issues/1665

The new behavior creates a new paragraph below the horizontal rule, instead of above.

## Implementation

I changed the implementation of `nodeInputRule` for the case when there's no group matched in the input rule regexp.

As far as I understand, the previous implementation was trying to replace the content of the existing node, not the node itself. We need to include the node boundaries as well to do so: `start - 1` and `end + 1`.

The new implementation first inserts the new node at the existing node position (`start - 1`) and then delete the remaining content. Let me know if that makes sense or if there's a better approach.

Grepping the codebase quickly, it seems that other usages of `nodeInputRule` always use a matching group, so this change should only affect the `HorizontalRule` extension.