### PR TITLE
fix autolink when code is not enabled for editor

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -87,6 +87,7 @@ export function autolink(options: AutolinkOptions): Plugin {
             }))
             // ignore link inside code mark
             .filter(link => {
+              if (!newState.schema.marks.code) return true; // maybe code is not enabled for this editor
               return !newState.doc.rangeHasMark(
                 link.from,
                 link.to,


### PR DESCRIPTION
## Please describe your changes
fix autolink issue when code extension is not enabled for the editor. See issue https://github.com/ueberdosis/tiptap/issues/4343 for more details

## How did you accomplish your changes
There is a filter in the auto link handler to avoid auto link in a code block. However, when code is not enabled for a particular editor instance, `schema.marks.code` will be `undefined`. The handler passed it to `rangHasMarks` without any validation, and cause an exception.

To fix the issue, we can just return early from the handler when `schema.marks.code` is a falsy value.

## How have you tested your changes

Yes. As the code change is very small, I verified it by applying the same change to my local `node_modules` folder.

## How can we verify your changes
To reproduce the issue, just setup an editor instance with `extension-link` included, but without `extension-code` included, typo a URL in the editor, then type a space, you should see an exception in the console, and link is not created.

Note, `extension-code` is part of `StarterKit`, that's why it does not happen for demos.

After applying this change, auto-link should work without any console error, with or without `extension-code`

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

https://github.com/ueberdosis/tiptap/issues/4343
