### PR TITLE
Register CSS through extensions

### DIFF
--- a/packages/core/src/utilities/createStyleTag.ts
+++ b/packages/core/src/utilities/createStyleTag.ts
@@ -1,5 +1,5 @@
-export function createStyleTag(style: string, nonce?: string): HTMLStyleElement {
-  const tiptapStyleTag = (<HTMLStyleElement>document.querySelector('style[data-tiptap-style]'))
+export function createStyleTag(style: string, nonce?: string, suffix?: string): HTMLStyleElement {
+  const tiptapStyleTag = (<HTMLStyleElement>document.querySelector(`style[data-tiptap-style${suffix ? `-${suffix}` : ''}]`))
 
   if (tiptapStyleTag !== null) {
     return tiptapStyleTag
@@ -11,7 +11,7 @@ export function createStyleTag(style: string, nonce?: string): HTMLStyleElement 
     styleNode.setAttribute('nonce', nonce)
   }
 
-  styleNode.setAttribute('data-tiptap-style', '')
+  styleNode.setAttribute(`data-tiptap-style${suffix ? `-${suffix}` : ''}`, '')
   styleNode.innerHTML = style
   document.getElementsByTagName('head')[0].appendChild(styleNode)
 


### PR DESCRIPTION
## Please describe your changes

Similar to the core of Tiptap, some extensions require basic styles to work. This PR adds the possibility to create CSS styles through extensions.

## How did you accomplish your changes

The `createStyleTag` function optionally receives another suffix parameter which adds another `data-tiptap-style` CSS block to the document.

## How have you tested your changes

Added a demo extension that calls `createStyleTag()` inside a PM plugin.

## How can we verify your changes

See above.

## Remarks

  /

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

  /
