### PR TITLE
Fix component names in Vue 3 devtools

### DIFF
--- a/packages/vue-3/src/NodeViewContent.ts
+++ b/packages/vue-3/src/NodeViewContent.ts
@@ -1,6 +1,8 @@
 import { defineComponent, h } from 'vue'
 
 export const NodeViewContent = defineComponent({
+  name: 'NodeViewContent',
+
   props: {
     as: {
       type: String,

--- a/packages/vue-3/src/NodeViewWrapper.ts
+++ b/packages/vue-3/src/NodeViewWrapper.ts
@@ -1,6 +1,8 @@
 import { defineComponent, h } from 'vue'
 
 export const NodeViewWrapper = defineComponent({
+  name: 'NodeViewWrapper',
+
   props: {
     as: {
       type: String,

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -108,6 +108,13 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
       // @ts-ignore
       // eslint-disable-next-line
       __cssModules: this.component.__cssModules,
+      // add support for vue devtools
+      // @ts-ignore
+      // eslint-disable-next-line
+      __name: this.component.__name,
+      // @ts-ignore
+      // eslint-disable-next-line
+      __file: this.component.__file,
     })
 
     this.renderer = new VueRenderer(extendedComponent, {


### PR DESCRIPTION
## Please describe your changes

Fix component names in Vue 3 devtools

## How did you accomplish your changes

Propogate `__name`, `__file` in `VueNodeViewRenderer`, and add `name` to `NodeViewContent` & `NodeViewWrapper`.

## How have you tested your changes

Ran `npm run start` and checked pages that show `NodeViews` with Vue 3

## How can we verify your changes

Do the same as I did above. With the Vue devtools installed in the browser.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

Fixes #3965
