### PR TITLE
fix: typo in focus.md

### DIFF
--- a/docs/api/commands/focus.md
+++ b/docs/api/commands/focus.md
@@ -8,7 +8,7 @@ See also: [setTextSelection](/api/commands/set-text-selection), [blur](/api/comm
 ## Parameters
 `position: 'start' | 'end' | 'all' | number | boolean | null (false)`
 
-By default, it’s restoring the cursor position (and text selection). Pass a position to move the cursor too.
+By default, it’s restoring the cursor position (and text selection). Pass a position to move the cursor to.
 
 `options: { scrollIntoView: boolean }`
 


### PR DESCRIPTION
## Please describe your changes

Fixes a typo in the focus page of the api documentation

## How did you accomplish your changes

```diff
- too
+ to
```

## How have you tested your changes

N/A

## How can we verify your changes

N/a

## Remarks

N/A

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

N/A
