### PR TITLE
fix (mention/heading): clashing heading markdown command and mention/suggestion with #

### DIFF
--- a/demos/src/Examples/HeadingMultipleMention/React/MentionList.jsx
+++ b/demos/src/Examples/HeadingMultipleMention/React/MentionList.jsx
@@ -1,0 +1,70 @@
+import './MentionList.scss'
+
+import React, {
+  forwardRef, useEffect, useImperativeHandle,
+  useState,
+} from 'react'
+
+export default forwardRef((props, ref) => {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  const selectItem = index => {
+    const item = props.items[index]
+
+    if (item) {
+      props.command({ id: item })
+    }
+  }
+
+  const upHandler = () => {
+    setSelectedIndex((selectedIndex + props.items.length - 1) % props.items.length)
+  }
+
+  const downHandler = () => {
+    setSelectedIndex((selectedIndex + 1) % props.items.length)
+  }
+
+  const enterHandler = () => {
+    selectItem(selectedIndex)
+  }
+
+  useEffect(() => setSelectedIndex(0), [props.items])
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }) => {
+      if (event.key === 'ArrowUp') {
+        upHandler()
+        return true
+      }
+
+      if (event.key === 'ArrowDown') {
+        downHandler()
+        return true
+      }
+
+      if (event.key === 'Enter') {
+        enterHandler()
+        return true
+      }
+
+      return false
+    },
+  }))
+
+  return (
+    <div className="items">
+      {props.items.length
+        ? props.items.map((item, index) => (
+          <button
+            className={`item ${index === selectedIndex ? 'is-selected' : ''}`}
+            key={index}
+            onClick={() => selectItem(index)}
+          >
+            {item}
+          </button>
+        ))
+        : <div className="item">No result</div>
+      }
+    </div>
+  )
+})

--- a/demos/src/Examples/HeadingMultipleMention/React/MentionList.scss
+++ b/demos/src/Examples/HeadingMultipleMention/React/MentionList.scss
@@ -1,0 +1,25 @@
+.items {
+  background: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0px 10px 20px rgba(0, 0, 0, 0.1);
+  color: rgba(0, 0, 0, 0.8);
+  font-size: 0.9rem;
+  overflow: hidden;
+  padding: 0.2rem;
+  position: relative;
+}
+
+.item {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.4rem;
+  display: block;
+  margin: 0;
+  padding: 0.2rem 0.4rem;
+  text-align: left;
+  width: 100%;
+
+  &.is-selected {
+    border-color: #000;
+  }
+}

--- a/demos/src/Examples/HeadingMultipleMention/React/index.jsx
+++ b/demos/src/Examples/HeadingMultipleMention/React/index.jsx
@@ -1,0 +1,42 @@
+import './styles.scss'
+
+import Mention from '@tiptap/extension-mention'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import React from 'react'
+
+import mention from './mention.js'
+import pageLink from './pageLink.js'
+
+export default () => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Mention.extend({ name: 'mention' }).configure({
+        HTMLAttributes: {
+          class: 'mention',
+        },
+        suggestion: mention,
+      }),
+      Mention.extend({ name: 'page-link' }).configure({
+        HTMLAttributes: {
+          class: 'page-link',
+        },
+        suggestion: pageLink,
+      }),
+    ],
+    content: `
+        <p>Hi everyone! Don’t forget the daily stand up at 8 AM. Read <span data-type="page-link" data-id="Page about cats"></span></p>
+        <p><span data-type="mention" data-id="Jennifer Grey"></span> Would you mind to share what you’ve been working on lately? We fear not much happened since Dirty Dancing.
+        <p><span data-type="mention" data-id="Winona Ryder"></span> <span data-type="mention" data-id="Axl Rose"></span> Let’s go through your most important points quickly.</p>
+        <p>I have a meeting with <span data-type="mention" data-id="Christina Applegate"></span> and don’t want to come late.</p>
+        <p>– Thanks, your big boss</p>
+      `,
+  })
+
+  if (!editor) {
+    return null
+  }
+
+  return <EditorContent editor={editor} />
+}

