### PR TITLE
Tweak `getTextBetween` to prepend `blockSeparator` to block node even if block node doesn't have any children 

### DIFF
--- a/packages/core/src/helpers/getTextBetween.ts
+++ b/packages/core/src/helpers/getTextBetween.ts
@@ -13,17 +13,15 @@ export function getTextBetween(
   const { from, to } = range
   const { blockSeparator = '\n\n', textSerializers = {} } = options || {}
   let text = ''
-  let separated = true
 
   startNode.nodesBetween(from, to, (node, pos, parent, index) => {
+    if (node.isBlock && pos > from) {
+      text += blockSeparator
+    }
+
     const textSerializer = textSerializers?.[node.type.name]
 
     if (textSerializer) {
-      if (node.isBlock && !separated) {
-        text += blockSeparator
-        separated = true
-      }
-
       if (parent) {
         text += textSerializer({
           node,
@@ -39,10 +37,6 @@ export function getTextBetween(
 
     if (node.isText) {
       text += node?.text?.slice(Math.max(from, pos) - pos, to - pos) // eslint-disable-line
-      separated = false
-    } else if (node.isBlock && !separated) {
-      text += blockSeparator
-      separated = true
     }
   })
 


### PR DESCRIPTION
## Please describe your changes

Currently `getTextBetween` function doesn't prepend `blockSeparator` to block nodes without children.

This PR updates it to prepend `blockSeparator` to block nodes in any case (even if block node doesn't have any children).

## How did you accomplish your changes

I have tweaked the implementation to not depend on child nodes of blocks when deciding whether `blockSeparator` should be prepended. 

## How have you tested your changes

I used preview link generated by Netlify bot below.

## How can we verify your changes

Use preview link generated by Netlify bot below.

## Remarks

Below are before/after examples.

### Without empty paragraph 

```
Hello!
How are you?
```

Before: `'Hello!'+BLOCK_SEPARATOR+'How are you?'`
After: `'Hello!'+BLOCK_SEPARATOR+'How are you?'`

### With empty paragraphs

```
Hello!

How are you?
```

Before: `'Hello!'+BLOCK_SEPARATOR+'How are you?'`
After: `'Hello!'+BLOCK_SEPARATOR+BLOCK_SEPARATOR+'How are you?'` **(it's breaking change, but I consider it a bugfix)**

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

N/A