### PR TITLE
Export createColGroup utility function

### DIFF
--- a/packages/extension-table/src/index.ts
+++ b/packages/extension-table/src/index.ts
@@ -2,5 +2,6 @@ import { Table } from './table.js'
 
 export * from './table.js'
 export * from './utilities/createTable.js'
+export * from './utilities/createColGroup.js'
 
 export default Table


### PR DESCRIPTION
## Please describe your changes

Changed to export the `createColGroup` function added in #4281.

## How did you accomplish your changes

The `createColGroup` function is needed when extending the output with `renderHTML()` in `extend()`, so it should be exported.

## How have you tested your changes

n/a

## How can we verify your changes

Functions can be imported successfully using 
```js
import { createColGroup } from @tiptap/extension-table
```

## Remarks

n/a

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

#4280, #4281
