### PR TITLE
fix issue with code pasting from VS Code when at the last line of code

### DIFF
--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -260,8 +260,15 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
 
             const { tr } = view.state
 
-            // create an empty code block
-            tr.replaceSelectionWith(this.type.create({ language }))
+            // create an empty code block´
+            // if the cursor is at the absolute end of the document, insert the code block before the cursor instead
+            // of replacing the selection as the replaceSelectionWith function will cause the insertion to
+            // happen at the previous node
+            if (view.state.selection.from === view.state.doc.nodeSize - (1 + (view.state.selection.$to.depth * 2))) {
+              tr.insert(view.state.selection.from - 1, this.type.create({ language }))
+            } else {
+              tr.replaceSelectionWith(this.type.create({ language }))
+            }
 
             // put cursor inside the newly created code block
             tr.setSelection(TextSelection.near(tr.doc.resolve(Math.max(0, tr.selection.from - 2))))


### PR DESCRIPTION
## Please describe your changes

This PR fixes an minor issue where code copied from VSCode wouldn't be correctly pasted at the end of a document because `replaceSelectionWith` would cause a buggy insertion when the end position of the selection is in a node at the end of the document.

## How did you accomplish your changes

I'm checking if the cursor is at the end - if so I insert the code block before the current position - otherwise I use the replaceSelectionWith function

## How have you tested your changes

Tested it locally in the default demo

## How can we verify your changes

See above

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
