### PR TITLE
Draft: (vue-3) render node only once

### DIFF
--- a/packages/vue-3/src/Editor.ts
+++ b/packages/vue-3/src/Editor.ts
@@ -7,9 +7,10 @@ import {
   markRaw,
   reactive,
   Ref,
+  RendererElement,
+  RendererNode,
+  VNode,
 } from 'vue'
-
-import { VueRenderer } from './VueRenderer.js'
 
 function useDebouncedRef<T>(value: T) {
   return customRef<T>((track, trigger) => {
@@ -42,7 +43,9 @@ export class Editor extends CoreEditor {
 
   private reactiveExtensionStorage: Ref<Record<string, any>>
 
-  public vueRenderers = reactive<Map<string, VueRenderer>>(new Map())
+  public vueRenderers = reactive<Map<string, VNode<RendererNode, RendererElement, {
+    [key: string]: any;
+}>>>(new Map())
 
   public contentComponent: ContentComponent | null = null
 

--- a/packages/vue-3/src/EditorContent.ts
+++ b/packages/vue-3/src/EditorContent.ts
@@ -1,5 +1,4 @@
 import {
-  DefineComponent,
   defineComponent,
   getCurrentInstance,
   h,
@@ -8,7 +7,6 @@ import {
   PropType,
   Ref,
   ref,
-  Teleport,
   unref,
   watchEffect,
 } from 'vue'
@@ -91,22 +89,7 @@ export const EditorContent = defineComponent({
 
     if (this.editor) {
       this.editor.vueRenderers.forEach(vueRenderer => {
-        const node = h(
-          Teleport,
-          {
-            to: vueRenderer.teleportElement,
-            key: vueRenderer.id,
-          },
-          h(
-            vueRenderer.component as DefineComponent,
-            {
-              ref: vueRenderer.id,
-              ...vueRenderer.props,
-            },
-          ),
-        )
-
-        vueRenderers.push(node)
+        vueRenderers.push(vueRenderer)
       })
     }
 

--- a/packages/vue-3/src/VueRenderer.ts
+++ b/packages/vue-3/src/VueRenderer.ts
@@ -1,11 +1,27 @@
 import { Editor } from '@tiptap/core'
-import { Component, markRaw, reactive } from 'vue'
+import {
+  Component, DefineComponent, h, markRaw, reactive, Teleport,
+} from 'vue'
 
 import { Editor as ExtendedEditor } from './Editor.js'
 
 export interface VueRendererOptions {
   editor: Editor,
   props?: Record<string, any>,
+}
+
+const nodeRenderer = (node: VueRenderer) => {
+  return h(
+    Teleport,
+    {
+      to: node.teleportElement,
+      key: node.id,
+    },
+    h(node.component as DefineComponent, {
+      ref: node.id,
+      ...node.props,
+    }),
+  )
 }
 
 export class VueRenderer {
@@ -28,7 +44,10 @@ export class VueRenderer {
     this.teleportElement = document.createElement('div')
     this.element = this.teleportElement
     this.props = reactive(props)
-    this.editor.vueRenderers.set(this.id, this)
+
+    const nodeRendered = nodeRenderer(this)
+
+    this.editor.vueRenderers.set(this.id, nodeRendered)
 
     if (this.editor.contentComponent) {
       this.editor.contentComponent.update()


### PR DESCRIPTION
## Please describe your changes

In this PR we change the way nodes are rendered into Vue components and held in locale state during content loading.

For each node in `EditorContent.ts`, the current node and all its predecessors are rendered for each new node, which implies a performance issue.

To avoid all nodes being rendered each time, we now keep the rendered nodes as a reference

## How did you accomplish your changes

Since we cannot mutate the `Editor` props in `render` method of `EditorContent`, we move the logic to render a node in `VueRenderer.ts`.
Instead of keeping a Map of VueRenderer instance for each node, we keep the rendered VNodes in Map.

For each new node, we render it and add it to the existing Map.
The `render` method of `EditorContent` now retrieves the VNodes and renders them.

## How have you tested your changes

[add a detailed description of how you tested your changes here]

## How can we verify your changes

[add a detailed description of how we can verify your changes here]

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

[Link to the related issues here](https://github.com/ueberdosis/tiptap/issues/5031)
