### PR TITLE
fix: Disallow only whitespace between markdown shortcuts delimiters

### DIFF
--- a/packages/extension-bold/src/bold.ts
+++ b/packages/extension-bold/src/bold.ts
@@ -28,10 +28,10 @@ declare module '@tiptap/core' {
   }
 }
 
-export const starInputRegex = /(?:^|\s)((?:\*\*)((?:[^*]+))(?:\*\*))$/
-export const starPasteRegex = /(?:^|\s)((?:\*\*)((?:[^*]+))(?:\*\*))/g
-export const underscoreInputRegex = /(?:^|\s)((?:__)((?:[^__]+))(?:__))$/
-export const underscorePasteRegex = /(?:^|\s)((?:__)((?:[^__]+))(?:__))/g
+export const starInputRegex = /(?:^|\s)(\*\*(?!\s+\*\*)((?:[^*]+))\*\*(?!\s+\*\*))$/
+export const starPasteRegex = /(?:^|\s)(\*\*(?!\s+\*\*)((?:[^*]+))\*\*(?!\s+\*\*))/g
+export const underscoreInputRegex = /(?:^|\s)(__(?!\s+__)((?:[^_]+))__(?!\s+__))$/
+export const underscorePasteRegex = /(?:^|\s)(__(?!\s+__)((?:[^_]+))__(?!\s+__))/g
 
 export const Bold = Mark.create<BoldOptions>({
   name: 'bold',

--- a/packages/extension-code/src/code.ts
+++ b/packages/extension-code/src/code.ts
@@ -28,8 +28,8 @@ declare module '@tiptap/core' {
   }
 }
 
-export const inputRegex = /(?:^|\s)((?:`)((?:[^`]+))(?:`))$/
-export const pasteRegex = /(?:^|\s)((?:`)((?:[^`]+))(?:`))/g
+export const inputRegex = /(?:^|\s)(`(?!\s+`)((?:[^`]+))`(?!\s+`))$/
+export const pasteRegex = /(?:^|\s)(`(?!\s+`)((?:[^`]+))`(?!\s+`))/g
 
 export const Code = Mark.create<CodeOptions>({
   name: 'code',

--- a/packages/extension-highlight/src/highlight.ts
+++ b/packages/extension-highlight/src/highlight.ts
@@ -29,8 +29,8 @@ declare module '@tiptap/core' {
   }
 }
 
-export const inputRegex = /(?:^|\s)((?:==)((?:[^~=]+))(?:==))$/
-export const pasteRegex = /(?:^|\s)((?:==)((?:[^~=]+))(?:==))/g
+export const inputRegex = /(?:^|\s)(==(?!\s+==)((?:[^=]+))==(?!\s+==))$/
+export const pasteRegex = /(?:^|\s)(==(?!\s+==)((?:[^=]+))==(?!\s+==))/g
 
 export const Highlight = Mark.create<HighlightOptions>({
   name: 'highlight',

--- a/packages/extension-italic/src/italic.ts
+++ b/packages/extension-italic/src/italic.ts
@@ -28,10 +28,10 @@ declare module '@tiptap/core' {
   }
 }
 
-export const starInputRegex = /(?:^|\s)((?:\*)((?:[^*]+))(?:\*))$/
-export const starPasteRegex = /(?:^|\s)((?:\*)((?:[^*]+))(?:\*))/g
-export const underscoreInputRegex = /(?:^|\s)((?:_)((?:[^_]+))(?:_))$/
-export const underscorePasteRegex = /(?:^|\s)((?:_)((?:[^_]+))(?:_))/g
+export const starInputRegex = /(?:^|\s)(\*(?!\s+\*)((?:[^*]+))\*(?!\s+\*))$/
+export const starPasteRegex = /(?:^|\s)(\*(?!\s+\*)((?:[^*]+))\*(?!\s+\*))/g
+export const underscoreInputRegex = /(?:^|\s)(_(?!\s+_)((?:[^_]+))_(?!\s+_))$/
+export const underscorePasteRegex = /(?:^|\s)(_(?!\s+_)((?:[^_]+))_(?!\s+_))/g
 
 export const Italic = Mark.create<ItalicOptions>({
   name: 'italic',

--- a/packages/extension-strike/src/strike.ts
+++ b/packages/extension-strike/src/strike.ts
@@ -29,8 +29,8 @@ declare module '@tiptap/core' {
   }
 }
 
-export const inputRegex = /(?:^|\s)((?:~~)((?:[^~]+))(?:~~))$/
-export const pasteRegex = /(?:^|\s)((?:~~)((?:[^~]+))(?:~~))/g
+export const inputRegex = /(?:^|\s)(~~(?!\s+~~)((?:[^~]+))~~(?!\s+~~))$/
+export const pasteRegex = /(?:^|\s)(~~(?!\s+~~)((?:[^~]+))~~(?!\s+~~))/g
 
 export const Strike = Mark.create<StrikeOptions>({
   name: 'strike',


### PR DESCRIPTION
## Please describe your changes

This PR disallows Markdown shortcuts (through typing or pasting) for all marks (`Bold`, `Code`, `Highlight`, `Italic`, and `Strike`) when the **content between the delimiters is only whitespace**.

## How did you accomplish your changes

Changed the input and paste Regex for all the marks mentioned above to keep supporting as much as possible from the current syntax, while only disallowing "empty strings" between the delimiters for the Markdown shortcuts of each mark.

> [!NOTE]
> The regular expression for all marks follows the exact same pattern, the only difference being the delimiter characters for each mark.

## How have you tested your changes

I've used both [regex101.com](https://regex101.com/):

![firefox_wzo9ORdntq](https://github.com/ueberdosis/tiptap/assets/96476/60d473d7-1c89-4b2c-9a1d-8ac9502b959f)


And the marks demos to test multiple patterns, here's an example for the `Highlight` extension:

![NVIDIA_Share_RoSfI1pELP](https://github.com/ueberdosis/tiptap/assets/96476/ebcb866d-6613-4c76-8317-4fcc1697bbe5)

## How can we verify your changes

The same way I did above.