### PR TITLE
fix(bubble-menu): fix debounce not working with collab

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,8 @@
     "vue-2",
     "vue-3"
   ],
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
 }

--- a/demos/package.json
+++ b/demos/package.json
@@ -18,7 +18,7 @@
     "shiki": "^0.10.0",
     "simplify-js": "^1.2.4",
     "y-prosemirror": "1.0.20",
-    "y-webrtc": "^10.2.3",
+    "y-webrtc": "^10.2.5",
     "yjs": "^13.5.39"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "shiki": "^0.10.0",
         "simplify-js": "^1.2.4",
         "y-prosemirror": "1.0.20",
-        "y-webrtc": "^10.2.3",
+        "y-webrtc": "^10.2.5",
         "yjs": "^13.5.39"
       },
       "devDependencies": {
@@ -19379,8 +19379,9 @@
       }
     },
     "node_modules/y-webrtc": {
-      "version": "10.2.3",
-      "license": "MIT",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.2.5.tgz",
+      "integrity": "sha512-ZyBNvTI5L28sQ2PQI0T/JvyWgvuTq05L21vGkIlcvNLNSJqAaLCBJRe3FHEqXoaogqWmRcEAKGfII4ErNXMnNw==",
       "dependencies": {
         "lib0": "^0.2.42",
         "simple-peer": "^9.11.0",
@@ -33004,7 +33005,7 @@
         "vue": "^3.0.5",
         "vue-router": "^4.0.11",
         "y-prosemirror": "1.0.20",
-        "y-webrtc": "^10.2.3",
+        "y-webrtc": "^10.2.5",
         "yjs": "^13.5.39"
       }
     },
@@ -33994,7 +33995,9 @@
       }
     },
     "y-webrtc": {
-      "version": "10.2.3",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.2.5.tgz",
+      "integrity": "sha512-ZyBNvTI5L28sQ2PQI0T/JvyWgvuTq05L21vGkIlcvNLNSJqAaLCBJRe3FHEqXoaogqWmRcEAKGfII4ErNXMnNw==",
       "requires": {
         "lib0": "^0.2.42",
         "simple-peer": "^9.11.0",

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -164,23 +164,34 @@ export class BubbleMenuView {
       return
     }
 
-    this.updateHandler(view, oldState)
+    const selectionChanged = !oldState?.selection.eq(view.state.selection)
+    const docChanged = !oldState?.doc.eq(view.state.doc)
+
+    this.updateHandler(view, selectionChanged, docChanged, oldState)
   }
 
   handleDebouncedUpdate = (view: EditorView, oldState?: EditorState) => {
+    const selectionChanged = !oldState?.selection.eq(view.state.selection)
+    const docChanged = !oldState?.doc.eq(view.state.doc)
+
+    if (!selectionChanged && !docChanged) {
+      return
+    }
+
     if (this.updateDebounceTimer) {
       clearTimeout(this.updateDebounceTimer)
     }
 
     this.updateDebounceTimer = window.setTimeout(() => {
-      this.updateHandler(view, oldState)
+      this.updateHandler(view, selectionChanged, docChanged, oldState)
     }, this.updateDelay)
   }
 
-  updateHandler = (view: EditorView, oldState?: EditorState) => {
+  updateHandler = (view: EditorView, selectionChanged: boolean, docChanged: boolean, oldState?: EditorState) => {
     const { state, composing } = view
-    const { doc, selection } = state
-    const isSame = oldState && oldState.doc.eq(doc) && oldState.selection.eq(selection)
+    const { selection } = state
+
+    const isSame = !selectionChanged && !docChanged
 
     if (composing || isSame) {
       return


### PR DESCRIPTION
## Please describe your changes

This PR should close #3953 via checking if changes were made to the doc/selection and exiting before clearing the callback timeout.

## How did you accomplish your changes

Add a simple check before clearing debounced timeouts if the doc was changed.

## How have you tested your changes

I created a local demo with collab/cursors and a bubble menu and tested to create selections on both clients - worked fine, also with collab and collab cursors. the bubble menu delay was also working fine.

## How can we verify your changes

Follow the same steps as above

## Remarks

The additional file changes were made to:

1. Test yjs via webrtc locally
2. Add auto formatting for eslint in js/jsx files

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

- #3953
