### PR TITLE
fix(core) 'enter' behavior on android custom node views

### DIFF
--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -5,6 +5,7 @@ import { NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
 import { Editor as CoreEditor } from './Editor'
 import { Node } from './Node'
 import { DecorationWithType, NodeViewRendererOptions, NodeViewRendererProps } from './types'
+import { isAndroid } from './utilities/isAndroid'
 import { isiOS } from './utilities/isiOS'
 
 export class NodeView<
@@ -212,14 +213,15 @@ export class NodeView<
       return false
     }
 
-    // try to prevent a bug on iOS that will break node views on enter
+    // try to prevent a bug on iOS and Android that will break node views on enter
     // this is because ProseMirror can’t preventDispatch on enter
     // this will lead to a re-render of the node view on enter
     // see: https://github.com/ueberdosis/tiptap/issues/1214
+    // see: https://github.com/ueberdosis/tiptap/issues/2534
     if (
       this.dom.contains(mutation.target)
       && mutation.type === 'childList'
-      && isiOS()
+      && (isiOS() || isAndroid())
       && this.editor.isFocused
     ) {
       const changedNodes = [

--- a/packages/core/src/utilities/isAndroid.ts
+++ b/packages/core/src/utilities/isAndroid.ts
@@ -1,0 +1,3 @@
+export function isAndroid(): boolean {
+  return navigator.platform === 'Android' || /android/i.test(navigator.userAgent)
+}


### PR DESCRIPTION
## Please describe your changes

Applied the same fix on iOS to Android, as Android appears to be having the same issue on enter

Credit to @Slapbox for finding the link to the existing fix made to iOS for the same issue.

## How did you accomplish your changes

N/A

## How have you tested your changes

Tested that both the React and Vue custom node view (w/content) examples worked on an Android device (Samsung Galaxy S22; Chrome)  and verified that hitting enter at the beginning, middle, or end of the custom node view works as expected


## Remarks

No tests were written. Doesn't seem reasonable/easy to test with cypress

## Checklist

- [X] The changes are not breaking the editor
- [X] Added tests where possible
- [X] Followed the guidelines
- [X] Fixed linting issues

## Related issues

fixes #2534
