### PR TITLE
fix(link): Fix autolinking and pasting

### DIFF
--- a/packages/extension-link/src/helpers/pasteHandler.ts
+++ b/packages/extension-link/src/helpers/pasteHandler.ts
@@ -51,7 +51,7 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
         const firstChildIsText = slice.content.firstChild?.type.name === 'text'
         const firstChildContainsLinkMark = slice.content.firstChild?.marks.some(mark => mark.type.name === options.type.name)
 
-        if (firstChildIsText && firstChildContainsLinkMark) {
+        if ((firstChildIsText && firstChildContainsLinkMark) || !options.linkOnPaste) {
           return false
         }
 

--- a/packages/extension-link/src/helpers/pasteHandler.ts
+++ b/packages/extension-link/src/helpers/pasteHandler.ts
@@ -1,5 +1,5 @@
 import { Editor } from '@tiptap/core'
-import { Mark, MarkType } from '@tiptap/pm/model'
+import { MarkType } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { find } from 'linkifyjs'
 
@@ -22,24 +22,28 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
           return false
         }
 
-        const pastedLinkMarks: Mark[] = []
         let textContent = ''
 
         slice.content.forEach(node => {
           textContent += node.textContent
-
-          node.marks.forEach(mark => {
-            if (mark.type.name === options.type.name) {
-              pastedLinkMarks.push(mark)
-            }
-          })
         })
 
-        const hasPastedLink = pastedLinkMarks.length > 0
+        let isAlreadyLink = false
+
+        slice.content.descendants(node => {
+          if (node.marks.some(mark => mark.type.name === options.type.name)) {
+            isAlreadyLink = true
+          }
+        })
+
+        if (isAlreadyLink) {
+          return
+        }
+
         const link = find(textContent).find(item => item.isLink && item.value === textContent)
 
         if (!selection.empty && options.linkOnPaste) {
-          const pastedLink = hasPastedLink ? pastedLinkMarks[0].attrs.href : link?.href || null
+          const pastedLink = link?.href || null
 
           if (pastedLink) {
             options.editor.commands.setMark(options.type, { href: pastedLink })


### PR DESCRIPTION
## Please describe your changes

This PR will fix multiple issues with the current auto linking.

- First fix is that pasteOnLink option was not working anymore
- I'll also fix an apparent issue that content after a pasted link is also autolinked? (wasn't able to reproduce for now)

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

fixes #4256 
fixes #4258
