### PR TITLE
fix(extension-table): update selection position when inserting a new …

### DIFF
--- a/packages/extension-table/src/table.ts
+++ b/packages/extension-table/src/table.ts
@@ -302,7 +302,7 @@ export const Table = Node.create<TableOptions>({
           const node = createTable(editor.schema, rows, cols, withHeaderRow)
 
           if (dispatch) {
-            const offset = tr.selection.anchor + 1
+            const offset = tr.selection.from + 1
 
             tr.replaceSelectionWith(node)
               .scrollIntoView()


### PR DESCRIPTION
…table

Typically when inserting a new table we want to select within the first cell of the newly inserted table. This change should ensure that occurs even if the original selection's head precedes the anchor.

fix #5143

## Changes Overview
Using the selection's `from` instead of `anchor` is a better approach since the user may be making a selection where the `head` precedes the `anchor`

## Implementation Approach
Changed the selection offset from `tr.selection.anchor + 1` to `tr.selection.from + 1`

## Testing Done
Made a selection from the end of the doc to the beginning, inserted a table and see that there is no error and that the selection is  set to within the first cell.

## Verification Steps

- Start with an empty editor
- Add content to the editor ensuring that it exceeds 44 characters
- Select the entire content starting from the end of the editor to the beginning of the editor to ensure that the selection's head precedes the anchor
- Insert a 3x3 table 
- See that there is no error and that the selection is within the first cell

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
https://github.com/ueberdosis/tiptap/issues/5143