### PR TITLE
fix: missing word in toggle-node.md

### DIFF
--- a/docs/api/commands/toggle-node.md
+++ b/docs/api/commands/toggle-node.md
@@ -1,5 +1,5 @@
 # toggleNode
-`toggleNode` will a node with another node.
+`toggleNode` will toggle a node with another node.
 
 ## Parameters
 `typeOrName: string | NodeType`


### PR DESCRIPTION
## Please describe your changes

Fixes a typo/missing word in docs page for toggleNode

## How did you accomplish your changes

```diff
- `toggleNode` will a node with another node.
+ `toggleNode` will toggle a node with another node.
```

## How have you tested your changes

n/a

## How can we verify your changes

n/a

## Remarks

n/a

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

n/a
