### PR TITLE
feature: allow to customize the tag of the contentDOMElement

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -170,6 +170,7 @@ export interface NodeViewRendererOptions {
   ignoreMutation:
     | ((props: { mutation: MutationRecord | { type: 'selection'; target: Element } }) => boolean)
     | null
+  contentDOMElementTag: string
 }
 
 export type NodeViewRendererProps = {

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -80,9 +80,13 @@ class ReactNodeView extends NodeView<
 
     ReactNodeViewProvider.displayName = 'ReactNodeView'
 
-    this.contentDOMElement = this.node.isLeaf
-      ? null
-      : document.createElement(this.node.isInline ? 'span' : 'div')
+    if (this.node.isLeaf) {
+      this.contentDOMElement = null
+    } else if (this.options.contentDOMElementTag) {
+      this.contentDOMElement = document.createElement(this.options.contentDOMElementTag)
+    } else {
+      this.contentDOMElement = document.createElement(this.node.isInline ? 'span' : 'div')
+    }
 
     if (this.contentDOMElement) {
       // For some reason the whiteSpace prop is not inherited properly in Chrome and Safari


### PR DESCRIPTION
## Please describe your changes

Added the option `contentDOMElementTag` to the `NodeViewRendererOptions` to allow users to provide as the desired element tag they would like to render.

This allows developers to solve the issue with injected divs inside a `table` when extending the table extension:
- https://github.com/ueberdosis/tiptap/issues/2675
- https://github.com/ueberdosis/tiptap/issues/2892

## How did you accomplish your changes

Added the option `contentDOMElementTag`

## How have you tested your changes

In `demos/src/GuideNodeViews/ReactComponentContent/React/Extension.js` we tested it using:

```js
return ReactNodeViewRenderer(Component, { contentDOMElementTag: 'main' })
```

You can see it in action here where we applied the patch via patch-packages: https://github.com/serenity-kit/Serenity/blob/68d7bb29979abf9833116c81f2db27156724a93d/packages/editor/extensions/tableExtension/tableExtension.ts#L15

## How can we verify your changes

Reproduce the test?

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

- https://github.com/ueberdosis/tiptap/issues/2675
- https://github.com/ueberdosis/tiptap/issues/2892