### PR TITLE
fix(react): fix rebinding events not overwriting editor.on

### DIFF
--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,5 +1,10 @@
 import { EditorOptions } from '@tiptap/core'
-import { DependencyList, useEffect, useState } from 'react'
+import {
+  DependencyList,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 
 import { Editor } from './Editor'
 
@@ -25,6 +30,15 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
     onUpdate,
   } = options
 
+  const onBeforeCreateRef = useRef(onBeforeCreate)
+  const onBlurRef = useRef(onBlur)
+  const onCreateRef = useRef(onCreate)
+  const onDestroyRef = useRef(onDestroy)
+  const onFocusRef = useRef(onFocus)
+  const onSelectionUpdateRef = useRef(onSelectionUpdate)
+  const onTransactionRef = useRef(onTransaction)
+  const onUpdateRef = useRef(onUpdate)
+
   // This effect will handle updating the editor instance
   // when the event handlers change.
   useEffect(() => {
@@ -33,45 +47,53 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
     }
 
     if (onBeforeCreate) {
-      editor.off('beforeCreate')
+      editor.off('beforeCreate', onBeforeCreateRef.current)
       editor.on('beforeCreate', onBeforeCreate)
     }
+    onBeforeCreateRef.current = onBeforeCreate
 
     if (onBlur) {
-      editor.off('blur')
+      editor.off('blur', onBlurRef.current)
       editor.on('blur', onBlur)
     }
+    onBlurRef.current = onBlur
 
     if (onCreate) {
-      editor.off('create')
+      editor.off('create', onCreateRef.current)
       editor.on('create', onCreate)
     }
+    onCreateRef.current = onCreate
 
     if (onDestroy) {
-      editor.off('destroy')
+      editor.off('destroy', onDestroyRef.current)
       editor.on('destroy', onDestroy)
     }
+    onDestroyRef.current = onDestroy
 
     if (onFocus) {
-      editor.off('focus')
+      editor.off('focus', onFocusRef.current)
       editor.on('focus', onFocus)
     }
+    onFocusRef.current = onFocus
 
     if (onSelectionUpdate) {
-      editor.off('selectionUpdate')
+      editor.off('selectionUpdate', onSelectionUpdateRef.current)
       editor.on('selectionUpdate', onSelectionUpdate)
     }
+    onSelectionUpdateRef.current = onSelectionUpdate
 
     if (onTransaction) {
-      editor.off('transaction')
+      editor.off('transaction', onTransactionRef.current)
       editor.on('transaction', onTransaction)
     }
+    onTransactionRef.current = onTransaction
 
     if (onUpdate) {
-      editor.off('update')
+      editor.off('update', onUpdateRef.current)
       editor.on('update', onUpdate)
     }
-  }, [onBeforeCreate, onBlur, onCreate, onDestroy, onFocus, onSelectionUpdate, onTransaction, onUpdate])
+    onUpdateRef.current = onUpdate
+  }, [onBeforeCreate, onBlur, onCreate, onDestroy, onFocus, onSelectionUpdate, onTransaction, onUpdate, editor])
 
   useEffect(() => {
     let isMounted = true


### PR DESCRIPTION
## Please describe your changes

This PR fixes the issue described in #3932 by unbinding specific event handlers instead of **all** event handlers in a hook inside `useEditor`.

## How did you accomplish your changes

1. Save the event handlers into refs to compare them afterwards for unbinding
2. Whenever a changed event handler is registered, unbind the old one, register the new one
3. Save the new one was the old one for next check

## How have you tested your changes

I created a local demo to test this behavior. It didn't create to many callbacks & correctly unregistered old ones. Also events registered via `Editor.on` were working correctly.

## How can we verify your changes

Create a local React demo and register a callback via `editor.on`.

## Remarks

Nothing to remark

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

- closes #3932 
