### PR TITLE
Rel cannot be set

### DIFF
--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -107,6 +107,9 @@ export const Link = Mark.create<LinkOptions>({
       target: {
         default: this.options.HTMLAttributes.target,
       },
+      rel: {
+        default: this.options.HTMLAttributes.rel,
+      },
       class: {
         default: this.options.HTMLAttributes.class,
       },


### PR DESCRIPTION
Without the addAttributes entry, passing the rel attribute doesn't work (tested in 2.0.3)

## Please describe your changes

Add the rel entry

## How did you accomplish your changes

Seeing that my rel attribute wasn't set, i tested with this entry, and it works

## How have you tested your changes

Tested locally on 2.0.3

## How can we verify your changes

Simply try to pass a rel attribute to setLink, it doesn't work

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
