### PR TITLE
fix duplicated text in PHP docs

### DIFF
--- a/docs/installation/php.md
+++ b/docs/installation/php.md
@@ -8,7 +8,7 @@ tableOfContents: true
 You can use Tiptap with Laravel, Livewire, Inertia.js, [Alpine.js](/installation/alpine), [Tailwind CSS](/guide/styling#with-tailwind-css), and even - yes you read that right - inside PHP.
 
 ## Tiptap for PHP
-We provide [an official PHP package to work with Tiptap content](/api/utilities/tiptap-php). A PHP package to work with Tiptap content. You can transform Tiptap-compatible JSON to HTML, and the other way around, sanitize your content, or just modify it.
+We provide [an official PHP package to work with Tiptap content](/api/utilities/tiptap-php). You can transform Tiptap-compatible JSON to HTML, and the other way around, sanitize your content, or just modify it.
 
 ## Laravel Livewire
 


### PR DESCRIPTION
The phrase "a PHP package to work with Tiptap content" is repeated twice.