### PR TITLE
Add `blockSeparator` option to `clipboardTextSerializer` core extension

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -9,7 +9,9 @@ import { EditorView } from '@tiptap/pm/view'
 import { CommandManager } from './CommandManager.js'
 import { EventEmitter } from './EventEmitter.js'
 import { ExtensionManager } from './ExtensionManager.js'
-import * as extensions from './extensions/index.js'
+import {
+  ClipboardTextSerializer, Commands, Editable, FocusEvents, Keymap, Tabindex,
+} from './extensions/index.js'
 import { createDocument } from './helpers/createDocument.js'
 import { getAttributes } from './helpers/getAttributes.js'
 import { getHTMLFromFragment } from './helpers/getHTMLFromFragment.js'
@@ -32,7 +34,7 @@ import {
 import { createStyleTag } from './utilities/createStyleTag.js'
 import { isFunction } from './utilities/isFunction.js'
 
-export { extensions }
+export * as extensions from './extensions/index.js'
 
 export interface HTMLElement {
   editor?: Editor
@@ -63,6 +65,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     editable: true,
     editorProps: {},
     parseOptions: {},
+    coreExtensionOptions: {},
     enableInputRules: true,
     enablePasteRules: true,
     enableCoreExtensions: true,
@@ -235,7 +238,17 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Creates an extension manager.
    */
   private createExtensionManager(): void {
-    const coreExtensions = this.options.enableCoreExtensions ? Object.values(extensions) : []
+
+    const coreExtensions = this.options.enableCoreExtensions ? [
+      Editable,
+      ClipboardTextSerializer.configure({
+        blockSeparator: this.options.coreExtensionOptions?.clipboardTextSerializer?.blockSeparator,
+      }),
+      Commands,
+      FocusEvents,
+      Keymap,
+      Tabindex,
+    ] : []
     const allExtensions = [...coreExtensions, ...this.options.extensions].filter(extension => {
       return ['extension', 'node', 'mark'].includes(extension?.type)
     })

--- a/packages/core/src/extensions/clipboardTextSerializer.ts
+++ b/packages/core/src/extensions/clipboardTextSerializer.ts
@@ -4,7 +4,11 @@ import { Extension } from '../Extension.js'
 import { getTextBetween } from '../helpers/getTextBetween.js'
 import { getTextSerializersFromSchema } from '../helpers/getTextSerializersFromSchema.js'
 
-export const ClipboardTextSerializer = Extension.create({
+export type ClipboardTextSerializerOptions = {
+  blockSeparator?: string,
+}
+
+export const ClipboardTextSerializer = Extension.create<ClipboardTextSerializerOptions>({
   name: 'clipboardTextSerializer',
 
   addOptions() {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,6 +59,11 @@ export interface EditorOptions {
   editable: boolean
   editorProps: EditorProps
   parseOptions: ParseOptions
+  coreExtensionOptions?: {
+    clipboardTextSerializer?: {
+      blockSeparator?: string
+    }
+  }
   enableInputRules: EnableRules
   enablePasteRules: EnableRules
   enableCoreExtensions: boolean


### PR DESCRIPTION
## Please describe your changes

This PR adds `blockSeparator` option to `clipboardTextSerializer` core extension. 

It will allow to override block separator (without copy pasting the entire extension from core) and add it to my editor.

```js
import { extensions } from '@tiptap/core';

const editor = new Editor({
  extensions: [
    extensions.ClipboardTextSerializer.configure({
      blockSeparator: '\n',
    }),
  ],
});
```

## How did you accomplish your changes

By making it possible to provide `blockSeparator` option to `clipboardTextSerializer` core extension.

## How have you tested your changes

I've copied the implementation from this PR to my project and tested it with and without `blockSeparator` parameter.

## How can we verify your changes

By doing this:

```js
import { extensions } from '@tiptap/core';

const editor = new Editor({
  extensions: [
    extensions.ClipboardTextSerializer.configure({
      blockSeparator: '\n',
    }),
  ],
});
```

## Remarks

If there is a better way to implement it, I'm open to it. 

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

N/A
