### PR TITLE
fix(suggestion): typescript build error in suggestion package

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -184,7 +184,7 @@ export function Suggestion<I = any>({
       },
 
       // Apply changes to the plugin state from a view transaction.
-      apply(transaction, prev, oldState, state) {
+      apply(transaction, prev, state) {
         const { isEditable } = editor
         const { composing } = editor.view
         const { selection } = transaction


### PR DESCRIPTION
## you can simply remove the oldState parameter from the function declaration if it’s not being used.

The error you’re seeing is because the oldState parameter in the apply function is declared but not used anywhere in the function.

## This should resolve the TypeScript error you’re seeing. If oldState is needed in the future, you can add it back. Remember, the noUnusedLocals rule is there to help keep your code clean and maintainable. It’s generally a good practice to remove unused variables. However, if you find this rule too restrictive for your project, you can turn it off in your tsconfig.json, but as you mentioned, it would apply to your whole project.
[add a detailed description of how you accomplished your changes here]


## Checklist

- [ ] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

[https://github.com/ueberdosis/tiptap/issues/4770]
