### PR TITLE
Forward `EditorContent` ref

### DIFF
--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -1,8 +1,24 @@
-import React, { HTMLProps } from 'react'
+import React, {
+  ForwardedRef, forwardRef, HTMLProps, LegacyRef, MutableRefObject,
+} from 'react'
 import ReactDOM, { flushSync } from 'react-dom'
 
 import { Editor } from './Editor.js'
 import { ReactRenderer } from './ReactRenderer.js'
+
+const mergeRefs = <T extends HTMLDivElement>(
+  ...refs: Array<MutableRefObject<T> | LegacyRef<T>>
+) => {
+  return (node: T) => {
+    refs.forEach(ref => {
+      if (typeof ref === 'function') {
+        ref(node)
+      } else if (ref) {
+        (ref as MutableRefObject<T | null>).current = node
+      }
+    })
+  }
+}
 
 const Portals: React.FC<{ renderers: Record<string, ReactRenderer> }> = ({ renderers }) => {
   return (
@@ -16,6 +32,7 @@ const Portals: React.FC<{ renderers: Record<string, ReactRenderer> }> = ({ rende
 
 export interface EditorContentProps extends HTMLProps<HTMLDivElement> {
   editor: Editor | null;
+  innerRef: ForwardedRef<HTMLDivElement | null>;
 }
 
 export interface EditorContentState {
@@ -135,11 +152,11 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
   }
 
   render() {
-    const { editor, ...rest } = this.props
+    const { editor, innerRef, ...rest } = this.props
 
     return (
       <>
-        <div ref={this.editorContentRef} {...rest} />
+        <div ref={mergeRefs(innerRef, this.editorContentRef)} {...rest} />
         {/* @ts-ignore */}
         <Portals renderers={this.state.renderers} />
       </>
@@ -148,13 +165,19 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
 }
 
 // EditorContent should be re-created whenever the Editor instance changes
-const EditorContentWithKey = (props: EditorContentProps) => {
-  const key = React.useMemo(() => {
-    return Math.floor(Math.random() * 0xFFFFFFFF).toString()
-  }, [props.editor])
+const EditorContentWithKey = forwardRef<HTMLDivElement, EditorContentProps>(
+  (props: Omit<EditorContentProps, 'innerRef'>, ref) => {
+    const key = React.useMemo(() => {
+      return Math.floor(Math.random() * 0xFFFFFFFF).toString()
+    }, [props.editor])
 
-  // Can't use JSX here because it conflicts with the type definition of Vue's JSX, so use createElement
-  return React.createElement(PureEditorContent, { key, ...props })
-}
+    // Can't use JSX here because it conflicts with the type definition of Vue's JSX, so use createElement
+    return React.createElement(PureEditorContent, {
+      key,
+      innerRef: ref,
+      ...props,
+    })
+  },
+)
 
 export const EditorContent = React.memo(EditorContentWithKey)

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -7,7 +7,7 @@ import { Editor } from './Editor.js'
 import { ReactRenderer } from './ReactRenderer.js'
 
 const mergeRefs = <T extends HTMLDivElement>(
-  ...refs: Array<MutableRefObject<T> | LegacyRef<T>>
+  ...refs: Array<MutableRefObject<T> | LegacyRef<T> | undefined>
 ) => {
   return (node: T) => {
     refs.forEach(ref => {
@@ -32,7 +32,7 @@ const Portals: React.FC<{ renderers: Record<string, ReactRenderer> }> = ({ rende
 
 export interface EditorContentProps extends HTMLProps<HTMLDivElement> {
   editor: Editor | null;
-  innerRef: ForwardedRef<HTMLDivElement | null>;
+  innerRef?: ForwardedRef<HTMLDivElement | null>;
 }
 
 export interface EditorContentState {


### PR DESCRIPTION
## Please describe your changes

Allow passing a `ref` to `EditorContent` to imperatively access the underlying `div` element.

My use case is to apply line clamping CSS to the `EditorContent` div based on its height.

## How did you accomplish your changes

1. Forward a ref passed to `EditorContentWithKey` to `PureEditorContent`
2. Attach the ref to the `div` element returned by `PureEditorContent`

## How have you tested your changes

Manual testing by rendering `EditorContent` with a ref prop.

## How can we verify your changes

Run this code and expect `div` to have a value:

```tsx
<EditorContent ref={(div) => {
  console.log('EditorContent ref:', div);
} />
```

## Remarks

`EditorContent` used to accept a ref but it broke in #4000. Prior to #4000 the value of ref was `PureEditorContent`:

```tsx
<EditorContent
  ref={(editorContent) => {
    const div = editorContent.editorContentRef.current;
  }}
/>
```

I simplified the value in this PR to the underlying `div` element thinking that we don't need to expose the implementation details.


## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
