### PR TITLE
Bump minor version of zeed-dom to include html parser bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19535,10 +19535,11 @@
       }
     },
     "node_modules/zeed-dom": {
-      "version": "0.9.24",
-      "license": "MIT",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/zeed-dom/-/zeed-dom-0.10.9.tgz",
+      "integrity": "sha512-qQQ7Wu7IJ3Vo/LjeKWj97A2Hi17di4ZdmgNZj6AWbDbpt3hvO4EMfjYVA2/2unLYT+XpmMq5fqaLqCeU7Im83A==",
       "dependencies": {
-        "css-what": "^6.0.1"
+        "css-what": "^6.1.0"
       },
       "engines": {
         "node": ">=14.13.1"
@@ -20311,7 +20312,7 @@
       "version": "2.2.0-rc.4",
       "license": "MIT",
       "dependencies": {
-        "zeed-dom": "^0.9.19"
+        "zeed-dom": "^0.10.9"
       },
       "devDependencies": {
         "@tiptap/core": "^2.2.0-rc.4",
@@ -24190,7 +24191,7 @@
       "requires": {
         "@tiptap/core": "^2.2.0-rc.4",
         "@tiptap/pm": "^2.2.0-rc.4",
-        "zeed-dom": "^0.9.19"
+        "zeed-dom": "^0.10.9"
       }
     },
     "@tiptap/pm": {
@@ -34177,9 +34178,11 @@
       "dev": true
     },
     "zeed-dom": {
-      "version": "0.9.24",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/zeed-dom/-/zeed-dom-0.10.9.tgz",
+      "integrity": "sha512-qQQ7Wu7IJ3Vo/LjeKWj97A2Hi17di4ZdmgNZj6AWbDbpt3hvO4EMfjYVA2/2unLYT+XpmMq5fqaLqCeU7Im83A==",
       "requires": {
-        "css-what": "^6.0.1"
+        "css-what": "^6.1.0"
       }
     }
   }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -37,7 +37,7 @@
     "@tiptap/pm": "^2.0.0"
   },
   "dependencies": {
-    "zeed-dom": "^0.9.19"
+    "zeed-dom": "^0.10.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Please describe your changes
Noticed a bug in `zeed-dom`, a downstream dep of Tiptap. I made [a PR](https://github.com/holtwick/zeed-dom/pull/9) and the maintainer has published a new version.

I didn't notice up front was that it's a minor version ahead of what Tiptap relies on. Using `yarn` resolutions, we've tested our app internally with my fork, and I've run the tests here, and all appears to be fine. But I'll leave it up to the maintainers here to confirm that all is well ✌️ 

## How did you accomplish your changes
Debugged with some logs in Tiptap, isolated to `parseHTML`, replicated in `zeed-dom` and fixed.

## How have you tested your changes
We opted to resolve the dep to my branch for now (see [PR here](https://github.com/bluesky-social/social-app/pull/1663)). I also ran any tests that seemed related in Cypress.

## How can we verify your changes
Unsure what else you'd like to do, but the e2e suite is extensive by the looks of it. Happy to help!

## Remarks
If y'all don't want to bump the minor version, we could probably make the same fix in `0.9.*` if we need to.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
