### PR TITLE
fix: default to rendering the editor immediately, while staying backward compatible

### DIFF
--- a/packages/react/src/Context.tsx
+++ b/packages/react/src/Context.tsx
@@ -1,9 +1,8 @@
-import { EditorOptions } from '@tiptap/core'
 import React, { createContext, ReactNode, useContext } from 'react'
 
 import { Editor } from './Editor.js'
 import { EditorContent } from './EditorContent.js'
-import { useEditor } from './useEditor.js'
+import { useEditor, UseEditorOptions } from './useEditor.js'
 
 export type EditorContextValue = {
   editor: Editor | null;
@@ -15,17 +14,25 @@ export const EditorContext = createContext<EditorContextValue>({
 
 export const EditorConsumer = EditorContext.Consumer
 
+/**
+ * A hook to get the current editor instance.
+ */
 export const useCurrentEditor = () => useContext(EditorContext)
 
-export type EditorProviderProps = {
+export type EditorProviderProps<TSelectorResult> = {
   children?: ReactNode;
   slotBefore?: ReactNode;
   slotAfter?: ReactNode;
-} & Partial<EditorOptions>
+} & UseEditorOptions<TSelectorResult>
 
-export const EditorProvider = ({
+/**
+ * This is the provider component for the editor.
+ * It allows the editor to be accessible across the entire component tree
+ * with `useCurrentEditor`.
+ */
+export function EditorProvider<TSelectorResult>({
   children, slotAfter, slotBefore, ...editorOptions
-}: EditorProviderProps) => {
+}: EditorProviderProps<TSelectorResult>) {
   const editor = useEditor(editorOptions)
 
   if (!editor) {

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -4,9 +4,143 @@ import {
   useEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 
 import { Editor } from './Editor.js'
+
+const isDev = process.env.NODE_ENV !== 'production'
+const isSSR = typeof window === 'undefined'
+const isNext = isSSR || Boolean(typeof window !== 'undefined' && (window as any).next)
+
+/**
+ * The options for the `useEditor` hook.
+ */
+export type UseEditorOptions<TSelectorResult> = Partial<EditorOptions> & {
+  /**
+   * Whether to render the editor on the first render.
+   * If client-side rendering, set this to `true`.
+   * If server-side rendering, set this to `false`.
+   * @default true
+   */
+  immediatelyRender?: boolean;
+  /**
+   * A selector function to determine the value to compare for re-rendering.
+   * @default `({ transactionNumber }) => transactionNumber + 1`
+   */
+  selector?: (editor:Editor, options: {
+    /**
+     * The previous value returned by the selector.
+     */
+    previousValue: TSelectorResult | null;
+    /**
+     * The current transaction number. Incremented on every transaction.
+     */
+    transactionNumber: number
+  }) => TSelectorResult;
+  /**
+   * A custom equality function to determine if the editor should re-render.
+   * @default `(a, b) => a === b`
+   */
+  equalityFn?: (a: TSelectorResult, b: TSelectorResult | null) => boolean;
+}
+
+/**
+ * To synchronize the editor instance with the component state,
+ * we need to create a separate instance that is not affected by the component re-renders.
+ */
+function makeEditorInstance<TSelectorResult>({
+  immediatelyRender,
+  options: initialOptions,
+  selector = (_e, { transactionNumber }) => (transactionNumber + 1) as unknown as TSelectorResult,
+  equalityFn = (a: TSelectorResult, b: TSelectorResult | null) => a === b,
+}: Pick<UseEditorOptions<TSelectorResult>, 'selector' | 'equalityFn' | 'immediatelyRender'> & {
+  options: Partial<EditorOptions>;
+}) {
+
+  let editor: Editor | null = null
+  let transactionNumber = 0
+  let prevSnapshot: [Editor | null, TSelectorResult | null] = [editor, null]
+  const subscribers = new Set<() => void>()
+
+  const editorInstance = {
+    /**
+     * Get the current editor instance.
+     */
+    getSnapshot() {
+      if (!editor) {
+        return prevSnapshot
+      }
+
+      const nextSnapshotResult = selector(editor, { previousValue: prevSnapshot[1], transactionNumber })
+
+      if (equalityFn(nextSnapshotResult, prevSnapshot[1])) {
+        return prevSnapshot
+      }
+
+      const nextSnapshot: [Editor, TSelectorResult | null] = [editor, nextSnapshotResult]
+
+      prevSnapshot = nextSnapshot
+      return nextSnapshot
+    },
+    /**
+     * Always disable the editor on the server-side.
+     */
+    getServerSnapshot() {
+      return null
+    },
+    /**
+     * Subscribe to the editor instance's changes.
+     */
+    subscribe(callback: () => void) {
+      subscribers.add(callback)
+      return () => {
+        subscribers.delete(callback)
+      }
+    },
+    /**
+     * Create the editor instance.
+     */
+    create(options: Partial<EditorOptions>) {
+      if (editor) {
+        editor.destroy()
+      }
+      editor = new Editor(options)
+      subscribers.forEach(callback => callback())
+
+      if (editor) {
+      /**
+       * This will force a re-render when the editor state changes.
+       * This is to support things like `editor.can().toggleBold()` in components that `useEditor`.
+       * This could be more efficient, but it's a good trade-off for now.
+       */
+        editor.on('transaction', () => {
+          transactionNumber += 1
+          subscribers.forEach(callback => callback())
+        })
+      }
+    },
+    /**
+     * Destroy the editor instance.
+     */
+    destroy(): void {
+      if (editor) {
+        // We need to destroy the editor asynchronously to avoid memory leaks
+        // because the editor instance is still being used in the component.
+        const editorToDestroy = editor
+
+        setTimeout(() => editorToDestroy.destroy())
+      }
+      editor = null
+    },
+  }
+
+  if (immediatelyRender) {
+    editorInstance.create(initialOptions)
+  }
+
+  return editorInstance
+}
 
 /**
  * This hook allows you to create an editor instance.
@@ -15,9 +149,57 @@ import { Editor } from './Editor.js'
  * @returns The editor instance
  * @example const editor = useEditor({ extensions: [...] })
  */
-export const useEditor = (options: Partial<EditorOptions> = {}, deps: DependencyList = []) => {
-  const editorRef = useRef<Editor | null>(null)
-  const [, forceUpdate] = useState({})
+function useEditor<TSelectorResult>(options: UseEditorOptions<TSelectorResult> & { immediatelyRender: true }, deps?: DependencyList): Editor;
+
+/**
+ * This hook allows you to create an editor instance.
+ * @param options The editor options
+ * @param deps The dependencies to watch for changes
+ * @returns The editor instance
+ * @example const editor = useEditor({ extensions: [...] })
+ */
+function useEditor<TSelectorResult>(options?: UseEditorOptions<TSelectorResult>, deps?: DependencyList): Editor | null;
+
+function useEditor<TSelectorResult>(options: UseEditorOptions<TSelectorResult> = {}, deps: DependencyList = []): Editor | null {
+  const [editorInstance] = useState(() => {
+    const instanceCreateOptions: Parameters<(typeof makeEditorInstance<TSelectorResult>)>[0] = {
+      immediatelyRender: Boolean(options.immediatelyRender),
+      equalityFn: options.equalityFn,
+      selector: options.selector,
+      options,
+    }
+
+    if (options.immediatelyRender === undefined) {
+      if (isSSR || isNext) {
+        // TODO in the next major release, we should throw an error here
+        if (isDev) {
+          /**
+           * Throw an error in development, to make sure the developer is aware that tiptap cannot be SSR'd
+           * and that they need to set `immediatelyRender` to `false` to avoid hydration mismatches.
+           */
+          console.warn('Tiptap Error: SSR has been detected, please set `immediatelyRender` explicitly to `false` to avoid hydration mismatches.')
+        }
+
+        // Best faith effort in production, run the code in the legacy mode to avoid hydration mismatches and errors in production
+        instanceCreateOptions.immediatelyRender = false
+        return makeEditorInstance(instanceCreateOptions)
+      }
+
+      // Default to `true` in client-side rendering
+      instanceCreateOptions.immediatelyRender = true
+      return makeEditorInstance(instanceCreateOptions)
+    }
+
+    if (options.immediatelyRender && isSSR && isDev) {
+      // Warn in development, to make sure the developer is aware that tiptap cannot be SSR'd, set `immediatelyRender` to `false` to avoid hydration mismatches.
+      throw new Error('Tiptap Error: SSR has been detected, and `immediatelyRender` has been set to `true` this is an unsupported configuration that may result in errors, explicitly set `immediatelyRender` to `false` to avoid hydration mismatches.')
+    }
+
+    return makeEditorInstance(instanceCreateOptions)
+  })
+
+  // Using the `useSyncExternalStore` hook to sync the editor instance with the component state
+  const editor = useSyncExternalStore(editorInstance.subscribe, editorInstance.getSnapshot, editorInstance.getServerSnapshot)?.[0] || null
 
   const {
     onBeforeCreate,
@@ -42,89 +224,91 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
   // This effect will handle updating the editor instance
   // when the event handlers change.
   useEffect(() => {
-    if (!editorRef.current) {
+    if (!editor) {
       return
     }
 
     if (onBeforeCreate) {
-      editorRef.current.off('beforeCreate', onBeforeCreateRef.current)
-      editorRef.current.on('beforeCreate', onBeforeCreate)
+      editor.off('beforeCreate', onBeforeCreateRef.current)
+      editor.on('beforeCreate', onBeforeCreate)
 
       onBeforeCreateRef.current = onBeforeCreate
     }
 
     if (onBlur) {
-      editorRef.current.off('blur', onBlurRef.current)
-      editorRef.current.on('blur', onBlur)
+      editor.off('blur', onBlurRef.current)
+      editor.on('blur', onBlur)
 
       onBlurRef.current = onBlur
     }
 
     if (onCreate) {
-      editorRef.current.off('create', onCreateRef.current)
-      editorRef.current.on('create', onCreate)
+      editor.off('create', onCreateRef.current)
+      editor.on('create', onCreate)
 
       onCreateRef.current = onCreate
     }
 
     if (onDestroy) {
-      editorRef.current.off('destroy', onDestroyRef.current)
-      editorRef.current.on('destroy', onDestroy)
+      editor.off('destroy', onDestroyRef.current)
+      editor.on('destroy', onDestroy)
 
       onDestroyRef.current = onDestroy
     }
 
     if (onFocus) {
-      editorRef.current.off('focus', onFocusRef.current)
-      editorRef.current.on('focus', onFocus)
+      editor.off('focus', onFocusRef.current)
+      editor.on('focus', onFocus)
 
       onFocusRef.current = onFocus
     }
 
     if (onSelectionUpdate) {
-      editorRef.current.off('selectionUpdate', onSelectionUpdateRef.current)
-      editorRef.current.on('selectionUpdate', onSelectionUpdate)
+      editor.off('selectionUpdate', onSelectionUpdateRef.current)
+      editor.on('selectionUpdate', onSelectionUpdate)
 
       onSelectionUpdateRef.current = onSelectionUpdate
     }
 
     if (onTransaction) {
-      editorRef.current.off('transaction', onTransactionRef.current)
-      editorRef.current.on('transaction', onTransaction)
+      editor.off('transaction', onTransactionRef.current)
+      editor.on('transaction', onTransaction)
 
       onTransactionRef.current = onTransaction
     }
 
     if (onUpdate) {
-      editorRef.current.off('update', onUpdateRef.current)
-      editorRef.current.on('update', onUpdate)
+      editor.off('update', onUpdateRef.current)
+      editor.on('update', onUpdate)
 
       onUpdateRef.current = onUpdate
     }
-  }, [onBeforeCreate, onBlur, onCreate, onDestroy, onFocus, onSelectionUpdate, onTransaction, onUpdate, editorRef.current])
+  }, [onBeforeCreate, onBlur, onCreate, onDestroy, onFocus, onSelectionUpdate, onTransaction, onUpdate, editor])
 
+  // This effect will handle creating/updating the editor instance
   useEffect(() => {
-    let isMounted = true
-
-    const editor = new Editor(options)
-
-    editorRef.current = editor
-
-    editorRef.current.on('transaction', () => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (isMounted) {
-            forceUpdate({})
-          }
-        })
-      })
-    })
-
-    return () => {
-      isMounted = false
-      editor.destroy()
+    if (!editor) {
+      // instantiate the editor if it doesn't exist
+      // for ssr, this is the first time the editor is created
+      editorInstance.create(options)
+    } else {
+      // if the editor does exist, update the editor options accordingly
+      editor.setOptions(options)
     }
   }, deps)
 
-  return editorRef.current
+  /**
+   * Destroy the editor instance when the component completely unmounts
+   * As opposed to the cleanup function in the effect above, this will
+   * only be called when the component is removed from the DOM, since it has no deps.
+   * */
+  useEffect(() => {
+    return () => {
+      editorInstance.destroy()
+    }
+  }, [])
+
+  return editor
 }
+
+export { useEditor }


### PR DESCRIPTION
## Changes Overview
A third PR for performance of the useEditor hook :sweat_smile:.

What I've done here is combine a few of the different approaches and added a bit of my own spin to it:

Prior art:
 - https://github.com/ueberdosis/tiptap/pull/4579
 - https://github.com/ueberdosis/tiptap/pull/4858
 - https://github.com/ueberdosis/tiptap/pull/4453/files#diff-13acb5e551812e195c1140c10ba5ac298a0005996d07756cfd77c2d4194cb350

What I've done here is to take a spin on #4579 and base it on a `useSyncExternalStore` instead (for efficient re-rendering handled by react).
While adding the performance optimization made by #4453 (re-using existing editor instances, and just updating their options if they change).
It is backward-compatible to people who use SSR (printing a warning and telling them they should set the new flag explicitly for forward-compatible but only in dev mode).
It is forward-compatible, where if you don't specify the new flag, people will automatically have the editor on first render.
If the flag is specified, you get better TS types since it is now guaranteed that you get an editor instance.
If you include the `select` function, you can effectively choose when the component should re-render by returning something different than selected before (inspired by `useSelector` in react-redux)
If you include the `equalityFn` function, you can choose how to compare your `select` function's return value (again inspired by `useSelector` in react-redux)

## Implementation Approach

I've introduced 3 new options to the `useEditor` hook (and subsequently the editor provider).

 - `immediatelyRender` which is to control the new vs. the old behavior
 - `select` which is to give the consumer fine-grained control over rendering by selecting the values they care about in re-rendering the editor
 - `equalityFn` which defines how to compare the values that the consumer generates with the `select` function

When not specifying the `immediateRender` value, if it is detected to be in SSR mode (i.e. no window object) it will be assumed to be `false` to not break Next.js users (but printing a message that they should be explicit about this), otherwise it will be assumed to be `true` reducing flicker in existing applications.

Eventually, when we have confidence to do so (i.e. the next major version) we can throw an error instead and have Next.js users (and other ssr frameworks) have to explicitly opt out for their use case (or perhaps a new hook).

## Testing Done

I tested in the demos using all possible options and in a next application here is a table for reference:

| env | immediatelyRender | result | error message |
| --- | ----------------- | ------ | ------------- |
| vite | false | useEditor returns null on first render, an editor instance afterwards | none |
| vite | true  | useEditor returns an editor instance consistently | none |
| vite | *missing* AKA undefined | useEditor returns an editor instance consistently, since not in SSR mode | none |
| next | false | useEditor returns null on first render (client & server), an editor instance afterwards (client only, since server renders only once) | none |
| next | true  | **Error** next can't use DOM APIs on the server & will fail to rehydrate | [An error is thrown](https://github.com/ueberdosis/tiptap/blob/115998b13a9ad9315d9cccba097d0f457ee3a9d7/packages/react/src/useEditor.ts#L195) stating this is an invalid configuration in dev mode |
| next | *missing* AKA undefined | **Warning** in the console. useEditor returns null on first render (client & server), an editor instance afterwards (client only, since server renders only once) | [A warning is printed to the console](https://github.com/ueberdosis/tiptap/blob/115998b13a9ad9315d9cccba097d0f457ee3a9d7/packages/react/src/useEditor.ts#L180) stating that the use should explicitly set the flag in dev mode |

Testing this sort of thing in react can be a little complicated (since you need to control when react re-renders) but if someone knows of a way to test this I'm happy to add tests for it.

## Verification Steps

Run the demos and set different values for `immediatelyRender` and in a Next.js app.

## Additional Notes

I'm unsure what version tiptap claims to be compatible with, and I know older versions do not have `useSyncExternalStore` but I also know that `react-redux` uses a shim to make it compatible with older versions.

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/5001
