### PR TITLE
feat(suggestion): add option to allow triggering chars to also be in suggestions

### DIFF
--- a/docs/api/utilities/suggestion.md
+++ b/docs/api/utilities/suggestion.md
@@ -21,6 +21,11 @@ Allows or disallows spaces in suggested items.
 
 Default: `false`
 
+### allowCharInSuggestedItem
+Allows or disallows the triggering char in suggested items. This option is incompatible with the `allowSpaces` option.
+
+Default: `false`
+
 ### allowedPrefixes
 The prefix characters that are allowed to trigger a suggestion. Set to `null` to allow any prefix character.
 

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -9,6 +9,7 @@ export interface SuggestionOptions<I = any> {
   editor: Editor
   char?: string
   allowSpaces?: boolean
+  allowToIncludeChar?: boolean
   allowedPrefixes?: string[] | null
   startOfLine?: boolean
   decorationTag?: string
@@ -50,6 +51,7 @@ export function Suggestion<I = any>({
   editor,
   char = '@',
   allowSpaces = false,
+  allowToIncludeChar = false,
   allowedPrefixes = [' '],
   startOfLine = false,
   decorationTag = 'span',
@@ -204,6 +206,7 @@ export function Suggestion<I = any>({
           const match = findSuggestionMatch({
             char,
             allowSpaces,
+            allowToIncludeChar,
             allowedPrefixes,
             startOfLine,
             $position: selection.$from,


### PR DESCRIPTION
## Please describe your changes

It's currently not possible to mention emails or federated usernames for instance, because the triggering char (often `@`) cannot be included in the mention suggestion itself. This option allows to have some, so that the mention will only end with a space. That makes it incompatible with the `allowSpaces` option.

## How did you accomplish your changes

Added the option in question and modified the regex matching the suggestion text to use it.

## How have you tested your changes

Tested that the new regex will also include the part after a secondary triggering character.

## How can we verify your changes

Add `allowToIncludeChar` to the suggestion settings, then type an email as suggestion.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

Closes #4447
