### PR TITLE
return invokation of command

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -99,7 +99,7 @@ export function Suggestion<I = any>({
             text: state.text,
             items: [],
             command: commandProps => {
-              command({
+              return command({
                 editor,
                 range: state.range,
                 props: commandProps,


### PR DESCRIPTION
## Please describe your changes

Return the invocation of command in order to get access to the return value in rendering component.

This allows one to act on it when for example doing an async action before updating the editor, like getting a suggestion from ChatGPT or fetching a response from an api to be inserted.

## How did you accomplish your changes

return the invocation of `command`

## How have you tested your changes

In my own SlashMenu extension based on https://tiptap.dev/docs/editor/experiments/commands where I wanted to render a spinner if the item command function returned a promise.

## How can we verify your changes

Return something from the items command function and check the value in the rendering component 
```javascript
// suggestion.js
return [
  {
    title: 'H1',
    command: ({ editor, range }) => {
      return new Promise((resolve) => {
        setTimeout(() => {
          editor
            .chain()
            .focus()
            .deleteRange(range)
            .setNode('heading', { level: 1 })
            .run()
          resolve()
        }, 1000)
      })
    },
  }
]


// CommandsList.vue
if (item) {
  console.log(this.command(item))
}
```

## Remarks

I didn't update the types of supported return value from the commands function, happy to get input on how to do that for increased type safety for supported return values

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues
