### PR TITLE
Allow the mention extension to have custom renderHTML

### DIFF
--- a/docs/api/nodes/mention.md
+++ b/docs/api/nodes/mention.md
@@ -42,17 +42,31 @@ Mention.configure({
 })
 ```
 
-### renderLabel
-Define how a mention label should be rendered.
+### renderText
+Define how a mention text should be rendered.
 
 ```js
 Mention.configure({
-  renderLabel({ options, node }) {
+  renderText({ options, node }) {
     return `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`
   }
 })
 ```
 
+### renderHTML
+Define how a mention html element should be rendered, this is useful if you want to render an element other than `span` (e.g `a`)
+
+```js
+Mention.configure({
+  renderHTML({ options, node }) {
+    return [
+      "a",
+      { href: '/profile/1' },
+      `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`,
+      ];
+  }
+})
+```
 ### suggestion
 [Read more](/api/utilities/suggestion)
 

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -6,7 +6,7 @@ import Suggestion, { SuggestionOptions } from '@tiptap/suggestion'
 export type MentionOptions = {
   HTMLAttributes: Record<string, any>
   /** @deprecated use renderText and renderHTML instead  */
-  renderLabel: (props: { options: MentionOptions; node: ProseMirrorNode }) => string
+  renderLabel?: (props: { options: MentionOptions; node: ProseMirrorNode }) => string
   renderText: (props: { options: MentionOptions; node: ProseMirrorNode }) => string
   renderHTML: (props: { options: MentionOptions; node: ProseMirrorNode }) => DOMOutputSpec
   suggestion: Omit<SuggestionOptions, 'editor'>
@@ -20,9 +20,6 @@ export const Mention = Node.create<MentionOptions>({
   addOptions() {
     return {
       HTMLAttributes: {},
-      renderLabel({ options, node }) {
-        return `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`
-      },
       renderText({ options, node }) {
         return `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`
       },
@@ -123,6 +120,17 @@ export const Mention = Node.create<MentionOptions>({
   },
 
   renderHTML({ node, HTMLAttributes }) {
+    if (this.options.renderLabel !== undefined) {
+      console.warn('renderLabel is deprecated use renderText and renderHTML instead')
+      return [
+        'span',
+        mergeAttributes({ 'data-type': this.name }, this.options.HTMLAttributes, HTMLAttributes),
+        this.options.renderLabel({
+          options: this.options,
+          node,
+        }),
+      ]
+    }
     return [
       'span',
       mergeAttributes({ 'data-type': this.name }, this.options.HTMLAttributes, HTMLAttributes),
@@ -134,6 +142,13 @@ export const Mention = Node.create<MentionOptions>({
   },
 
   renderText({ node }) {
+    if (this.options.renderLabel !== undefined) {
+      console.warn('renderLabel is deprecated use renderText and renderHTML instead')
+      return this.options.renderLabel({
+        options: this.options,
+        node,
+      })
+    }
     return this.options.renderText({
       options: this.options,
       node,

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -1,11 +1,14 @@
 import { mergeAttributes, Node } from '@tiptap/core'
-import { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { DOMOutputSpec, Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { PluginKey } from '@tiptap/pm/state'
 import Suggestion, { SuggestionOptions } from '@tiptap/suggestion'
 
 export type MentionOptions = {
   HTMLAttributes: Record<string, any>
+  /** @deprecated use renderText and renderHTML instead  */
   renderLabel: (props: { options: MentionOptions; node: ProseMirrorNode }) => string
+  renderText: (props: { options: MentionOptions; node: ProseMirrorNode }) => string
+  renderHTML: (props: { options: MentionOptions; node: ProseMirrorNode }) => DOMOutputSpec
   suggestion: Omit<SuggestionOptions, 'editor'>
 }
 
@@ -19,6 +22,16 @@ export const Mention = Node.create<MentionOptions>({
       HTMLAttributes: {},
       renderLabel({ options, node }) {
         return `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`
+      },
+      renderText({ options, node }) {
+        return `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`
+      },
+      renderHTML({ options, node }) {
+        return [
+          'span',
+          this.HTMLAttributes,
+          `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`,
+        ]
       },
       suggestion: {
         char: '@',
@@ -113,7 +126,7 @@ export const Mention = Node.create<MentionOptions>({
     return [
       'span',
       mergeAttributes({ 'data-type': this.name }, this.options.HTMLAttributes, HTMLAttributes),
-      this.options.renderLabel({
+      this.options.renderHTML({
         options: this.options,
         node,
       }),
@@ -121,7 +134,7 @@ export const Mention = Node.create<MentionOptions>({
   },
 
   renderText({ node }) {
-    return this.options.renderLabel({
+    return this.options.renderText({
       options: this.options,
       node,
     })

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -131,14 +131,19 @@ export const Mention = Node.create<MentionOptions>({
         }),
       ]
     }
-    return [
-      'span',
-      mergeAttributes({ 'data-type': this.name }, this.options.HTMLAttributes, HTMLAttributes),
-      this.options.renderHTML({
-        options: this.options,
-        node,
-      }),
-    ]
+    const html = this.options.renderHTML({
+      options: this.options,
+      node,
+    })
+
+    if (typeof html === 'string') {
+      return [
+        'span',
+        mergeAttributes({ 'data-type': this.name }, this.options.HTMLAttributes, HTMLAttributes),
+        html,
+      ]
+    }
+    return html
   },
 
   renderText({ node }) {


### PR DESCRIPTION
## Please describe your changes

Currently the mention extension's `renderLabel` doesn't allow returning HTML and expect returning string, there is a workaround by tricking the typesystem but this breaks when generating text from `JSONContent` (i.e using `generateText` from `@tiptap/core` , this should allow the user to customize the text and html rendering.

This can be very useful when one wants to render and `a` tag instead of just a `span` tag so that it can link to the profile of the mention person

## How did you accomplish your changes

Basically introduced two new functions `renderText` and `renderHTML` 

## How have you tested your changes
Yes, tested it on my current project (Laravel with Inertiajs)

## How can we verify your changes

It can be tested using the mention demo

## Remarks
N/A

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

#3325
