### PR TITLE
fix(strikethrough): update strikethrough shortcut

### DIFF
--- a/demos/src/Marks/Strike/React/index.spec.js
+++ b/demos/src/Marks/Strike/React/index.spec.js
@@ -58,15 +58,15 @@ context('/src/Marks/Strike/React/', () => {
 
   it('should strike the selected text when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { modKey: true, shiftKey: true, key: 'x' })
+      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('contain', 'Example Text')
   })
 
   it('should toggle the selected text striked when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { modKey: true, shiftKey: true, key: 'x' })
-      .trigger('keydown', { modKey: true, shiftKey: true, key: 'x' })
+      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('not.exist')
   })

--- a/demos/src/Marks/Strike/Vue/index.spec.js
+++ b/demos/src/Marks/Strike/Vue/index.spec.js
@@ -64,15 +64,15 @@ context('/src/Marks/Strike/Vue/', () => {
 
   it('should strike the selected text when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { modKey: true, shiftKey: true, key: 'x' })
+      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('contain', 'Example Text')
   })
 
   it('should toggle the selected text striked when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { modKey: true, shiftKey: true, key: 'x' })
-      .trigger('keydown', { modKey: true, shiftKey: true, key: 'x' })
+      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('not.exist')
   })

--- a/packages/extension-strike/src/strike.ts
+++ b/packages/extension-strike/src/strike.ts
@@ -1,4 +1,5 @@
 import {
+  isMacOS,
   Mark,
   markInputRule,
   markPasteRule,
@@ -78,9 +79,15 @@ export const Strike = Mark.create<StrikeOptions>({
   },
 
   addKeyboardShortcuts() {
-    return {
-      'Mod-Shift-x': () => this.editor.commands.toggleStrike(),
+    const shortcuts: Record<string, () => boolean> = {}
+
+    if (isMacOS()) {
+      shortcuts['Mod-Shift-s'] = () => this.editor.commands.toggleStrike()
+    } else {
+      shortcuts['Ctrl-Shift-s'] = () => this.editor.commands.toggleStrike()
     }
+
+    return shortcuts
   },
 
   addInputRules() {


### PR DESCRIPTION
## Please describe your changes

This PR changes the shortcut for strikethrough to a more standardized version similar to other apps (Notion, Dropbox Paper).

Now the default shortcut is `Mod+Shift+s` for MacOS and `Ctrl+Shift+s` for other operation systems.

See https://defkey.com/search?irq=strikethrough

## How did you accomplish your changes

Changed the addKeyboardShortcuts function

## How have you tested your changes

Tested them locally on MacOS and Windows.

## How can we verify your changes

Check the deployed demo

## Remarks

nothing

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

closes #2540 