### PR TITLE
prevent opening link when clicking on selection containing a link

### DIFF
--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -15,8 +15,11 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
           return false
         }
 
-        const eventTarget = event.target as HTMLElement;
-        if (eventTarget.nodeName !== 'A') return false;
+        const eventTarget = event.target as HTMLElement
+
+        if (eventTarget.nodeName !== 'A') {
+          return false
+        }
 
         const attrs = getAttributes(view.state, options.type.name)
         const link = (event.target as HTMLLinkElement)

--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -15,6 +15,9 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
           return false
         }
 
+        const eventTarget = event.target as HTMLElement;
+        if (eventTarget.nodeName !== 'A') return false;
+
         const attrs = getAttributes(view.state, options.type.name)
         const link = (event.target as HTMLLinkElement)
 


### PR DESCRIPTION
## Please describe your changes

This code will check whether a clicked node name is 'A'. This will fix the issue when `openOnClick` is enabled, that causes clicking on a selection to open a link that's somewhere within the selection, even though user clicked some other element.


## How did you accomplish your changes

I have tried these changes in our repo that uses Tiptap for our pages editor.

## How have you tested your changes

Our QA engineer tested whether this fix solves the issue.

## How can we verify your changes

To reproduce the current issue:
 1. `openOnClick` must be enabled in link-extension config
 2. Add some link somewhere within the paragraph and some other text
 3. Select the text and the link
 4. Click somewhere, not directly on the link
 5. It will open a link

These changes will make click open link only when user clicks on the link itself.
 
## Remarks

No remarks.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues


