### PR TITLE
Fix unexpected token in index.js (Rollup)

### DIFF
--- a/packages/core/src/commands/joinItemBackward.ts
+++ b/packages/core/src/commands/joinItemBackward.ts
@@ -14,7 +14,9 @@ declare module '@tiptap/core' {
 }
 
 export const joinItemBackward: RawCommands['joinItemBackward'] = () => ({
-  tr, state, dispatch,
+  state,
+  dispatch,
+  tr,
 }) => {
   try {
     const point = joinPoint(state.doc, state.selection.$from.pos, -1)
@@ -30,7 +32,7 @@ export const joinItemBackward: RawCommands['joinItemBackward'] = () => ({
     }
 
     return true
-  } catch {
+  } catch (e) {
     return false
   }
 }


### PR DESCRIPTION
"catch {"   should be   "catch (e) {"

## Please describe your changes

[add a description of your changes here]

catch { to catch (e) {

[add a detailed description of how you accomplished your changes here]

Rollup gives unexpected token

[add a detailed description of how you tested your changes here]

## How can we verify your changes

[add a detailed description of how we can verify your changes here]

## Remarks

[add any additional remarks here]

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

[add a link to the related issues here]
