### PR TITLE
Add undoable option to ParseRule

### DIFF
--- a/packages/core/src/PasteRule.ts
+++ b/packages/core/src/PasteRule.ts
@@ -1,4 +1,5 @@
 import { EditorState, Plugin } from '@tiptap/pm/state'
+import { closeHistory } from '@tiptap/pm/history'
 
 import { CommandManager } from './CommandManager.js'
 import { Editor } from './Editor.js'
@@ -25,6 +26,7 @@ export type PasteRuleFinder = RegExp | ((text: string) => PasteRuleMatch[] | nul
 
 export class PasteRule {
   find: PasteRuleFinder
+  undoable: boolean
 
   handler: (props: {
     state: EditorState
@@ -37,6 +39,7 @@ export class PasteRule {
 
   constructor(config: {
     find: PasteRuleFinder
+    undoable?: boolean
     handler: (props: {
       state: EditorState
       range: Range
@@ -48,6 +51,7 @@ export class PasteRule {
   }) {
     this.find = config.find
     this.handler = config.handler
+    this.undoable = config.undoable || false
   }
 }
 
@@ -231,6 +235,10 @@ export function pasteRulesPlugin(props: { editor: Editor; rules: PasteRule[] }):
           return
         }
 
+        if (rule.undoable) {
+          setTimeout(() => { editor.view.dispatch(tr) }, 0);
+          return closeHistory(state.tr)
+        }
         return tr
       },
     })


### PR DESCRIPTION
This is more of a POC than a true PR. Is this a change you would support?

## Please describe your changes

The reason I'm interested in this is I want to convert pasted video links into embedded videos (or similar for other media). But it's possible that someone actually wants a link instead of an embedded video. This logic allows them to Mod-z and have the text they pasted show up again.

## How did you accomplish your changes

I've tested this logic separately on my own repo, but this commit I just did in GitHub. It's not mergeable.

## How have you tested your changes

I haven't tested this, please don't merge it :)

## How can we verify your changes

In a real PR, I'll include sample paste rules that are undoable.

## Remarks

Just looking for initial feedback

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

None.