### PR TITLE
fix: typo in commands.md

### DIFF
--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -14,7 +14,7 @@ All available commands are accessible through an editor instance. Let’s say yo
 editor.commands.setBold()
 ```
 
-While that’s perfectly fine and does make the selected bold, you’d likely want to change multiple commands in one run. Let’s have a look at how that works.
+While that’s perfectly fine and does make the selected bold, you’d likely want to chain multiple commands in one run. Let’s have a look at how that works.
 
 ### Chain commands
 Most commands can be combined to one call. That’s shorter than separate function calls in most cases. Here is an example to make the selected text bold:


### PR DESCRIPTION
## Please describe your changes

Fixes a typo in the commands doc page

## How did you accomplish your changes

```diff
- change
+ chain
```

## How have you tested your changes

n/a

## How can we verify your changes

n/a

## Remarks

If this isn't a typo, I apologize, but 'change' doesn't make sense in this context.

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

n/a
