### PR TITLE
Fix typo in collaboration.md

### DIFF
--- a/docs/api/extensions/collaboration.md
+++ b/docs/api/extensions/collaboration.md
@@ -53,7 +53,7 @@ Collaboration.configure({
 ```
 
 ## Commands
-The `Collboration` extension comes with its own history extension. Make sure to disable the default extension, if you’re working with the `StarterKit`.
+The `Collaboration` extension comes with its own history extension. Make sure to disable the default extension, if you’re working with the `StarterKit`.
 
 ### undo()
 Undo the last change.


### PR DESCRIPTION
## Please describe your changes
Fixes a typo in the collaboration documentation.

## Checklist

- [X] The changes are not breaking the editor
- [X] Added tests where possible
- [X] Followed the guidelines
- [X] Fixed linting issues