### PR TITLE
allow users to pass a custom `findSuggestionMatch` to Suggestion plugin

### DIFF
--- a/docs/api/utilities/suggestion.md
+++ b/docs/api/utilities/suggestion.md
@@ -56,6 +56,14 @@ A render function for the autocomplete popup.
 
 Default: `() => ({})`
 
+### findSuggestionMatch
+Optional param to replace the built-in regex matching of editor content that triggers a suggestion.
+See [the
+source](https://github.com/estrattonbailey/tiptap/blob/develop/packages/suggestion/src/findSuggestionMatch.ts#L18)
+for more detail.
+
+Default: `findSuggestionMatch(config: Trigger): SuggestionMatch`
+
 
 ## Source code
 [packages/suggestion/](https://github.com/ueberdosis/tiptap/blob/main/packages/suggestion/)

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -2,7 +2,7 @@ import { Editor, Range } from '@tiptap/core'
 import { EditorState, Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet, EditorView } from '@tiptap/pm/view'
 
-import { findSuggestionMatch } from './findSuggestionMatch.js'
+import { findSuggestionMatch as defaultFindSuggestionMatch } from './findSuggestionMatch.js'
 
 export interface SuggestionOptions<I = any> {
   pluginKey?: PluginKey
@@ -24,6 +24,7 @@ export interface SuggestionOptions<I = any> {
     onKeyDown?: (props: SuggestionKeyDownProps) => boolean
   }
   allow?: (props: { editor: Editor; state: EditorState; range: Range }) => boolean
+  findSuggestionMatch?: typeof defaultFindSuggestionMatch
 }
 
 export interface SuggestionProps<I = any> {
@@ -58,6 +59,7 @@ export function Suggestion<I = any>({
   items = () => [],
   render = () => ({}),
   allow = () => true,
+  findSuggestionMatch = defaultFindSuggestionMatch,
 }: SuggestionOptions<I>) {
   let props: SuggestionProps<I> | undefined
   const renderer = render?.()


### PR DESCRIPTION
## Please describe your changes
Hey there 👋 we're using Tiptap and the Suggestions plugin to implement hashtags in our editor. Our hashtag validation is a little more complex than what the default `findSuggestionMatch` allows, so I started investigating how I could replace the matching with a custom version. This seemed to be the most straightforward approach.

Disclaimer: this might be more of a conversation starter than a fix, but fwiw it does work for my needs right now. Happy to help improve.

## How did you accomplish your changes
Just added a new property `findSuggestionMatch` to the `Suggestion` plugin, with types that match the built-in function.

## How have you tested your changes
Just manually integrating at the moment, but lmk if I can assist with a test suite.

## How can we verify your changes
I think it's straightforward.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues
N/A