--- a/demos/src/Examples/HeadingMultipleMention/React/index.spec.js
+++ b/demos/src/Examples/HeadingMultipleMention/React/index.spec.js
@@ -1,0 +1,40 @@
+context('/src/Examples/HeadingMultipleMention/React/', () => {
+  before(() => {
+    cy.visit('/src/Examples/HeadingMultipleMention/React/')
+  })
+  beforeEach(() => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.commands.setContent('<p></p>')
+    })
+  })
+
+  it('selecting element from page link doesn\'t trigger heading', () => {
+    cy.get('.tiptap')
+      .type('\n#')
+      .type('{downarrow}')
+      .type('{enter}')
+      .should('contain', 'Dogs page')
+      .get('h1')
+      .should('not.exist')
+  })
+  it('page link and user mention works together', () => {
+    cy.get('.tiptap')
+      .type('\n#')
+      .type('{downarrow}')
+      .type('{enter}')
+      .should('contain', 'Dogs page')
+      .type(' @')
+      .type('{downarrow}')
+      .type('{enter}')
+      .should('contain', 'Cyndi Lauper')
+      .get('h1')
+      .should('not.exist')
+  })
+  it('can still trigger heading if nothing is selected from mention', () => {
+    cy.get('.tiptap')
+      .type('\n# Heading!')
+      .get('h1')
+      .should('contain', 'Heading!')
+
+  })
+})

--- a/demos/src/Examples/HeadingMultipleMention/React/mention.js
+++ b/demos/src/Examples/HeadingMultipleMention/React/mention.js
@@ -1,0 +1,98 @@
+import { PluginKey } from '@tiptap/pm/state'
+import { ReactRenderer } from '@tiptap/react'
+import tippy from 'tippy.js'
+
+import MentionList from './MentionList.jsx'
+
+const mentionPluginKey = new PluginKey('mention')
+
+export default {
+  pluginKey: mentionPluginKey,
+  char: '@',
+  items: ({ query }) => {
+    return [
+      'Lea Thompson',
+      'Cyndi Lauper',
+      'Tom Cruise',
+      'Madonna',
+      'Jerry Hall',
+      'Joan Collins',
+      'Winona Ryder',
+      'Christina Applegate',
+      'Alyssa Milano',
+      'Molly Ringwald',
+      'Ally Sheedy',
+      'Debbie Harry',
+      'Olivia Newton-John',
+      'Elton John',
+      'Michael J. Fox',
+      'Axl Rose',
+      'Emilio Estevez',
+      'Ralph Macchio',
+      'Rob Lowe',
+      'Jennifer Grey',
+      'Mickey Rourke',
+      'John Cusack',
+      'Matthew Broderick',
+      'Justine Bateman',
+      'Lisa Bonet',
+    ]
+      .filter(item => item.toLowerCase().startsWith(query.toLowerCase()))
+      .slice(0, 5)
+  },
+
+  render: () => {
+    let component
+    let popup
+
+    return {
+      onStart: props => {
+        component = new ReactRenderer(MentionList, {
+          props,
+          editor: props.editor,
+        })
+
+        if (!props.clientRect) {
+          return
+        }
+
+        popup = tippy('body', {
+          getReferenceClientRect: props.clientRect,
+          appendTo: () => document.body,
+          content: component.element,
+          showOnCreate: true,
+          interactive: true,
+          trigger: 'manual',
+          placement: 'bottom-start',
+        })
+      },
+
+      onUpdate(props) {
+        component.updateProps(props)
+
+        if (!props.clientRect) {
+          return
+        }
+
+        popup[0].setProps({
+          getReferenceClientRect: props.clientRect,
+        })
+      },
+
+      onKeyDown(props) {
+        if (props.event.key === 'Escape') {
+          popup[0].hide()
+
+          return true
+        }
+
+        return component.ref?.onKeyDown(props)
+      },
+
+      onExit() {
+        popup[0].destroy()
+        component.destroy()
+      },
+    }
+  },
+}

