### PR TITLE
Documentation: Add missing editor getters

### DIFF
--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -154,6 +154,27 @@ Check if there is content.
 editor.isEmpty
 ```
 
+### isFocused
+Check if the editor is focused.
+
+```js
+editor.isFocused
+```
+
+### isDestroyed
+Check if the editor is destroyed.
+
+```js
+editor.isDestroyed
+```
+
+### isCapturingTransaction
+Check if the editor is capturing a transaction.
+
+```js
+editor.isCapturingTransaction
+```
+
 ## Settings
 
 ### element


### PR DESCRIPTION
## Please describe your changes

I added the following editor getters to the docs, since they are currently missing and only discoverable through autocompletion: `isFocused`, `isDestroyed`, `isCapturingTransaction`.

## How did you accomplish your changes

–

## How have you tested your changes

–

## How can we verify your changes

You can check the docs at `/api/editor` to verify my changes.

## Remarks

–

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

–
