### PR TITLE
Prevent history checkpoints during backspace in empty editor

### DIFF
--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -27,7 +27,6 @@ export const Keymap = Extension.create({
           ? parentPos === $anchor.pos
           : Selection.atStart(doc).from === pos
 
-        // 
         if (
           !empty
           || !parent.type.isTextblock

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -27,7 +27,14 @@ export const Keymap = Extension.create({
           ? parentPos === $anchor.pos
           : Selection.atStart(doc).from === pos
 
-        if (!empty || !isAtStart || !parent.type.isTextblock || parent.textContent.length) {
+        // 
+        if (
+          !empty
+          || !parent.type.isTextblock
+          || parent.textContent.length
+          || !isAtStart
+          || (isAtStart && $anchor.parent.type.name === 'paragraph') // prevent clearNodes when no nodes to clear, otherwise history stack is appended
+        ) {
           return false
         }
 


### PR DESCRIPTION
## Please describe your changes

Prevent running `clearNodes` when there's no nodes to clear to avoid useless history checkpoints

## How did you accomplish your changes

Check if the first node in editor is a paragraph and if so, return `false`

## How have you tested your changes

Locally

## How can we verify your changes

Locally and checking `editor.state.history$.done.eventCount`

## Remarks

It would be better if there were some `schema.nodes.defaultNode`, but in lieu of that I've assumed `paragraph` is the default.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

#5062