### PR TITLE
fix: parse only allowed text align alignments

### DIFF
--- a/packages/extension-text-align/src/text-align.ts
+++ b/packages/extension-text-align/src/text-align.ts
@@ -63,11 +63,12 @@ export const TextAlign = Extension.create<TextAlignOptions>({
         attributes: {
           textAlign: {
             default: this.options.defaultAlignment,
-            parseHTML: (element) => {
+            parseHTML: element => {
               const alignment = element.style.textAlign || this.options.defaultAlignment
+
               return this.options.alignments.includes(alignment) ? alignment : this.options.defaultAlignment
             },
-            renderHTML: (attributes) => {
+            renderHTML: attributes => {
               if (attributes.textAlign === this.options.defaultAlignment) {
                 return {}
               }

--- a/packages/extension-text-align/src/text-align.ts
+++ b/packages/extension-text-align/src/text-align.ts
@@ -63,8 +63,11 @@ export const TextAlign = Extension.create<TextAlignOptions>({
         attributes: {
           textAlign: {
             default: this.options.defaultAlignment,
-            parseHTML: element => element.style.textAlign || this.options.defaultAlignment,
-            renderHTML: attributes => {
+            parseHTML: (element) => {
+              const alignment = element.style.textAlign || this.options.defaultAlignment
+              return this.options.alignments.includes(alignment) ? alignment : this.options.defaultAlignment
+            },
+            renderHTML: (attributes) => {
               if (attributes.textAlign === this.options.defaultAlignment) {
                 return {}
               }


### PR DESCRIPTION
## Changes Overview
TextAlign extension should respects alignments config options, so when you for example copy paste alignment that is not configured, it will insert it as default.

## Implementation Approach
I am just checking if provided value used in parseHTML is from allowed/configured list.

## Testing Done
I have not added test, because this is really a small change/fix.

## Verification Steps
Try to configure text aligns that exclude justify, copy/paste text from website where is justified. On paste it should be left, because justify is not supported by provided config.

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
(https://github.com/ueberdosis/tiptap/issues/5010)
