### PR TITLE
feature(html): allow caller to specify a `document` implementation in `generateHTML()`

### DIFF
--- a/packages/html/src/getHTMLFromFragment.ts
+++ b/packages/html/src/getHTMLFromFragment.ts
@@ -1,7 +1,17 @@
 import { DOMSerializer, Node, Schema } from '@tiptap/pm/model'
 import { createHTMLDocument, VHTMLDocument } from 'zeed-dom'
 
-export function getHTMLFromFragment(doc: Node, schema: Schema): string {
+export function getHTMLFromFragment(doc: Node, schema: Schema, options?: { document?: Document }): string {
+  if (options?.document) {
+    // The caller is relying on their own document implementation. Use this
+    // instead of the default zeed-dom.
+    const contentNode = Node.fromJSON(schema, doc);
+    const wrap = document.createElement('div');
+    const serializedDocument = DOMSerializer.fromSchema(schema).serializeFragment(doc.content, { document: options.document }, wrap);
+    return wrap.innerHTML;
+  }
+
+  // Use zeed-dom for serialization.
   const document = DOMSerializer.fromSchema(schema).serializeFragment(doc.content, {
     document: createHTMLDocument() as unknown as Document,
   }) as unknown as VHTMLDocument

--- a/packages/html/src/getHTMLFromFragment.ts
+++ b/packages/html/src/getHTMLFromFragment.ts
@@ -5,16 +5,16 @@ export function getHTMLFromFragment(doc: Node, schema: Schema, options?: { docum
   if (options?.document) {
     // The caller is relying on their own document implementation. Use this
     // instead of the default zeed-dom.
-    const contentNode = Node.fromJSON(schema, doc);
-    const wrap = document.createElement('div');
-    const serializedDocument = DOMSerializer.fromSchema(schema).serializeFragment(doc.content, { document: options.document }, wrap);
-    return wrap.innerHTML;
+    const wrap = options.document.createElement('div')
+
+    DOMSerializer.fromSchema(schema).serializeFragment(doc.content, { document: options.document }, wrap)
+    return wrap.innerHTML
   }
 
   // Use zeed-dom for serialization.
-  const document = DOMSerializer.fromSchema(schema).serializeFragment(doc.content, {
+  const zeedDocument = DOMSerializer.fromSchema(schema).serializeFragment(doc.content, {
     document: createHTMLDocument() as unknown as Document,
   }) as unknown as VHTMLDocument
 
-  return document.render()
+  return zeedDocument.render()
 }


### PR DESCRIPTION
## Please describe your changes

Allows callers of the `generateHTML()` fn to pass their own `document` implementation. This is necessary because `renderHTML()` can return a `DOMElement` as a `DOMOutputSpec`. However, the `renderHTML()` method on nodes doesn't provide access to the `document` used in the render (at least as far as I can tell). 

TipTap assumes that the `document` passed to [DOMSerializer](https://prosemirror.net/docs/ref/#model.DOMSerializer) can always be the `document` that comes from `zeed-dom`. However, `zeed-dom` appears to be incompatible with jsdom. Without the change in this PR, any node that returns an `HTMLElement` created via jsdom is serialized as the string `{}`.

## How did you accomplish your changes

I added an option to `generateHTML()` that allows callers to specify a `document` alternative to `zeed-dom`.

## How have you tested your changes

I have this implementation working in another project. I've not yet tested it in this repo--as my first PR, I want to see where the tests fail an then follow up.

## How can we verify your changes

TBD

## Remarks

An alternative might be to add the `document` being used to serialize the fragment to the `renderHTML()` method, so that a node could do something like:

```
renderHTML(params): {
  return params.document.createElement('div');
}
```

As it stands with this PR, they can just use:

```
renderHTML(params): {
  // this `document` must be made available globally by other
  // set up code.
  return document.createElement('div');
}
```

That approach would be a little less magical, and perhaps easier to use on the part of the caller. However, the approach I've taken works for my project and I'd like feedback from the maintainers before going on that more involved API change.

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

[add a link to the related issues here]
