### PR TITLE
feat(extension/youtube): Allow youtube shorts urls to be embedded

### DIFF
--- a/packages/extension-youtube/src/utils.ts
+++ b/packages/extension-youtube/src/utils.ts
@@ -67,7 +67,7 @@ export const getEmbedUrlFromYoutubeUrl = (options: GetEmbedUrlOptions) => {
     return `${getYoutubeEmbedUrl(nocookie)}${id}`
   }
 
-  const videoIdRegex = /v=([-\w]+)/gm
+  const videoIdRegex = /(?:v=|shorts\/)([-\w]+)/gm
   const matches = videoIdRegex.exec(url)
 
   if (!matches || !matches[1]) {


### PR DESCRIPTION
## Please describe your changes

Youtube uses /shorts/ for their shorts video. The /embed url works with these id's, the regex did not support them though.

## How did you accomplish your changes

This updates the videoId regex to also support the /shorts/ urls.

## How have you tested your changes

Tested with several youtube urls
youtu.be link: https://youtu.be/vwXeKbL_k6w?si=jPPIRP8x_0h1RU71
youtube.com embed link: https://www.youtube.com/embed/vwXeKbL_k6w
for example this short: https://youtube.com/shorts/5toiGG5I9yM?si=N6idQiwCYltCKpDC 

## How can we verify your changes

[add a detailed description of how we can verify your changes here]

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

Fixes https://github.com/ueberdosis/tiptap/issues/3582
