### PR TITLE
fix(docs): correct capitalization in signing header

### DIFF
--- a/docs/collaboration/webhook.md
+++ b/docs/collaboration/webhook.md
@@ -22,7 +22,7 @@ A sample payload of the webhook request looks like this:
 
 ### Signing
 
-All requests to your webhook URL will contain a header called `X-Hocuspocus-Signature-256` that signs the entire message with your secret. You can find it in the [settings](https://collab.tiptap.dev/apps/settings) of your Tiptap Collab app.
+All requests to your webhook URL will contain a header called `x-hocuspocus-signature-256` that signs the entire message with your secret. You can find it in the [settings](https://collab.tiptap.dev/apps/settings) of your Tiptap Collab app.
 
 ### Changelog
 


### PR DESCRIPTION
Lowercases the signing header for webhook requests.

The request header for signing webhook requests is displayed with capitalizations in the docs. 

HTTP headers are case insensitive, but if you're in (for example) a NextJS app and look for a `X-Hocuspocus-Signature-256` header in a webhook request, it'll return undefined. However, looking for a `x-hocuspocus-signature-256` header will work.
