### PR TITLE
Add support for custom selection builders

### DIFF
--- a/docs/api/extensions/collaboration-cursor.md
+++ b/docs/api/extensions/collaboration-cursor.md
@@ -33,6 +33,9 @@ Default: `{ user: null, color: null }`
 ### render
 A render function for the cursor, look at [the extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-cursor/) for an example.
 
+### selectionRender
+A render function for the selection, look at [the extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-cursor/) for an example.
+
 ## Commands
 
 ### updateUser()

--- a/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
+++ b/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
@@ -1,5 +1,6 @@
 import { Extension } from '@tiptap/core'
-import { yCursorPlugin } from 'y-prosemirror'
+import { DecorationAttrs } from 'prosemirror-view'
+import { defaultSelectionBuilder, yCursorPlugin } from 'y-prosemirror'
 
 type CollaborationCursorStorage = {
   users: { clientId: number, [key: string]: any }[],
@@ -9,6 +10,7 @@ export interface CollaborationCursorOptions {
   provider: any,
   user: Record<string, any>,
   render (user: Record<string, any>): HTMLElement,
+  selectionRender (user: Record<string, any>): DecorationAttrs
   /**
    * @deprecated The "onUpdate" option is deprecated. Please use `editor.storage.collaborationCursor.users` instead. Read more: https://tiptap.dev/api/extensions/collaboration-cursor
    */
@@ -68,6 +70,7 @@ export const CollaborationCursor = Extension.create<CollaborationCursorOptions, 
 
         return cursor
       },
+      selectionRender: defaultSelectionBuilder,
       onUpdate: defaultOnUpdate,
     }
   },
@@ -118,6 +121,7 @@ export const CollaborationCursor = Extension.create<CollaborationCursorOptions, 
         // @ts-ignore
         {
           cursorBuilder: this.options.render,
+          selectionBuilder: this.options.selectionRender,
         },
       ),
     ]


### PR DESCRIPTION
## Please describe your changes

Add support for custom selection builders.

## How did you accomplish your changes

Added new field to the extension options, type and passing along parameter to the `y-prosemirror` extension. Passing by default the existing default value to avoid breaking anything.

## How have you tested your changes

Ran the existing collaboration demo locally with the changes applied. Verified that the cursor and selection is shown correctly.

## How can we verify your changes

You can clone code and check that the collaboration cursor and selection is not broken.

## Remarks

N/A

## Checklist

- [x] The changes are not breaking the editor
- [] Added tests where possible - N/A
- [x] Followed the guidelines
- [x] Fixed linting issues
