### PR TITLE
fix(core) Nested chain not preserving dispatch state

### DIFF
--- a/packages/core/src/CommandManager.ts
+++ b/packages/core/src/CommandManager.ts
@@ -133,7 +133,7 @@ export class CommandManager {
         transaction: tr,
       }),
       dispatch: shouldDispatch ? () => undefined : undefined,
-      chain: () => this.createChain(tr),
+      chain: () => this.createChain(tr, shouldDispatch),
       can: () => this.createCan(tr),
       get commands() {
         return Object.fromEntries(

--- a/tests/cypress/integration/core/can.spec.ts
+++ b/tests/cypress/integration/core/can.spec.ts
@@ -167,4 +167,32 @@ describe('can', () => {
 
     expect(canSetMarkToBold).to.eq(true)
   })
+
+  it('nested "can" chain has an undefined dispatch', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, History],
+    })
+
+    let capturedOuterDispatch: ((args?: any) => any) | undefined
+    let capturedInnerDispatch: ((args?: any) => any) | undefined
+
+    editor
+      .can()
+      .chain()
+      .command(({ chain, dispatch: outterDispatch }) => {
+        capturedOuterDispatch = outterDispatch
+        return chain()
+          .command(({ dispatch: innerDispatch }) => {
+            capturedInnerDispatch = innerDispatch
+            return true
+          })
+          .run()
+      })
+      .run()
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(capturedOuterDispatch).to.be.undefined
+    // eslint-disable-next-line no-unused-expressions
+    expect(capturedInnerDispatch).to.be.undefined
+  })
 })

--- a/tests/cypress/integration/core/can.spec.ts
+++ b/tests/cypress/integration/core/can.spec.ts
@@ -168,7 +168,7 @@ describe('can', () => {
     expect(canSetMarkToBold).to.eq(true)
   })
 
-  it('nested "can" chain has an undefined dispatch', () => {
+  it('builds and passes down an undefined dispatch for nested "can" chain', () => {
     const editor = new Editor({
       extensions: [Document, Paragraph, Text, History],
     })


### PR DESCRIPTION
## Please describe your changes

Ensured that chains preserve the parent chain's dispatch state

## How did you accomplish your changes

Simply passed the "shouldDispatch" state down to the next chain that gets built when building command props

## How have you tested your changes

Added tests and did basic regression testing of the default editor demo

## How can we verify your changes

Verify tests pass and consider any other consequences/regression testing


## Checklist

- [X] The changes are not breaking the editor
- [X] Added tests where possible
- [X] Followed the guidelines
- [X] Fixed linting issues

## Related issues

fixes #4147 