### PR TITLE
fix: clear nodes when cursor at start of empty isolating parent

### DIFF
--- a/demos/src/Experiments/IsolatingClear/React/index.jsx
+++ b/demos/src/Experiments/IsolatingClear/React/index.jsx
@@ -1,0 +1,216 @@
+import './styles.scss'
+
+import { Color } from '@tiptap/extension-color'
+import ListItem from '@tiptap/extension-list-item'
+import TextStyle from '@tiptap/extension-text-style'
+import { EditorContent, Node, useEditor } from '@tiptap/react'
+import React from 'react'
+
+import { content } from '../content'
+
+const WrapperBlock = Node.create({
+  name: 'wrapperBlock',
+
+  group: 'block',
+
+  isolating: true,
+
+  content: 'block*',
+
+  parseHTML() {
+    return [{ tag: 'div[data-wrapper-block]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', { ...HTMLAttributes, 'data-wrapper-block': true }, 0]
+  },
+})
+
+const MenuBar = ({ editor }) => {
+  if (!editor) {
+    return null
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        disabled={
+          !editor.can()
+            .chain()
+            .focus()
+            .toggleBold()
+            .run()
+        }
+        className={editor.isActive('bold') ? 'is-active' : ''}
+      >
+        bold
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        disabled={
+          !editor.can()
+            .chain()
+            .focus()
+            .toggleItalic()
+            .run()
+        }
+        className={editor.isActive('italic') ? 'is-active' : ''}
+      >
+        italic
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+        disabled={
+          !editor.can()
+            .chain()
+            .focus()
+            .toggleStrike()
+            .run()
+        }
+        className={editor.isActive('strike') ? 'is-active' : ''}
+      >
+        strike
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleCode().run()}
+        disabled={
+          !editor.can()
+            .chain()
+            .focus()
+            .toggleCode()
+            .run()
+        }
+        className={editor.isActive('code') ? 'is-active' : ''}
+      >
+        code
+      </button>
+      <button onClick={() => editor.chain().focus().unsetAllMarks().run()}>
+        clear marks
+      </button>
+      <button onClick={() => editor.chain().focus().clearNodes().run()}>
+        clear nodes
+      </button>
+      <button
+        onClick={() => editor.chain().focus().setParagraph().run()}
+        className={editor.isActive('paragraph') ? 'is-active' : ''}
+      >
+        paragraph
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+        className={editor.isActive('heading', { level: 1 }) ? 'is-active' : ''}
+      >
+        h1
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        className={editor.isActive('heading', { level: 2 }) ? 'is-active' : ''}
+      >
+        h2
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+        className={editor.isActive('heading', { level: 3 }) ? 'is-active' : ''}
+      >
+        h3
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleHeading({ level: 4 }).run()}
+        className={editor.isActive('heading', { level: 4 }) ? 'is-active' : ''}
+      >
+        h4
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleHeading({ level: 5 }).run()}
+        className={editor.isActive('heading', { level: 5 }) ? 'is-active' : ''}
+      >
+        h5
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleHeading({ level: 6 }).run()}
+        className={editor.isActive('heading', { level: 6 }) ? 'is-active' : ''}
+      >
+        h6
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+        className={editor.isActive('bulletList') ? 'is-active' : ''}
+      >
+        bullet list
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        className={editor.isActive('orderedList') ? 'is-active' : ''}
+      >
+        ordered list
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+        className={editor.isActive('codeBlock') ? 'is-active' : ''}
+      >
+        code block
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleBlockquote().run()}
+        className={editor.isActive('blockquote') ? 'is-active' : ''}
+      >
+        blockquote
+      </button>
+      <button onClick={() => editor.chain().focus().setHorizontalRule().run()}>
+        horizontal rule
+      </button>
+      <button onClick={() => editor.chain().focus().setHardBreak().run()}>
+        hard break
+      </button>
+      <button
+        onClick={() => editor.chain().focus().undo().run()}
+        disabled={
+          !editor.can()
+            .chain()
+            .focus()
+            .undo()
+            .run()
+        }
+      >
+        undo
+      </button>
+      <button
+        onClick={() => editor.chain().focus().redo().run()}
+        disabled={
+          !editor.can()
+            .chain()
+            .focus()
+            .redo()
+            .run()
+        }
+      >
+        redo
+      </button>
+      <button
+        onClick={() => editor.chain().focus().setColor('#958DF1').run()}
+        className={editor.isActive('textStyle', { color: '#958DF1' }) ? 'is-active' : ''}
+      >
+        purple
+      </button>
+    </>
+  )
+}
+
+export default () => {
+  const editor = useEditor({
+    extensions: [
+      WrapperBlock,
+      Color.configure({ types: [TextStyle.name, ListItem.name] }),
+      TextStyle.configure({ types: [ListItem.name] }),
+    ],
+    content,
+  })
+
+  return (
+    <div>
+      <MenuBar editor={editor} />
+      <EditorContent editor={editor} />
+    </div>
+  )
+}

