### PR TITLE
Link click fix

### DIFF
--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -1,5 +1,6 @@
 import './styles.scss'
 
+import Bold from '@tiptap/extension-bold'
 import Code from '@tiptap/extension-code'
 import Document from '@tiptap/extension-document'
 import Link from '@tiptap/extension-link'
@@ -15,13 +16,14 @@ export default () => {
       Paragraph,
       Text,
       Code,
+      Bold,
       Link.configure({
-        openOnClick: false,
+        openOnClick: true,
       }),
     ],
     content: `
         <p>
-          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web">world wide web</a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
+          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web"><b>world wide web</b>></a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
         </p>
         <p>
           By default every link will get a <code>rel="noopener noreferrer nofollow"</code> attribute. It’s configurable though.

--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -23,7 +23,7 @@ export default () => {
     ],
     content: `
         <p>
-          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web"><b>world wide web</b>></a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
+          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web"><b>world wide web</b></a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
         </p>
         <p>
           By default every link will get a <code>rel="noopener noreferrer nofollow"</code> attribute. It’s configurable though.

--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -15,9 +15,15 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
           return false
         }
 
-        const eventTarget = event.target as HTMLElement
+        let a = event.target as HTMLElement
+        const els = []
 
-        if (eventTarget.nodeName !== 'A') {
+        while (a.nodeName !== 'DIV') {
+          els.push(a)
+          a = a.parentNode as HTMLElement
+        }
+
+        if (!els.find(value => value.nodeName === 'A')) {
           return false
         }
 
@@ -28,9 +34,7 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
         const target = link?.target ?? attrs.target
 
         if (link && href) {
-          if (view.editable) {
-            window.open(href, target)
-          }
+          window.open(href, target)
 
           return true
         }


### PR DESCRIPTION
## Please describe your changes

I am improving on this pull request, which doesnt solve the issue (actually brings another one): https://github.com/ueberdosis/tiptap/pull/4346#event-10276708233 

In the mentioned PR only when the exact A element is clicked, it opens the link. But there are cases, when you have mark Bold or some other on the link text as well. The B / STRONG element is rendered INSIDE the A element, thus the condition nodeName !== 'A' does check and it cancels opening the link. I fixed that.

## How did you accomplish your changes

I iterate all clicked nodes nodeParents till I approach parent DIV node (inline node must be inside block node, so this is logical rule; Link is inline node). If none of those parent nodes are not A node, only then do I cancel the link opening. This handles all other marks (ie STRONG element inside A element etc) where it previously mistakengly canceled it.

Also I removed the condition that links are opened only when editor is in editable state. I think expected behaviour should be that links are always openable, even if the editor is not right in its edit state.

## How have you tested your changes

I added test case into demos/src/Marks/Link/React/index.jsx (added B node inside first A node in the sample content). Previously the link didnt open, now it opens correctly.

## How can we verify your changes

Test it, like I did.

## Remarks

## Checklist

- [x ] The changes are not breaking the editor
- [ x] Added tests where possible
- [ x] Followed the guidelines
- [ x] Fixed linting issues

## Related issues

https://github.com/ueberdosis/tiptap/pull/4346#event-10276708233
