### PR TITLE
fix: configure should use the parent of the current instance, to avoid duplication

### DIFF
--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -457,6 +457,7 @@ export class Extension<Options = any, Storage = any> {
     // with different calls of `configure`
     const extension = this.extend()
 
+    extension.parent = this.parent
     extension.options = mergeDeep(this.options as Record<string, any>, options) as Options
 
     extension.storage = callOrReturn(

--- a/tests/cypress/integration/core/extendExtensions.spec.ts
+++ b/tests/cypress/integration/core/extendExtensions.spec.ts
@@ -43,6 +43,30 @@ describe('extend extensions', () => {
     })
   })
 
+  it('should have a parent', () => {
+    const extension = Extension
+      .create({
+        addAttributes() {
+          return {
+            foo: {},
+          }
+        },
+      })
+
+    const newExtension = extension
+      .extend({
+        addAttributes() {
+          return {
+            bar: {},
+          }
+        },
+      })
+
+    const parent = newExtension.parent
+
+    expect(parent).to.eq(extension)
+  })
+
   it('should merge configs', () => {
     const extension = Extension
       .create({
@@ -104,6 +128,40 @@ describe('extend extensions', () => {
     })
   })
 
+  it('should set parents multiple times', () => {
+    const grandparentExtension = Extension
+      .create({
+        addAttributes() {
+          return {
+            foo: {},
+          }
+        },
+      })
+
+    const parentExtension = grandparentExtension
+      .extend({
+        addAttributes() {
+          return {
+            ...this.parent?.(),
+            bar: {},
+          }
+        },
+      })
+
+    const childExtension = parentExtension
+      .extend({
+        addAttributes() {
+          return {
+            ...this.parent?.(),
+            baz: {},
+          }
+        },
+      })
+
+    expect(parentExtension.parent).to.eq(grandparentExtension)
+    expect(childExtension.parent).to.eq(parentExtension)
+  })
+
   it('should merge configs without direct parent configuration', () => {
     const extension = Extension
       .create({
@@ -129,5 +187,168 @@ describe('extend extensions', () => {
       foo: {},
       bar: {},
     })
+  })
+
+  it('should call ancestors only once', () => {
+    const callCounts = {
+      grandparent: 0,
+      parent: 0,
+      child: 0,
+    }
+
+    const extension = Extension
+      .create({
+        addAttributes() {
+          callCounts.grandparent += 1
+          return {
+            foo: {},
+          }
+        },
+      })
+      .extend({
+        addAttributes() {
+          callCounts.parent += 1
+          return {
+            ...this.parent?.(),
+            bar: {},
+          }
+        },
+      })
+      .extend({
+        addAttributes() {
+          callCounts.child += 1
+          return {
+            ...this.parent?.(),
+            bar: {},
+          }
+        },
+      })
+
+    getExtensionField(extension, 'addAttributes')()
+
+    expect(callCounts).to.deep.eq({
+      grandparent: 1,
+      parent: 1,
+      child: 1,
+    })
+  })
+
+  it('should call ancestors only once on configure', () => {
+    const callCounts = {
+      grandparent: 0,
+      parent: 0,
+      child: 0,
+    }
+
+    const extension = Extension
+      .create({
+        addAttributes() {
+          callCounts.grandparent += 1
+          return {
+            foo: {},
+          }
+        },
+      })
+      .extend({
+        addAttributes() {
+          callCounts.parent += 1
+          return {
+            ...this.parent?.(),
+            bar: {},
+          }
+        },
+      })
+      .extend({
+        addAttributes() {
+          callCounts.child += 1
+          return {
+            ...this.parent?.(),
+            bar: {},
+          }
+        },
+      })
+      .configure({
+        baz: {},
+      })
+
+    getExtensionField(extension, 'addAttributes')()
+
+    expect(callCounts).to.deep.eq({
+      grandparent: 1,
+      parent: 1,
+      child: 1,
+    })
+  })
+
+  it('should use grandparent as parent on configure (not parent)', () => {
+    const grandparentExtension = Extension
+      .create({
+        addAttributes() {
+          return {
+            foo: {},
+          }
+        },
+      })
+
+    const parentExtension = grandparentExtension
+      .extend({
+        addAttributes() {
+          return {
+            ...this.parent?.(),
+            bar: {},
+          }
+        },
+      })
+
+    const childExtension = parentExtension
+      .configure({
+        baz: {},
+      })
+
+    expect(parentExtension.parent).to.eq(grandparentExtension)
+    expect(childExtension.parent).to.eq(grandparentExtension)
+  })
+
+  it('should use parent\'s config on `configure`', () => {
+    const grandparentExtension = Extension
+      .create({
+        name: 'grandparent',
+        addAttributes() {
+          return {
+            foo: {},
+          }
+        },
+      })
+
+    const parentExtension = grandparentExtension
+      .extend({
+        name: 'parent',
+        addAttributes() {
+          return {
+            ...this.parent?.(),
+            bar: {},
+          }
+        },
+      })
+
+    const childExtension = parentExtension
+      .configure({
+        baz: {},
+      })
+
+    expect(childExtension.config.name).to.eq('parent')
+  })
+
+  it('should inherit config on configure', () => {
+
+    const parentExtension = Extension
+      .create({
+        name: 'did-inherit',
+      })
+
+    const childExtension = parentExtension
+      .configure()
+
+    expect(childExtension.config.name).to.eq('did-inherit')
   })
 })

--- a/tests/cypress/integration/core/extensionOptions.spec.ts
+++ b/tests/cypress/integration/core/extensionOptions.spec.ts
@@ -84,6 +84,40 @@ describe('extension options', () => {
     })
   })
 
