### PR TITLE
fix(suggestion): unused parameter oldState in apply.

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -184,7 +184,7 @@ export function Suggestion<I = any>({
       },
 
       // Apply changes to the plugin state from a view transaction.
-      apply(transaction, prev, oldState, state) {
+      apply(transaction, prev, _oldState, state) {
         const { isEditable } = editor
         const { composing } = editor.view
         const { selection } = transaction


### PR DESCRIPTION
## Please describe your changes

Ignore unused parameter in suggestion plugin during typescript build.

## How have you tested your changes

Add this typescript compiler option

```
{
  "compilerOptions": {
    ...
    "noUnusedParameters": true,
   ...
  },
  ...
```
Build project, it should build fine with suggested code changed.

```
npm --prefix ./packages/suggestion run build
```

Before the change this results in error:
```
[!] (plugin rpt2) Error: /home/marem/developpement/tiptap/packages/suggestion/src/suggestion.ts(187,32): semantic error TS6133: 'oldState' is declared but its value is never read.
```

After the change build is be ok.

## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

https://github.com/ueberdosis/tiptap/issues/4770
