### PR TITLE
Change to unnecessarily resolved positions

### DIFF
--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -157,7 +157,7 @@ export class BubbleMenuView {
 
   update(view: EditorView, oldState?: EditorState) {
     const { state } = view
-    const hasValidSelection = state.selection.$from.pos !== state.selection.$to.pos
+    const hasValidSelection = state.selection.from !== state.selection.to
 
     if (this.updateDelay > 0 && hasValidSelection) {
       this.handleDebouncedUpdate(view, oldState)


### PR DESCRIPTION
## Please describe your changes

I think in the `hasValidSelection` boolean expression inside of the Bubble Menu plugin there is no obvious reason for why `$from.pos` and `$to.pos` are used instead of the properties of `selection` object with the same name.

## How did you accomplish your changes

I swapped resolved positions with unresolved ones in `hasValidSelection`.

## How have you tested your changes

I compared the values returned by both versions of the expression while tinkering with the menu. Also, as far as I'm aware, the ProseMirror documentation states that they're literally the same.

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [ ] Fixed linting issues
