### PR TITLE
Core: Fix classes being duplicated on mergeAttributes function

### DIFF
--- a/packages/core/src/utilities/mergeAttributes.ts
+++ b/packages/core/src/utilities/mergeAttributes.ts
@@ -14,7 +14,9 @@ export function mergeAttributes(...objects: Record<string, any>[]): Record<strin
         }
 
         if (key === 'class') {
-          mergedAttributes[key] = [mergedAttributes[key], value].join(' ')
+          if (!mergedAttributes[key].includes(value)) {
+            mergedAttributes[key] = [mergedAttributes[key], value].join(' ')
+          }
         } else if (key === 'style') {
           mergedAttributes[key] = [mergedAttributes[key], value].join('; ')
         } else {

--- a/packages/core/src/utilities/mergeAttributes.ts
+++ b/packages/core/src/utilities/mergeAttributes.ts
@@ -14,9 +14,14 @@ export function mergeAttributes(...objects: Record<string, any>[]): Record<strin
         }
 
         if (key === 'class') {
-          if (!mergedAttributes[key].includes(value)) {
-            mergedAttributes[key] = [mergedAttributes[key], value].join(' ')
-          }
+          const valueClasses: string[] = value.split(' ')
+          const existingClasses: string[] = mergedAttributes[key].split(' ')
+
+          const insertClasses = valueClasses.filter(
+            valueClass => !existingClasses.includes(valueClass),
+          )
+
+          mergedAttributes[key] = [...existingClasses, ...insertClasses].join(' ')
         } else if (key === 'style') {
           mergedAttributes[key] = [mergedAttributes[key], value].join('; ')
         } else {


### PR DESCRIPTION
## Please describe your changes

Before this change, the class attribute on `HTMLAttributes` would be duplicated inside the `mergeAttributes` function, because there was no check if a class already exists on the `HTMLAttributes` string (coming from defaultOptions and inputOptions).

This PR fixes this.

## How did you accomplish your changes

Added a check if the className is already included inside the class attribute.

## How have you tested your changes

Tested locally in the link demo with normal class and BEM class style

## How can we verify your changes

See above

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

fixes #4282 
