### PR TITLE
Fix html docs page routing to itself

### DIFF
--- a/docs/links.yaml
+++ b/docs/links.yaml
@@ -336,7 +336,8 @@
               link: /api/extensions/unique-id
               type: pro
         - title: Utilities
-          link: /api/utilities/html
+          link: /api/utilities/
+          redirect: /api/utilities/html
           items:
             - title: HTML
               link: /api/utilities/html


### PR DESCRIPTION

## Please describe your changes

In the utlities/html docs page, the "next page" button now says Suggestions instead of HTML and routes to next page in docs. The changes redirects the api/utilities page to html instead of creating page as if it is the "utilities" page

## How did you accomplish your changes

Just a small change in the links.yaml that redirects to html page when clicking on utilities page

## How have you tested your changes

Check to see if the UI is updated with the correct link on api/utilities/html page

## How can we verify your changes

Check to see if the UI is updated with the correct link on api/utilities/html page

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

