### PR TITLE
fix: allowing 'ref' access for 'EditorContent' in react

### DIFF
--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -148,13 +148,13 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
 }
 
 // EditorContent should be re-created whenever the Editor instance changes
-const EditorContentWithKey = (props: EditorContentProps) => {
+const EditorContentWithKey = React.forwardRef((props: EditorContentProps, ref: React.RefObject<any>) => {
   const key = React.useMemo(() => {
     return Math.floor(Math.random() * 0xFFFFFFFF).toString()
   }, [props.editor])
 
   // Can't use JSX here because it conflicts with the type definition of Vue's JSX, so use createElement
-  return React.createElement(PureEditorContent, { key, ...props })
+  return React.createElement(PureEditorContent, { key, ref, ...props })
 }
 
 export const EditorContent = React.memo(EditorContentWithKey)

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -155,6 +155,6 @@ const EditorContentWithKey = React.forwardRef((props: EditorContentProps, ref: R
 
   // Can't use JSX here because it conflicts with the type definition of Vue's JSX, so use createElement
   return React.createElement(PureEditorContent, { key, ref, ...props })
-}
+})
 
 export const EditorContent = React.memo(EditorContentWithKey)

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -148,7 +148,7 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
 }
 
 // EditorContent should be re-created whenever the Editor instance changes
-const EditorContentWithKey = React.forwardRef((props: EditorContentProps, ref: React.RefObject<any>) => {
+const EditorContentWithKey = React.forwardRef((props: EditorContentProps, ref: React.ForwardedRef<any>) => {
   const key = React.useMemo(() => {
     return Math.floor(Math.random() * 0xFFFFFFFF).toString()
   }, [props.editor])


### PR DESCRIPTION
## Please describe your changes

Adding `forwardRef` to `EditorContentWithKey`

## How did you accomplish your changes

by adding a `forwardRef` on `EditorContentWithKey`

## How have you tested your changes

By creating my own version of `EditorContentWithKey` with `forwardRef` and testing it in my project.

## How can we verify your changes

Use the new version with `ref` on `EditorContent` and it should not throw any warning/errors for using ref on a `functional` component.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [x] Fixed linting issues

## Related issues

#4470 
