### PR TITLE
Fix: Bump y-prosemirror for collaboration-content and collaboration-content-cursor

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -19,7 +19,7 @@
     "remixicon": "^2.5.0",
     "shiki": "^0.10.0",
     "simplify-js": "^1.2.4",
-    "y-prosemirror": "1.0.20",
+    "y-prosemirror": "^1.2.1",
     "y-webrtc": "^10.2.5",
     "yjs": "^13.5.39"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "remixicon": "^2.5.0",
         "shiki": "^0.10.0",
         "simplify-js": "^1.2.4",
-        "y-prosemirror": "1.0.20",
+        "y-prosemirror": "^1.2.1",
         "y-webrtc": "^10.2.5",
         "yjs": "^13.5.39"
       },
@@ -19402,8 +19402,9 @@
       }
     },
     "node_modules/y-prosemirror": {
-      "version": "1.0.20",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
+      "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
       "dependencies": {
         "lib0": "^0.2.42"
       },
@@ -19416,7 +19417,7 @@
         "prosemirror-state": "^1.2.3",
         "prosemirror-view": "^1.9.10",
         "y-protocols": "^1.0.1",
-        "yjs": "^13.3.2"
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/y-protocols": {
@@ -19703,7 +19704,7 @@
       "devDependencies": {
         "@tiptap/core": "^2.1.14",
         "@tiptap/pm": "^2.1.14",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       },
       "funding": {
         "type": "github",
@@ -19712,7 +19713,7 @@
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
         "@tiptap/pm": "^2.0.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       }
     },
     "packages/extension-collaboration-cursor": {
@@ -19721,7 +19722,7 @@
       "license": "MIT",
       "devDependencies": {
         "@tiptap/core": "^2.1.14",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       },
       "funding": {
         "type": "github",
@@ -19729,7 +19730,7 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       }
     },
     "packages/extension-color": {
@@ -23943,14 +23944,14 @@
       "requires": {
         "@tiptap/core": "^2.1.14",
         "@tiptap/pm": "^2.1.14",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       }
     },
     "@tiptap/extension-collaboration-cursor": {
       "version": "file:packages/extension-collaboration-cursor",
       "requires": {
         "@tiptap/core": "^2.1.14",
-        "y-prosemirror": "1.0.20"
+        "y-prosemirror": "^1.2.1"
       }
     },
     "@tiptap/extension-color": {
@@ -33111,7 +33112,7 @@
         "vite-plugin-checker": "^0.3.4",
         "vue": "^3.0.5",
         "vue-router": "^4.0.11",
-        "y-prosemirror": "1.0.20",
+        "y-prosemirror": "^1.2.1",
         "y-webrtc": "^10.2.5",
         "yjs": "^13.5.39"
       }
@@ -34099,7 +34100,9 @@
       "dev": true
     },
     "y-prosemirror": {
-      "version": "1.0.20",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
+      "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
       "requires": {
         "lib0": "^0.2.42"
       }

--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -30,11 +30,11 @@
   ],
   "devDependencies": {
     "@tiptap/core": "^2.1.14",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -31,12 +31,12 @@
   "devDependencies": {
     "@tiptap/core": "^2.1.14",
     "@tiptap/pm": "^2.1.14",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0",
     "@tiptap/pm": "^2.0.0",
-    "y-prosemirror": "1.0.20"
+    "y-prosemirror": "^1.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Please describe your changes

Sets version of y-prosemirror to not be pinned to 1.0.20 due to [an issue](https://github.com/yjs/y-prosemirror/issues/133) causing yjs and Prosemirror to lose its synchronisation. 

## How did you accomplish your changes

Bumped versions and ran `npm i` to update package-lock.

## How have you tested your changes

Tested by forcing version to 1.2.1.

## How can we verify your changes

See [y-prosemirror issue](https://github.com/yjs/y-prosemirror/issues/133) for reproduction. 

## Remarks

In our project we can't reproduce this bug that's been haunting us for a few months now.

## Checklist

- [X] The changes are not breaking the editor
- [X] Added tests where possible
- [X] Followed the guidelines
- [X] Fixed linting issues

## Related issues

https://github.com/yjs/y-prosemirror/issues/133