+  it('should be extendable multiple times', () => {
+    const extension = Extension.create({
+      addOptions() {
+        return {
+          foo: 1,
+          bar: 1,
+        }
+      },
+    }).extend({
+      addOptions() {
+        return {
+          ...this.parent?.(),
+          baz: 1,
+        }
+      },
+    })
+
+    const newExtension = extension.extend({
+      addOptions() {
+        return {
+          ...this.parent?.(),
+          bax: 1,
+        }
+      },
+    })
+
+    expect(newExtension.options).to.deep.eq({
+      foo: 1,
+      bar: 1,
+      baz: 1,
+      bax: 1,
+    })
+  })
+
   it('should be overwritable', () => {
     const extension = Extension
       .create({
@@ -136,6 +170,23 @@ describe('extension options', () => {
         id: 'bar',
       },
     })
+  })
+
+  it('should configure retaining existing config', () => {
+    const extension = Extension.create({
+      name: 'parent',
+      addOptions() {
+        return {
+          foo: 1,
+          bar: 1,
+        }
+      },
+    })
+
+    const newExtension = extension
+      .configure()
+
+    expect(newExtension.config.name).to.eq('parent')
   })
 
   it('should create its own instance on configure', () => {


### PR DESCRIPTION
## Changes Overview

Based on the approach taken by https://github.com/ueberdosis/tiptap/discussions/5136 and validated for appropriate behavior with a barrage of tests.

The gist of what is happening here is that `extend()` will always set the new child's `parent` property to be `this` (establishing a child -> parent relationship).

When doing `.configure()` it is [doing a `.extend()`](https://github.com/ueberdosis/tiptap/blob/8cbd8e237779e7b04c0af297159e1886e26da9f0/packages/core/src/Extension.ts#L458). Doing this directly on an extension (i.e. one that is not already `.extend`'d), as it will create a child -> parent relationship with pretty much the exact same config so it ends up overwriting itself with it's same options.
But what we really want is not a child -> parent relationship, but to just overwrite some options while maintaining an effective "copy" of the child (i.e. preserving it's child -> parent relationship).

This is pretty complicated, so I'm going to add a diagram explaining the current behavior and desired behavior here:

![what it was](https://github.com/ueberdosis/tiptap/assets/1852538/c319964e-5e12-4082-aa5b-341a5fe214fa)

![should be this](https://github.com/ueberdosis/tiptap/assets/1852538/85d2009c-8232-4ab8-817f-e373835bdeb7)

There was a lot of digging for this one:

It should resolve:
 - https://github.com/ueberdosis/tiptap/issues/4981
 - https://github.com/ueberdosis/tiptap/issues/4257

It may resolve:
 - https://github.com/ueberdosis/tiptap/issues/4704

## Implementation Approach
Someone had implemented this already: https://github.com/ueberdosis/tiptap/discussions/5136
I just validated that it worked and made sense with a barrage of tests. The root behavior I was trying to fix was https://github.com/ueberdosis/tiptap/issues/4704 

## Testing Done
Most of the code was adding tests to make sure that I understood what the problem was and if it fixed it.

## Verification Steps
Run the tests with the `Extension.ts` file as it was before and note the tests that it fails to pass now without it

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
