### PR TITLE
fix: tab shortcut always returns true in listitem

### DIFF
--- a/packages/extension-list-item/src/list-item.ts
+++ b/packages/extension-list-item/src/list-item.ts
@@ -57,8 +57,14 @@ export const ListItem = Node.create<ListItemOptions>({
   addKeyboardShortcuts() {
     return {
       Enter: () => this.editor.commands.splitListItem(this.name),
-      Tab: () => this.editor.commands.sinkListItem(this.name),
-      'Shift-Tab': () => this.editor.commands.liftListItem(this.name),
+      Tab: () => {
+        this.editor.commands.sinkListItem(this.name)
+        return true
+      },
+      'Shift-Tab': () => {
+        this.editor.commands.liftListItem(this.name)
+        return true
+      },
     }
   },
 })


### PR DESCRIPTION
## Changes Overview
When I click tab on listItem or taskItem, the default `sinkListItem` command is executed and the result is returned. When `sinkListItem` returns `false`, the browser default behavior is automatically triggered, such as focusing on input on the page.

## Implementation Approach
In the shortcut key handling function of listItem, always returns true for tab-related events, preventing subsequent behavior of the event

## Verification Steps
1. Open preview page: [local](http://localhost:3000/preview/Experiments/All) or [online](https://deploy-preview-5145--tiptap-embed.netlify.app/preview/Experiments/All)
2. Select the first line of any list
3. Click tab, before, the page will automatically jump to the taskItem position, after this change, nothing will happen.

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
