### PR TITLE
fix: make blockquote shortcut work in starter-kit

### DIFF
--- a/.changeset/five-tigers-kick.md
+++ b/.changeset/five-tigers-kick.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/starter-kit": patch
+---
+
+fix(starter-kit): make blockquote shortcut work in starter-kit

--- a/packages/starter-kit/src/starter-kit.ts
+++ b/packages/starter-kit/src/starter-kit.ts
@@ -139,12 +139,12 @@ export const StarterKit = Extension.create<StarterKitOptions>({
   addExtensions() {
     const extensions = []
 
-    if (this.options.blockquote !== false) {
-      extensions.push(Blockquote.configure(this.options?.blockquote))
-    }
-
     if (this.options.bold !== false) {
       extensions.push(Bold.configure(this.options?.bold))
+    }
+
+    if (this.options.blockquote !== false) {
+      extensions.push(Blockquote.configure(this.options?.blockquote))
     }
 
     if (this.options.bulletList !== false) {


### PR DESCRIPTION
Because blockquote uses `Mod-Shift-b`, and bold uses `Mod-b`, the bold shortcut will override the blockquote shortcut if added to the extensions later.

Fixes #4994

## Please describe your changes

Changed the order in which the `bold`/`blockquote` extensions are added in the starter-kit. This is because plugins added later will override plugins added earlier, because of f8efdf797a10a01235b75091729b15aca076e47a (#1547).

## How did you accomplish your changes

Changed the order in which the `bold`/`blockquote` extensions are added in the starter-kit. I realise that this breaks the alphabetical ordering, but it's more important that the shortcuts work correctly.

## How have you tested your changes

Tested locally with the `Examples/Default` editor, which uses `starter-kit`. 

## How can we verify your changes

Load the Examples/Default example and check that `Mod-shift-b` (`Control Shift B` / `Cmd Shift B`) toggles Blockquote, and that `Mod-b` (`Control B` / `Cmd B`) toggles Bold, as expected.

## Remarks

It would be better if `Mod-b` didn't override `Mod-shift-b` regardless of plugin order, but it seems like this is handled by Prosemirror.

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

* Fixes #4994
* Possibly caused by f8efdf797a10a01235b75091729b15aca076e47a (#1547)