### PR TITLE
Bump prosemirror-view version to fix Google translation in editor

### DIFF
--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -143,7 +143,7 @@
     "prosemirror-tables": "^1.3.0",
     "prosemirror-trailing-node": "^2.0.2",
     "prosemirror-transform": "^1.7.0",
-    "prosemirror-view": "^1.28.2"
+    "prosemirror-view": "^1.31.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Please describe your changes
Google translate doesn't work on the editor because the translate attribute is not being properly passed. This PR bumps `prosemirror-view` to the version with the fix.

## How did you accomplish your changes
I found the version that had the fix and updated the version in `package.json`

https://github.com/ProseMirror/prosemirror-view/releases/tag/1.31.2

## How have you tested your changes
Manually tested in browser

## Checklist
[x] The changes are not breaking the editor
[x] Added tests where possible
[x] Followed the guidelines
[x] Fixed linting issues

## Related issues
Close #3826  