### PR TITLE
fix: Don't init when editor is destroyed

### DIFF
--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -49,7 +49,7 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
   init() {
     const { editor } = this.props
 
-    if (editor && editor.options.element) {
+    if (editor && !editor.isDestroyed && editor.options.element) {
       if (editor.contentComponent) {
         return
       }


### PR DESCRIPTION
## Please describe your changes

Adds a check to see if the `EditorContent` editor is already destroyed when `init` is called. This can happen due to using `React.StrictMode` where the editor is re-rendered back-to-back automatically by React.

## How did you accomplish your changes

Extended the existing check to include verifying that the editor hasn't already been destroyed.

## How have you tested your changes

Manual testing.

## How can we verify your changes

Unfortunately, I don't have a clean reproduction available at this time.

## Remarks


## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

This issue is similar to the various problems described in https://github.com/ueberdosis/tiptap/issues/1451 (and other linked issues in that thread) and manifests itself with the same `TypeError: Cannot read property 'matchesNode' of null`.