### PR TITLE
Destroy editor in safe

### DIFF
--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import React, { HTMLProps } from 'react'
 import ReactDOM, { flushSync } from 'react-dom'
 
@@ -124,7 +125,6 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
     if (!editor.options.element.firstChild) {
       return
     }
-
     const newElement = document.createElement('div')
 
     newElement.append(...editor.options.element.childNodes)
@@ -148,12 +148,27 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
 }
 
 // EditorContent should be re-created whenever the Editor instance changes
-const EditorContentWithKey = (props: EditorContentProps) => {
-  const key = React.useMemo(() => {
-    return Math.floor(Math.random() * 0xFFFFFFFF).toString()
-  }, [props.editor])
+class EditorContentWithKey extends React.Component<EditorContentProps> {
+  key: string
 
-  return <PureEditorContent key={key} {...props as any} />
+  constructor(props: EditorContentProps) {
+    super(props)
+    this.key = this.generateKey()
+  }
+
+  componentDidUpdate(prevProps: EditorContentProps) {
+    if (this.props.editor !== prevProps.editor) {
+      this.key = this.generateKey()
+    }
+  }
+
+  generateKey() {
+    return Math.floor(Math.random() * 0xFFFFFFFF).toString()
+  }
+
+  render() {
+    return <PureEditorContent key={this.key} {...this.props as any} />
+  }
 }
 
 export const EditorContent = React.memo(EditorContentWithKey)

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file */
 import React, { HTMLProps } from 'react'
 import ReactDOM, { flushSync } from 'react-dom'
 
@@ -125,6 +124,7 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
     if (!editor.options.element.firstChild) {
       return
     }
+
     const newElement = document.createElement('div')
 
     newElement.append(...editor.options.element.childNodes)
@@ -148,27 +148,13 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
 }
 
 // EditorContent should be re-created whenever the Editor instance changes
-class EditorContentWithKey extends React.Component<EditorContentProps> {
-  key: string
-
-  constructor(props: EditorContentProps) {
-    super(props)
-    this.key = this.generateKey()
-  }
-
-  componentDidUpdate(prevProps: EditorContentProps) {
-    if (this.props.editor !== prevProps.editor) {
-      this.key = this.generateKey()
-    }
-  }
-
-  generateKey() {
+const EditorContentWithKey = (props: EditorContentProps) => {
+  const key = React.useMemo(() => {
     return Math.floor(Math.random() * 0xFFFFFFFF).toString()
-  }
+  }, [props.editor])
 
-  render() {
-    return <PureEditorContent key={this.key} {...this.props as any} />
-  }
+  // Can't use JSX here because it conflicts with the type definition of Vue's JSX, so use createElement
+  return React.createElement(PureEditorContent, { key, ...props })
 }
 
 export const EditorContent = React.memo(EditorContentWithKey)

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -147,4 +147,13 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
   }
 }
 
-export const EditorContent = React.memo(PureEditorContent)
+// EditorContent should be re-created whenever the Editor instance changes
+const EditorContentWithKey = (props: EditorContentProps) => {
+  const key = React.useMemo(() => {
+    return Math.floor(Math.random() * 0xFFFFFFFF).toString()
+  }, [props.editor])
+
+  return <PureEditorContent key={key} {...props as any} />
+}
+
+export const EditorContent = React.memo(EditorContentWithKey)

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -113,10 +113,15 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
     })
 
     return () => {
-      instance.destroy()
       isMounted = false
     }
   }, deps)
+
+  useEffect(() => {
+    return () => {
+      editor?.destroy()
+    }
+  }, [editor])
 
   return editor
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "include": ["./src"]
-}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src"]
+}


### PR DESCRIPTION
## Please describe your changes

Fix https://github.com/ueberdosis/tiptap/issues/3764

## How did you accomplish your changes

There are two issues:

- The EditorContent is reused even though the instance of the editor has changed.
- The deletion of the editor occurs before the deletion of the EditorContent.

I solved those issues. 

## How have you tested your changes

I tested by changing `demos/src/Examples/CustomParagraph/React/index.jsx` below.

<details><summary>Test code</summary>

```jsx
import './styles.scss'

import { EditorContent, useEditor } from '@tiptap/react'
import StarterKit from '@tiptap/starter-kit'
import React, { useEffect } from 'react'

import { Paragraph } from './Paragraph.jsx'

export default () => {
  const [data, setData] = React.useState({ content: '' })

  useEffect(() => {
    const timer = setInterval(() => {
      setData({
        content: `
      <p>
        Each line shows the number of characters in the paragraph.
      </p>
      `,
      })
    }, 5000)

    return () => clearInterval(timer)
  }, [])

  const editor = useEditor({
    extensions: [
      StarterKit.configure({
        paragraph: false,
      }),
      Paragraph,
    ],
    content: data.content,
  }, [data])

  return (
    <EditorContent editor={editor} />
  )
}

```

</details> 

## How can we verify your changes

By running the above example code on the develop branch, you will see that the flushSync error appears, but it does not appear on this branch.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

[add a link to the related issues here]
