### PR TITLE
fix(core): fix new lines being added via elementFromString

### DIFF
--- a/demos/src/Issues/2720/React/index.spec.js
+++ b/demos/src/Issues/2720/React/index.spec.js
@@ -20,4 +20,11 @@ context('/src/Issues/2720/React/', () => {
     // check if the content html is correct
     cy.get('.tiptap').should('contain.html', 'Hello World\nThis is content with a new line. Is this working?\n\nLets see if multiple new lines are inserted correctly')
   })
+
+  it('should keep newlines in pre tag', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.commands.setContent('<pre><code>foo\nbar</code></pre>')
+      cy.get('.tiptap').should('contain.html', '<pre><code>foo\nbar</code></pre>')
+    })
+  })
 })

--- a/packages/core/src/helpers/createNodeFromContent.ts
+++ b/packages/core/src/helpers/createNodeFromContent.ts
@@ -40,7 +40,6 @@ export function createNodeFromContent(
   }
 
   if (typeof content === 'string') {
-    content = content.split('\n').map(part => part.trim()).join('') // we need to remove new lines since the parser will add breaks
     const parser = DOMParser.fromSchema(schema)
 
     return options.slice

--- a/packages/core/src/utilities/elementFromString.ts
+++ b/packages/core/src/utilities/elementFromString.ts
@@ -1,6 +1,26 @@
+const removeWhitespaces = (node: HTMLElement) => {
+  const children = node.childNodes
+
+  for (let i = children.length - 1; i >= 0; i -= 1) {
+    const child = children[i]
+
+    if (child.nodeType === 3 && child.nodeValue && !/\S/.test(child.nodeValue)) {
+      node.removeChild(child)
+    } else if (child.nodeType === 1) {
+      removeWhitespaces(child as HTMLElement)
+    }
+  }
+
+  return node
+}
+
 export function elementFromString(value: string): HTMLElement {
   // add a wrapper to preserve leading and trailing whitespace
   const wrappedValue = `<body>${value}</body>`
 
-  return new window.DOMParser().parseFromString(wrappedValue, 'text/html').body
+  const html = new window.DOMParser().parseFromString(wrappedValue, 'text/html').body
+
+  removeWhitespaces(html)
+
+  return removeWhitespaces(html)
 }


### PR DESCRIPTION
## Please describe your changes

This PR fixes an issue that adds new lines on the parser level of the browser. It traverses through the actual dom instead of using string replacements removing all newlines added additionally by the parser.

## How did you accomplish your changes

See above

## How have you tested your changes

I added a new test to check if newlines are kept in pre tags.

## How can we verify your changes

Check out the local demo of Issue #2720


## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
