### PR TITLE
feat(extension-link): add openOnMetaClick option to handle meta/ctrl on click

### DIFF
--- a/packages/extension-link/CHANGELOG.md
+++ b/packages/extension-link/CHANGELOG.md
@@ -5,6 +5,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.2.3](https://github.com/ueberdosis/tiptap/compare/v2.2.2...v2.2.3) (2024-02-15)
 
+Add openOnMetaClick option to link extension
+**Note:** Version bump only for package @tiptap/extension-link
+
+## [2.2.3](https://github.com/ueberdosis/tiptap/compare/v2.2.2...v2.2.3) (2024-02-15)
+
 **Note:** Version bump only for package @tiptap/extension-link
 
 

--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tiptap/extension-link",
   "description": "link extension for tiptap",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "homepage": "https://tiptap.dev",
   "keywords": [
     "tiptap",

--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -4,6 +4,7 @@ import { Plugin, PluginKey } from '@tiptap/pm/state'
 
 type ClickHandlerOptions = {
   type: MarkType
+  withCMD: boolean
 }
 
 export function clickHandler(options: ClickHandlerOptions): Plugin {
@@ -12,6 +13,10 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
     props: {
       handleClick: (view, pos, event) => {
         if (event.button !== 0) {
+          return false
+        }
+
+        if (options.withCMD && !(event.metaKey || event.ctrlKey)) {
           return false
         }
 

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -29,6 +29,10 @@ export interface LinkOptions {
    */
   openOnClick: boolean
   /**
+   * If enabled, links will be opened on click+META or click+CTRL.
+   */
+  openOnMetaClick: boolean
+  /**
    * Adds a link to the current selection if the pasted content only contains an url.
    */
   linkOnPaste: boolean
@@ -207,6 +211,14 @@ export const Link = Mark.create<LinkOptions>({
       plugins.push(
         clickHandler({
           type: this.type,
+          'withCMD': false
+        }),
+      )
+    } else if (this.options.openOnMetaClick) {
+      plugins.push(
+        clickHandler({
+          type: this.type,
+          'withCMD': true
         }),
       )
     }


### PR DESCRIPTION
## Please describe your changes

Add new option to link extension. `openOnMetaClick`. When it is true clicks on the link will work only when CMD/Ctrl are pressed.

## How did you accomplish your changes

[add a detailed description of how you accomplished your changes here]

## How have you tested your changes

[add a detailed description of how you tested your changes here]

## How can we verify your changes

[add a detailed description of how we can verify your changes here]

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

[add a link to the related issues here]
