### PR TITLE
fix(history): use correct shortcuts for undo/redo

### DIFF
--- a/packages/extension-history/src/history.ts
+++ b/packages/extension-history/src/history.ts
@@ -51,11 +51,8 @@ export const History = Extension.create<HistoryOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-z': () => this.editor.commands.undo(),
-      'Mod-Z': () => this.editor.commands.undo(),
-      'Mod-y': () => this.editor.commands.redo(),
-      'Mod-Y': () => this.editor.commands.redo(),
       'Shift-Mod-z': () => this.editor.commands.redo(),
-      'Shift-Mod-Z': () => this.editor.commands.redo(),
+      'Mod-y': () => this.editor.commands.redo(),
 
       // Russian keyboard layouts
       'Mod-я': () => this.editor.commands.undo(),


### PR DESCRIPTION
## Please describe your changes

The problem with the shortcuts for undo/redo. the decision is made immediately for z/y.

I will use the abstract Ctrl-Shift-Z to avoid overlapping with tiptap.

I will describe for z:
- when you press Ctrl-Shift-Z, Mod-Z and Shift-Mod-z catch this event, that is, potentially we have two handlers for the same event, but with different functions, and they are not always executed together
- If the undo stack is not empty, then only the Mod-Z handler will be captured, which will execute undo by shortcut Ctrl-Shift-Z, we get a completely diametric behavior, the behavior should have been called redo
- If the undo stack is empty, then Mod-Z will work, saying that it did nothing, and we will run in Shift-Mod-z, finally getting the same redo

Shift-Mod-Z doesn't make sense according to "Modifiers can be given in any order. Shift- (or s-), Alt- (or a-), Ctrl- (or c- or Control-) and Cmd- (or more Meta-) are recognized. For characters that are created by holding shift, the Shift- prefix is implied, and should not be added explicitly" [prosemirror](https://prosemirror.net/docs/ref/#keymap).

Only bindings with Shift are used for clarity.

## How did you accomplish your changes

The solution is to set the correct commands and remove duplicate handlers

## How have you tested your changes

tested locally. with stack length: 0, 1, 5

## How can we verify your changes

open demo and see correct undo/redo behavior

## Remarks

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

 Fixes #4403
