### PR TITLE
fix(extension/youtube) Youtube base URL no longer matches youtube node

### DIFF
--- a/demos/src/Nodes/Youtube/React/index.jsx
+++ b/demos/src/Nodes/Youtube/React/index.jsx
@@ -52,7 +52,7 @@ export default () => {
     content: `
       <p>Tiptap now supports YouTube embeds! Awesome!</p>
       <div data-youtube-video>
-        <iframe src="https://www.youtube.com/watch?v=cqHqLQgVCgY"></iframe>
+        <iframe src="https://www.youtube.com/watch?v=aqz-KE-bpKQ"></iframe>
       </div>
       <p>Try adding your own video to this editor!</p>
     `,

--- a/demos/src/Nodes/Youtube/React/index.spec.js
+++ b/demos/src/Nodes/Youtube/React/index.spec.js
@@ -17,6 +17,16 @@ context('/src/Nodes/Youtube/React/', () => {
     })
   })
 
+  it('adds a video via pasting', () => {
+    cy.get('.tiptap').paste({
+      pastePayload: 'https://music.youtube.com/watch?v=hBp4dgE7Bho&feature=share',
+      pasteType: 'text/plain',
+    })
+    cy.get('.tiptap div[data-youtube-video] iframe')
+      .should('have.length', 1)
+      .should('have.attr', 'src', 'https://www.youtube.com/embed/hBp4dgE7Bho?controls=0')
+  })
+
   it('adds a video with 320 width and 240 height', () => {
     cy.window().then(win => {
       cy.stub(win, 'prompt', () => 'https://music.youtube.com/watch?v=hBp4dgE7Bho&feature=share')
@@ -55,6 +65,30 @@ context('/src/Nodes/Youtube/React/', () => {
       cy.get('.tiptap div[data-youtube-video] iframe')
         .should('have.length', 1)
         .should('have.attr', 'src', 'https://www.youtube.com/embed/wRakoMYVHm8?controls=0')
+    })
+  })
+
+  const invalidLinks = [
+    'https://www.youtube.com/',
+    'https://www.youtube.com',
+    'http://notavalidlinkyoutube.com/watch?v=hBp4dgE7Bho&feature=share',
+  ]
+
+  invalidLinks.forEach(url => {
+    it(`does not add a video with invalid url ${url}`, () => {
+      cy.window().then(win => {
+        cy.stub(win, 'prompt', () => url)
+        cy.get('#add').eq(0).click()
+        cy.get('.tiptap div[data-youtube-video] iframe').should('have.length', 0)
+      })
+    })
+
+    it(`does not add a video with invalid via pasting url ${url}`, () => {
+      cy.get('.tiptap').paste({
+        pastePayload: url,
+        pasteType: 'text/plain',
+      })
+      cy.get('.tiptap div[data-youtube-video] iframe').should('have.length', 0)
     })
   })
 })

--- a/demos/src/Nodes/Youtube/Vue/index.spec.js
+++ b/demos/src/Nodes/Youtube/Vue/index.spec.js
@@ -17,6 +17,16 @@ context('/src/Nodes/Youtube/Vue/', () => {
     })
   })
 
+  it('adds a video via pasting', () => {
+    cy.get('.tiptap').paste({
+      pastePayload: 'https://music.youtube.com/watch?v=hBp4dgE7Bho&feature=share',
+      pasteType: 'text/plain',
+    })
+    cy.get('.tiptap div[data-youtube-video] iframe')
+      .should('have.length', 1)
+      .should('have.attr', 'src', 'https://www.youtube.com/embed/hBp4dgE7Bho?controls=0')
+  })
+
   it('adds a video with 320 width and 240 height', () => {
     cy.window().then(win => {
       cy.stub(win, 'prompt', () => 'https://music.youtube.com/watch?v=hBp4dgE7Bho&feature=share')
@@ -55,6 +65,30 @@ context('/src/Nodes/Youtube/Vue/', () => {
       cy.get('.tiptap div[data-youtube-video] iframe')
         .should('have.length', 1)
         .should('have.attr', 'src', 'https://www.youtube.com/embed/wRakoMYVHm8?controls=0')
+    })
+  })
+
+  const invalidLinks = [
+    'https://www.youtube.com/',
+    'https://www.youtube.com',
+    'http://notavalidlinkyoutube.com/watch?v=hBp4dgE7Bho&feature=share',
+  ]
+
+  invalidLinks.forEach(url => {
+    it(`does not add a video with invalid url ${url}`, () => {
+      cy.window().then(win => {
+        cy.stub(win, 'prompt', () => url)
+        cy.get('#add').eq(0).click()
+        cy.get('.tiptap div[data-youtube-video] iframe').should('have.length', 0)
+      })
+    })
+
+    it(`does not add a video with invalid via pasting url ${url}`, () => {
+      cy.get('.tiptap').paste({
+        pastePayload: url,
+        pasteType: 'text/plain',
+      })
+      cy.get('.tiptap div[data-youtube-video] iframe').should('have.length', 0)
     })
   })
 })

--- a/packages/extension-youtube/src/utils.ts
+++ b/packages/extension-youtube/src/utils.ts
@@ -1,5 +1,5 @@
-export const YOUTUBE_REGEX = /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be)(?!.*\/channel\/)(?!\/@)(.+)?$/
-export const YOUTUBE_REGEX_GLOBAL = /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be)(?!.*\/channel\/)(?!\/@)(.+)?$/g
+export const YOUTUBE_REGEX = /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be)(?!.*\/channel\/)(?!\/@)(\/.+)$/
+export const YOUTUBE_REGEX_GLOBAL = /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be)(?!.*\/channel\/)(?!\/@)(\/.+)$/g
 
 export const isValidYoutubeUrl = (url: string) => {
   return url.match(YOUTUBE_REGEX)


### PR DESCRIPTION
## Please describe your changes

Simply changed the regex to only include youtube URLs if they have something beyond the base route:

youtube.com`(\/.*)+`

## How have you tested your changes

Added automated tests and spot checked the youtube extension in the demo app

## How can we verify your changes

Verify issue of an IFrame being created for the base youtube URL (youtube.com) no longer shows using the youtube extension demo

## Checklist

- [X] The changes are not breaking the editor
- [X] Added tests where possible
- [X] Followed the guidelines
- [X] Fixed linting issues

## Related issues

Fixes #4560
