### PR TITLE
fix(link): restore pasteHandler and add existing url check

### DIFF
--- a/packages/extension-link/src/helpers/pasteHandler.ts
+++ b/packages/extension-link/src/helpers/pasteHandler.ts
@@ -1,0 +1,52 @@
+import { Editor } from '@tiptap/core'
+import { MarkType } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { find } from 'linkifyjs'
+
+type PasteHandlerOptions = {
+  editor: Editor
+  type: MarkType
+}
+
+export function pasteHandler(options: PasteHandlerOptions): Plugin {
+  return new Plugin({
+    key: new PluginKey('handlePasteLink'),
+    props: {
+      handlePaste: (view, event, slice) => {
+        const { state } = view
+        const { selection } = state
+        const { empty } = selection
+
+        if (empty) {
+          return false
+        }
+
+        let textContent = ''
+
+        slice.content.forEach(node => {
+          textContent += node.textContent
+        })
+
+        const link = find(textContent).find(item => item.isLink && item.value === textContent)
+
+        if (!textContent || !link) {
+          return false
+        }
+
+        const html = event.clipboardData.getData('text/html')
+
+        const hrefRegex = /href="([^"]*)"/
+
+        const existingLink = html?.match(hrefRegex)
+
+        const url = existingLink ? existingLink[1] : link.href
+
+        options.editor.commands.setMark(options.type, {
+          href: url,
+        })
+
+        return true
+      },
+    },
+  })
+}

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -4,6 +4,7 @@ import { find, registerCustomProtocol, reset } from 'linkifyjs'
 
 import { autolink } from './helpers/autolink.js'
 import { clickHandler } from './helpers/clickHandler.js'
+import { pasteHandler } from './helpers/pasteHandler.js'
 
 export interface LinkProtocolOptions {
   scheme: string;
@@ -201,6 +202,15 @@ export const Link = Mark.create<LinkOptions>({
     if (this.options.openOnClick) {
       plugins.push(
         clickHandler({
+          type: this.type,
+        }),
+      )
+    }
+
+    if (this.options.linkOnPaste) {
+      plugins.push(
+        pasteHandler({
+          editor: this.editor,
           type: this.type,
         }),
       )


### PR DESCRIPTION
## Please describe your changes

This PR should fix the changed behaviour from #4484 and restores the link pasting on existing text. It also adds additional logic to pull the actual URL from a copied link instead of the link text content.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

closes #4484 
