### PR TITLE
Fix TypeScript types for Suggestion `command`, allowing for generic override

### DIFF
--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -3,10 +3,24 @@ import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { PluginKey } from '@tiptap/pm/state'
 import Suggestion, { SuggestionOptions } from '@tiptap/suggestion'
 
-export type MentionOptions = {
+// See `addAttributes` below
+export interface MentionNodeAttrs {
+  /**
+   * The identifier for the selected item that was mentioned, stored as a `data-id`
+   * attribute.
+   */
+  id: string | null;
+  /**
+   * The label to be rendered by the editor as the displayed text for this mentioned
+   * item, if provided. Stored as a `data-label` attribute. See `renderLabel`.
+   */
+  label?: string | null;
+}
+
+export type MentionOptions<SuggestionItem = any, Attrs extends Record<string, any> = MentionNodeAttrs> = {
   HTMLAttributes: Record<string, any>
-  renderLabel: (props: { options: MentionOptions; node: ProseMirrorNode }) => string
-  suggestion: Omit<SuggestionOptions, 'editor'>
+  renderLabel: (props: { options: MentionOptions<SuggestionItem, Attrs>; node: ProseMirrorNode }) => string
+  suggestion: Omit<SuggestionOptions<SuggestionItem, Attrs>, 'editor'>
 }
 
 export const MentionPluginKey = new PluginKey('mention')

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -4,7 +4,7 @@ import { Decoration, DecorationSet, EditorView } from '@tiptap/pm/view'
 
 import { findSuggestionMatch } from './findSuggestionMatch'
 
-export interface SuggestionOptions<I = any> {
+export interface SuggestionOptions<I = any, TSelected = any> {
   pluginKey?: PluginKey
   editor: Editor
   char?: string
@@ -13,26 +13,26 @@ export interface SuggestionOptions<I = any> {
   startOfLine?: boolean
   decorationTag?: string
   decorationClass?: string
-  command?: (props: { editor: Editor; range: Range; props: any }) => void
+  command?: (props: { editor: Editor; range: Range; props: TSelected }) => void
   items?: (props: { query: string; editor: Editor }) => I[] | Promise<I[]>
   render?: () => {
-    onBeforeStart?: (props: SuggestionProps<I>) => void
-    onStart?: (props: SuggestionProps<I>) => void
-    onBeforeUpdate?: (props: SuggestionProps<I>) => void
-    onUpdate?: (props: SuggestionProps<I>) => void
-    onExit?: (props: SuggestionProps<I>) => void
-    onKeyDown?: (props: SuggestionKeyDownProps) => boolean
+    onBeforeStart?: (props: SuggestionProps<I, TSelected>) => void;
+    onStart?: (props: SuggestionProps<I, TSelected>) => void;
+    onBeforeUpdate?: (props: SuggestionProps<I, TSelected>) => void;
+    onUpdate?: (props: SuggestionProps<I, TSelected>) => void;
+    onExit?: (props: SuggestionProps<I, TSelected>) => void;
+    onKeyDown?: (props: SuggestionKeyDownProps) => boolean;
   }
   allow?: (props: { editor: Editor; state: EditorState; range: Range }) => boolean
 }
 
-export interface SuggestionProps<I = any> {
+export interface SuggestionProps<I = any, TSelected = any> {
   editor: Editor
   range: Range
   query: string
   text: string
   items: I[]
-  command: (props: any) => void
+  command: (props: TSelected) => void
   decorationNode: Element | null
   clientRect?: (() => DOMRect | null) | null
 }
@@ -45,7 +45,7 @@ export interface SuggestionKeyDownProps {
 
 export const SuggestionPluginKey = new PluginKey('suggestion')
 
-export function Suggestion<I = any>({
+export function Suggestion<I = any, TSelected = any>({
   pluginKey = SuggestionPluginKey,
   editor,
   char = '@',
@@ -58,8 +58,8 @@ export function Suggestion<I = any>({
   items = () => [],
   render = () => ({}),
   allow = () => true,
-}: SuggestionOptions<I>) {
-  let props: SuggestionProps<I> | undefined
+}: SuggestionOptions<I, TSelected>) {
+  let props: SuggestionProps<I, TSelected> | undefined
   const renderer = render?.()
 
   const plugin: Plugin<any> = new Plugin({

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -13,7 +13,7 @@ export interface SuggestionOptions<I = any> {
   startOfLine?: boolean
   decorationTag?: string
   decorationClass?: string
-  command?: (props: { editor: Editor; range: Range; props: I }) => void
+  command?: (props: { editor: Editor; range: Range; props: any }) => void
   items?: (props: { query: string; editor: Editor }) => I[] | Promise<I[]>
   render?: () => {
     onBeforeStart?: (props: SuggestionProps<I>) => void
@@ -32,7 +32,7 @@ export interface SuggestionProps<I = any> {
   query: string
   text: string
   items: I[]
-  command: (props: I) => void
+  command: (props: any) => void
   decorationNode: Element | null
   clientRect?: (() => DOMRect | null) | null
 }


### PR DESCRIPTION
## Please describe your changes

As of https://github.com/ueberdosis/tiptap/pull/2610 (https://github.com/ueberdosis/tiptap/commit/7cae9673f0086973b4d31e1343375ed5ad04ee0a), new generics were added for Suggestion options and props. However, there is a subtle bug in the current typing: the object selected with the suggestion `command` need not have the same types as the `items` in the suggestion options. For instance, in Tiptap's official demo https://tiptap.dev/api/nodes/mention, the suggestion `items` are each `string`s, but the selected Mention is of type `{id: string;}` (for the attributes of the Mention node):

```ts
  const selectItem = index => {
    const item = props.items[index]

    if (item) {
      props.command({ id: item })
    }
  }
```

i.e., there should be no restriction that when you select something with the suggestion `command`, it must use the identical structure as the suggested items, as that results in a type error in the above perfectly functional code. When using the suggestion plugin within the Mention extension, for instance, the value passed to the SuggestionProps `props.command()` function must be a `Record<string, any>`, as it's directly/exclusively used to set the `attrs` of a `Node` via `insertContentAt` (and you need not use that identical shape for suggestion options themselves):

https://github.com/ueberdosis/tiptap/blob/44996d60bebd80f3dcc897909f59d83a0eff6337/packages/extension-mention/src/mention.ts#L42
    https://github.com/ueberdosis/tiptap/blob/f8695073968c5c6865ad8faf05351020abb2a3cc/packages/core/src/types.ts#L79

## How did you accomplish your changes

This fixes the type definitions so that suggestions can correctly refer separately to their own items (of `any` type), while ensuring the `command`ed item can be defined with its own type definition. This allows use with the Mention extension, where you can still require the correct object structure needed for mention node attributes. In addition, the `Mention` extension now has more specific typing so that it requires a configured `suggestion` to pass in objects of the expected structure (`id` and `label`).

## How have you tested your changes

Tested these types with my local version of suggestion/mention extensions, included an extension that `extend`s `Mention` and further overrides its attributes, and it resolved type errors that were otherwise present.

## How can we verify your changes

Use TypeScript with the original mention example from Tiptap.

## Remarks

There are two commits: the first is the simplest fix, which just sets the `command` argument to `any` (most basic way to resolve the type error). The second commit adds a generic so that the type can be specified and narrowed by callers, which the Mention extension now does by default as well.

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

n/a
