### PR TITLE
fix: add missing attributes in extension-link

### DIFF
--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -46,11 +46,11 @@ declare module '@tiptap/core' {
       /**
        * Set a link mark
        */
-      setLink: (attributes: { href: string; target?: string | null }) => ReturnType
+      setLink: (attributes: { href: string; target?: string | null; rel?: string | null; class?: string | null }) => ReturnType
       /**
        * Toggle a link mark
        */
-      toggleLink: (attributes: { href: string; target?: string | null }) => ReturnType
+      toggleLink: (attributes: { href: string; target?: string | null; rel?: string | null; class?: string | null }) => ReturnType
       /**
        * Unset a link mark
        */


### PR DESCRIPTION
Despite `rel` and `class` already being defined as an attribute in `addAttributes()`, the interface was missing these two particular attributes so it wasn't accessible when using TypeScript without workarounds.

## Please describe your changes / How did you accomplish your changes

I added the missing attributes to the interface

## How have you tested your changes

Full disclosure, I haven't tested it yet. This is a quick PR that I made from GitHub's web editor so that I don't forget to test it later and submit a fix properly.

## How can we verify your changes

Open a typescript file and try to add a link through
```ts
editor?.value?.chain().focus()?.extendMarkRange('link')
  .setLink({
    href: 'https://google.es',
    class: 'button' // this will give you an error without this PR
  })
```

## Remarks

-

## Checklist

- [ ] The changes are not breaking the editor (untested)
- [ ] Added tests where possible (not applicable)
- [ ] Followed the guidelines (haven't read yet, sorry :(
- [ ] Fixed linting issues (not applicable I think?)

## Related issues
