### PR TITLE
add link to version 1 of the docs

### DIFF
--- a/docs/overview/upgrade-guide.md
+++ b/docs/overview/upgrade-guide.md
@@ -7,6 +7,8 @@ tableOfContents: true
 ## Introduction
 First of all, Tiptap v1 isn’t supported anymore and won’t receive any further updates.
 
+If you’re still using Tiptap v1, you can find the documentation [here](https://v1.tiptap.dev/), but we strongly recommend that you upgrade to version 2.
+
 Yes, it’s tedious work to upgrade your favorite text editor to a new API, but we made sure you’ve got enough reasons to upgrade to the newest version.
 
 * Autocompletion in your IDE (thanks to TypeScript)


### PR DESCRIPTION
## Please describe your changes

The docs of Tiptap version 1 are only available via the link in the footer of the website. We want to remove it because version 1 is quite old. Instead, I put a link in the upgrade guide, so everybody can find it there. Tiptap is still available via https://v1.tiptap.dev/ and it's possible to find it with Google.

## How did you accomplish your changes

Add a new paragraph to the upgrade guide close to the top.

## How have you tested your changes

n/a

## How can we verify your changes

n/a

## Remarks

n/a

## Checklist

- [X] The changes are not breaking the editor
- [X] Added tests where possible
- [X] Followed the guidelines
- [X] Fixed linting issues

## Related issues

n/a
