### PR TITLE
fix(typography): require spaces after divisions to not break dates

### DIFF
--- a/demos/src/Extensions/Typography/React/index.spec.js
+++ b/demos/src/Extensions/Typography/React/index.spec.js
@@ -9,6 +9,15 @@ context('/src/Extensions/Typography/React/', () => {
     })
   })
 
+  it('should keep dates as they are', () => {
+    cy.get('.tiptap').type('1/4/2024').should('contain', '1/4/2024')
+  })
+
+  it('should make a fraction only with spaces afterwards', () => {
+    cy.get('.tiptap').type('1/4').should('contain', '1/4')
+    cy.get('.tiptap').type('{selectall}{backspace}1/4 ').should('contain', '¼')
+  })
+
   it('should make an em dash from two dashes', () => {
     cy.get('.tiptap').type('-- emDash').should('contain', '— emDash')
   })

--- a/packages/extension-typography/src/typography.ts
+++ b/packages/extension-typography/src/typography.ts
@@ -86,7 +86,7 @@ export const registeredTrademark = (override?: string) => textInputRule({
 })
 
 export const oneHalf = (override?: string) => textInputRule({
-  find: /(?:^|\s)(1\/2)$/,
+  find: /(?:^|\s)(1\/2)\s$/,
   replace: override ?? '½',
 })
 
@@ -126,12 +126,12 @@ export const superscriptThree = (override?: string) => textInputRule({
 })
 
 export const oneQuarter = (override?: string) => textInputRule({
-  find: /(?:^|\s)(1\/4)$/,
+  find: /(?:^|\s)(1\/4)\s$/,
   replace: override ?? '¼',
 })
 
 export const threeQuarters = (override?: string) => textInputRule({
-  find: /(?:^|\s)(3\/4)$/,
+  find: /(?:^|\s)(3\/4)\s$/,
   replace: override ?? '¾',
 })
 


### PR DESCRIPTION
## Please describe your changes

This PR changes the regex for all division replacements to **require** a space after a division. This way dates won't be broken when typing 1/4/2024 for example. See issue #4663

## How did you accomplish your changes

I added a required whitespace after the division regexes.

## How have you tested your changes

I added two new tests that will check if those requirements are met.

## How can we verify your changes

Check the tests for the Typography demo page

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

Closes #4663 
