### PR TITLE
Fix: Change resizable table min width style key

### DIFF
--- a/demos/src/Nodes/Table/React/index.spec.js
+++ b/demos/src/Nodes/Table/React/index.spec.js
@@ -63,7 +63,7 @@ context('/src/Nodes/Table/React/', () => {
       const html = editor.getHTML()
 
       expect(html).to.equal(
-        '<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>',
+        '<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>',
       )
     })
   })
@@ -75,7 +75,7 @@ context('/src/Nodes/Table/React/', () => {
       const html = editor.getHTML()
 
       expect(html).to.equal(
-        '<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>',
+        '<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>',
       )
     })
   })

--- a/demos/src/Nodes/Table/Vue/index.spec.js
+++ b/demos/src/Nodes/Table/Vue/index.spec.js
@@ -62,7 +62,7 @@ context('/src/Nodes/Table/Vue/', () => {
 
       const html = editor.getHTML()
 
-      expect(html).to.equal('<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>')
+      expect(html).to.equal('<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>')
     })
   })
 
@@ -72,7 +72,7 @@ context('/src/Nodes/Table/Vue/', () => {
 
       const html = editor.getHTML()
 
-      expect(html).to.equal('<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>')
+      expect(html).to.equal('<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>')
     })
   })
 

--- a/packages/extension-table/src/table.ts
+++ b/packages/extension-table/src/table.ts
@@ -123,7 +123,7 @@ export const Table = Node.create<TableOptions>({
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         style: tableWidth
           ? `width: ${tableWidth}`
-          : `minWidth: ${tableMinWidth}`,
+          : `min-width: ${tableMinWidth}`,
       }),
       colgroup,
       ['tbody', 0],


### PR DESCRIPTION
## Please describe your changes

Change table style from minWidth to min-width so that html recognize the style key.

## How did you accomplish your changes

Change the style return data from minWidth to min-width in `renderHTML` function

## How have you tested your changes

Updated the test file both react and vue and succesfully ran the test in local.

## How can we verify your changes

Use `resizable: true` option for table, and call `editor.getHTML()` on update.

## Remarks
Here is the output before the changes / the incident
```html
 <table style="width: 100%; border-collapse: collapse; minwidth: 50px">
```
Let me know if I need to write the issue
 
## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

No related issues. Detected while i'm working on my own project.
