### PR TITLE
fix(link): fix links autolinking when not needed

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -63,10 +63,6 @@ export function autolink(options: AutolinkOptions): Plugin {
             }
           })
 
-        if (!needsAutolink) {
-          return
-        }
-
         // now let’s see if we can add new links
         const nodesInChangedRanges = findChildrenInRange(
           newState.doc,
@@ -130,6 +126,10 @@ export function autolink(options: AutolinkOptions): Plugin {
             }))
             // add link mark
             .forEach(link => {
+              if (getMarksBetween(link.from, link.to, newState.doc).some(item => item.mark.type === options.type)) {
+                return
+              }
+
               tr.addMark(
                 link.from,
                 link.to,


### PR DESCRIPTION
## Please describe your changes

This PR changes the autolink behavior. Before links were always autolinked, even when the autolinked text was already a link. This is weird behavior - as a manually / already set link should always have priority over automatically linked content.

**Example:**

You have a link that has the textContent `mysite.com` but a link mark with a href attr to `https://mysite.com?ref=my-referral-id` the autolink prior to this PR would still autolink to `mysite.com` completely removing any manually set attributes.

## How did you accomplish your changes

Right before the autolink would set the link mark on words with spaces/breaks I added a check to see if the `link.from` and `link.to` already has a link mark inbetween. If so we just avoid autolinking to keep the already existing link.

## How have you tested your changes

- Local link demo

## How can we verify your changes

1. Check out this PR
2. Open the Link demo
3. Paste links / set links manually with urls as a textcontent and run autolinking on them.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