--- a/demos/src/Examples/HeadingMultipleMention/React/pageLink.js
+++ b/demos/src/Examples/HeadingMultipleMention/React/pageLink.js
@@ -1,0 +1,76 @@
+import { PluginKey } from '@tiptap/pm/state'
+import { ReactRenderer } from '@tiptap/react'
+import tippy from 'tippy.js'
+
+import MentionList from './MentionList.jsx'
+
+const pageLinkKey = new PluginKey('pageLink')
+
+export default {
+  char: '#',
+  pluginKey: pageLinkKey,
+  items: ({ query }) => {
+    return [
+      'Page about cats',
+      'Dogs page',
+      'List of weird animals',
+    ]
+      .filter(item => item.toLowerCase().startsWith(query.toLowerCase()))
+      .slice(0, 5)
+  },
+
+  render: () => {
+    let component
+    let popup
+
+    return {
+      onStart: props => {
+        component = new ReactRenderer(MentionList, {
+          props,
+          editor: props.editor,
+        })
+
+        if (!props.clientRect) {
+          return
+        }
+
+        popup = tippy('body', {
+          getReferenceClientRect: props.clientRect,
+          appendTo: () => document.body,
+          content: component.element,
+          showOnCreate: true,
+          interactive: true,
+          trigger: 'manual',
+          placement: 'bottom-start',
+        })
+      },
+
+      onUpdate(props) {
+        component.updateProps(props)
+
+        if (!props.clientRect) {
+          return
+        }
+
+        popup[0].setProps({
+          getReferenceClientRect: props.clientRect,
+        })
+      },
+
+      onKeyDown(props) {
+        if (props.event.key === 'Escape') {
+          popup[0].hide()
+
+          return true
+        }
+
+        return component.ref?.onKeyDown(props)
+      },
+
+      onExit() {
+        popup[0].destroy()
+        component.destroy()
+      },
+    }
+  },
+}

--- a/demos/src/Examples/HeadingMultipleMention/React/styles.scss
+++ b/demos/src/Examples/HeadingMultipleMention/React/styles.scss
@@ -1,0 +1,12 @@
+.tiptap {
+  > * + * {
+    margin-top: 0.75em;
+  }
+}
+
+.mention, .page-link{
+  border: 1px solid #000;
+  border-radius: 0.4rem;
+  box-decoration-break: clone;
+  padding: 0.1rem 0.3rem;
+}

--- a/docs/api/nodes/mention.md
+++ b/docs/api/nodes/mention.md
@@ -83,3 +83,7 @@ Mention.configure({
 
 ## Usage
 https://embed.tiptap.dev/preview/Nodes/Mention
+
+### Notes
+
+The mention node has higher priority (101 instead of the default 100) so it can get priority over heading markdown command when used with `#`.

--- a/packages/extension-heading/src/heading.ts
+++ b/packages/extension-heading/src/heading.ts
@@ -1,4 +1,6 @@
-import { mergeAttributes, Node, textblockTypeInputRule } from '@tiptap/core'
+import {
+  inputRulesPlugin, mergeAttributes, Node, textblockTypeInputRule,
+} from '@tiptap/core'
 
 export type Level = 1 | 2 | 3 | 4 | 5 | 6
 
@@ -92,8 +94,10 @@ export const Heading = Node.create<HeadingOptions>({
     }), {})
   },
 
-  addInputRules() {
-    return this.options.levels.map(level => {
+  // This is added as a PM plugin instead of an input rule so it can be pre-empted by other plugins with higher priority
+  // Fixes the bug where the '#' char couldn't get to the Suggestion plugin
+  addProseMirrorPlugins() {
+    const rules = this.options.levels.map(level => {
       return textblockTypeInputRule({
         find: new RegExp(`^(#{1,${level}})\\s$`),
         type: this.type,
@@ -102,5 +106,7 @@ export const Heading = Node.create<HeadingOptions>({
         },
       })
     })
+
+    return [inputRulesPlugin({ editor: this.editor, rules })]
   },
 })

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -16,7 +16,8 @@ export const MentionPluginKey = new PluginKey('mention')
 
 export const Mention = Node.create<MentionOptions>({
   name: 'mention',
-
+  // Fixes collision with Heading '#' input rule
+  priority: 101,
   addOptions() {
     return {
       HTMLAttributes: {},


### PR DESCRIPTION
## Please describe your changes

Fixes https://github.com/ueberdosis/tiptap/issues/2570
Now mention nodes with # will preempt the heading markdown input rule

## How did you accomplish your changes

Instead of using `addInputRules` I've added the heading input rule as a separate ProseMirror plugin. After this higher priority extensions will be ahead of this input rule. For the same reason I set the Mention node's priority to 101.

## How have you tested your changes

Added 3 E2E tests, one checks if there's no heading created is something is selected from the mention lis, one checks that we can still use the heading shortcut if we don't select anything, one checks if two mention plugins with '@' and '#' can work together.

## How can we verify your changes

Run the E2E test, or visit `preview/Examples/HeadingMultipleMention`

## Remarks

Added some documentation to Mention about higher priority.

## Checklist

- [ x] The changes are not breaking the editor
- [ x] Added tests where possible
- [ x] Followed the guidelines
- [ x] Fixed linting issues
