### PR TITLE
React: Fix ReactNodeView renderer element updates not being applied

### DIFF
--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -153,6 +153,9 @@ class ReactNodeView extends NodeView<
       const oldNode = this.node
       const oldDecorations = this.decorations
 
+      Object.keys(node.attrs).forEach(key => {
+        this.renderer.element.setAttribute(key, node.attrs[key])
+      })
       this.node = node
       this.decorations = decorations
 
@@ -169,6 +172,9 @@ class ReactNodeView extends NodeView<
       return true
     }
 
+    Object.keys(node.attrs).forEach(key => {
+      this.renderer.element.setAttribute(key, node.attrs[key])
+    })
     this.node = node
     this.decorations = decorations
 


### PR DESCRIPTION
## Please describe your changes

Currently, updates on attributes of `ReactNodeView` are not applied to its renderer element. It's noticeable when you are using elements that depends on its attributes to render correctly like `colspan` in td elements. This PR tries to fix that issue.

## How did you accomplish your changes

Added a loop updating all the renderer element attributes on the update method of the class `ReactNodeView`.

## How have you tested your changes

Tested locally.

## How can we verify your changes

Add a NodeView to the table cell extension and try to merge them. More details on the linked issue.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

Fixes https://github.com/ueberdosis/tiptap/issues/4239
