### PR TITLE
fix: Prevent auto-linking when typing URL inside inline code mark

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -112,18 +112,27 @@ export function autolink(options: AutolinkOptions): Plugin {
 
           find(lastWordBeforeSpace)
             .filter(link => link.isLink)
-            .filter(link => {
-              if (options.validate) {
-                return options.validate(link.value)
-              }
-              return true
-            })
             // Calculate link position.
             .map(link => ({
               ...link,
               from: lastWordAndBlockOffset + link.start + 1,
               to: lastWordAndBlockOffset + link.end + 1,
             }))
+            // ignore link inside code mark
+            .filter(link => {
+              return !newState.doc.rangeHasMark(
+                link.from,
+                link.to,
+                newState.schema.marks.code,
+              )
+            })
+            // validate link
+            .filter(link => {
+              if (options.validate) {
+                return options.validate(link.value)
+              }
+              return true
+            })
             // Add link mark.
             .forEach(link => {
               if (getMarksBetween(link.from, link.to, newState.doc).some(item => item.mark.type === options.type)) {


### PR DESCRIPTION
## Please describe your changes

At [Doist](https://doist.com) we have [extended the Code extension](https://github.com/Doist/typist/blob/main/src/extensions/rich-text/rich-text-code.ts) to allow all marks (e.g., Bold, Italic, and Strikethrough) to coexist with the `Code` mark, which gives a behaviour that more closely resembles GitHub, allowing us to render inline code marks with formatting and links, like this: **[`Typist`](https://typist.doist.dev)**.

However, this created an [issue](https://github.com/Doist/typist/issues/319) for us, where URLs typed inside inline code marks were automatically converted into links, which is not the behaviour we want. Here's a demo of our own editor based on Tiptap exhibiting the issue:

https://github.com/Doist/typist/assets/1322846/5f4d92e2-2293-41f7-9f60-27d1219f6228

## How did you accomplish your changes

Added a filter rule to the autolink helper where we check if the detected link being typed is inside a code mark, if it is, we discard it.

## How have you tested your changes

Manually by bringing the [autolink.ts](https://github.com/rfgamaral/tiptap/blob/main/packages/extension-link/src/helpers/autolink.ts) file into our own editor and our [own extended Link extension](https://github.com/Doist/typist/blob/main/src/extensions/rich-text/rich-text-link.ts) with the changes proposed in this PR.

## How can we verify your changes

Tweak the editor running on Tiptap's homepage to run the Code extension without excluding all other marks ([ref](https://tiptap.dev/api/schema#excludes)), and to use the changes proposed here. Then try something similar to demo above.

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues