### PR TITLE
Update alpine.md with better info about proxy limitations

### DIFF
--- a/docs/installation/alpine.md
+++ b/docs/installation/alpine.md
@@ -48,7 +48,7 @@ import StarterKit from '@tiptap/starter-kit'
 
 document.addEventListener('alpine:init', () => {
   Alpine.data('editor', (content) => {
-    let editor
+    let editor // Alpine's reactive engine automatically wraps component properties in proxy objects. Attempting to use a proxied editor instance to apply a transaction will cause a "Range Error: Applying a mismatched transaction", so be sure to unwrap it using Alpine.raw(), or simply avoid storing your editor as a component property, as shown in this example.
 
     return {
       updatedAt: Date.now(), // force Alpine to rerender on selection change


### PR DESCRIPTION
The issue described in #1515 is now mentioned in the Alpine documentation so that readers understand why the example does not store the editor as component data and why they should not do so either.

## Please describe your changes

I struggled for days trying to get Alpine to work with TipTap before finding #1515
The current documentation makes no mention of the limitations with storing the editor as an Alpine component property. The proposed changes attempt to concisely convey all of the necessary information for readers to understand why the Alpine example is the way that it is and warns them of the incompatibility which would very likely be unexpected.

## How did you accomplish your changes

The proposed changes adds a comment to the code example at the point where the editor reference is created, explaining why it is not simply made a component property, and even mentions the exact error that the reader can expect to see if they've done so. This will surely help people like myself who were encountering this error during integration.

## Related issues
[https://github.com/ueberdosis/tiptap/issues/1515](https://github.com/ueberdosis/tiptap/issues/1515)
