### PR TITLE
fix(horizontal-rule): fix insertion being broken on empty docs

### DIFF
--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -59,7 +59,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
 
                   if ($to.nodeAfter) {
                     if ($to.nodeAfter.isTextblock) {
-                      tr.setSelection(TextSelection.create(tr.doc, $to.pos))
+                      tr.setSelection(TextSelection.create(tr.doc, $to.pos + 1))
                     } else if ($to.nodeAfter.isBlock) {
                       tr.setSelection(NodeSelection.create(tr.doc, $to.pos))
                     } else {

--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -44,7 +44,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
           const currentChain = chain()
 
           if ($originTo.parentOffset === 0) {
-            currentChain.insertContentAt($originTo.pos - 2, { type: this.name })
+            currentChain.insertContentAt(Math.max($originTo.pos - 2, 0), { type: this.name })
           } else {
             currentChain.insertContent({ type: this.name })
           }
@@ -59,7 +59,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
 
                   if ($to.nodeAfter) {
                     if ($to.nodeAfter.isTextblock) {
-                      tr.setSelection(TextSelection.create(tr.doc, $to.pos + 1))
+                      tr.setSelection(TextSelection.create(tr.doc, $to.pos))
                     } else if ($to.nodeAfter.isBlock) {
                       tr.setSelection(NodeSelection.create(tr.doc, $to.pos))
                     } else {


### PR DESCRIPTION
## Please describe your changes

This PR fixes a bug that would try to insert the hr outside of the document range.

## How did you accomplish your changes

I used `Math.max` to set a minimum position of 0.

## How have you tested your changes

Tested it locally inside the demo.

## How can we verify your changes

Check the demo locally too, try to insert a hr into an empty document.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
