### PR TITLE
Fix delete code block in ordered list

### DIFF
--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -138,6 +138,12 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
         }
 
         if (isAtStart || !$anchor.parent.textContent.length) {
+          if (this.editor.isActive('orderedList'))
+            return this.editor
+              .chain()
+              .insertContent('<p></p>')
+              .deleteNode(this.name)
+              .run()
           return this.editor.commands.clearNodes()
         }
 

--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -44,7 +44,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
           const currentChain = chain()
 
           if ($originTo.parentOffset === 0) {
-            currentChain.insertContentAt($originTo.pos - 2, { type: this.name })
+            currentChain.insertContentAt(Math.max($originTo.pos - 2, 0), { type: this.name })
           } else {
             currentChain.insertContent({ type: this.name })
           }


### PR DESCRIPTION
## Please describe your changes

fix orderedList truncated after the codeBlock is deleted in the orderedList.

## How did you accomplish your changes

Currently using clearNodes to delete the code block when the code block is empty. However, when the code block is in an ordered list, deleting this code block causes the ordered list to be truncated.

In order to solve this problem, we can additionally process the ordered list in the delete event, instead of deleting the code block through clearNodes, delete it through deleteNode.

## How have you tested your changes

Yes. As the code change is very small, I verified it by applying the same change to my local node_modules folder.

## How can we verify your changes

To reproduce the problem, just insert a block code in the ordered list, then type a Backspace and you should see the exception, the ordered list is truncated.

After applying this change, the issue was fixed.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues
