### PR TITLE
HorizontalRule: fix setHorizontalRule putting cursor at non-text positions

### DIFF
--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -78,14 +78,26 @@ export function nodeInputRule(config: {
         const posAfter = $to.end()
 
         if ($to.nodeAfter) {
-          tr.setSelection(TextSelection.create(tr.doc, $to.pos))
+          let nextTextPos: number | null = null
+
+          tr.doc.nodesBetween($to.pos, tr.doc.content.size, (node, pos) => {
+            if (node.isText && nextTextPos === null) {
+              nextTextPos = pos
+            }
+          })
+
+          if (!nextTextPos) {
+            nextTextPos = $to.pos + 1
+          }
+
+          tr.setSelection(TextSelection.create(tr.doc, nextTextPos))
         } else {
           // add node after horizontal rule if it’s the end of the document
           const node = $to.parent.type.contentMatch.defaultType?.create()
 
           if (node) {
             tr.insert(posAfter, node)
-            tr.setSelection(TextSelection.create(tr.doc, posAfter))
+            tr.setSelection(TextSelection.create(tr.doc, posAfter + 1))
           }
         }
 

--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -49,14 +49,26 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
                   const posAfter = $to.end()
 
                   if ($to.nodeAfter) {
-                    tr.setSelection(TextSelection.create(tr.doc, $to.pos))
+                    let nextTextPos: number | null = null
+
+                    tr.doc.nodesBetween($to.pos, tr.doc.content.size, (node, pos) => {
+                      if (node.isText && nextTextPos === null) {
+                        nextTextPos = pos
+                      }
+                    })
+
+                    if (!nextTextPos) {
+                      nextTextPos = $to.pos + 1
+                    }
+
+                    tr.setSelection(TextSelection.create(tr.doc, nextTextPos))
                   } else {
                     // add node after horizontal rule if it’s the end of the document
                     const node = $to.parent.type.contentMatch.defaultType?.create()
 
                     if (node) {
                       tr.insert(posAfter, node)
-                      tr.setSelection(TextSelection.create(tr.doc, posAfter))
+                      tr.setSelection(TextSelection.create(tr.doc, posAfter + 1))
                     }
                   }
 


### PR DESCRIPTION
## Please describe your changes

This PR fixes an issue with the `setHorizontalRule` function placing the selection at non-text positions (for example `doc`) after inserting a HorizontalRule node.

## How did you accomplish your changes

I modified the insert positions of the functions and added a small part of code to determine the next text-node which the cursor can be placed in.

## How have you tested your changes

Locally with the HorizontalRule demo.

## How can we verify your changes

See above

## Remarks

Nothing

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

fixes #3003
