### PR TITLE
Update extension-collaboration & extension-collaboration-cursor package.json

### DIFF
--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -30,11 +30,11 @@
   ],
   "devDependencies": {
     "@tiptap/core": "^2.2.0-rc.4",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.0.20"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.0.20"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -31,12 +31,12 @@
   "devDependencies": {
     "@tiptap/core": "^2.2.0-rc.4",
     "@tiptap/pm": "^2.2.0-rc.4",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.0.20"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
     "@tiptap/pm": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.0.20"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Please describe your changes

Updating the peer dependencies to the latest version of y-prosemirror so it won't show an error. 

Currently when using @tiptap/extension-collaboration and with latest `y-prosemirror` will show a warning.
```
warning " > @tiptap/extension-collaboration@2.2.0-rc.4" has incorrect peer dependency "y-prosemirror@1.0.20".
warning " > @tiptap/extension-collaboration-cursor@2.2.0-rc.4" has incorrect peer dependency "y-prosemirror@1.0.20".
```

## How did you accomplish your changes

Updating the package.json. 

## How have you tested your changes

Its safe to update as I tested with latest version. 


## How can we verify your changes

Verified in my own app with the latest version for y-prosemirror — ^1.2.1

## Checklist

- [ x] The changes are not breaking the editor
- [ x] Added tests where possible
- [ x] Fixed linting issues
- [ x] Followed the guidelines

