### PR TITLE
test: get tests running on macOS again by leveraging built-in platform detection

### DIFF
--- a/demos/src/Marks/Strike/React/index.spec.js
+++ b/demos/src/Marks/Strike/React/index.spec.js
@@ -58,15 +58,15 @@ context('/src/Marks/Strike/React/', () => {
 
   it('should strike the selected text when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('contain', 'Example Text')
   })
 
   it('should toggle the selected text striked when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
-      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('not.exist')
   })

--- a/demos/src/Marks/Strike/Vue/index.spec.js
+++ b/demos/src/Marks/Strike/Vue/index.spec.js
@@ -64,15 +64,15 @@ context('/src/Marks/Strike/Vue/', () => {
 
   it('should strike the selected text when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('contain', 'Example Text')
   })
 
   it('should toggle the selected text striked when the keyboard shortcut is pressed', () => {
     cy.get('.tiptap')
-      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
-      .trigger('keydown', { ctrlKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 's' })
+      .trigger('keydown', { modKey: true, shiftKey: true, key: 's' })
       .find('s')
       .should('not.exist')
   })

--- a/packages/extension-strike/src/strike.ts
+++ b/packages/extension-strike/src/strike.ts
@@ -1,5 +1,4 @@
 import {
-  isMacOS,
   Mark,
   markInputRule,
   markPasteRule,
@@ -98,15 +97,9 @@ export const Strike = Mark.create<StrikeOptions>({
   },
 
   addKeyboardShortcuts() {
-    const shortcuts: Record<string, () => boolean> = {}
-
-    if (isMacOS()) {
-      shortcuts['Mod-Shift-s'] = () => this.editor.commands.toggleStrike()
-    } else {
-      shortcuts['Ctrl-Shift-s'] = () => this.editor.commands.toggleStrike()
+    return {
+      'Mod-Shift-s': () => this.editor.commands.toggleStrike(),
     }
-
-    return shortcuts
   },
 
   addInputRules() {


### PR DESCRIPTION
## Changes Overview

The tests were failing to run on a macOS machine because the keyboard shortcut for strike was trying to implement it's own platform detection.
Instead of relying on the existing keyboard shortcut code: https://github.com/ueberdosis/tiptap/blob/b941eea6daba09d48a5d18ccc1b9a1d84b2249dd/packages/core/src/commands/keyboardShortcut.ts#L30-L34

The tests that were being run only ever sent the CTRL key instead of using the platform-independent `modKey`

## Implementation Approach
Simplify the keyboard shortcut handler to utilize the built-in Mod which means CMD on macOS and CTRL on Windows

## Testing Done
I ran the demo [src/Marks/Strike](http://localhost:3000/preview/Marks/Strike) and everything worked as expected.

## Verification Steps
Run the tests on macOS host, and on CI. Verify shortcut on your own

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
