### PR TITLE
Fixes resizeable columns when the first row has a colspan

### DIFF
--- a/demos/src/Examples/Tables/React/index.jsx
+++ b/demos/src/Examples/Tables/React/index.jsx
@@ -155,8 +155,8 @@ export default () => {
       <table>
         <tbody>
           <tr>
-            <th>Name</th>
-            <th colspan="3">Description</th>
+            <th colwidth="200">Name</th>
+            <th colspan="3" colwidth="150,100">Description</th>
           </tr>
           <tr>
             <td>Cyndi Lauper</td>

--- a/packages/extension-table-cell/src/table-cell.ts
+++ b/packages/extension-table-cell/src/table-cell.ts
@@ -28,7 +28,7 @@ export const TableCell = Node.create<TableCellOptions>({
         parseHTML: element => {
           const colwidth = element.getAttribute('colwidth')
           const value = colwidth
-            ? [parseInt(colwidth, 10)]
+            ? colwidth.split(',').map(width => parseInt(width, 10))
             : null
 
           return value

--- a/packages/extension-table-header/src/table-header.ts
+++ b/packages/extension-table-header/src/table-header.ts
@@ -27,7 +27,7 @@ export const TableHeader = Node.create<TableHeaderOptions>({
         parseHTML: element => {
           const colwidth = element.getAttribute('colwidth')
           const value = colwidth
-            ? [parseInt(colwidth, 10)]
+            ? colwidth.split(',').map(width => parseInt(width, 10))
             : null
 
           return value


### PR DESCRIPTION
The width of columns get lost when the first row has a colspan that spans the sized columns because the colwidth (which has a comma separated list of column-widths) gets cast to an int and thus removing the other column-widths

## Please describe your changes

The comma separated column-widths for the spanned columns are now split before that are cast to an int.

## How did you accomplish your changes

By calling .split on the colwidth variable each width can be parsed separately. 

## How have you tested your changes

I added the colwidth attribute to the existing example and noticed that it did not behave as expected. Only the first of the spanned columns got the right width. After I changed the code the result was like expected and all columns have the right size, either the given pixel value or it fills the remaining space.

## How can we verify your changes

1. Create a table
2. Merge the columns/cells of the first row
3. Resize multiple columns that are spanned by the first row
4. Use the output HTML as the input for a new table when tiptap loads
5. The size of each column must be equal to the value that it was given.

## Remarks

The issue was with both TableCell and TableHeader

## Checklist

- [v] The changes are not breaking the editor
- [ ] Added tests where possible
- [v] Followed the guidelines
- [ ] Fixed linting issues

## Related issues
