### PR TITLE
fix(extension-link): make the javascript link detection case insensitive

### DIFF
--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -161,9 +161,7 @@ export const Link = Mark.create<LinkOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
-    // False positive; we're explicitly checking for javascript: links to ignore them
-    // eslint-disable-next-line no-script-url
-    if (HTMLAttributes.href?.toLowerCase().trim().startsWith('javascript:')) {
+    if (HTMLAttributes.href?.substring(0, HTMLAttributes.href.indexOf(':')).toLowerCase().trim() === 'javascript') {
       // strip out the href
       return ['a', mergeAttributes(this.options.HTMLAttributes, { ...HTMLAttributes, href: '' }), 0]
     }

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -163,7 +163,7 @@ export const Link = Mark.create<LinkOptions>({
   renderHTML({ HTMLAttributes }) {
     // False positive; we're explicitly checking for javascript: links to ignore them
     // eslint-disable-next-line no-script-url
-    if (HTMLAttributes.href?.toLowerCase().startsWith('javascript:')) {
+    if (HTMLAttributes.href?.toLowerCase().trim().startsWith('javascript:')) {
       // strip out the href
       return ['a', mergeAttributes(this.options.HTMLAttributes, { ...HTMLAttributes, href: '' }), 0]
     }

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -163,7 +163,7 @@ export const Link = Mark.create<LinkOptions>({
   renderHTML({ HTMLAttributes }) {
     // False positive; we're explicitly checking for javascript: links to ignore them
     // eslint-disable-next-line no-script-url
-    if (HTMLAttributes.href?.startsWith('javascript:')) {
+    if (HTMLAttributes.href?.toLowerCase().startsWith('javascript:')) {
       // strip out the href
       return ['a', mergeAttributes(this.options.HTMLAttributes, { ...HTMLAttributes, href: '' }), 0]
     }

--- a/tests/cypress/integration/extensions/link.spec.ts
+++ b/tests/cypress/integration/extensions/link.spec.ts
@@ -20,45 +20,53 @@ describe('extension-link', () => {
   }
   const getEditorEl = () => document.querySelector(`.${editorElClass}`)
 
-  it('does not output src tag for javascript schema', () => {
-    editor = new Editor({
-      element: createEditorEl(),
-      extensions: [
-        Document,
-        Text,
-        Paragraph,
-        Link,
-      ],
-      content: {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: 'hello world!',
-                marks: [
-                  {
-                    type: 'link',
-                    attrs: {
-                      // We have to disable the eslint rule here because we're trying to purposely test eval urls
-                      // eslint-disable-next-line no-script-url
-                      href: 'javascript:alert(window.origin)',
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    })
-
+  const invalidUrls = [
+    // We have to disable the eslint rule here because we're trying to purposely test eval urls
     // eslint-disable-next-line no-script-url
-    expect(editor.getHTML()).to.not.include('javascript:alert(window.origin)')
+    'javascript:alert(window.origin)',
+    // eslint-disable-next-line no-script-url
+    'jAvAsCrIpT:alert(window.origin)',
+  ]
 
-    editor?.destroy()
-    getEditorEl()?.remove()
+  invalidUrls.forEach(url => {
+    it('does not output src tag for javascript schema', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Link,
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'hello world!',
+                  marks: [
+                    {
+                      type: 'link',
+                      attrs: {
+                        href: url,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      // eslint-disable-next-line no-script-url
+      expect(editor.getHTML()).to.not.include('javascript:alert(window.origin)')
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
   })
 })

--- a/tests/cypress/integration/extensions/link.spec.ts
+++ b/tests/cypress/integration/extensions/link.spec.ts
@@ -25,6 +25,8 @@ describe('extension-link', () => {
     // eslint-disable-next-line no-script-url
     'javascript:alert(window.origin)',
     // eslint-disable-next-line no-script-url
+    '    javascript:alert(window.origin)',
+    // eslint-disable-next-line no-script-url
     'jAvAsCrIpT:alert(window.origin)',
   ]
 

--- a/tests/cypress/integration/extensions/youtube.spec.ts
+++ b/tests/cypress/integration/extensions/youtube.spec.ts
@@ -24,6 +24,8 @@ describe('extension-youtube', () => {
     // We have to disable the eslint rule here because we're trying to purposely test eval urls
     // eslint-disable-next-line no-script-url
     'javascript:alert(window.origin)//embed/',
+    // eslint-disable-next-line no-script-url
+    'jAvAsCrIpT:alert(window.origin)//embed/',
     'https://youtube.google.com/embed/fdsafsdf',
     'https://youtube.com.bad/embed',
   ]

--- a/tests/cypress/integration/extensions/youtube.spec.ts
+++ b/tests/cypress/integration/extensions/youtube.spec.ts
@@ -25,6 +25,8 @@ describe('extension-youtube', () => {
     // eslint-disable-next-line no-script-url
     'javascript:alert(window.origin)//embed/',
     // eslint-disable-next-line no-script-url
+    '    javascript:alert(window.origin)',
+    // eslint-disable-next-line no-script-url
     'jAvAsCrIpT:alert(window.origin)//embed/',
     'https://youtube.google.com/embed/fdsafsdf',
     'https://youtube.com.bad/embed',


### PR DESCRIPTION
## Changes Overview
The fix for the XSS vulnerability in #4602 does not make the check on javascript URL in a case insentive way.

## Implementation Approach
Convert the href attribute to lowercase before testing if it starts with "javascript:"

## Testing Done
Increased the Cypress test coverage and ran it.

## Verification Steps
Verify non-breaking on link and youtube extension, and ensure the new tests pass.

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#3673 
#4600 
#4602
#5157