### PR TITLE
Fix failure to validate pasted links

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -33,7 +33,7 @@ function isValidLinkStructure(tokens: Array<ReturnType<MultiToken['toObject']>>)
 
 type AutolinkOptions = {
   type: MarkType
-  validate?: (url: string) => boolean
+  validate: (url: string) => boolean
 }
 
 export function autolink(options: AutolinkOptions): Plugin {
@@ -126,12 +126,7 @@ export function autolink(options: AutolinkOptions): Plugin {
               )
             })
             // validate link
-            .filter(link => {
-              if (options.validate) {
-                return options.validate(link.value)
-              }
-              return true
-            })
+            .filter(link => options.validate(link.value))
             // Add link mark.
             .forEach(link => {
               if (getMarksBetween(link.from, link.to, newState.doc).some(item => item.mark.type === options.type)) {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -99,7 +99,7 @@ export const Link = Mark.create<LinkOptions>({
         rel: 'noopener noreferrer nofollow',
         class: null,
       },
-      validate: value => true,
+      validate: url => !!url,
     }
   },
 
@@ -166,7 +166,7 @@ export const Link = Mark.create<LinkOptions>({
           const foundLinks: PasteRuleMatch[] = []
 
           if (text) {
-            const { validate } = this.options;
+            const { validate } = this.options
             const links = find(text).filter(item => item.isLink && validate(item.value))
 
             if (links.length) {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -41,7 +41,7 @@ export interface LinkOptions {
    * @param url - The url to be validated.
    * @returns - True if the url is valid, false otherwise.
    */
-  validate?: (url: string) => boolean
+  validate: (url: string) => boolean
 }
 
 declare module '@tiptap/core' {
@@ -99,7 +99,7 @@ export const Link = Mark.create<LinkOptions>({
         rel: 'noopener noreferrer nofollow',
         class: null,
       },
-      validate: undefined,
+      validate: value => true,
     }
   },
 
@@ -166,7 +166,8 @@ export const Link = Mark.create<LinkOptions>({
           const foundLinks: PasteRuleMatch[] = []
 
           if (text) {
-            const links = find(text).filter(item => item.isLink)
+            const { validate } = this.options;
+            const links = find(text).filter(item => item.isLink && validate(item.value))
 
             if (links.length) {
               links.forEach(link => (foundLinks.push({


### PR DESCRIPTION
Also defaults `validate` option to `val => !!val` rather than `undefined`

## Please describe your changes

Fix failure to validate pasted links (#5060)

## How did you accomplish your changes

Add code which was missing to check pasted links are valid like all others

## How have you tested your changes

I have not

## How can we verify your changes

Probably manually. I assume automated tests do not cover this since this regression was able to sneak into `2.2.0`

## Remarks

Fixes #5060

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

#5060
