### PR TITLE
Allow usage of addToHistory for collaboration extension 

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -17,7 +17,7 @@
     "remixicon": "^2.5.0",
     "shiki": "^0.10.0",
     "simplify-js": "^1.2.4",
-    "y-prosemirror": "1.0.20",
+    "y-prosemirror": "1.1.3",
     "y-webrtc": "^10.2.3",
     "yjs": "^13.5.39"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "remixicon": "^2.5.0",
         "shiki": "^0.10.0",
         "simplify-js": "^1.2.4",
-        "y-prosemirror": "1.0.20",
+        "y-prosemirror": "1.1.3",
         "y-webrtc": "^10.2.3",
         "yjs": "^13.5.39"
       },
@@ -19350,8 +19350,9 @@
       }
     },
     "node_modules/y-prosemirror": {
-      "version": "1.0.20",
-      "license": "MIT",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.1.3.tgz",
+      "integrity": "sha512-FZW/mm8SxHy/iO4RG40LAIrzzoh6qDNQBdrK20JJSh7Rq41CifVhsydMbara44gGJkGRC5s4CQtJAZUqzVM4rw==",
       "dependencies": {
         "lib0": "^0.2.42"
       },
@@ -19364,7 +19365,7 @@
         "prosemirror-state": "^1.2.3",
         "prosemirror-view": "^1.9.10",
         "y-protocols": "^1.0.1",
-        "yjs": "^13.3.2"
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/y-protocols": {
@@ -19650,7 +19651,7 @@
       "devDependencies": {
         "@tiptap/core": "^2.1.0-rc.0",
         "@tiptap/pm": "^2.1.0-rc.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "1.1.3"
       },
       "funding": {
         "type": "github",
@@ -19659,7 +19660,7 @@
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
         "@tiptap/pm": "^2.0.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "1.1.3"
       }
     },
     "packages/extension-collaboration-cursor": {
@@ -19668,7 +19669,7 @@
       "license": "MIT",
       "devDependencies": {
         "@tiptap/core": "^2.1.0-rc.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "1.1.3"
       },
       "funding": {
         "type": "github",
@@ -19676,7 +19677,7 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "1.1.3"
       }
     },
     "packages/extension-color": {
@@ -23695,14 +23696,14 @@
       "requires": {
         "@tiptap/core": "^2.1.0-rc.0",
         "@tiptap/pm": "^2.1.0-rc.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "1.1.3"
       }
     },
     "@tiptap/extension-collaboration-cursor": {
       "version": "file:packages/extension-collaboration-cursor",
       "requires": {
         "@tiptap/core": "^2.1.0-rc.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "1.1.3"
       }
     },
     "@tiptap/extension-color": {
@@ -33003,7 +33004,7 @@
         "vite-plugin-checker": "^0.3.4",
         "vue": "^3.0.5",
         "vue-router": "^4.0.11",
-        "y-prosemirror": "1.0.20",
+        "y-prosemirror": "1.1.3",
         "y-webrtc": "^10.2.3",
         "yjs": "^13.5.39"
       }
@@ -33982,7 +33983,9 @@
       "dev": true
     },
     "y-prosemirror": {
-      "version": "1.0.20",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.1.3.tgz",
+      "integrity": "sha512-FZW/mm8SxHy/iO4RG40LAIrzzoh6qDNQBdrK20JJSh7Rq41CifVhsydMbara44gGJkGRC5s4CQtJAZUqzVM4rw==",
       "requires": {
         "lib0": "^0.2.42"
       }

--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -30,11 +30,11 @@
   ],
   "devDependencies": {
     "@tiptap/core": "^2.1.0-rc.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "1.1.3"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "1.1.3"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -31,12 +31,12 @@
   "devDependencies": {
     "@tiptap/core": "^2.1.0-rc.0",
     "@tiptap/pm": "^2.1.0-rc.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "1.1.3"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
     "@tiptap/pm": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "1.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Please describe your changes

Tiptap editors with collaboration extensions ignores the `addToHistory` meta data since it uses the y-prosemirror history stack instead. However! the recent updates to y-prosemirror honors the `addToHistory` meta data. see the y-prosemirror readme [here](https://github.com/yjs/y-prosemirror#undoredo). Tiptap is currently at the y-prosemirror version 1.0.20 and the fix was finalized at 1.1.3. 

## How did you accomplish your changes

This PR updates the version to 1.1.3!

## How have you tested your changes
I played around with the collaboration demo in the deploy preview and the editor is working well!

## How can we verify your changes
How do you recommend I confirm the `addToHistory` for collaboration extension fix with this branch? 

## Remarks
you can see the changes in y-prosemirror's [releases](https://github.com/yjs/y-prosemirror/releases) that the changelog from 1.0.20 to 1.1.3 are few and fairly minor. 
 
## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

