### PR TITLE
React: fix editor cleanup

### DIFF
--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -99,7 +99,8 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
   useEffect(() => {
     let isMounted = true
 
-    editorRef.current = new Editor(options)
+    const editor = new Editor(options)
+    editorRef.current = editor
 
     editorRef.current.on('transaction', () => {
       requestAnimationFrame(() => {
@@ -113,14 +114,9 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
 
     return () => {
       isMounted = false
+      editor.destroy()
     }
   }, deps)
-
-  useEffect(() => {
-    return () => {
-      return editorRef.current?.destroy()
-    }
-  }, [])
 
   return editorRef.current
 }


### PR DESCRIPTION
## Please describe your changes

Hi! I noticed that editor.destroy() is not being called for each reference that is being created, this should fix the problem.

## How did you accomplish your changes

Cleaning up editor was moved to the return of useEffect that creates a new editor, this way for each editor instantiated there will be a respective cleanup fn.

## How have you tested your changes

## How can we verify your changes

[add a detailed description of how we can verify your changes here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

