### PR TITLE
Added CSS.escape to font-family.ts

### DIFF
--- a/packages/extension-font-family/src/font-family.ts
+++ b/packages/extension-font-family/src/font-family.ts
@@ -44,7 +44,7 @@ export const FontFamily = Extension.create<FontFamilyOptions>({
               }
 
               return {
-                style: `font-family: ${attributes.fontFamily}`,
+                style: `font-family: ${CSS.escape(attributes.fontFamily)}`,
               }
             },
           },

--- a/packages/extension-font-family/src/font-family.ts
+++ b/packages/extension-font-family/src/font-family.ts
@@ -44,7 +44,7 @@ export const FontFamily = Extension.create<FontFamilyOptions>({
               }
 
               return {
-                style: `font-family: ${CSS.escape(attributes.fontFamily)}`,
+                style: `font-family: ${attributes.fontFamily.split(',').map((fontFamily: string) => CSS.escape(fontFamily.trim())).join(', ')}`,
               }
             },
           },


### PR DESCRIPTION
## Please describe your changes

Added CSS.escape to renderHTML. Prevents invalid css when using fonts with numbers in their names, like https://fonts.google.com/specimen/Exo+2

## How did you accomplish your changes

Added CSS.escape() to renderHTML

## How have you tested your changes

Tested local 

## How can we verify your changes
Before <img width="197" alt="Screenshot 2023-10-18 at 15 07 03" src="https://github.com/ueberdosis/tiptap/assets/2072500/4f9d7680-daf5-4bdf-9b1b-55bbd3abae19">
After
<img width="195" alt="image" src="https://github.com/ueberdosis/tiptap/assets/2072500/dc05fe7d-a391-46cd-bee9-41c1d48c50f4">

## Remarks
-

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues
