### PR TITLE
hotfix(core): Fix input rules not working if at last position of a block

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
         'newline-after-var': ['error', 'always'],
         'no-continue': 'off',
         'no-alert': 'off',
-        'no-console': ['warn', { allow: ['warn', 'error'] }],
+        'no-console': ['error'],
         semi: ['error', 'never'],
         'import/order': 'off',
         'import/extensions': ['error', 'ignorePackages'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
         'newline-after-var': ['error', 'always'],
         'no-continue': 'off',
         'no-alert': 'off',
-        'no-console': ['error'],
+        'no-console': ['error', { allow: ['warn', 'error'] }],
         semi: ['error', 'never'],
         'import/order': 'off',
         'import/extensions': ['error', 'ignorePackages'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
         'newline-after-var': ['error', 'always'],
         'no-continue': 'off',
         'no-alert': 'off',
-        'no-console': ['error', { allow: ['warn', 'error'] }],
+        'no-console': ['warn', { allow: ['warn', 'error'] }],
         semi: ['error', 'never'],
         'import/order': 'off',
         'import/extensions': ['error', 'ignorePackages'],

--- a/demos/src/Experiments/OnUpdateRerender/React/index.jsx
+++ b/demos/src/Experiments/OnUpdateRerender/React/index.jsx
@@ -35,7 +35,7 @@ export default () => {
   const [index, setIndex] = React.useState(0)
 
   const handleUpdate = ({ editor: currentEditor }) => {
-    console.log(index, 'onUpdate', currentEditor.getHTML())
+    console.log(index, 'onUpdate', currentEditor.getHTML()) // eslint-disable-line no-console
   }
 
   return (

--- a/demos/src/Experiments/OnUpdateRerender/Vue/TiptapComponent.vue
+++ b/demos/src/Experiments/OnUpdateRerender/Vue/TiptapComponent.vue
@@ -40,7 +40,7 @@ export default {
         </p>
       `,
       onUpdate: ({ editor: currentEditor }) => {
-        console.log(this.count, 'onUpdate', currentEditor.getHTML())
+        console.log(this.count, 'onUpdate', currentEditor.getHTML()) // eslint-disable-line no-console
       },
     })
   },

--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -86,7 +86,7 @@ export function nodeInputRule(config: {
           }
         } else {
           // add node after horizontal rule if it’s the end of the document
-          const defaultNode = $to.parent.type.contentMatch.defaultType?.create()
+          const defaultNode = $to.parent.type.contentMatch.defaultType?.create() || state.doc.type.contentMatch.defaultType?.create()
 
           if (defaultNode) {
             const newPos = start + newNode.nodeSize

--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -76,23 +76,23 @@ export function nodeInputRule(config: {
       }
 
       if (config.blockReplace && config.addExtraNewline) {
-        const posAfter = $to.end()
-
         if ($to.nodeAfter) {
           if ($to.nodeAfter.isTextblock) {
             tr.setSelection(TextSelection.create(tr.doc, $to.pos + 1))
           } else if ($to.nodeAfter.isBlock) {
             tr.setSelection(NodeSelection.create(tr.doc, $to.pos))
           } else {
-            tr.setSelection(TextSelection.create(tr.doc, $to.pos))
+            tr.setSelection(TextSelection.create(tr.doc, $to.pos - 1))
           }
         } else {
           // add node after horizontal rule if it’s the end of the document
-          const node = $to.parent.type.contentMatch.defaultType?.create()
+          const defaultNode = $to.parent.type.contentMatch.defaultType?.create()
 
-          if (node) {
-            tr.insert(posAfter, node)
-            tr.setSelection(TextSelection.create(tr.doc, posAfter + 1))
+          if (defaultNode) {
+            const newPos = start + newNode.nodeSize
+
+            tr.insert(newPos, defaultNode)
+            tr.setSelection(TextSelection.create(tr.doc, newPos))
           }
         }
 

--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -79,7 +79,6 @@ export function nodeInputRule(config: {
         const posAfter = $to.end()
 
         if ($to.nodeAfter) {
-          console.log($to.node().type.name)
           if ($to.nodeAfter.isTextblock) {
             tr.setSelection(TextSelection.create(tr.doc, $to.pos + 1))
           } else if ($to.nodeAfter.isBlock) {


### PR DESCRIPTION
## Please describe your changes

This PR fixes an issue introduced in 2.1.0 that caused inputRules to not work correctly if the position was the last position of an isolating block range.

## How did you accomplish your changes

I added better position handling for the inputRule class.

## How have you tested your changes

I tested the following extensions locally:

- HorizontalRule
- Image
- Figure

## How can we verify your changes

Test the nodeInput behavior on the following demos:

- HorizontalRule
- Image
- Figure

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
