### PR TITLE
fix(extension-link): fixes link going to wrong url

### DIFF
--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -16,7 +16,7 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
         }
 
         const attrs = getAttributes(view.state, options.type.name)
-        const link = (event.target as HTMLElement)?.closest('a')
+        const link = (event.target as HTMLLinkElement)
 
         const href = link?.href ?? attrs.href
         const target = link?.target ?? attrs.target


### PR DESCRIPTION
## Please describe your changes

Fixes links using incorrect url onClick.

## How did you accomplish your changes

Casting the type of the target to HTMLLinkElement and removing `.closest('a')`

## How have you tested your changes

Built the package and imported it to our repo. Worked like a charm.

## How can we verify your changes

Test on the localhost editor app.

## Remarks

This fix is necessary because right now have two links in the same editor results in the second link going to the first link.

closest('a') was returning the wrong href.

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

https://github.com/ueberdosis/tiptap/issues/4056