### PR TITLE
change wildly to widely

### DIFF
--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -45,7 +45,7 @@ Here is an interactive example where you can see that in action:
 https://embed.tiptap.dev/preview/GuideContent/ExportJSON?hideSource
 
 ### Option 2: HTML
-HTML can be easily rendered in other places, for example in emails and it’s wildly used, so it’s probably easier to switch the editor at some point. Anyway, every editor instance provides a method to get HTML from the current document:
+HTML can be easily rendered in other places, for example in emails and it’s widely used, so it’s probably easier to switch the editor at some point. Anyway, every editor instance provides a method to get HTML from the current document:
 
 ```js
 const html = editor.getHTML()


### PR DESCRIPTION
## Please describe your changes

Fixed what I expect is a typo in the Output documentation, changing the adverb "wildly" to "widely".

## How did you accomplish your changes

N/A

## How have you tested your changes

N/A

## How can we verify your changes

N/A

## Remarks

N/A

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues\
