### PR TITLE
fix: fix ts error for BubbleMenu and FloatingMenu in @tiptap/react

### DIFF
--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -5,7 +5,8 @@ import { useCurrentEditor } from './Context.js'
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 
-export type BubbleMenuProps = Omit<Optional<BubbleMenuPluginProps, 'pluginKey' | 'editor'>, 'element'> & {
+export type BubbleMenuProps = Omit<Optional<BubbleMenuPluginProps, 'pluginKey'>, 'element' | 'editor'> & {
+  editor: BubbleMenuPluginProps['editor'] | null;
   className?: string;
   children: React.ReactNode;
   updateDelay?: number;

--- a/packages/react/src/FloatingMenu.tsx
+++ b/packages/react/src/FloatingMenu.tsx
@@ -7,7 +7,8 @@ import { useCurrentEditor } from './Context.js'
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 
-export type FloatingMenuProps = Omit<Optional<FloatingMenuPluginProps, 'pluginKey' | 'editor'>, 'element'> & {
+export type FloatingMenuProps = Omit<Optional<FloatingMenuPluginProps, 'pluginKey'>, 'element' | 'editor'> & {
+  editor: FloatingMenuPluginProps['editor'] | null;
   className?: string,
   children: React.ReactNode
 }


### PR DESCRIPTION
## Please describe your changes

`useEditor` return type is `Editor | null` 
<img width="509" alt="image" src="https://github.com/ueberdosis/tiptap/assets/102515482/de577273-17f5-4322-8abe-6f91eb9a5d1c">
But `FloatingMenu` and `BubbleMenu`  's props of `editor` is `Editor | undefined` 
I have solved it.



[add a description of your changes here]
Change `FloatingMenu` and `BubbleMenu`  's props of `editor` from `Editor | undefined`  to `Editor | null`


## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues

## Related issues

[add a link to the related issues here]