--- a/demos/src/Experiments/IsolatingClear/React/index.spec.js
+++ b/demos/src/Experiments/IsolatingClear/React/index.spec.js
@@ -1,0 +1,143 @@
+context('/src/Examples/Default/React/', () => {
+  before(() => {
+    cy.visit('/src/Examples/Default/React/')
+  })
+
+  beforeEach(() => {
+    cy.get('.ProseMirror').then(([{ editor }]) => {
+      editor.commands.setContent('<h1>Example Text</h1>')
+      cy.get('.ProseMirror').type('{selectall}')
+    })
+  })
+
+  it('should apply the paragraph style when the keyboard shortcut is pressed', () => {
+    cy.get('.ProseMirror h1').should('exist')
+    cy.get('.ProseMirror p').should('not.exist')
+
+    cy.get('.ProseMirror')
+      .trigger('keydown', { modKey: true, altKey: true, key: '0' })
+      .find('p')
+      .should('contain', 'Example Text')
+  })
+
+  const buttonMarks = [
+    { label: 'bold', tag: 'strong' },
+    { label: 'italic', tag: 'em' },
+    { label: 'strike', tag: 's' },
+  ]
+
+  buttonMarks.forEach(m => {
+    it(`should disable ${m.label} when the code tag is enabled for cursor`, () => {
+      cy.get('.ProseMirror').type('{selectall}Hello world')
+      cy.get('button').contains('code').click()
+      cy.get('button').contains(m.label).should('be.disabled')
+    })
+
+    it(`should enable ${m.label} when the code tag is disabled for cursor`, () => {
+      cy.get('.ProseMirror').type('{selectall}Hello world')
+      cy.get('button').contains('code').click()
+      cy.get('button').contains('code').click()
+      cy.get('button').contains(m.label).should('not.be.disabled')
+    })
+
+    it(`should disable ${m.label} when the code tag is enabled for selection`, () => {
+      cy.get('.ProseMirror').type('{selectall}Hello world{selectall}')
+      cy.get('button').contains('code').click()
+      cy.get('button').contains(m.label).should('be.disabled')
+    })
+
+    it(`should enable ${m.label} when the code tag is disabled for selection`, () => {
+      cy.get('.ProseMirror').type('{selectall}Hello world{selectall}')
+      cy.get('button').contains('code').click()
+      cy.get('button').contains('code').click()
+      cy.get('button').contains(m.label).should('not.be.disabled')
+    })
+
+    it(`should apply ${m.label} when the button is pressed`, () => {
+      cy.get('.ProseMirror').type('{selectall}Hello world')
+      cy.get('button').contains('paragraph').click()
+      cy.get('.ProseMirror').type('{selectall}')
+      cy.get('button').contains(m.label).click()
+      cy.get(`.ProseMirror ${m.tag}`).should('exist').should('have.text', 'Hello world')
+    })
+  })
+
+  it('should clear marks when the button is pressed', () => {
+    cy.get('.ProseMirror').type('{selectall}Hello world')
+    cy.get('button').contains('paragraph').click()
+    cy.get('.ProseMirror').type('{selectall}')
+    cy.get('button').contains('bold').click()
+    cy.get('.ProseMirror strong').should('exist').should('have.text', 'Hello world')
+    cy.get('button').contains('clear marks').click()
+    cy.get('.ProseMirror strong').should('not.exist')
+  })
+
+  it('should clear nodes when the button is pressed', () => {
+    cy.get('.ProseMirror').type('{selectall}Hello world')
+    cy.get('button').contains('bullet list').click()
+    cy.get('.ProseMirror ul').should('exist').should('have.text', 'Hello world')
+    cy.get('.ProseMirror').type('{enter}A second item{enter}A third item{selectall}')
+    cy.get('button').contains('clear nodes').click()
+    cy.get('.ProseMirror ul').should('not.exist')
+    cy.get('.ProseMirror p').should('have.length', 3)
+  })
+
+  const buttonNodes = [
+    { label: 'h1', tag: 'h1' },
+    { label: 'h2', tag: 'h2' },
+    { label: 'h3', tag: 'h3' },
+    { label: 'h4', tag: 'h4' },
+    { label: 'h5', tag: 'h5' },
+    { label: 'h6', tag: 'h6' },
+    { label: 'bullet list', tag: 'ul' },
+    { label: 'ordered list', tag: 'ol' },
+    { label: 'code block', tag: 'pre code' },
+    { label: 'blockquote', tag: 'blockquote' },
+  ]
+
+  buttonNodes.forEach(n => {
+    it(`should set ${n.label} when the button is pressed`, () => {
+      cy.get('button').contains('paragraph').click()
+      cy.get('.ProseMirror').type('{selectall}Hello world{selectall}')
+
+      cy.get('button').contains(n.label).click()
+      cy.get(`.ProseMirror ${n.tag}`).should('exist').should('have.text', 'Hello world')
+      cy.get('button').contains(n.label).click()
+      cy.get(`.ProseMirror ${n.tag}`).should('not.exist')
+    })
+  })
+
+  it('should add a hr when on the same line as a node', () => {
+    cy.get('.ProseMirror').type('{rightArrow}')
+    cy.get('button').contains('horizontal rule').click()
+    cy.get('.ProseMirror hr').should('exist')
+    cy.get('.ProseMirror h1').should('exist')
+  })
+
+  it('should add a hr when on a new line', () => {
+    cy.get('.ProseMirror').type('{rightArrow}{enter}')
+    cy.get('button').contains('horizontal rule').click()
+    cy.get('.ProseMirror hr').should('exist')
+    cy.get('.ProseMirror h1').should('exist')
+  })
+
+  it('should add a br', () => {
+    cy.get('.ProseMirror').type('{rightArrow}')
+    cy.get('button').contains('hard break').click()
+    cy.get('.ProseMirror h1 br').should('exist')
+  })
+
+  it('should undo', () => {
+    cy.get('.ProseMirror').type('{selectall}{backspace}')
+    cy.get('button').contains('undo').click()
+    cy.get('.ProseMirror').should('contain', 'Hello world')
+  })
+
+  it('should redo', () => {
+    cy.get('.ProseMirror').type('{selectall}{backspace}')
+    cy.get('button').contains('undo').click()
+    cy.get('.ProseMirror').should('contain', 'Hello world')
+    cy.get('button').contains('redo').click()
+    cy.get('.ProseMirror').should('not.contain', 'Hello world')
+  })
+})

