### PR TITLE
Add Vue 3.4+ composition api v-model example

### DIFF
--- a/docs/installation/nuxt.md
+++ b/docs/installation/nuxt.md
@@ -105,6 +105,33 @@ You’re probably used to bind your data with `v-model` in forms, that’s also 
 
 https://embed.tiptap.dev/preview/GuideGettingStarted/VModel
 
+Using the composition API with Vue 3.4+
+
+```html
+<template>
+  <ClientOnly>
+    <editor-content :editor="editor" />
+  </ClientOnly>
+</template>
+
+<script lang="ts" setup>
+import { useEditor, EditorContent } from "@tiptap/vue-3";
+import StarterKit from "@tiptap/starter-kit";
+
+const modelValue = defineModel();
+
+const editor = useEditor({
+  content: modelValue.value,
+  extensions: [StarterKit],
+  onUpdate: ({ editor }) => {
+    modelValue.value = editor.getHTML();
+  },
+});
+</script>
+```
+
+Or the Options API 
+
 ```html
 <template>
   <editor-content :editor="editor" />


### PR DESCRIPTION
## Please describe your changes

Added an example for Nuxt with Vue 3.4+ to use the v-model on the TipTap editor. 

## How did you accomplish your changes

I have managed it myself in my own project and will use it in production. 

## How have you tested your changes

Yes

## How can we verify your changes

Create a nuxt 3 project and add TipTap using the this code. 

## Remarks

x

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [] Fixed linting issues

## Related issues

x

