### PR TITLE
fix for data attributes not rendering after pr #4082

### DIFF
--- a/docs/api/nodes/mention.md
+++ b/docs/api/nodes/mention.md
@@ -61,7 +61,7 @@ Mention.configure({
   renderHTML({ options, node }) {
     return [
       "a",
-      { href: '/profile/1' },
+      mergeAttributes({ href: '/profile/1' }, options.HTMLAttributes),
       `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`,
       ];
   }

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -26,7 +26,7 @@ export const Mention = Node.create<MentionOptions>({
       renderHTML({ options, node }) {
         return [
           'span',
-          this.HTMLAttributes,
+          mergeAttributes(this.HTMLAttributes, options.HTMLAttributes),
           `${options.suggestion.char}${node.attrs.label ?? node.attrs.id}`,
         ]
       },
@@ -131,8 +131,11 @@ export const Mention = Node.create<MentionOptions>({
         }),
       ]
     }
+    const mergedOptions = { ...this.options }
+
+    mergedOptions.HTMLAttributes = mergeAttributes({ 'data-type': this.name }, this.options.HTMLAttributes, HTMLAttributes)
     const html = this.options.renderHTML({
-      options: this.options,
+      options: mergedOptions,
       node,
     })
 


### PR DESCRIPTION
## Please describe your changes

after pr #4082 there is a regression where data attributes don't trickle down to the last render function, this fixes it

## How did you accomplish your changes

I passed the html attributes to the last `renderHtml` by merging

## How have you tested your changes

I ran the demo and verified the rendered attributes

## How can we verify your changes

run the demo and inspect the mention elements, you should see data attributes render correctly

## Remarks

Not sure if this is the right way to accomplish this since it is mutating the options object, the other fix would be to change the type of `renderHTML` to `  renderHTML: (props: { options: MentionOptions; node: ProseMirrorNode, HTMLAttributes?:Record<string, any>}) => DOMOutputSpec
` and pass the merged attributes

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [x] Fixed linting issues

## Related issues

#4082 
