### PR TITLE
docs(react): fix typo on React installation code block

### DIFF
--- a/docs/installation/react.md
+++ b/docs/installation/react.md
@@ -68,7 +68,7 @@ export default Tiptap
 
 ```jsx
 // src/Tiptap.jsx
-import { useEditor, EditorContent FloatingMenu, BubbleMenu } from '@tiptap/react'
+import { useEditor, EditorContent, FloatingMenu, BubbleMenu } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 
 // define your extension array


### PR DESCRIPTION
## Please describe your changes

This PR adds a small typo fix for the code block inside the [React installation](https://tiptap.dev/installation/react) page.

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues
