### PR TITLE
Pass onFirstRender option to ySyncPlugin

### DIFF
--- a/packages/extension-collaboration/src/collaboration.ts
+++ b/packages/extension-collaboration/src/collaboration.ts
@@ -147,6 +147,10 @@ export const Collaboration = Extension.create<CollaborationOptions>({
       }
     }
 
-    return [ySyncPlugin(fragment), yUndoPluginInstance]
+    const onFirstRender = this.options.onFirstRender
+    const ySyncPluginOptions = onFirstRender ? { onFirstRender } : {}
+    const ySyncPluginInstance = ySyncPlugin(fragment, ySyncPluginOptions)
+
+    return [ySyncPluginInstance, yUndoPluginInstance]
   },
 })


### PR DESCRIPTION
## Please describe your changes

There is an option called `onFirstRender` in the `CollaborationOptions` type; however, it is not used anywhere. This commit passes the option to the Yjs' sync plugin.

We use this callback together with the HocuspocusProvider to understand when the content is synced and ready on the editor for the first time. Then, we can safely set the cursor to the beginning of the text editor. 

## How did you accomplish your changes

Just used the existing option and correctly passed it to the `ySyncPlugin` function that creates the plugin.

## How can we verify your changes

You can pass `onFirstRender` option to the Collaboration extension and see it gets called when the plugin first renders.

## Checklist

- [] The changes are not breaking the editor
- [] Added tests where possible
- [] Followed the guidelines
- [] Fixed linting issues
