### PR TITLE
Update link of hocuspocus in introduction.md

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -22,7 +22,7 @@ There is no provided user interface, you are absolutely free to build whatever i
 
 ## Do you enjoy real-time editing?
 
-Great! We do so, too. [Hocuspocus](https://hocuspocus.dev) is our yjs-based real-time solution for conflict-free text editing with Tiptap.
+Great! We do so, too. [Hocuspocus](https://tiptap.dev/docs/hocuspocus/introduction) is our yjs-based real-time solution for conflict-free text editing with Tiptap.
 
 Even better: Our managed solution [Tiptap Collab](https://tiptap.dev/collab) is just a few clicks away.<br />
 – Enhance your Tiptap experience with multiplayer support in minutes instead of hours.


### PR DESCRIPTION
## Please describe your changes

Changed hocuspocus link to refer to the actual hocuspocus page (https://tiptap.dev/docs/hocuspocus/introduction) instead of the URL https://hocuspocus.dev that redirects to https://tiptap.dev/

## How did you accomplish your changes

n/a

## How have you tested your changes

n/a

## How can we verify your changes

visually

## Remarks

n/a

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

n/a
