### PR TITLE
fix: only start at block with removing if not an inline node

### DIFF
--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -57,7 +57,9 @@ export function nodeInputRule(config: {
         // insert node from input rule
         tr.replaceWith(matchStart, end, newNode)
       } else if (match[0]) {
-        tr.insert(start - 1, config.type.create(attributes)).delete(
+        const insertionStart = config.type.isInline ? start : start - 1
+
+        tr.insert(insertionStart, config.type.create(attributes)).delete(
           tr.mapping.map(start),
           tr.mapping.map(end),
         )


### PR DESCRIPTION
## Please describe your changes

In the pull request: https://github.com/ueberdosis/tiptap/pull/4341 (originally: https://github.com/ueberdosis/tiptap/pull/3859), a fix was implemented for HorizontalRule. This made sure that for this extension/node, which is a block node, it would replace the whole block. This lead to problems in my implementation where I use an inline node. This is why I decided to, instead of overwriting the inputrule handing, fixing the issue in this PR. 

## How did you accomplish your changes

I've looked into previous versions of @tiptap/core to see where this issue first occured, and back-tracked it to the PR's mentioned above. It seemed like this change was made taking into account existing nodes in the TipTap repository, which use NodeInputRule and are block.
From what I could figure out, I don't think you want the replacement of the whole block to happen in case of an inline node, which is why I decided to create this PR.

## How have you tested your changes

I've been testing this change in the example of the HorizontalRule, but also creating a small inline node. This confirmed my suspisions, as it seemed like it now supported both only adding and removing the node, but still also supported for block nodes to replace the whole block.

## How can we verify your changes

Use the demo environment from the HorizontalRule, and see if this does still work like expected. Then create a small node like 
 ```js
Node.create({
  name: 'variable',

  group: 'inline',
  inline: true,
  atom: true,

  // Parse attributes
  addAttributes() {
    return {
      value: { },
    }
  },
  // Render replacementField in html
  renderHTML({ node }) {
    return ['span', {}, `|${node.attrs.value}|`]
  },

  addInputRules() {
    return [
      nodeInputRule({
        find: /\{\{\d\}\}/,
        type: this.type,
        getAttributes: node => {
          return {
            value: node.input,
          }
        },
      }),
    ]
  },
})

```
and add that as well. From this you should see that you can add the inline node on the same line, but still keep the HorizontalRule replacing the whole block.

## Remarks

Tried to do everything as would be expected, but this is honestly my first time contributing to an open source project. I've tried to look if I needed to add tests somewhere, but couldn't find an already existing test file for this, so didn't add them for now. Please let me know if you need any more information.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

https://github.com/ueberdosis/tiptap/pull/3859
https://github.com/ueberdosis/tiptap/pull/4341
https://github.com/ueberdosis/tiptap/issues/4796