### PR TITLE
feat(core): add editor to this context in schema functions

### DIFF
--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -31,7 +31,7 @@ export class ExtensionManager {
   constructor(extensions: Extensions, editor: Editor) {
     this.editor = editor
     this.extensions = ExtensionManager.resolve(extensions)
-    this.schema = getSchemaByResolvedExtensions(this.extensions)
+    this.schema = getSchemaByResolvedExtensions(this.extensions, editor)
 
     this.extensions.forEach(extension => {
       // store extension storage in editor

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -311,6 +311,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<MarkConfig<Options, Storage>>['inclusive']
+          editor?: Editor
         }) => MarkSpec['inclusive'])
 
     /**
@@ -323,6 +324,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<MarkConfig<Options, Storage>>['excludes']
+          editor?: Editor
         }) => MarkSpec['excludes'])
 
     /**
@@ -340,6 +342,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<MarkConfig<Options, Storage>>['group']
+          editor?: Editor
         }) => MarkSpec['group'])
 
     /**
@@ -352,6 +355,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<MarkConfig<Options, Storage>>['spanning']
+          editor?: Editor
         }) => MarkSpec['spanning'])
 
     /**
@@ -364,6 +368,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<MarkConfig<Options, Storage>>['code']
+          editor?: Editor
         }) => boolean)
 
     /**
@@ -374,6 +379,7 @@ declare module '@tiptap/core' {
       options: Options
       storage: Storage
       parent: ParentConfig<MarkConfig<Options, Storage>>['parseHTML']
+      editor?: Editor
     }) => MarkSpec['parseDOM']
 
     /**
@@ -386,6 +392,7 @@ declare module '@tiptap/core' {
             options: Options
             storage: Storage
             parent: ParentConfig<MarkConfig<Options, Storage>>['renderHTML']
+            editor?: Editor
           },
           props: {
             mark: ProseMirrorMark
@@ -402,6 +409,7 @@ declare module '@tiptap/core' {
       options: Options
       storage: Storage
       parent: ParentConfig<MarkConfig<Options, Storage>>['addAttributes']
+      editor?: Editor
     }) => Attributes | {}
   }
 }

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -164,6 +164,7 @@ declare module '@tiptap/core' {
             options: Options
             storage: Storage
             parent: ParentConfig<NodeConfig<Options, Storage>>['extendMarkSchema']
+            editor?: Editor
           },
           extension: Node,
         ) => Record<string, any>)
@@ -325,6 +326,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['content']
+          editor?: Editor
         }) => NodeSpec['content'])
 
     /**
@@ -337,6 +339,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['marks']
+          editor?: Editor
         }) => NodeSpec['marks'])
 
     /**
@@ -349,6 +352,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['group']
+          editor?: Editor
         }) => NodeSpec['group'])
 
     /**
@@ -361,6 +365,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['inline']
+          editor?: Editor
         }) => NodeSpec['inline'])
 
     /**
@@ -373,6 +378,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['atom']
+          editor?: Editor
         }) => NodeSpec['atom'])
 
     /**
@@ -385,6 +391,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['selectable']
+          editor?: Editor
         }) => NodeSpec['selectable'])
 
     /**
@@ -397,6 +404,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['draggable']
+          editor?: Editor
         }) => NodeSpec['draggable'])
 
     /**
@@ -409,6 +417,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['code']
+          editor?: Editor
         }) => NodeSpec['code'])
 
     /**
@@ -421,6 +430,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['whitespace']
+          editor?: Editor
         }) => NodeSpec['whitespace'])
 
     /**
@@ -433,6 +443,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['defining']
+          editor?: Editor
         }) => NodeSpec['defining'])
 
     /**
@@ -445,6 +456,7 @@ declare module '@tiptap/core' {
           options: Options
           storage: Storage
           parent: ParentConfig<NodeConfig<Options, Storage>>['isolating']
+          editor?: Editor
         }) => NodeSpec['isolating'])
 
     /**
@@ -455,6 +467,7 @@ declare module '@tiptap/core' {
       options: Options
       storage: Storage
       parent: ParentConfig<NodeConfig<Options, Storage>>['parseHTML']
+      editor?: Editor
     }) => NodeSpec['parseDOM']
 
     /**
@@ -467,6 +480,7 @@ declare module '@tiptap/core' {
             options: Options
             storage: Storage
             parent: ParentConfig<NodeConfig<Options, Storage>>['renderHTML']
+            editor?: Editor
           },
           props: {
             node: ProseMirrorNode
@@ -485,6 +499,7 @@ declare module '@tiptap/core' {
             options: Options
             storage: Storage
             parent: ParentConfig<NodeConfig<Options, Storage>>['renderText']
+            editor?: Editor
           },
           props: {
             node: ProseMirrorNode
@@ -503,6 +518,7 @@ declare module '@tiptap/core' {
       options: Options
       storage: Storage
       parent: ParentConfig<NodeConfig<Options, Storage>>['addAttributes']
+      editor?: Editor
     }) => Attributes | {}
   }
 }

--- a/packages/core/src/helpers/getSchema.ts
+++ b/packages/core/src/helpers/getSchema.ts
@@ -1,11 +1,12 @@
 import { Schema } from '@tiptap/pm/model'
 
+import { Editor } from '../Editor'
 import { ExtensionManager } from '../ExtensionManager'
 import { Extensions } from '../types'
 import { getSchemaByResolvedExtensions } from './getSchemaByResolvedExtensions'
 
-export function getSchema(extensions: Extensions): Schema {
+export function getSchema(extensions: Extensions, editor?: Editor): Schema {
   const resolvedExtensions = ExtensionManager.resolve(extensions)
 
-  return getSchemaByResolvedExtensions(resolvedExtensions)
+  return getSchemaByResolvedExtensions(resolvedExtensions, editor)
 }

--- a/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
+++ b/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
@@ -1,6 +1,6 @@
 import { MarkSpec, NodeSpec, Schema } from '@tiptap/pm/model'
 
-import { MarkConfig, NodeConfig } from '..'
+import { Editor, MarkConfig, NodeConfig } from '..'
 import { AnyConfig, Extensions } from '../types'
 import { callOrReturn } from '../utilities/callOrReturn'
 import { isEmptyObject } from '../utilities/isEmptyObject'
@@ -12,8 +12,9 @@ import { splitExtensions } from './splitExtensions'
 
 function cleanUpSchemaItem<T>(data: T) {
   return Object.fromEntries(
+    // @ts-ignore
     Object.entries(data).filter(([key, value]) => {
-      if (key === 'attrs' && isEmptyObject(value)) {
+      if (key === 'attrs' && isEmptyObject(value as {} | undefined)) {
         return false
       }
 
@@ -22,7 +23,7 @@ function cleanUpSchemaItem<T>(data: T) {
   ) as T
 }
 
-export function getSchemaByResolvedExtensions(extensions: Extensions): Schema {
+export function getSchemaByResolvedExtensions(extensions: Extensions, editor?: Editor): Schema {
   const allAttributes = getAttributesFromExtensions(extensions)
   const { nodeExtensions, markExtensions } = splitExtensions(extensions)
   const topNode = nodeExtensions.find(extension => getExtensionField(extension, 'topNode'))?.name
@@ -36,6 +37,7 @@ export function getSchemaByResolvedExtensions(extensions: Extensions): Schema {
         name: extension.name,
         options: extension.options,
         storage: extension.storage,
+        editor,
       }
 
       const extraNodeFields = extensions.reduce((fields, e) => {
@@ -124,6 +126,7 @@ export function getSchemaByResolvedExtensions(extensions: Extensions): Schema {
         name: extension.name,
         options: extension.options,
         storage: extension.storage,
+        editor,
       }
 
       const extraMarkFields = extensions.reduce((fields, e) => {


### PR DESCRIPTION
This PR adds `editor` to the `this` context inside our schema functions for Nodes and Marks.

This means, inside your `renderHTML` function you could access `this.editor`.