### PR TITLE
Fix: resizable table min width

### DIFF
--- a/.changeset/hungry-jokes-wash.md
+++ b/.changeset/hungry-jokes-wash.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-table": patch
+---
+
+Set correct `min-width` for a table fixes #5217

--- a/demos/src/Nodes/Table/React/index.spec.js
+++ b/demos/src/Nodes/Table/React/index.spec.js
@@ -63,7 +63,7 @@ context('/src/Nodes/Table/React/', () => {
       const html = editor.getHTML()
 
       expect(html).to.equal(
-        '<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>',
+        '<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>',
       )
     })
   })
@@ -75,7 +75,7 @@ context('/src/Nodes/Table/React/', () => {
       const html = editor.getHTML()
 
       expect(html).to.equal(
-        '<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>',
+        '<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>',
       )
     })
   })

--- a/demos/src/Nodes/Table/Vue/index.spec.js
+++ b/demos/src/Nodes/Table/Vue/index.spec.js
@@ -62,7 +62,7 @@ context('/src/Nodes/Table/Vue/', () => {
 
       const html = editor.getHTML()
 
-      expect(html).to.equal('<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>')
+      expect(html).to.equal('<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>')
     })
   })
 
@@ -72,7 +72,7 @@ context('/src/Nodes/Table/Vue/', () => {
 
       const html = editor.getHTML()
 
-      expect(html).to.equal('<table style="minWidth: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>')
+      expect(html).to.equal('<table style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>')
     })
   })
 

--- a/packages/extension-table/src/table.ts
+++ b/packages/extension-table/src/table.ts
@@ -286,7 +286,7 @@ export const Table = Node.create<TableOptions>({
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         style: tableWidth
           ? `width: ${tableWidth}`
-          : `minWidth: ${tableMinWidth}`,
+          : `min-width: ${tableMinWidth}`,
       }),
       colgroup,
       ['tbody', 0],


### PR DESCRIPTION
## Please describe your changes

Change the `minWidth` to `min-width` in table style attribute

## How did you accomplish your changes

By changing the table attributes

## How have you tested your changes

Tested in local and already changed the unit tests

## How can we verify your changes

You can get the output via `editor.getHTML()` and see if the result changed

## Remarks

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

- No issues for this, but I found it when I am working with table
