### PR TITLE
Fix: configured/extended extensions should keep their original config

### DIFF
--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -357,7 +357,7 @@ export class Extension<Options = any, Storage = any> {
   extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
     extendedConfig: Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>> = {},
   ) {
-    const extension = new Extension<ExtendedOptions, ExtendedStorage>(extendedConfig)
+    const extension = new Extension<ExtendedOptions, ExtendedStorage>({ ...this.config, ...extendedConfig })
 
     extension.parent = this
 

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -489,7 +489,7 @@ export class Mark<Options = any, Storage = any> {
   extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
     extendedConfig: Partial<MarkConfig<ExtendedOptions, ExtendedStorage>> = {},
   ) {
-    const extension = new Mark<ExtendedOptions, ExtendedStorage>(extendedConfig)
+    const extension = new Mark<ExtendedOptions, ExtendedStorage>({ ...this.config, ...extendedConfig })
 
     extension.parent = this
 

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -598,7 +598,7 @@ export class Node<Options = any, Storage = any> {
   extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
     extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>> = {},
   ) {
-    const extension = new Node<ExtendedOptions, ExtendedStorage>(extendedConfig)
+    const extension = new Node<ExtendedOptions, ExtendedStorage>({ ...this.config, ...extendedConfig })
 
     extension.parent = this
 


### PR DESCRIPTION
## Please describe your changes

Extensions, marks and nodes should keep their original config when they are extended or configured. 

## How did you accomplish your changes

n/a.

## How have you tested your changes

Tested locally.

## How can we verify your changes

```
import Code from '@tiptap/extension-code'
import Document from '@tiptap/extension-document'
import Paragraph from '@tiptap/extension-paragraph'
import Text from '@tiptap/extension-text'
import { EditorContent, useEditor } from '@tiptap/react'
import React from 'react'

export default () => {
  const editor = useEditor({
    extensions: [Document, Paragraph, Text, Code.configure({
      HTMLAttributes: {
        class: 'my-custom-class',
      },
    })],
    content: `
        <p>This isn’t code.</p>
        <p><code>This is code.</code></p>
      `,
  })

  if (!editor) {
    return null
  }

  return (
    <>
      <button
        onClick={() => editor.chain().focus().toggleCode().run()}
        className={editor.isActive('code') ? 'is-active' : ''}
      >
        toggleCode
      </button>
      <button
        onClick={() => editor.chain().focus().setCode().run()}
        disabled={editor.isActive('code')}
      >
        setCode
      </button>
      <button
        onClick={() => editor.chain().focus().unsetCode().run()}
        disabled={!editor.isActive('code')}
      >
        unsetCode
      </button>

      <EditorContent editor={editor} />
    </>
  )
}
```

Before this fix, the instance of `Code` doesn't have `excludes`, `code` or `exitable` set. This prevents the right arrow keyboard shortcut to exit the code mark for instance. After the fix, the config is correctly extended and the new instance of `Code` uses the correct values for `excludes`, `code` or `exitable`. Same goes for `Extension` and `Node`. 

## Remarks

This is especially noticeable when users use the StarterKit. StarterKit configures all extensions with `undefined` by default, which strips them all from their default config. 

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

I haven't filed an issue. 
