### PR TITLE
Fix nested lists style issue

### DIFF
--- a/demos/src/Nodes/TaskItem/React/styles.scss
+++ b/demos/src/Nodes/TaskItem/React/styles.scss
@@ -18,5 +18,14 @@ ul[data-type="taskList"] {
     > div {
       flex: 1 1 auto;
     }
+    
+    ul li,
+    ol li {
+      display: list-item;
+    }
+
+    ul[data-type="taskList"] > li {
+      display: flex;
+    }
   }
 }

--- a/demos/src/Nodes/TaskItem/Vue/index.vue
+++ b/demos/src/Nodes/TaskItem/Vue/index.vue
@@ -83,6 +83,15 @@ ul[data-type="taskList"] {
     > div {
       flex: 1 1 auto;
     }
+  
+    ul li,
+    ol li {
+    	display: list-item;
+    }
+    
+    ul[data-type="taskList"] > li {
+    	display: flex;
+    }
   }
 }
 </style>

--- a/demos/src/Nodes/TaskList/React/styles.scss
+++ b/demos/src/Nodes/TaskList/React/styles.scss
@@ -18,5 +18,14 @@ ul[data-type="taskList"] {
     > div {
       flex: 1 1 auto;
     }
+
+    ul li,
+    ol li {
+    	display: list-item;
+    }
+    
+    ul[data-type="taskList"] > li {
+    	display: flex;
+    }
   }
 }

--- a/demos/src/Nodes/TaskList/Vue/index.vue
+++ b/demos/src/Nodes/TaskList/Vue/index.vue
@@ -83,6 +83,15 @@ ul[data-type="taskList"] {
     > div {
       flex: 1 1 auto;
     }
+
+    ul li,
+    ol li {
+    	display: list-item;
+    }
+    
+    ul[data-type="taskList"] > li {
+    	display: flex;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Please describe your changes

Changes are applied to usage code sample of TaskList and TaskItem extensions. 
With previous css code given, style of bullet lists and ordered lists which are nested inside of TaskItems were not correct.

![image](https://github.com/ueberdosis/tiptap/assets/137985975/a494f53d-7781-49b9-bb1c-f16568096fa1)

## How did you accomplish your changes

By styling

## How have you tested your changes

## How can we verify your changes

![image](https://github.com/ueberdosis/tiptap/assets/137985975/fcd355ab-bcb7-4b78-bc4c-8799f8cae603)


## Remarks

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues
