### PR TITLE
fix(extension-link): fix link not being kept when pasting url with link

### DIFF
--- a/packages/extension-link/src/helpers/linkifyPaste.ts
+++ b/packages/extension-link/src/helpers/linkifyPaste.ts
@@ -1,0 +1,49 @@
+import { Editor } from '@tiptap/core'
+import { MarkType } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { find } from 'linkifyjs'
+
+export type LinkifyPastePluginOptions = {
+  editor: Editor
+  type: MarkType
+}
+
+export const LinkifyPastePlugin = ({ editor, type }: LinkifyPastePluginOptions) => {
+  return new Plugin({
+    key: new PluginKey('linkifyPaste'),
+
+    props: {
+      handlePaste(view, event, slice) {
+        let linkHref: string | null = null
+        let link = null
+
+        // this only needs to run the linkify if the slice contains one text node
+        // that is not already a link & the text is a valid URL
+        slice.content.forEach(node => {
+          link = find(node.textContent).find(item => item.isLink)
+
+          if (link && node.marks.some(mark => mark.type === type)) {
+            return
+          }
+
+          const text = node.textContent
+
+          if (!text || !link) {
+            return
+          }
+
+          linkHref = link.href
+        })
+
+        if (!linkHref || !link) {
+          return false
+        }
+
+        // handle pasting of links
+        editor.chain().insertContent(`<a href="${linkHref}">${slice.content.child(0).textContent}</a>`).focus().run()
+
+        return true
+      },
+    },
+  })
+}

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -1,9 +1,10 @@
-import { Mark, markPasteRule, mergeAttributes } from '@tiptap/core'
+import { Mark, mergeAttributes } from '@tiptap/core'
 import { Plugin } from '@tiptap/pm/state'
-import { find, registerCustomProtocol, reset } from 'linkifyjs'
+import { registerCustomProtocol, reset } from 'linkifyjs'
 
 import { autolink } from './helpers/autolink'
 import { clickHandler } from './helpers/clickHandler'
+import { LinkifyPastePlugin } from './helpers/linkifyPaste'
 import { pasteHandler } from './helpers/pasteHandler'
 
 export interface LinkProtocolOptions {
@@ -146,33 +147,13 @@ export const Link = Mark.create<LinkOptions>({
     }
   },
 
-  addPasteRules() {
-    return [
-      markPasteRule({
-        find: text => find(text)
-          .filter(link => {
-            if (this.options.validate) {
-              return this.options.validate(link.value)
-            }
-
-            return true
-          })
-          .filter(link => link.isLink)
-          .map(link => ({
-            text: link.value,
-            index: link.start,
-            data: link,
-          })),
-        type: this.type,
-        getAttributes: match => ({
-          href: match.data?.href,
-        }),
-      }),
-    ]
-  },
-
   addProseMirrorPlugins() {
     const plugins: Plugin[] = []
+
+    plugins.push(LinkifyPastePlugin({
+      editor: this.editor,
+      type: this.type,
+    }))
 
     if (this.options.autolink) {
       plugins.push(


### PR DESCRIPTION
## Please describe your changes

This PR fixes an issue where for example a link gets copied from another richtext (for example Google Docs). When the copied text is a URL (for example `https://github.com/`) but this URL text is already a link (for example `https://github.com/ == LINKS TO ==> https://github.com/my/repo`) the link gets dismissed and the text gets pasted as a URL.

## How did you accomplish your changes

I removed the default pasteHandler as the paste handler will always trigger before any custom logic. The paster handler itself also doesn't know about any marks of the pasted content but only the content text so it wasn't possible to handle the check if a pasted content is already a link in there.

I moved the logic into it's own plugin that will handle said behavior.

## How have you tested your changes

I created a Google Docs file with two lines. The document looked like this:

- [tiptap.dev](https://tiptap.dev/hello)
- https://tiptap.dev (this one is not auto linked in Google Docs)

When copying the first line, the pasted content was:

```
tiptap.dev (linking correctly to https://tiptap.dev/hello as defined in the Google Doc)
```

When copying the second line, the pasted content was:

```
https://tiptap.dev (linking to https://tiptap.dev - this was done via the autolink paste handler)
```

## How can we verify your changes

Clone and checkout this branch, then create a demo (or use the existing Marks/Link demo) and paste in content as I described above.

## Remarks

Nothing to remark here

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

- No relating issues
