### PR TITLE
fix: #4327

### DIFF
--- a/demos/src/Examples/Issue4327/React/foo.ts
+++ b/demos/src/Examples/Issue4327/React/foo.ts
@@ -1,0 +1,26 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+
+export default Node.create({
+  name: 'foo',
+
+  group: 'inline',
+
+  inline: true,
+
+  parseHTML() {
+    return [
+      {
+        tag: 'span',
+        getAttrs: node => (node as HTMLElement).hasAttribute('data-foo') && null,
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes({ 'data-foo': '', HTMLAttributes }), 'foo']
+  },
+
+  renderText() {
+    return 'foo'
+  },
+})

--- a/demos/src/Examples/Issue4327/React/index.tsx
+++ b/demos/src/Examples/Issue4327/React/index.tsx
@@ -1,0 +1,27 @@
+import './styles.scss'
+
+import { EditorContent, FloatingMenu, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import React from 'react'
+
+import Foo from './foo.js'
+
+export default () => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit, Foo,
+    ],
+    content: `
+      <p><span data-foo=''>foo</span></p>
+    `,
+  })
+
+  return (
+    <>
+      {editor && <FloatingMenu editor={editor} tippyOptions={{ duration: 100 }}>
+        <div>Hello</div>
+      </FloatingMenu>}
+      <EditorContent editor={editor} />
+    </>
+  )
+}

--- a/demos/src/Examples/Issue4327/React/styles.scss
+++ b/demos/src/Examples/Issue4327/React/styles.scss
@@ -1,0 +1,10 @@
+.tiptap {
+  > * + * {
+    margin-top: 0.75em;
+  }
+
+  ul,
+  ol {
+    padding: 0 1rem;
+  }
+}

--- a/demos/src/Examples/Issue4327/foo.ts
+++ b/demos/src/Examples/Issue4327/foo.ts
@@ -1,0 +1,26 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+
+export default Node.create({
+  name: 'foo',
+
+  group: 'inline',
+
+  inline: true,
+
+  parseHTML() {
+    return [
+      {
+        tag: 'span',
+        getAttrs: node => (node as HTMLElement).hasAttribute('data-foo') && null,
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes({ 'data-foo': '', HTMLAttributes }), 'foo']
+  },
+
+  renderText() {
+    return 'foo'
+  },
+})

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -1,4 +1,7 @@
-import { Editor, posToDOMRect } from '@tiptap/core'
+import {
+  Editor, getText, getTextSerializersFromSchema, posToDOMRect,
+} from '@tiptap/core'
+import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { EditorState, Plugin, PluginKey } from '@tiptap/pm/state'
 import { EditorView } from '@tiptap/pm/view'
 import tippy, { Instance, Props } from 'tippy.js'
@@ -35,11 +38,15 @@ export class FloatingMenuView {
 
   public tippyOptions?: Partial<Props>
 
+  private getTextContent(node:ProseMirrorNode) {
+    return getText(node, { textSerializers: getTextSerializersFromSchema(this.editor.schema) })
+  }
+
   public shouldShow: Exclude<FloatingMenuPluginProps['shouldShow'], null> = ({ view, state }) => {
     const { selection } = state
     const { $anchor, empty } = selection
     const isRootDepth = $anchor.depth === 1
-    const isEmptyTextBlock = $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !$anchor.parent.textContent
+    const isEmptyTextBlock = $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !this.getTextContent($anchor.parent)
 
     if (
       !view.hasFocus()

--- a/tests/cypress/integration/Issue4327/index.spec.ts
+++ b/tests/cypress/integration/Issue4327/index.spec.ts
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+import { Editor } from '@tiptap/core'
+
+interface EditorElement extends HTMLElement {
+  editor: Editor
+}
+context('/cypress/integration/Issue4327/React/', () => {
+  before(() => {
+    cy.visit('/src/Examples/Issue4327/React/')
+  })
+  it('should not show menu when node has renderText returning text with length > 0', () => {
+    cy.get('.tiptap').then(([editorElement]) => {
+      (editorElement as EditorElement).editor.commands.focus()
+    }).get('.ProseMirror-focused').get('#app')
+      .should('not.have.descendants', '[data-tippy-root]')
+  })
+})


### PR DESCRIPTION
## Please describe your changes

Fix issue 4327

> It uses Node.textContent which uses NodeSpec.leafText to fill it. But Tiptap does not fill NodeSpec.leafText using Tiptap's Node.renderText, rather Tiptap has its own separate mechanism to generate text content from Nodes


## How did you accomplish your changes

Used Tiptap method of getting text, which use renderText, instead of textContent which does not.

## How have you tested your changes

Added a new example with associated spec.

## How can we verify your changes

Run the test or view the example and see that there is no menu shown editor has focus.

## Remarks

Note that the spec is currently not with the ui example due to [cypress issue on windows](https://github.com/cypress-io/cypress/issues/8599). (Perhaps demos folder could go in tests ? )
If pr is approved then I will move the spec in to the demos folder.
Also the ui is in Examples - do you want in Experiments / a new Issues folder ?
Should I expose a helper - getText(node,schema,blockseparator) ?

As this change uses TipTap renderText and not ProseMirror leafText the result will differ if Node extension is provided that has added leafText with extendNodeSchema or changed the schema in onBeforeCreate.
I don't think that any public repos are doing this.
https://github.com/search?q=tiptap+leafText&type=code
Regardless, The getTextSerializersFromSchema method could be changed to invoke the spec leafText if it had been provided.  This would also ensure that editor.getText, generateText and the clipboardTextSerializer can also work with leafText.

Similar issues to this one where renderText is not used ( and  spec.leafText is )
[Node.textContent](https://github.com/search?q=repo%3Aueberdosis%2Ftiptap+.textcontent&type=code) is used in other places in Tiptap.  Potentially issues there too.
[Node.textBetween](https://github.com/ProseMirror/prosemirror-model/blob/387576a887335b5dccba4c940b7935e1da13ef73/src/node.ts#L100) => [Fragment.textBetween](https://github.com/ProseMirror/prosemirror-model/blob/387576a887335b5dccba4c940b7935e1da13ef73/src/fragment.ts#L64) => invokes leafText and not renderText.
Should [Tiptap usages of Node.textBetween](https://github.com/search?q=repo%3Aueberdosis%2Ftiptap+.textBetween&type=code) be changed to use [Tiptap getTextBetween ( and schema text serializers)](https://github.com/ueberdosis/tiptap/blob/7832b96afbfc58574785043259230801e179310f/packages/core/src/helpers/getTextBetween.ts#L5) ?

renderText and how to ensure it is used is not well documented in the docs.  This is the only mention
https://tiptap.dev/api/schema

> Here is the example from the [Mention](https://tiptap.dev/api/nodes/mention) extension:
```
renderText({ node }) {
  return `@${node.attrs.id}`
},
```
(This is not the case anymore for mention extension )
```
  renderText({ node }) {
    return this.options.renderLabel({
      options: this.options,
      node,
    })
  },
```
As such users expect renderText to be used when using the ProseMirror api - https://github.com/ueberdosis/tiptap/issues/4310

It is possible to add leafText to the spec so that it calls renderText although the signatures are different.  ( Could use onBeforeCreate to get the editor and the doc for parent and index but impossible to get the pos argument.  ) 

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

https://github.com/ueberdosis/tiptap/issues/4327
