### PR TITLE
Fix onPaste handling in link extension in rc.4

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -32,11 +32,6 @@ export function autolink(options: AutolinkOptions): Plugin {
       let needsAutolink = true
 
       changes.forEach(({ oldRange, newRange }) => {
-        // Do not autolink if in code block.
-        if (newState.doc.resolve(newRange.from).parent.type.spec.code) {
-          return
-        }
-
         // At first we check if we have to remove links.
         getMarksBetween(oldRange.from, oldRange.to, oldState.doc)
           .filter(item => item.mark.type === options.type)

--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -32,7 +32,12 @@ export function autolink(options: AutolinkOptions): Plugin {
       let needsAutolink = true
 
       changes.forEach(({ oldRange, newRange }) => {
-        // at first we check if we have to remove links
+        // Do not autolink if in code block.
+        if (newState.doc.resolve(newRange.from).parent.type.spec.code) {
+          return
+        }
+
+        // At first we check if we have to remove links.
         getMarksBetween(oldRange.from, oldRange.to, oldState.doc)
           .filter(item => item.mark.type === options.type)
           .forEach(oldMark => {
@@ -56,14 +61,14 @@ export function autolink(options: AutolinkOptions): Plugin {
               needsAutolink = false
             }
 
-            // remove only the link, if it was a link before too
-            // because we don’t want to remove links that were set manually
+            // Remove only the link, if it was a link before too.
+            // Because we don’t want to remove links that were set manually.
             if (wasLink && !isLink) {
               tr.removeMark(needsAutolink ? newMark.from : newMark.to - 1, newMark.to, options.type)
             }
           })
 
-        // now let’s see if we can add new links
+        // Now let’s see if we can add new links.
         const nodesInChangedRanges = findChildrenInRange(
           newState.doc,
           newRange,
@@ -74,7 +79,7 @@ export function autolink(options: AutolinkOptions): Plugin {
         let textBeforeWhitespace: string | undefined
 
         if (nodesInChangedRanges.length > 1) {
-          // Grab the first node within the changed ranges (ex. the first of two paragraphs when hitting enter)
+          // Grab the first node within the changed ranges (ex. the first of two paragraphs when hitting enter).
           textBlock = nodesInChangedRanges[0]
           textBeforeWhitespace = newState.doc.textBetween(
             textBlock.pos,
@@ -84,7 +89,7 @@ export function autolink(options: AutolinkOptions): Plugin {
           )
         } else if (
           nodesInChangedRanges.length
-          // We want to make sure to include the block seperator argument to treat hard breaks like spaces
+          // We want to make sure to include the block seperator argument to treat hard breaks like spaces.
           && newState.doc.textBetween(newRange.from, newRange.to, ' ', ' ').endsWith(' ')
         ) {
           textBlock = nodesInChangedRanges[0]
@@ -118,13 +123,13 @@ export function autolink(options: AutolinkOptions): Plugin {
               }
               return true
             })
-            // calculate link position
+            // Calculate link position.
             .map(link => ({
               ...link,
               from: lastWordAndBlockOffset + link.start + 1,
               to: lastWordAndBlockOffset + link.end + 1,
             }))
-            // add link mark
+            // Add link mark.
             .forEach(link => {
               if (getMarksBetween(link.from, link.to, newState.doc).some(item => item.mark.type === options.type)) {
                 return

--- a/packages/extension-link/src/helpers/pasteHandler.ts
+++ b/packages/extension-link/src/helpers/pasteHandler.ts
@@ -18,8 +18,11 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
         const { selection } = state
 
         const pastedLinkMarks: Mark[] = []
+        let textContent = ''
 
         slice.content.forEach(node => {
+          textContent += node.textContent
+
           node.marks.forEach(mark => {
             if (mark.type.name === options.type.name) {
               pastedLinkMarks.push(mark)
@@ -28,32 +31,28 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
         })
 
         const hasPastedLink = pastedLinkMarks.length > 0
-
-        let textContent = ''
-
-        slice.content.forEach(node => {
-          textContent += node.textContent
-        })
-
         const link = find(textContent).find(item => item.isLink && item.value === textContent)
 
         if (!selection.empty && options.linkOnPaste) {
           const pastedLink = hasPastedLink ? pastedLinkMarks[0].attrs.href : link?.href || null
 
           if (pastedLink) {
-            options.editor.commands.setMark(options.type, {
-              href: pastedLink,
-            })
+            options.editor.commands.setMark(options.type, { href: pastedLink })
+
             return true
           }
         }
 
-        if (slice.content.firstChild?.type.name === 'text' && slice.content.firstChild?.marks.some(mark => mark.type.name === options.type.name)) {
+        const firstChildIsText = slice.content.firstChild?.type.name === 'text'
+        const firstChildContainsLinkMark = slice.content.firstChild?.marks.some(mark => mark.type.name === options.type.name)
+
+        if (firstChildIsText && firstChildContainsLinkMark) {
           return false
         }
 
         if (link && selection.empty) {
           options.editor.commands.insertContent(`<a href="${link.href}">${link.href}</a>`)
+
           return true
         }
 
@@ -62,13 +61,15 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
 
         if (!selection.empty) {
           deleteOnly = true
+
           tr.delete(selection.from, selection.to)
         }
 
         let currentPos = selection.from
+        let fragmentLinks = []
 
         slice.content.forEach(node => {
-          const fragmentLinks = find(node.textContent)
+          fragmentLinks = find(node.textContent)
 
           tr.insert(currentPos - 1, node)
 
@@ -78,7 +79,6 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
             fragmentLinks.forEach(fragmentLink => {
               const linkStart = currentPos + fragmentLink.start
               const linkEnd = currentPos + fragmentLink.end
-
               const hasMark = tr.doc.rangeHasMark(linkStart, linkEnd, options.type)
 
               if (!hasMark) {
@@ -90,8 +90,11 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
           currentPos += node.nodeSize
         })
 
-        if (tr.docChanged && !deleteOnly) {
+        const hasFragmentLinks = fragmentLinks.length > 0
+
+        if (tr.docChanged && !deleteOnly && hasFragmentLinks) {
           options.editor.view.dispatch(tr)
+
           return true
         }
 

--- a/packages/extension-link/src/helpers/pasteHandler.ts
+++ b/packages/extension-link/src/helpers/pasteHandler.ts
@@ -17,6 +17,11 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
         const { state } = view
         const { selection } = state
 
+        // Do not proceed if in code block.
+        if (state.doc.resolve(selection.from).parent.type.spec.code) {
+          return false
+        }
+
         const pastedLinkMarks: Mark[] = []
         let textContent = ''
 


### PR DESCRIPTION
## Please describe your changes
The link extension mistakenly inserted pasted content at wrong position in rc-4 https://github.com/ueberdosis/tiptap/blob/0e2df9d1f530bc7980a476afa269da29159d5892/packages/extension-link/src/helpers/pasteHandler.ts#L74

This handling was originally reserved for links and not for other types. 
A check has been introduced that dispatches the transaction only for pasting links.

It also prevents processing links in onPaste in code blocks.

## How did you accomplish your changes
Added a condition to only dispatch insert transaction if pasted content is a link fragment.

## How have you tested your changes
- Copy and paste any type of content (e.g. text). In RC-4 it got inserted at position -1. This should be fixed now. 
- Paste this into a code block: `<a href="https://www.google.com">Google</a>`

## How can we verify your changes
See above and below.

Before: 
https://github.com/ueberdosis/tiptap/assets/11420688/6bcc45a6-c226-4859-a1b4-74387d271692

After: 
https://github.com/ueberdosis/tiptap/assets/11420688/7da50487-7f54-4d19-b0a3-00c2bb29a5be

## Remarks
Still feels like there is some room for optimizations regarding pasting links.

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues