### PR TITLE
fix(core): fix error when merging class attributes

### DIFF
--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -17,6 +17,9 @@ export default () => {
       Code,
       Link.configure({
         openOnClick: false,
+        HTMLAttributes: {
+          class: 'my-class',
+        },
       }),
     ],
     content: `

--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -17,9 +17,6 @@ export default () => {
       Code,
       Link.configure({
         openOnClick: false,
-        HTMLAttributes: {
-          class: 'my-class',
-        },
       }),
     ],
     content: `

--- a/demos/src/Marks/Link/React/index.spec.js
+++ b/demos/src/Marks/Link/React/index.spec.js
@@ -1,3 +1,5 @@
+import Link from '@tiptap/extension-link'
+
 context('/src/Marks/Link/React/', () => {
   before(() => {
     cy.visit('/src/Marks/Link/React/')
@@ -7,6 +9,18 @@ context('/src/Marks/Link/React/', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
       editor.commands.setContent('<p>Example Text</p>')
       cy.get('.tiptap').type('{selectall}')
+    })
+  })
+
+  it('should add a custom class to a link', () => {
+    const linkExtension = Link.configure({
+      HTMLAttributes: {
+        class: 'foo',
+      },
+    })
+
+    expect(linkExtension.options.HTMLAttributes).to.deep.include({
+      class: 'foo',
     })
   })
 

--- a/packages/core/src/utilities/mergeAttributes.ts
+++ b/packages/core/src/utilities/mergeAttributes.ts
@@ -14,8 +14,8 @@ export function mergeAttributes(...objects: Record<string, any>[]): Record<strin
         }
 
         if (key === 'class') {
-          const valueClasses: string[] = value.split(' ')
-          const existingClasses: string[] = mergedAttributes[key].split(' ')
+          const valueClasses: string[] = value ? value.split(' ') : []
+          const existingClasses: string[] = mergedAttributes[key] ? mergedAttributes[key].split(' ') : []
 
           const insertClasses = valueClasses.filter(
             valueClass => !existingClasses.includes(valueClass),


### PR DESCRIPTION
## Please describe your changes

This PR fixes an issue that caused a crash in `mergeAttributes` when one of the `value` or `mergedAttributes` is not set.

## How did you accomplish your changes

I added checks to the mergeAttribute function that will throw back a fallback value of `[]`.

## How have you tested your changes

I tried adding a class in my local demo. I also added a test to check, if the option is set correctly afterwards.

## How can we verify your changes

Run the local demo and configure the extension to have a class – it should work without any error throws & the test should run through.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
