### PR TITLE
Initialize editor before setting event handlers

### DIFF
--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -32,6 +32,26 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
   const onTransactionRef = useRef(onTransaction)
   const onUpdateRef = useRef(onUpdate)
 
+  useEffect(() => {
+    let isMounted = true
+
+    editorRef.current = new Editor(options)
+
+    editorRef.current.on('transaction', () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (isMounted) {
+            forceUpdate({})
+          }
+        })
+      })
+    })
+
+    return () => {
+      isMounted = false
+    }
+  }, deps)
+
   // This effect will handle updating the editor instance
   // when the event handlers change.
   useEffect(() => {
@@ -95,26 +115,6 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
       onUpdateRef.current = onUpdate
     }
   }, [onBeforeCreate, onBlur, onCreate, onDestroy, onFocus, onSelectionUpdate, onTransaction, onUpdate, editorRef.current])
-
-  useEffect(() => {
-    let isMounted = true
-
-    editorRef.current = new Editor(options)
-
-    editorRef.current.on('transaction', () => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (isMounted) {
-            forceUpdate({})
-          }
-        })
-      })
-    })
-
-    return () => {
-      isMounted = false
-    }
-  }, deps)
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Please describe your changes

Currently, the editor is initialized after the callback bindings are hooked up. The two `useEffect` call order should be swapped. The one that hooks up callbacks is run first, then the one where the instance is created is run second. This means there is an attempt to set bindings when the editor does not exists. And once it is created, it needs to re-render and hook up the callbacks again.

## How did you accomplish your changes

Moving `useEffect` that creates editor instance to be the first one to run.

## How have you tested your changes

I have tested it with my basic editor. I haven't run extensive testing.

## How can we verify your changes

It should still work the same way it does now from API and user perspective. There will be just one less re-render on initial mount. 

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
