### PR TITLE
VueNodeViewRenderer should return `null` for `contentDOM` for a non-leaf node with no `NodeViewContent`

### DIFF
--- a/.changeset/shy-clouds-smoke.md
+++ b/.changeset/shy-clouds-smoke.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/vue-3": patch
+---
+
+VueNodeViewRenderer should return `null` for `contentDOM` for a non-leaf node with no `NodeViewContent`

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -136,9 +136,7 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
       return null
     }
 
-    const contentElement = this.dom.querySelector('[data-node-view-content]')
-
-    return (contentElement || this.dom) as HTMLElement | null
+    return this.dom.querySelector('[data-node-view-content]') as HTMLElement | null
   }
 
   update(node: ProseMirrorNode, decorations: DecorationWithType[]) {


### PR DESCRIPTION
## Please describe your changes

For a non-leaf node with no `NodeViewContent` return `null` instead of `this.dom`, this allows the node view itself to handle rendering the child content, instead of overriding the entire node with its child contents, not allowing to render it at all.

## How did you accomplish your changes

I changed a line of code.

## How have you tested your changes

In my own project.

## How can we verify your changes

Create a node view that has child `content`, but no `NodeViewContent`.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

Fixes #3937
