### PR TITLE
fix: do not use window.open for links in readonly mode

### DIFF
--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -22,7 +22,9 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
         const target = link?.target ?? attrs.target
 
         if (link && href) {
-          if (view.editable) window.open(href, target)
+          if (view.editable) {
+            window.open(href, target)
+          }
 
           return true
         }

--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -22,7 +22,7 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
         const target = link?.target ?? attrs.target
 
         if (link && href) {
-          window.open(href, target)
+          if (view.editable) window.open(href, target)
 
           return true
         }


### PR DESCRIPTION
## Please describe your changes

This PR prevents opening of links using `window.open` on clicking them in readonly mode. 

## How did you accomplish your changes

When `contenteditable` is `true`, the browser doesn't allow direct link opens on clicking the `a` element. This is why we need to call `window.open` to open our links.

However, when `contenteditable` is `false`, the default browser mechanism for opening links works and there is no need for using `window.open`.

Without this change, TipTap would open 2 new tabs on clicking a link.

## How have you tested your changes

By enabling readonly mode and clicking on links.

## How can we verify your changes

By enabling readonly mode and clicking on links.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues
