### PR TITLE
chore: upgrades y-prosemirror to ^1.2.1. It used to be locked to 1.0.…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19703,7 +19703,7 @@
       "devDependencies": {
         "@tiptap/core": "^2.2.0-rc.4",
         "@tiptap/pm": "^2.2.0-rc.4",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       },
       "funding": {
         "type": "github",
@@ -19712,7 +19712,7 @@
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
         "@tiptap/pm": "^2.0.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       }
     },
     "packages/extension-collaboration-cursor": {
@@ -19721,7 +19721,7 @@
       "license": "MIT",
       "devDependencies": {
         "@tiptap/core": "^2.2.0-rc.4",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       },
       "funding": {
         "type": "github",
@@ -19729,7 +19729,47 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
+      }
+    },
+    "packages/extension-collaboration-cursor/node_modules/y-prosemirror": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
+      "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
+      "dev": true,
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
+      }
+    },
+    "packages/extension-collaboration/node_modules/y-prosemirror": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
+      "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
+      "dev": true,
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "packages/extension-color": {
@@ -23943,14 +23983,36 @@
       "requires": {
         "@tiptap/core": "^2.2.0-rc.4",
         "@tiptap/pm": "^2.2.0-rc.4",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
+      },
+      "dependencies": {
+        "y-prosemirror": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
+          "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
+          "dev": true,
+          "requires": {
+            "lib0": "^0.2.42"
+          }
+        }
       }
     },
     "@tiptap/extension-collaboration-cursor": {
       "version": "file:packages/extension-collaboration-cursor",
       "requires": {
         "@tiptap/core": "^2.2.0-rc.4",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
+      },
+      "dependencies": {
+        "y-prosemirror": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
+          "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
+          "dev": true,
+          "requires": {
+            "lib0": "^0.2.42"
+          }
+        }
       }
     },
     "@tiptap/extension-color": {

--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -30,11 +30,11 @@
   ],
   "devDependencies": {
     "@tiptap/core": "^2.2.0-rc.4",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -31,12 +31,12 @@
   "devDependencies": {
     "@tiptap/core": "^2.2.0-rc.4",
     "@tiptap/pm": "^2.2.0-rc.4",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
     "@tiptap/pm": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/src/collaboration.ts
+++ b/packages/extension-collaboration/src/collaboration.ts
@@ -124,7 +124,7 @@ export const Collaboration = Extension.create<CollaborationOptions>({
         undoManager.restore = () => {}
       }
 
-      const viewRet = originalUndoPluginView(view)
+      const viewRet = originalUndoPluginView ? originalUndoPluginView(view) : undefined
 
       return {
         destroy: () => {
@@ -142,7 +142,9 @@ export const Collaboration = Extension.create<CollaborationOptions>({
             undoManager._observers = observers
           }
 
-          viewRet.destroy()
+          if (viewRet?.destroy) {
+            viewRet.destroy()
+          }
         },
       }
     }


### PR DESCRIPTION
This upgrades y-prosemirror to v1.2.1. We used to lock the version to 1.0.20 because of a bug in y-prosemirror, but that got fixed in v1.1.13.

Verified here: https://codesandbox.io/s/quirky-brattain-tbtinr?file=/package.json (by https://github.com/yjs/y-prosemirror/issues/117)


closes #4353
closes #4626