### PR TITLE
fix(list-keymap): fix broken imports causing typescript errors

### DIFF
--- a/packages/extension-list-keymap/src/listHelpers/findListItemPos.ts
+++ b/packages/extension-list-keymap/src/listHelpers/findListItemPos.ts
@@ -1,7 +1,6 @@
+import { getNodeType } from '@tiptap/core'
 import { NodeType } from '@tiptap/pm/model'
 import { EditorState } from '@tiptap/pm/state'
-
-import { getNodeType } from '../../../core/src/helpers/getNodeType.js'
 
 export const findListItemPos = (typeOrName: string | NodeType, state: EditorState) => {
   const { $from } = state.selection

--- a/packages/extension-list-keymap/src/listHelpers/getNextListDepth.ts
+++ b/packages/extension-list-keymap/src/listHelpers/getNextListDepth.ts
@@ -1,6 +1,6 @@
+import { getNodeAtPosition } from '@tiptap/core'
 import { EditorState } from '@tiptap/pm/state'
 
-import { getNodeAtPosition } from '../../../core/src/helpers/getNodeAtPosition.js'
 import { findListItemPos } from './findListItemPos.js'
 
 export const getNextListDepth = (typeOrName: string, state: EditorState) => {

--- a/packages/extension-list-keymap/src/listHelpers/handleBackspace.ts
+++ b/packages/extension-list-keymap/src/listHelpers/handleBackspace.ts
@@ -1,8 +1,6 @@
+import { Editor, isAtStartOfNode, isNodeActive } from '@tiptap/core'
 import { Node } from '@tiptap/pm/model'
 
-import { Editor } from '../../../core/src/Editor.js'
-import { isAtStartOfNode } from '../../../core/src/helpers/isAtStartOfNode.js'
-import { isNodeActive } from '../../../core/src/helpers/isNodeActive.js'
 import { findListItemPos } from './findListItemPos.js'
 import { hasListBefore } from './hasListBefore.js'
 import { hasListItemBefore } from './hasListItemBefore.js'

--- a/packages/extension-list-keymap/src/listHelpers/handleDelete.ts
+++ b/packages/extension-list-keymap/src/listHelpers/handleDelete.ts
@@ -1,6 +1,5 @@
-import { Editor } from '../../../core/src/Editor.js'
-import { isAtEndOfNode } from '../../../core/src/helpers/isAtEndOfNode.js'
-import { isNodeActive } from '../../../core/src/helpers/isNodeActive.js'
+import { Editor, isAtEndOfNode, isNodeActive } from '@tiptap/core'
+
 import { nextListIsDeeper } from './nextListIsDeeper.js'
 import { nextListIsHigher } from './nextListIsHigher.js'
 

--- a/packages/extension-list-keymap/src/listHelpers/listItemHasSubList.ts
+++ b/packages/extension-list-keymap/src/listHelpers/listItemHasSubList.ts
@@ -1,7 +1,6 @@
+import { getNodeType } from '@tiptap/core'
 import { Node } from '@tiptap/pm/model'
 import { EditorState } from '@tiptap/pm/state'
-
-import { getNodeType } from '../../../core/src/helpers/getNodeType.js'
 
 export const listItemHasSubList = (typeOrName: string, state: EditorState, node?: Node) => {
   if (!node) {


### PR DESCRIPTION
## Please describe your changes

This PR fixes a few imports inside the list-keymap extension that were broken because automatic import updates in 2.1.0.

## How did you accomplish your changes

Just fixes those imports

## Related issues

closes #4342 
