### PR TITLE
fix: mark nocookie youtube url as valid when parsing html

### DIFF
--- a/packages/extension-youtube/src/utils.ts
+++ b/packages/extension-youtube/src/utils.ts
@@ -1,4 +1,4 @@
-export const YOUTUBE_REGEX = /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be)\/(?!channel\/)(?!@)(.+)?$/
+export const YOUTUBE_REGEX = /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be|youtube-nocookie\.com)\/(?!channel\/)(?!@)(.+)?$/
 export const YOUTUBE_REGEX_GLOBAL = /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be)\/(?!channel\/)(?!@)(.+)?$/g
 
 export const isValidYoutubeUrl = (url: string) => {

--- a/tests/cypress/integration/extensions/youtube.spec.ts
+++ b/tests/cypress/integration/extensions/youtube.spec.ts
@@ -57,4 +57,32 @@ describe('extension-youtube', () => {
       getEditorEl()?.remove()
     })
   })
+
+  it('when nocookie youtube url is passed, still outputs html with iframe with the url', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        Youtube,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'youtube',
+            attrs: {
+              src: 'https://www.youtube-nocookie.com/embed/testvideoid',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(editor.getHTML()).to.include('https://www.youtube-nocookie.com/embed/testvideoid')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
 })


### PR DESCRIPTION
## Please describe your changes

Extended the `YOUTUBE_REGEX` in youtube extension to consider nocookie URL as valid.

## How did you accomplish your changes

Added `youtube-nocookie\.com` into the regex.

## How have you tested your changes

Locally via link to my app and added automated tests.

## How can we verify your changes

Set content of the editor to e.g.

```html
<div data-youtube-video=""><iframe class="w-full aspect-video" width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" src="https://www.youtube-nocookie.com/embed/dh72Dz0OqLk" start="0"></iframe></div>
```

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

[add a link to the related issues here]
