### PR TITLE
fix: revert `font-family` escaping introduced by #4545

### DIFF
--- a/demos/src/Extensions/FontFamily/React/index.jsx
+++ b/demos/src/Extensions/FontFamily/React/index.jsx
@@ -73,6 +73,13 @@ export default () => {
       >
         CSS variable
       </button>
+      <button
+        onClick={() => editor.chain().focus().setFontFamily('"Comic Sans MS", "Comic Sans"').run()}
+        className={editor.isActive('textStyle', { fontFamily: '"Comic Sans"' }) ? 'is-active' : ''}
+        data-test-id="comic-sans-quoted"
+      >
+        Comic Sans quoted
+      </button>
       <button onClick={() => editor.chain().focus().unsetFontFamily().run()} data-test-id="unsetFontFamily">
         unsetFontFamily
       </button>

--- a/demos/src/Extensions/FontFamily/React/index.jsx
+++ b/demos/src/Extensions/FontFamily/React/index.jsx
@@ -1,3 +1,5 @@
+import './styles.scss'
+
 import Document from '@tiptap/extension-document'
 import FontFamily from '@tiptap/extension-font-family'
 import Paragraph from '@tiptap/extension-paragraph'
@@ -15,6 +17,7 @@ export default () => {
         <p><span style="font-family: serif">Serious people use serif fonts anyway.</span></p>
         <p><span style="font-family: monospace">The cool kids can apply monospace fonts aswell.</span></p>
         <p><span style="font-family: cursive">But hopefully we all can agree, that cursive fonts are the best.</span></p>
+        <p><span style="font-family: var(--title-font-family)">Then there are CSS variables, the new hotness.</span></p>
       `,
   })
 
@@ -27,6 +30,7 @@ export default () => {
       <button
         onClick={() => editor.chain().focus().setFontFamily('Inter').run()}
         className={editor.isActive('textStyle', { fontFamily: 'Inter' }) ? 'is-active' : ''}
+        data-test-id="inter"
       >
         Inter
       </button>
@@ -37,28 +41,39 @@ export default () => {
             ? 'is-active'
             : ''
         }
+        data-test-id="comic-sans"
       >
         Comic Sans
       </button>
       <button
         onClick={() => editor.chain().focus().setFontFamily('serif').run()}
         className={editor.isActive('textStyle', { fontFamily: 'serif' }) ? 'is-active' : ''}
+        data-test-id="serif"
       >
         serif
       </button>
       <button
         onClick={() => editor.chain().focus().setFontFamily('monospace').run()}
         className={editor.isActive('textStyle', { fontFamily: 'monospace' }) ? 'is-active' : ''}
+        data-test-id="monospace"
       >
         monospace
       </button>
       <button
         onClick={() => editor.chain().focus().setFontFamily('cursive').run()}
         className={editor.isActive('textStyle', { fontFamily: 'cursive' }) ? 'is-active' : ''}
+        data-test-id="cursive"
       >
         cursive
       </button>
-      <button onClick={() => editor.chain().focus().unsetFontFamily().run()}>
+      <button
+        onClick={() => editor.chain().focus().setFontFamily('var(--title-font-family)').run()}
+        className={editor.isActive('textStyle', { fontFamily: 'var(--title-font-family)' }) ? 'is-active' : ''}
+        data-test-id="css-variable"
+      >
+        CSS variable
+      </button>
+      <button onClick={() => editor.chain().focus().unsetFontFamily().run()} data-test-id="unsetFontFamily">
         unsetFontFamily
       </button>
 

--- a/demos/src/Extensions/FontFamily/React/index.spec.js
+++ b/demos/src/Extensions/FontFamily/React/index.spec.js
@@ -3,5 +3,47 @@ context('/src/Extensions/FontFamily/React/', () => {
     cy.visit('/src/Extensions/FontFamily/React/')
   })
 
-  // TODO: Write tests
+  beforeEach(() => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.commands.setContent('<p>Example Text</p>')
+    })
+    cy.get('.tiptap').type('{selectall}')
+  })
+
+  it('should set the font-family of the selected text', () => {
+    cy.get('[data-test-id="monospace"]')
+      .should('not.have.class', 'is-active')
+      .click()
+      .should('have.class', 'is-active')
+
+    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: monospace')
+  })
+
+  it('should remove the font-family of the selected text', () => {
+    cy.get('[data-test-id="monospace"]').click()
+
+    cy.get('.tiptap span').should('exist')
+
+    cy.get('[data-test-id="unsetFontFamily"]').click()
+
+    cy.get('.tiptap span').should('not.exist')
+  })
+
+  it('should quote font-family that have spaces in them', () => {
+    cy.get('[data-test-id="comic-sans"]')
+      .should('not.have.class', 'is-active')
+      .click()
+      .should('have.class', 'is-active')
+
+    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: "Comic Sans MS", "Comic Sans"')
+  })
+
+  it('should allow CSS variables as a font-family', () => {
+    cy.get('[data-test-id="css-variable"]')
+      .should('not.have.class', 'is-active')
+      .click()
+      .should('have.class', 'is-active')
+
+    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: var(--title-font-family)')
+  })
 })

--- a/demos/src/Extensions/FontFamily/React/index.spec.js
+++ b/demos/src/Extensions/FontFamily/React/index.spec.js
@@ -29,13 +29,13 @@ context('/src/Extensions/FontFamily/React/', () => {
     cy.get('.tiptap span').should('not.exist')
   })
 
-  it('should quote font-family that have spaces in them', () => {
+  it('should work with font-family that have spaces in them', () => {
     cy.get('[data-test-id="comic-sans"]')
       .should('not.have.class', 'is-active')
       .click()
       .should('have.class', 'is-active')
 
-    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: "Comic Sans MS", "Comic Sans"')
+    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: Comic Sans MS, Comic Sans')
   })
 
   it('should allow CSS variables as a font-family', () => {

--- a/demos/src/Extensions/FontFamily/React/styles.scss
+++ b/demos/src/Extensions/FontFamily/React/styles.scss
@@ -1,0 +1,15 @@
+
+html {
+  --title-font-family: 'Helvetica', sans-serif;
+}
+
+.tiptap {
+  > * + * {
+    margin-top: 0.75em;
+  }
+
+  ul,
+  ol {
+    padding: 0 1rem;
+  }
+}

--- a/packages/extension-font-family/src/font-family.ts
+++ b/packages/extension-font-family/src/font-family.ts
@@ -56,7 +56,8 @@ export const FontFamily = Extension.create<FontFamilyOptions>({
               }
 
               return {
-                style: `font-family: ${attributes.fontFamily.split(',').map((fontFamily: string) => CSS.escape(fontFamily.trim())).join(', ')}`,
+                style: `font-family: ${attributes.fontFamily.split(',')
+                  .map((fontFamily: string) => (fontFamily.match(/(\d|\s)+/g) ? `"${fontFamily.trim()}"` : fontFamily.trim())).join(', ')}`,
               }
             },
           },

--- a/packages/extension-font-family/src/font-family.ts
+++ b/packages/extension-font-family/src/font-family.ts
@@ -56,14 +56,7 @@ export const FontFamily = Extension.create<FontFamilyOptions>({
               }
 
               return {
-                style: `font-family: ${attributes.fontFamily.split(',').map((str: string) => {
-                  // TODO this is subpar, we should just use the fontFamily verbatim and make the user escape it
-                  const fontFamily = str.trim()
-                  const hasNumbersOrWhitespace = fontFamily.match(/(\d|\s)+/)
-                  const isAlreadyQuoted = fontFamily.match(/^".*"$/)
-
-                  return hasNumbersOrWhitespace && !isAlreadyQuoted ? `"${fontFamily}"` : fontFamily
-                }).join(', ')}`,
+                style: `font-family: ${attributes.fontFamily}`,
               }
             },
           },

--- a/packages/extension-font-family/src/font-family.ts
+++ b/packages/extension-font-family/src/font-family.ts
@@ -56,8 +56,14 @@ export const FontFamily = Extension.create<FontFamilyOptions>({
               }
 
               return {
-                style: `font-family: ${attributes.fontFamily.split(',')
-                  .map((fontFamily: string) => (fontFamily.match(/(\d|\s)+/g) ? `"${fontFamily.trim()}"` : fontFamily.trim())).join(', ')}`,
+                style: `font-family: ${attributes.fontFamily.split(',').map((str: string) => {
+                  // TODO this is subpar, we should just use the fontFamily verbatim and make the user escape it
+                  const fontFamily = str.trim()
+                  const hasNumbersOrWhitespace = fontFamily.match(/(\d|\s)+/)
+                  const isAlreadyQuoted = fontFamily.match(/^".*"$/)
+
+                  return hasNumbersOrWhitespace && !isAlreadyQuoted ? `"${fontFamily}"` : fontFamily
+                }).join(', ')}`,
               }
             },
           },


### PR DESCRIPTION
## Changes Overview

Using `CSS.escape` is the wrong tool for the job here:
 - it is meant for CSS selectors and does not handle CSS variables properly.
 - you can't use `var(--title)` as a font-family because it was getting escaped to `var\(--title\)`

Instead, this reverts back to the previous behavior and forces the caller to specify an actual valid CSS font-family value.

## Implementation Approach

I was notified that CSS variables don't work as the name.
CSS.escape did not look the right tool for the job.

I considered trying to quote the font-family using [this stack overflow mentioned how to do it](https://stackoverflow.com/questions/7638775/do-i-need-to-wrap-quotes-around-font-family-names-in-css), but I ended up going back on that decision because it is just over complicated and it really should be the caller's responsibility to input valid font-family values. But you can see my previous working example in [my previous commit](https://github.com/ueberdosis/tiptap/pull/5164/commits/b0e9336012fea137f01d3a34be8b5d4ad0bd2852)

## Testing Done

Added tests for font-family setting and new button for CSS variable

## Verification Steps
Try it with: http://localhost:3000/preview/Extensions/FontFamily

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
PR: #4545
The original issue could have been avoided if they quoted properly
