### PR TITLE
fix: whitespace being stripped from generateJSON

### DIFF
--- a/packages/html/src/generateJSON.ts
+++ b/packages/html/src/generateJSON.ts
@@ -1,11 +1,12 @@
 import { Extensions, getSchema } from '@tiptap/core'
-import { DOMParser } from '@tiptap/pm/model'
+import { DOMParser, ParseOptions } from '@tiptap/pm/model'
 import { parseHTML } from 'zeed-dom'
 
 /**
  * Generates a JSON object from the given HTML string and converts it into a Prosemirror node with content.
  * @param {string} html - The HTML string to be converted into a Prosemirror node.
  * @param {Extensions} extensions - The extensions to be used for generating the schema.
+ * @param {ParseOptions} options - The options to be supplied to the parser.
  * @returns {Record<string, any>} - The generated JSON object.
  * @example
  * const html = '<p>Hello, world!</p>'
@@ -13,9 +14,9 @@ import { parseHTML } from 'zeed-dom'
  * const json = generateJSON(html, extensions)
  * console.log(json) // { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello, world!' }] }] }
  */
-export function generateJSON(html: string, extensions: Extensions): Record<string, any> {
+export function generateJSON(html: string, extensions: Extensions, options?: ParseOptions): Record<string, any> {
   const schema = getSchema(extensions)
   const dom = parseHTML(html) as unknown as Node
 
-  return DOMParser.fromSchema(schema).parse(dom).toJSON()
+  return DOMParser.fromSchema(schema).parse(dom, options).toJSON()
 }


### PR DESCRIPTION
## Changes Overview
Allows the options to be supplied to the DOM parser which allows one to supply (among other options) `preserveWhitespace: true` to the parser. There is an outstanding bug where whitespace is being stripped when using generateJSON. This makes importing data into tiptap impossible (for me).

## Implementation Approach
Added the parameter as an optional parameter so its entirely opt in.

## Testing Done
Ran this on my project and it solved the issue regarding whitespace.

## Verification Steps
Ran this on my project and it solved the issue regarding whitespace.

## Additional Notes


## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/4432
