### PR TITLE
Refactor NodePos class to support block nodes

### DIFF
--- a/packages/core/src/NodePos.ts
+++ b/packages/core/src/NodePos.ts
@@ -8,23 +8,35 @@ import { Content, Range } from './types.js'
 export class NodePos {
   private resolvedPos: ResolvedPos
 
+  private isBlock: boolean
+
   private editor: Editor
 
-  constructor(pos: ResolvedPos, editor: Editor) {
-    this.resolvedPos = pos
-    this.editor = editor
+  private get name(): string {
+    return this.node.type.name
   }
 
+  constructor(pos: ResolvedPos, editor: Editor, isBlock = false, node: Node | null = null) {
+    this.isBlock = isBlock
+    this.resolvedPos = pos
+    this.editor = editor
+    this.currentNode = node
+  }
+
+  private currentNode: Node | null = null
+
   get node(): Node {
-    return this.resolvedPos.node()
+    return this.currentNode || this.resolvedPos.node()
   }
 
   get element(): HTMLElement {
     return this.editor.view.domAtPos(this.pos).node as HTMLElement
   }
 
+  public actualDepth: number | null = null
+
   get depth(): number {
-    return this.resolvedPos.depth
+    return this.actualDepth ?? this.resolvedPos.depth
   }
 
   get pos(): number {
@@ -36,7 +48,20 @@ export class NodePos {
   }
 
   set content(content: Content) {
-    this.editor.commands.insertContentAt({ from: this.from, to: this.to }, content)
+    let from = this.from
+    let to = this.to
+
+    if (this.isBlock) {
+      if (this.content.size === 0) {
+        console.error(`You can’t set content on a block node. Tried to set content on ${this.name} at ${this.pos}`)
+        return
+      }
+
+      from = this.from + 1
+      to = this.to - 1
+    }
+
+    this.editor.commands.insertContentAt({ from, to }, content)
   }
 
   get attributes() : { [key: string]: any } {
@@ -52,6 +77,10 @@ export class NodePos {
   }
 
   get from(): number {
+    if (this.isBlock) {
+      return this.pos
+    }
+
     return this.resolvedPos.start(this.resolvedPos.depth)
   }
 
@@ -63,6 +92,10 @@ export class NodePos {
   }
 
   get to(): number {
+    if (this.isBlock) {
+      return this.pos + this.size
+    }
+
     return this.resolvedPos.end(this.resolvedPos.depth) + (this.node.isText ? 0 : 1)
   }
 
@@ -78,7 +111,7 @@ export class NodePos {
   }
 
   get before(): NodePos | null {
-    let $pos = this.resolvedPos.doc.resolve(this.from - 2)
+    let $pos = this.resolvedPos.doc.resolve(this.from - (this.isBlock ? 1 : 2))
 
     if ($pos.depth !== this.depth) {
       $pos = this.resolvedPos.doc.resolve(this.from - 3)
@@ -88,7 +121,7 @@ export class NodePos {
   }
 
   get after(): NodePos | null {
-    let $pos = this.resolvedPos.doc.resolve(this.to + 2)
+    let $pos = this.resolvedPos.doc.resolve(this.to + (this.isBlock ? 2 : 1))
 
     if ($pos.depth !== this.depth) {
       $pos = this.resolvedPos.doc.resolve(this.to + 3)
@@ -101,14 +134,22 @@ export class NodePos {
     const children: NodePos[] = []
 
     this.node.content.forEach((node, offset) => {
-      const targetPos = this.pos + offset + 1
+      const isBlock = node.isBlock && !node.isTextblock
+
+      const targetPos = this.pos + offset + (isBlock ? 0 : 1)
       const $pos = this.resolvedPos.doc.resolve(targetPos)
 
-      if ($pos.depth === this.depth) {
+      if (!isBlock && $pos.depth <= this.depth) {
         return
       }
 
-      children.push(new NodePos($pos, this.editor))
+      const childNodePos = new NodePos($pos, this.editor, isBlock, isBlock ? node : null)
+
+      if (isBlock) {
+        childNodePos.actualDepth = this.depth + 1
+      }
+
+      children.push(new NodePos($pos, this.editor, isBlock, isBlock ? node : null))
     })
 
     return children
@@ -160,14 +201,14 @@ export class NodePos {
     let nodes: NodePos[] = []
 
     // iterate through children recursively finding all nodes which match the selector with the node name
-    if (!this.children || this.children.length === 0) {
+    if (this.isBlock || !this.children || this.children.length === 0) {
       return nodes
     }
 
-    this.children.forEach(node => {
-      if (node.node.type.name === selector) {
+    this.children.forEach(childPos => {
+      if (childPos.node.type.name === selector) {
         if (Object.keys(attributes).length > 0) {
-          const nodeAttributes = node.node.attrs
+          const nodeAttributes = childPos.node.attrs
           const attrKeys = Object.keys(attributes)
 
           for (let index = 0; index < attrKeys.length; index += 1) {
@@ -179,14 +220,14 @@ export class NodePos {
           }
         }
 
-        nodes.push(node)
+        nodes.push(childPos)
 
         if (firstItemOnly) {
           return
         }
       }
 
-      nodes = nodes.concat(node.querySelectorAll(selector))
+      nodes = nodes.concat(childPos.querySelectorAll(selector))
     })
 
     return nodes


### PR DESCRIPTION
## Please describe your changes

This PR adds support for block nodes in the NodePos implementation. This is still a bit janky but at least block nodes are now found. Reason for this jank is that [ResolvedPos in Prosemirror won't find block nodes at their positions but the `doc` node and the depth of 0](https://discuss.prosemirror.net/t/resolvepos-works-unexpected-for-atom-block-node/5087/3).

This is bad because I used ResolvedPos for all the position mapping inside the NodePos class. In the future we should see if we can improve on this. This means that currently `.before`, `.after`, etc. won't be very exact and could lead to wrong positions as I'm trying to find those positions by checking if a nodepos is a block nodepos.

## How did you accomplish your changes

1. Added information about `isBlock` into a nodePos together with it's actual `depth` that I try to get from the context of the `children` getter.
2. Updated the children getter to pass down those informations to the newly found NodePos instances

## How have you tested your changes

I used a customized Examples/Default demo locally.

## How can we verify your changes

You can do the same above - bind the editor created in the demo to window.editor and then try to do things like `editor.$node('bulletList')`

## Remarks

As I said above this still is a bit jank as the ResolvedPos implementation of Prosemirror doesn't give me correct information about a nodes depth. We'll probably need to improve this class over time as we run into more and more issues.

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

closes #4840
