### PR TITLE
Fix clicking formatted link

### DIFF
--- a/demos/src/Marks/Link/Vue/index.vue
+++ b/demos/src/Marks/Link/Vue/index.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script>
+import Bold from '@tiptap/extension-bold'
 import Code from '@tiptap/extension-code'
 import Document from '@tiptap/extension-document'
 import Link from '@tiptap/extension-link'
@@ -36,13 +37,14 @@ export default {
         Paragraph,
         Text,
         Code,
+        Bold,
         Link.configure({
           openOnClick: false,
         }),
       ],
       content: `
         <p>
-          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web">world wide web</a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool? Let’s try <a href="https://statamic.com/">another one!</a> Yep, seems to work.
+          Wow, this editor has support for links to the whole <a href="https://en.wikipedia.org/wiki/World_Wide_Web">world wide web</a>. We tested a lot of URLs and I think you can add *every URL* you want. Isn’t that cool?<strong>Let’s try <a href="https://statamic.com/">another one!</a></strong> Yep, seems to work.
         </p>
         <p>
           By default every link will get a <code>rel="noopener noreferrer nofollow"</code> attribute. It’s configurable though.

--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -17,7 +17,7 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
 
         const eventTarget = event.target as HTMLElement
 
-        if (eventTarget.nodeName !== 'A') {
+        if (eventTarget.nodeName !== 'A' && !eventTarget.closest('a')) {
           return false
         }
 


### PR DESCRIPTION
## Please describe your changes

- Adds a check whether clicked event target is a child of an anchor tag. Fixes #4425
- Added a Bold extension and one bold link in link extension preview.

## How did you accomplish your changes

I have added a check using `closest` on event target. 

## How have you tested your changes

Tested locally

## How can we verify your changes

You can verify this by changing `openOnClick` in link extension config, and then by clicking on a link within bold text.

## Remarks

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues
#4425 
