### PR TITLE
chore: add streamlined github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,40 +1,43 @@
-name: Bug report
+name: Bug Report
 title: "[Bug]: "
-description: You've found a bug within the editor core or one of the extensions? Feel free to create a bug report to help us fixing it.
+description: Found a bug in the editor core or one of the extensions? Report it here to help us improve.
 labels:
   - "Type: Bug"
   - "Category: Open Source"
   - "Status: New"
 body:
+  - type: markdown
+    attributes:
+      value: "### Please provide details to help us diagnose the bug."
   - type: input
     id: packages
     attributes:
-      label: Which packages did you experience the bug in?
-      description: Please list all packages that you are using.
+      label: Affected Packages
+      description: List the packages you were using when the bug occurred.
       placeholder: core, extension-mention, react
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: What Tiptap version are you using?
-      description: Please list the version of all packages that you are using.
+      label: Version(s)
+      description: Specify the version(s) of the affected packages.
       placeholder: 2.0.0
     validations:
       required: true
   - type: textarea
     id: problem
     attributes:
-      label: What’s the bug you are facing?
-      description: A clear and concise description of what the bug is.
-      placeholder: "I’m always frustrated when …"
+      label: Bug Description
+      description: Provide a clear and concise description of what the bug is.
+      placeholder: "The issue occurs when..."
     validations:
       required: true
   - type: dropdown
     id: browser
     attributes:
-      label: What browser are you using?
-      description: Please list the browser that you are using.
+      label: Browser Used
+      description: Select the browser where the bug was observed.
       options:
         - Chrome
         - Firefox
@@ -47,45 +50,38 @@ body:
     attributes:
       value: |
         ### CodeSandbox templates
