### PR TITLE
Handle NodeViews in BubbleMenu positioning

### DIFF
--- a/demos/src/Extensions/BubbleMenu/React/index.jsx
+++ b/demos/src/Extensions/BubbleMenu/React/index.jsx
@@ -1,18 +1,69 @@
 import './styles.scss'
 
-import { BubbleMenu, EditorContent, useEditor } from '@tiptap/react'
+import {
+  BubbleMenu, EditorContent, Node, NodeViewWrapper, ReactNodeViewRenderer, useEditor,
+} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import React, { useEffect } from 'react'
+
+const CustomNodeView = () => {
+  return (
+    <NodeViewWrapper>
+      <div contentEditable={false} style={{ float: 'left', aspectRatio: 1, backgroundColor: 'red' }}>This is my node view!</div>
+    </NodeViewWrapper>
+  )
+}
+
+const CustomNodeViewNode = Node.create({
+  name: 'customNodeView',
+
+  group: 'block',
+
+  content: 'inline*',
+
+  selectable: true,
+
+  defining: true,
+
+  atom: true,
+
+  isolating: true,
+
+  renderHTML() {
+    return ['div', { class: 'custom-node-view' }, 0]
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div.custom-node-view',
+      },
+    ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(CustomNodeView)
+  },
+})
 
 export default () => {
   const editor = useEditor({
     extensions: [
       StarterKit,
+      CustomNodeViewNode,
     ],
     content: `
+      <div class="custom-node-view"></div>
       <p>
         Hey, try to select some text here. There will popup a menu for selecting some inline styles. Remember: you have full control about content and styling of this menu.
       </p>
+      <div class="custom-node-view"></div>
+      <div class="custom-node-view"></div>
+      <p>
+        Hey, try to select some text here. There will popup a menu for selecting some inline styles. Remember: you have full control about content and styling of this menu.
+      </p>
+      <div class="custom-node-view"></div>
+      <div class="custom-node-view"></div>
     `,
   })
 
@@ -30,7 +81,7 @@ export default () => {
         <input type="checkbox" checked={isEditable} onChange={() => setIsEditable(!isEditable)} />
         Editable
       </div>
-      {editor && <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }}>
+      {editor && <BubbleMenu updateDelay={2000} editor={editor} tippyOptions={{ duration: 100 }}>
         <button
           onClick={() => editor.chain().focus().toggleBold().run()}
           className={editor.isActive('bold') ? 'is-active' : ''}

--- a/demos/src/Extensions/BubbleMenu/React/index.jsx
+++ b/demos/src/Extensions/BubbleMenu/React/index.jsx
@@ -1,69 +1,20 @@
 import './styles.scss'
 
 import {
-  BubbleMenu, EditorContent, Node, NodeViewWrapper, ReactNodeViewRenderer, useEditor,
+  BubbleMenu, EditorContent, useEditor,
 } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import React, { useEffect } from 'react'
-
-const CustomNodeView = () => {
-  return (
-    <NodeViewWrapper>
-      <div contentEditable={false} style={{ float: 'left', aspectRatio: 1, backgroundColor: 'red' }}>This is my node view!</div>
-    </NodeViewWrapper>
-  )
-}
-
-const CustomNodeViewNode = Node.create({
-  name: 'customNodeView',
-
-  group: 'block',
-
-  content: 'inline*',
-
-  selectable: true,
-
-  defining: true,
-
-  atom: true,
-
-  isolating: true,
-
-  renderHTML() {
-    return ['div', { class: 'custom-node-view' }, 0]
-  },
-
-  parseHTML() {
-    return [
-      {
-        tag: 'div.custom-node-view',
-      },
-    ]
-  },
-
-  addNodeView() {
-    return ReactNodeViewRenderer(CustomNodeView)
-  },
-})
 
 export default () => {
   const editor = useEditor({
     extensions: [
       StarterKit,
-      CustomNodeViewNode,
     ],
     content: `
-      <div class="custom-node-view"></div>
       <p>
         Hey, try to select some text here. There will popup a menu for selecting some inline styles. Remember: you have full control about content and styling of this menu.
       </p>
-      <div class="custom-node-view"></div>
-      <div class="custom-node-view"></div>
-      <p>
-        Hey, try to select some text here. There will popup a menu for selecting some inline styles. Remember: you have full control about content and styling of this menu.
-      </p>
-      <div class="custom-node-view"></div>
-      <div class="custom-node-view"></div>
     `,
   })
 
@@ -81,7 +32,7 @@ export default () => {
         <input type="checkbox" checked={isEditable} onChange={() => setIsEditable(!isEditable)} />
         Editable
       </div>
-      {editor && <BubbleMenu updateDelay={2000} editor={editor} tippyOptions={{ duration: 100 }}>
+      {editor && <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }}>
         <button
           onClick={() => editor.chain().focus().toggleBold().run()}
           className={editor.isActive('bold') ? 'is-active' : ''}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6564,12 +6564,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "dev": true,
@@ -13328,7 +13322,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -19345,12 +19340,10 @@
       "version": "2.0.0-beta.220",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21",
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/pm": "^2.0.0-beta.220",
-        "@types/lodash": "^4.14.191"
+        "@tiptap/pm": "^2.0.0-beta.220"
       },
       "funding": {
         "type": "github",
@@ -24496,8 +24489,6 @@
       "version": "file:packages/extension-bubble-menu",
       "requires": {
         "@tiptap/pm": "^2.0.0-beta.220",
-        "@types/lodash": "^4.14.191",
-        "lodash": "^4.17.21",
         "tippy.js": "^6.3.7"
       }
     },
@@ -24915,12 +24906,6 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
     "@types/minimatch": {
@@ -29258,7 +29243,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/packages/extension-bubble-menu/package.json
+++ b/packages/extension-bubble-menu/package.json
@@ -33,7 +33,6 @@
     "@tiptap/pm": "^2.0.0-beta.209"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
     "tippy.js": "^6.3.7"
   },
   "repository": {
@@ -43,8 +42,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@tiptap/pm": "^2.0.0-beta.220",
-    "@types/lodash": "^4.14.191"
+    "@tiptap/pm": "^2.0.0-beta.220"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -201,7 +201,13 @@ export class BubbleMenuView {
         this.tippyOptions?.getReferenceClientRect
         || (() => {
           if (isNodeSelection(state.selection)) {
-            const node = view.nodeDOM(from) as HTMLElement
+            let node = view.nodeDOM(from) as HTMLElement
+
+            const nodeViewWrapper = node.querySelector('[data-node-view-wrapper]')
+
+            if (nodeViewWrapper) {
+              node = nodeViewWrapper.firstChild as HTMLElement
+            }
 
             if (node) {
               return node.getBoundingClientRect()

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -3,7 +3,6 @@ import {
 } from '@tiptap/core'
 import { EditorState, Plugin, PluginKey } from '@tiptap/pm/state'
 import { EditorView } from '@tiptap/pm/view'
-import debounce from 'lodash/debounce'
 import tippy, { Instance, Props } from 'tippy.js'
 
 export interface BubbleMenuPluginProps {
@@ -42,6 +41,8 @@ export class BubbleMenuView {
   public tippyOptions?: Partial<Props>
 
   public updateDelay: number
+
+  private updateDebounceTimer: number | undefined
 
   public shouldShow: Exclude<BubbleMenuPluginProps['shouldShow'], null> = ({
     view,
@@ -159,10 +160,21 @@ export class BubbleMenuView {
     const hasValidSelection = state.selection.$from.pos !== state.selection.$to.pos
 
     if (this.updateDelay > 0 && hasValidSelection) {
-      debounce(this.updateHandler, this.updateDelay)(view, oldState)
-    } else {
-      this.updateHandler(view, oldState)
+      this.handleDebouncedUpdate(view, oldState)
+      return
     }
+
+    this.updateHandler(view, oldState)
+  }
+
+  handleDebouncedUpdate = (view: EditorView, oldState?: EditorState) => {
+    if (this.updateDebounceTimer) {
+      clearTimeout(this.updateDebounceTimer)
+    }
+
+    this.updateDebounceTimer = window.setTimeout(() => {
+      this.updateHandler(view, oldState)
+    }, this.updateDelay)
   }
 
   updateHandler = (view: EditorView, oldState?: EditorState) => {

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -215,7 +215,7 @@ export class BubbleMenuView {
           if (isNodeSelection(state.selection)) {
             let node = view.nodeDOM(from) as HTMLElement
 
-            const nodeViewWrapper = node.querySelector('[data-node-view-wrapper]')
+            const nodeViewWrapper = node.dataset.nodeViewWrapper ? node : node.querySelector('[data-node-view-wrapper]')
 
             if (nodeViewWrapper) {
               node = nodeViewWrapper.firstChild as HTMLElement


### PR DESCRIPTION
This PR should close #1313.

## Fixing bubble menu positions in combination with float

Before this PR, the position for the bubble menu was always determined by the currently selected element (either the text positions or the node that was selected).

Since node views are usually wrapped by either:

1. A `data-node-view-wrapper` OR
2. A react node view renderer element

the positionings for the bubble menu could be mixed up when several positioning methods were used.

In the example of #1313 `float` was used to position said elements left/right of inline content which caused those wrapper elements to be of full-width, but have a height of `0`.

This PR now resolves this by checking the selected node - if the selected node contains a `data-node-view-wrapper` or is a node view wrapper, the **first child** of the node view will be picked as a reference point.

## Fixing debounce issues

This PR also removes lodash and implements a small custom debouncer. This should help with duplicated functions on update and keeps bundle size and dependencies smaller.