### PR TITLE
docs: Fix keyboard shortcut for strikethrough

### DIFF
--- a/docs/api/keyboard-shortcuts.md
+++ b/docs/api/keyboard-shortcuts.md
@@ -27,7 +27,7 @@ Most of the core extensions register their own keyboard shortcuts. Depending on 
 | Bold          | `Control`&nbsp;`B`              | `Cmd`&nbsp;`B`              |
 | Italicize     | `Control`&nbsp;`I`              | `Cmd`&nbsp;`I`              |
 | Underline     | `Control`&nbsp;`U`              | `Cmd`&nbsp;`U`              |
-| Strikethrough | `Control`&nbsp;`Shift`&nbsp;`X` | `Cmd`&nbsp;`Shift`&nbsp;`X` |
+| Strikethrough | `Control`&nbsp;`Shift`&nbsp;`S` | `Cmd`&nbsp;`Shift`&nbsp;`S` |
 | Highlight     | `Control`&nbsp;`Shift`&nbsp;`H` | `Cmd`&nbsp;`Shift`&nbsp;`H` |
 | Code          | `Control`&nbsp;`E`              | `Cmd`&nbsp;`E`              |
 


### PR DESCRIPTION
## Please describe your changes

Simple PR to fix docs, with regards to the keyboard shortcut for strikethrough text formatting.

## How did you accomplish your changes

Simple markdown editing of `keyboard-shortcuts.md`.

## How have you tested your changes

Tested manually with Tiptap editor in React and Next.js projects.

## How can we verify your changes

Check the keyboard shortcuts that are defined in [strike extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-strike/src/strike.ts). 

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [ ] Fixed linting issues