--- a/demos/src/Experiments/IsolatingClear/React/styles.scss
+++ b/demos/src/Experiments/IsolatingClear/React/styles.scss
@@ -1,0 +1,62 @@
+/* Basic editor styles */
+.ProseMirror {
+  > * + * {
+    margin-top: 0.75em;
+  }
+
+  ul,
+  ol {
+    padding: 0 1rem;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    line-height: 1.1;
+  }
+
+  code {
+    background-color: rgba(#616161, 0.1);
+    color: #616161;
+  }
+
+  pre {
+    background: #0D0D0D;
+    color: #FFF;
+    font-family: 'JetBrainsMono', monospace;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+
+    code {
+      color: inherit;
+      padding: 0;
+      background: none;
+      font-size: 0.8rem;
+    }
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  blockquote {
+    padding-left: 1rem;
+    border-left: 2px solid rgba(#0D0D0D, 0.1);
+  }
+
+  hr {
+    border: none;
+    border-top: 2px solid rgba(#0D0D0D, 0.1);
+    margin: 2rem 0;
+  }
+
+  div[data-wrapper-block] {
+    border: 2px solid #000;
+    padding: 1rem;
+    margin: 1rem 0;
+  }
+}

--- a/demos/src/Experiments/IsolatingClear/content.ts
+++ b/demos/src/Experiments/IsolatingClear/content.ts
@@ -1,0 +1,14 @@
+export const content = `
+  <div data-wrapper-block>
+    <p>Change me into a headline.</p>
+  </div>
+  <div data-wrapper-block>
+    <p>Change me into a headline.</p>
+  </div>
+  <div data-wrapper-block>
+    <p>Change me into a headline.</p>
+  </div>
+  <div data-wrapper-block>
+    <p>Change me into a headline.</p>
+  </div>
+`

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -20,12 +20,11 @@ export const Keymap = Extension.create({
         const $parentPos = $anchor.parent.isTextblock ? tr.doc.resolve(pos - 1) : $anchor
         const parentIsIsolating = $parentPos.parent.type.spec.isolating
 
-        // Since we check the parent node from the $anchor position  -1 (to address for paragraphs)
-        // we dont need to do any other position checking. If an isolating node is found, we are always
-        // at the first position of a paragraph (for example)
-        // we just need to check, if there is only one child node in the parent node
-        // so we don't break the behavior of the backspace key in other situations
-        const isAtStart = (parentIsIsolating && $parentPos.parent.childCount === 1) || Selection.atStart(doc).from === pos
+        const parentPos = $anchor.pos - $anchor.parentOffset
+
+        const isAtStart = (parentIsIsolating && $parentPos.parent.childCount === 1)
+          ? parentPos === $anchor.pos
+          : Selection.atStart(doc).from === pos
 
         if (!empty || !isAtStart || !parent.type.isTextblock || parent.textContent.length) {
           return false

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -23,7 +23,9 @@ export const Keymap = Extension.create({
         // Since we check the parent node from the $anchor position  -1 (to address for paragraphs)
         // we dont need to do any other position checking. If an isolating node is found, we are always
         // at the first position of a paragraph (for example)
-        const isAtStart = parentIsIsolating || Selection.atStart(doc).from === pos
+        // we just need to check, if there is only one child node in the parent node
+        // so we don't break the behavior of the backspace key in other situations
+        const isAtStart = (parentIsIsolating && $parentPos.parent.childCount === 1) || Selection.atStart(doc).from === pos
 
         if (!empty || !isAtStart || !parent.type.isTextblock || parent.textContent.length) {
           return false

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -17,7 +17,7 @@ export const Keymap = Extension.create({
         const { selection, doc } = tr
         const { empty, $anchor } = selection
         const { pos, parent } = $anchor
-        const $parentPos = tr.doc.resolve(pos - 1)
+        const $parentPos = $anchor.parent.isTextblock ? tr.doc.resolve(pos - 1) : $anchor
         const parentIsIsolating = $parentPos.parent.type.spec.isolating
 
         // Since we check the parent node from the $anchor position  -1 (to address for paragraphs)

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -17,7 +17,13 @@ export const Keymap = Extension.create({
         const { selection, doc } = tr
         const { empty, $anchor } = selection
         const { pos, parent } = $anchor
-        const isAtStart = Selection.atStart(doc).from === pos
+        const $parentPos = tr.doc.resolve(pos - 1)
+        const parentIsIsolating = $parentPos.parent.type.spec.isolating
+
+        // Since we check the parent node from the $anchor position  -1 (to address for paragraphs)
+        // we dont need to do any other position checking. If an isolating node is found, we are always
+        // at the first position of a paragraph (for example)
+        const isAtStart = parentIsIsolating || Selection.atStart(doc).from === pos
 
         if (!empty || !isAtStart || !parent.type.isTextblock || parent.textContent.length) {
           return false


### PR DESCRIPTION
## Please describe your changes

This fix will solve the issue that when a cursor is **inside an isolating** node and the isolating node is empty, the nodes inside are not cleared similar to how they are cleared on the document.

## How did you accomplish your changes

Inside the `keymap.ts` we also check for the current textNodes parent (or direct parent if it is not a textNode) and if said parent is `isolating`. If we are inside an isolating node, we use the relative parentOffset to check that we're at the start of a node.

## How have you tested your changes

- Used an isolating node to test the behavior, nodes were cleared correctly
- Used it directly in the document: nodes were still cleared correctly

## How can we verify your changes

1. Create an isolating node
2. Add content
3. Make this content a headline
4. Use backspace to completely remove the content
5. Use backspace again to clear the headline and turn it back into a paragraph

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

No related issues
