### PR TITLE
Fix input rules not honouring levels settings

### DIFF
--- a/packages/extension-heading/src/heading.ts
+++ b/packages/extension-heading/src/heading.ts
@@ -95,7 +95,7 @@ export const Heading = Node.create<HeadingOptions>({
   addInputRules() {
     return this.options.levels.map(level => {
       return textblockTypeInputRule({
-        find: new RegExp(`^(#{1,${level}})\\s$`),
+        find: new RegExp(`^(#{${Math.min(...this.options.levels)},${level}})\\s$`),
         type: this.type,
         getAttributes: {
           level,


### PR DESCRIPTION
## Please describe your changes
make the input rules for heading extension honour the levels configuration properly

## How did you accomplish your changes

updated the code

## How have you tested your changes

updated the code, tested that with a config array [2,3,4,5,6] that typing a single # did not invoke the heading

## How can we verify your changes

with a config array [2,3,4,5,6] type a single # followed by a space. It should not change to a h1


## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

closes https://github.com/ueberdosis/tiptap/issues/4503