### PR TITLE
fix(react): update select state when text selection is around

### DIFF
--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -99,6 +99,9 @@ class ReactNodeView extends NodeView<
 
     const { className = '' } = this.options
 
+    this.handleSelectionUpdate = this.handleSelectionUpdate.bind(this)
+    this.editor.on('selectionUpdate', this.handleSelectionUpdate)
+
     this.renderer = new ReactRenderer(ReactNodeViewProvider, {
       editor: this.editor,
       props,
@@ -125,6 +128,16 @@ class ReactNodeView extends NodeView<
     }
 
     return this.contentDOMElement
+  }
+
+  handleSelectionUpdate() {
+    const { from, to } = this.editor.state.selection
+
+    if (from <= this.getPos() && to >= this.getPos() + this.node.nodeSize) {
+      this.selectNode()
+    } else {
+      this.deselectNode()
+    }
   }
 
   update(node: ProseMirrorNode, decorations: DecorationWithType[]) {
@@ -178,6 +191,7 @@ class ReactNodeView extends NodeView<
 
   destroy() {
     this.renderer.destroy()
+    this.editor.off('selectionUpdate', this.handleSelectionUpdate)
     this.contentDOMElement = null
   }
 }


### PR DESCRIPTION
## Please describe your changes

This fix will now correctly update the `props.selected` prop when a React component is inside a selection.

## How did you accomplish your changes

I created a selection update handler that will check if the react node position is inside the current selection.

## How have you tested your changes

I used the ReactComponent demo to test those changes.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
