### PR TITLE
Fix mod+z/mod+y failed with capslock

### DIFF
--- a/packages/extension-history/src/history.ts
+++ b/packages/extension-history/src/history.ts
@@ -51,8 +51,11 @@ export const History = Extension.create<HistoryOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-z': () => this.editor.commands.undo(),
+      'Mod-Z': () => this.editor.commands.undo(),
       'Mod-y': () => this.editor.commands.redo(),
+      'Mod-Y': () => this.editor.commands.redo(),
       'Shift-Mod-z': () => this.editor.commands.redo(),
+      'Shift-Mod-Z': () => this.editor.commands.redo(),
 
       // Russian keyboard layouts
       'Mod-я': () => this.editor.commands.undo(),


### PR DESCRIPTION
## Please describe your changes

Fix undo/redo don't work with Capslock enabled

## How did you accomplish your changes

Add uppercase matches for existing lowercase keyboardShortcuts

## How have you tested your changes

No; it's difficult to test TipTap changes on the fly but if there's some easy way I'd be happy to test it

## How can we verify your changes

Turn capslock on and test Mod-Z and Mod-Y behavior

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

Should resolves #4055 without ill effects