-
-        * Javascript: https://codesandbox.io/s/tiptap-js-fv1lyo
-        * React: https://codesandbox.io/s/tiptap-react-qidlsv
-        * Vue 2: https://codesandbox.io/s/tiptap-vue-2-25nq3g
-        * Vue 3: https://codesandbox.io/p/sandbox/tiptap-vue-3-ci7q9h
+        Please use the appropriate template below to provide a code example:
+        * JavaScript: [JS Template](https://codesandbox.io/s/tiptap-js-fv1lyo)
+        * React: [React Template](https://codesandbox.io/s/tiptap-react-qidlsv)
+        * Vue 2: [Vue 2 Template](https://codesandbox.io/s/tiptap-vue-2-25nq3g)
+        * Vue 3: [Vue 3 Template](https://codesandbox.io/p/sandbox/tiptap-vue-3-ci7q9h)
   - type: input
     id: sandbox
     attributes:
-      label: Code example
-      description: "Can you provide a CodeSandbox, Stackblitz, GitHub repository or any other kind of code example? This way, we can reproduce your issue faster."
-      placeholder: https://codesandbox.io/s/tiptap-react-issue-template-nwvwck?file=/src/App.js
+      label: Code Example URL
+      description: "Link a CodeSandbox, Stackblitz, GitHub repository, or similar to help us reproduce the issue faster."
+      placeholder: https://codesandbox.io/s/example
     validations:
       required: false
   - type: textarea
     id: expectation
     attributes:
-      label: What did you expect to happen?
-      description: A clear and concise description of what you expected to happen.
+      label: Expected Behavior
+      description: Describe what you expected to happen.
     validations:
       required: true
   - type: textarea
     id: context
     attributes:
-      label: Anything to add? (optional)
-      description: "Add any other context, screenshots, videos or GIFs here."
+      label: Additional Context (Optional)
+      description: "Add any other context about the problem here, such as screenshots or videos."
   - type: checkboxes
     attributes:
-      label: Did you update your dependencies?
-      description: "Use `npm update` to update your dependencies."
+      label: Dependency Updates
+      description: "Have you updated your dependencies? This can often resolve issues."
       options:
-        - label: Yes, I’ve updated my dependencies to use the latest version of all packages.
+        - label: Yes, I've updated all my dependencies.
           required: true
-  - type: checkboxes
-    attributes:
-      label: Are you sponsoring us?
-      options:
-        - label: Yes, I’m a sponsor. 💖
-          required: false
   - type: markdown
     attributes:
-      value: |
-        Thanks for taking the time to send us feedback!
+      value: "Thank you for helping us improve our open-source projects by reporting this issue!"

--- a/.github/ISSUE_TEMPLATE/bug_report_pro.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_pro.yml
@@ -1,40 +1,43 @@
-name: Bug report (Tiptap Pro feature)
+name: Bug Report (Tiptap Pro)
 title: "[PRO]: "
-description: You have found a bug in one of the features of Tiptap Pro? Feel free to report your issue here.
+description: If you've encountered a bug with Tiptap Pro features, please report it here.
 labels:
   - "Type: Bug"
   - "Category: Pro"
   - "Status: New"
 body:
+  - type: markdown
+    attributes:
+      value: "### Please ensure this issue is for Tiptap Pro features only. Provide as much detail as possible to help us identify the issue quickly."
   - type: input
     id: packages
     attributes:
-      label: Which packages did you experience the bug in?
-      description: Please list all packages that you are using.
+      label: Affected Packages
+      description: List all Tiptap Pro packages where you experienced the bug.
       placeholder: core, extension-mention, react
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: What Tiptap version are you using?
-      description: Please list the version of all packages that you are using.
+      label: Version(s)
+      description: Specify the version(s) of the affected packages.
       placeholder: 2.0.0
     validations:
       required: true
   - type: textarea
     id: problem
     attributes:
-      label: What’s the bug you are facing?
-      description: A clear and concise description of what the bug is.
-      placeholder: "I’m always frustrated when …"
+      label: Description of the Bug
+      description: Provide a clear and concise description of what the bug is.
+      placeholder: "The issue occurs when..."
     validations:
       required: true
   - type: dropdown
     id: browser
     attributes:
-      label: What browser are you using?
-      description: Please list the browser that you are using.
+      label: Browser Used
+      description: Select the browser where the bug was observed.
       options:
         - Chrome
         - Firefox
@@ -45,47 +48,44 @@ body:
       required: true
   - type: markdown
     attributes:
+      value: "### Helpful Code Examples"
+  - type: markdown
+    attributes:
+      value: "Providing a CodeSandbox link is crucial for diagnosing issues faster. Below are templates you might use:"
+  - type: markdown
+    attributes:
       value: |
-        ### CodeSandbox templates
-
-        * Javascript: https://codesandbox.io/s/tiptap-js-fv1lyo
-        * React: https://codesandbox.io/s/tiptap-react-qidlsv
-        * Vue 2: https://codesandbox.io/s/tiptap-vue-2-25nq3g
-        * Vue 3: https://codesandbox.io/p/sandbox/tiptap-vue-3-ci7q9h
+        - JavaScript: [Template](https://codesandbox.io/s/tiptap-js-fv1lyo)
+        - React: [Template](https://codesandbox.io/s/tiptap-react-qidlsv)
+        - Vue 2: [Template](https://codesandbox.io/s/tiptap-vue-2-25nq3g)
+        - Vue 3: [Template](https://codesandbox.io/p/sandbox/tiptap-vue-3-ci7q9h)
   - type: input
     id: sandbox
     attributes:
-      label: Code example
-      description: "Can you provide a CodeSandbox, Stackblitz, GitHub repository or any other kind of code example? This way, we can reproduce your issue faster."
-      placeholder: https://codesandbox.io/s/tiptap-react-issue-template-nwvwck?file=/src/App.js
+      label: Code Example (Preferred)
+      description: "Provide a link to a CodeSandbox or other code repository to help us reproduce the issue."
+      placeholder: https://codesandbox.io/s/example
     validations:
       required: false
   - type: textarea
     id: expectation
     attributes:
-      label: What did you expect to happen?
-      description: A clear and concise description of what you expected to happen.
+      label: Expected Behavior
+      description: Describe what you expected to happen.
     validations:
       required: true
   - type: textarea
     id: context
     attributes:
-      label: Anything to add? (optional)
-      description: "Add any other context, screenshots, videos or GIFs here."
+      label: Additional Context (Optional)
+      description: "Add any other context about the problem here, like screenshots or videos."
   - type: checkboxes
     attributes:
-      label: Did you update your dependencies?
-      description: "Use `npm update` to update your dependencies."
+      label: Dependency Updates
+      description: "Have you updated your dependencies? It can often resolve issues."
       options:
-        - label: Yes, I’ve updated my dependencies to use the latest version of all packages.
+        - label: Yes, I've updated all my dependencies.
           required: true
-  - type: checkboxes
-    attributes:
-      label: Are you sponsoring us?
-      options:
-        - label: Yes, I’m a sponsor. 💖
-          required: false
   - type: markdown
     attributes:
-      value: |
-        Thanks for taking the time to send us feedback!
+      value: "Thank you for contributing to Tiptap Pro by reporting this issue!"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,16 +2,16 @@ blank_issues_enabled: false
 contact_links:
   - name: New Feature Request
     url: https://github.com/ueberdosis/tiptap/discussions/new?category=feature-requests
-    about: You want to create a new feature request for Tiptap? Feel free to do so here.
+    about: Interested in proposing a new feature for Tiptap? Submit your feature request here.
   - name: Help & Support
     url: https://github.com/ueberdosis/tiptap/discussions/new?category=questions-help
-    about: You need help with Tiptap or have a question? Feel free to ask here.
+    about: Require assistance or have inquiries about using Tiptap? Ask your questions here.
   - name: Join our Discord
     url: https://discord.gg/WtJ49jGshW
-    about: You want to chat with other Tiptap users? Feel free to join our Discord server.
+    about: Interested in engaging with the Tiptap community? Join our Discord server.
   - name: Present your project
     url: https://github.com/ueberdosis/tiptap/discussions/new?category=showcase
-    about: You built something awesome with Tiptap? Feel free to show it off here.
+    about: Developed something impressive using Tiptap? Share your project with the community here.
   - name: Present your Tiptap extensions
     url: https://github.com/ueberdosis/tiptap/discussions/new?category=community-extensions
-    about: You built a Tiptap extension? Feel free to show it off here.
+    about: Created a Tiptap extension? Showcase your work to the community here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,24 @@
-## Please describe your changes
+## Changes Overview
+<!-- Briefly describe your changes. -->
 
-[add a description of your changes here]
+## Implementation Approach
+<!-- Describe your approach to implementing these changes. Keep it concise. -->
 
-## How did you accomplish your changes
+## Testing Done
+<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
 
-[add a detailed description of how you accomplished your changes here]
+## Verification Steps
+<!-- Describe steps reviewers can take to verify the functionality of your changes. -->
 
-## How have you tested your changes
-
-[add a detailed description of how you tested your changes here]
-
-## How can we verify your changes
-
-[add a detailed description of how we can verify your changes here]
-
-## Remarks
-
-[add any additional remarks here]
+## Additional Notes
+<!-- Add any other notes or screenshots about the PR here. -->
 
 ## Checklist
+- [ ] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
+- [ ] My changes do not break the library.
+- [ ] I have added tests where applicable.
+- [ ] I have followed the project guidelines.
+- [ ] I have fixed any lint issues.
 
-- [ ] The changes are not breaking the editor
-- [ ] Added tests where possible
-- [ ] Followed the guidelines
-- [ ] Fixed linting issues
-
-## Related issues
-
-[add a link to the related issues here]
+## Related Issues
+<!-- Link any related issues here -->


### PR DESCRIPTION
## Please describe your changes

I updated our Github template files for issues, PRs and the issue configuration page

## How did you accomplish your changes

Updated said files in our `.github` directory.

## How have you tested your changes

No testing required

## How can we verify your changes

No verification required

## Remarks

Feel free to come back with feedback regarding these.

## Checklist

- [x] The changes are not breaking the editor
- [x] Added tests where possible
- [x] Followed the guidelines
- [x] Fixed linting issues
