### PR TITLE
feat: error handling of invalid content for a schema

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -33,6 +33,9 @@ The editor isn’t focused anymore.
 ### destroy
 The editor is being destroyed.
 
+### contentError
+The content does not match the schema.
+
 
 ## Register event listeners
 There are three ways to register event listeners.
@@ -65,6 +68,9 @@ const editor = new Editor({
   },
   onDestroy() {
     // The editor is being destroyed.
+  },
+  onContentError({ editor, error }) {
+    // The editor content does not match the schema.
   },
 })
 ```
@@ -104,6 +110,10 @@ editor.on('blur', ({ editor, event }) => {
 
 editor.on('destroy', () => {
   // The editor is being destroyed.
+})
+
+editor.on('contentError', ({ editor, error }) => {
+  // The editor content does not match the schema.
 })
 ```
 
@@ -152,6 +162,9 @@ const CustomExtension = Extension.create({
   },
   onDestroy() {
     // The editor is being destroyed.
+  },
+  onContentError({ editor, error }) {
+   // The editor content does not match the schema.
   },
 })
 ```

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -36,7 +36,6 @@ The editor is being destroyed.
 ### contentError
 The content does not match the schema.
 
-
 ## Register event listeners
 There are three ways to register event listeners.
 

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -68,7 +68,7 @@ const editor = new Editor({
   onDestroy() {
     // The editor is being destroyed.
   },
-  onContentError({ editor, error }) {
+  onContentError({ editor, error, disableCollaboration }) {
     // The editor content does not match the schema.
   },
 })
@@ -111,7 +111,7 @@ editor.on('destroy', () => {
   // The editor is being destroyed.
 })
 
-editor.on('contentError', ({ editor, error }) => {
+editor.on('contentError', ({ editor, error, disableCollaboration }) => {
   // The editor content does not match the schema.
 })
 ```
@@ -162,7 +162,7 @@ const CustomExtension = Extension.create({
   onDestroy() {
     // The editor is being destroyed.
   },
-  onContentError({ editor, error }) {
+  onContentError({ editor, error, disableCollaboration }) {
    // The editor content does not match the schema.
   },
 })

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -9,7 +9,7 @@ Unlike many other editors, Tiptap is based on a [schema](https://prosemirror.net
 
 This schema is *very* strict. You can’t use any HTML element or attribute that is not defined in your schema.
 
-Let me give you one example: If you paste something like `This is <strong>important</strong>` into Tiptap, but don’t have any extension that handles `strong` tags, you’ll only see `This is important` – without the strong tags.
+Let me give you one example: If you paste something like `This is <strong>important</strong>` into Tiptap, but don’t have any extension that handles `strong` tags, you’ll only see `This is important` – without the strong tags. If you want to know when this happens, you can listen to the [`contentError`](/api/events#contenterror) event after enabling the `enableContentCheck` option.
 
 ## How a schema looks like
 When you’ll work with the provided extensions only, you don’t have to care that much about the schema. If you’re building your own extensions, it’s probably helpful to understand how the schema works. Let’s look at the most simple schema for a typical ProseMirror editor:

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -294,6 +294,10 @@ export class Editor extends EventEmitter<EditorEvents> {
         { errorOnInvalidContent: this.options.enableContentCheck },
       )
     } catch (e) {
+      if (!(e instanceof Error) || ['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
+        // Not the content error we were expecting
+        throw e
+      }
       this.emit('contentError', {
         editor: this,
         error: e as Error,

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -295,7 +295,20 @@ export class Editor extends EventEmitter<EditorEvents> {
       )
     } catch (e) {
       this.emit('contentError', { editor: this, error: e as Error })
-      return
+
+      // Remove the collaboration extension if the content is invalid, to not sync invalid content
+      this.options.extensions = this.options.extensions.filter(extension => extension.name !== 'collaboration')
+
+      // Recreate the extension manager without the invalid extensions
+      this.createExtensionManager()
+
+      // Content is invalid, but attempt to create it anyway, stripping out the invalid parts
+      doc = createDocument(
+        this.options.content,
+        this.schema,
+        this.options.parseOptions,
+        { errorOnInvalidContent: false },
+      )
     }
     const selection = resolveFocusPosition(doc, this.options.autofocus)
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -294,14 +294,17 @@ export class Editor extends EventEmitter<EditorEvents> {
         { errorOnInvalidContent: this.options.enableContentCheck },
       )
     } catch (e) {
+      this.emit('contentError', {
+        editor: this,
+        error: e as Error,
+        disableCollaboration: () => {
+          // To avoid syncing back invalid content, reinitialize the extensions without the collaboration extension
+          this.options.extensions = this.options.extensions.filter(extension => extension.name !== 'collaboration')
 
-      // Remove the collaboration extension if the content is invalid, to not sync invalid content
-      this.options.extensions = this.options.extensions.filter(extension => extension.name !== 'collaboration')
-
-      // Recreate the extension manager without the invalid extensions
-      this.createExtensionManager()
-
-      this.emit('contentError', { editor: this, error: e as Error })
+          // Restart the initialization process by recreating the extension manager with the new set of extensions
+          this.createExtensionManager()
+        },
+      })
 
       // Content is invalid, but attempt to create it anyway, stripping out the invalid parts
       doc = createDocument(

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -294,7 +294,7 @@ export class Editor extends EventEmitter<EditorEvents> {
         { errorOnInvalidContent: this.options.enableContentCheck },
       )
     } catch (e) {
-      if (!(e instanceof Error) || ['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
+      if (!(e instanceof Error) || !['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
         // Not the content error we were expecting
         throw e
       }

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -294,13 +294,14 @@ export class Editor extends EventEmitter<EditorEvents> {
         { errorOnInvalidContent: this.options.enableContentCheck },
       )
     } catch (e) {
-      this.emit('contentError', { editor: this, error: e as Error })
 
       // Remove the collaboration extension if the content is invalid, to not sync invalid content
       this.options.extensions = this.options.extensions.filter(extension => extension.name !== 'collaboration')
 
       // Recreate the extension manager without the invalid extensions
       this.createExtensionManager()
+
+      this.emit('contentError', { editor: this, error: e as Error })
 
       // Content is invalid, but attempt to create it anyway, stripping out the invalid parts
       doc = createDocument(

--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -22,7 +22,7 @@ export class EventEmitter<T extends Record<string, any>> {
     return this
   }
 
-  protected emit<EventName extends StringKeyOf<T>>(event: EventName, ...args: CallbackType<T, EventName>): this {
+  public emit<EventName extends StringKeyOf<T>>(event: EventName, ...args: CallbackType<T, EventName>): this {
     const callbacks = this.callbacks[event]
 
     if (callbacks) {

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -35,8 +35,21 @@ declare module '@tiptap/core' {
            * Whether to update the selection after inserting the content.
            */
           updateSelection?: boolean
+
+          /**
+           * Whether to apply input rules after inserting the content.
+           */
           applyInputRules?: boolean
+
+          /**
+           * Whether to apply paste rules after inserting the content.
+           */
           applyPasteRules?: boolean
+
+          /**
+           * Whether to throw an error if the content is invalid.
+           */
+          errorOnInvalidContent?: boolean
         },
       ) => ReturnType
     }
@@ -62,6 +75,7 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
         preserveWhitespace: 'full',
         ...options.parseOptions,
       },
+      errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
     })
 
     // don’t dispatch an empty fragment because this can lead to strange errors

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -81,6 +81,10 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
         errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
       })
     } catch (e) {
+      if (!(e instanceof Error) || ['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
+        // Not the content error we were expecting
+        throw e
+      }
       // Only ever throws if enableContentCheck or errorOnInvalidContent is true
       editor.emit('contentError', { editor, error: e as Error })
       return false

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -81,12 +81,6 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
         errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
       })
     } catch (e) {
-      if (!(e instanceof Error) || !['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
-        // Not the content error we were expecting
-        throw e
-      }
-      // Only ever throws if enableContentCheck or errorOnInvalidContent is true
-      editor.emit('contentError', { editor, error: e as Error })
       return false
     }
 

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -81,7 +81,7 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
         errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
       })
     } catch (e) {
-      if (!(e instanceof Error) || ['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
+      if (!(e instanceof Error) || !['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
         // Not the content error we were expecting
         throw e
       }

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -70,13 +70,21 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
       ...options,
     }
 
-    const content = createNodeFromContent(value, editor.schema, {
-      parseOptions: {
-        preserveWhitespace: 'full',
-        ...options.parseOptions,
-      },
-      errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
-    })
+    let content: Fragment | ProseMirrorNode
+
+    try {
+      content = createNodeFromContent(value, editor.schema, {
+        parseOptions: {
+          preserveWhitespace: 'full',
+          ...options.parseOptions,
+        },
+        errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
+      })
+    } catch (e) {
+      // Only ever throws if enableContentCheck or errorOnInvalidContent is true
+      editor.emit('contentError', { editor, error: e as Error })
+      return false
+    }
 
     // don’t dispatch an empty fragment because this can lead to strange errors
     if (content.toString() === '<>') {

--- a/packages/core/src/commands/setContent.ts
+++ b/packages/core/src/commands/setContent.ts
@@ -54,12 +54,6 @@ export const setContent: RawCommands['setContent'] = (content, emitUpdate = fals
       errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
     })
   } catch (e) {
-    if (!(e instanceof Error) || !['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
-      // Not the content error we were expecting
-      throw e
-    }
-    // Only ever throws if enableContentCheck or errorOnInvalidContent is true
-    editor.emit('contentError', { editor, error: e as Error })
     return false
   }
 

--- a/packages/core/src/commands/setContent.ts
+++ b/packages/core/src/commands/setContent.ts
@@ -30,14 +30,25 @@ declare module '@tiptap/core' {
          * @default {}
          */
         parseOptions?: ParseOptions,
+        /**
+         * Options for `setContent`.
+         */
+        options?: {
+          /**
+           * Whether to throw an error if the content is invalid.
+           */
+           errorOnInvalidContent?: boolean
+        },
       ) => ReturnType
     }
   }
 }
 
-export const setContent: RawCommands['setContent'] = (content, emitUpdate = false, parseOptions = {}) => ({ tr, editor, dispatch }) => {
+export const setContent: RawCommands['setContent'] = (content, emitUpdate = false, parseOptions = {}, options = {}) => ({ tr, editor, dispatch }) => {
   const { doc } = tr
-  const document = createDocument(content, editor.schema, parseOptions)
+  const document = createDocument(content, editor.schema, parseOptions, {
+    errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
+  })
 
   if (dispatch) {
     tr.replaceWith(0, doc.content.size, document).setMeta('preventUpdate', !emitUpdate)

--- a/packages/core/src/commands/setContent.ts
+++ b/packages/core/src/commands/setContent.ts
@@ -54,7 +54,7 @@ export const setContent: RawCommands['setContent'] = (content, emitUpdate = fals
       errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
     })
   } catch (e) {
-    if (!(e instanceof Error) || ['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
+    if (!(e instanceof Error) || !['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
       // Not the content error we were expecting
       throw e
     }

--- a/packages/core/src/commands/setContent.ts
+++ b/packages/core/src/commands/setContent.ts
@@ -54,6 +54,10 @@ export const setContent: RawCommands['setContent'] = (content, emitUpdate = fals
       errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
     })
   } catch (e) {
+    if (!(e instanceof Error) || ['[tiptap error]: Invalid JSON content', '[tiptap error]: Invalid HTML content'].includes(e.message)) {
+      // Not the content error we were expecting
+      throw e
+    }
     // Only ever throws if enableContentCheck or errorOnInvalidContent is true
     editor.emit('contentError', { editor, error: e as Error })
     return false

--- a/packages/core/src/helpers/createDocument.ts
+++ b/packages/core/src/helpers/createDocument.ts
@@ -14,6 +14,11 @@ export function createDocument(
   content: Content,
   schema: Schema,
   parseOptions: ParseOptions = {},
+  options: { errorOnInvalidContent?: boolean } = {},
 ): ProseMirrorNode {
-  return createNodeFromContent(content, schema, { slice: false, parseOptions }) as ProseMirrorNode
+  return createNodeFromContent(content, schema, {
+    slice: false,
+    parseOptions,
+    errorOnInvalidContent: options.errorOnInvalidContent,
+  }) as ProseMirrorNode
 }

--- a/packages/core/src/helpers/createNodeFromContent.ts
+++ b/packages/core/src/helpers/createNodeFromContent.ts
@@ -47,7 +47,6 @@ export function createNodeFromContent(
 
       return schema.nodeFromJSON(content)
     } catch (error) {
-
       if (options.errorOnInvalidContent) {
         throw new Error('[tiptap error]: Invalid JSON content', { cause: error as Error })
       }

--- a/packages/core/src/helpers/createNodeFromContent.ts
+++ b/packages/core/src/helpers/createNodeFromContent.ts
@@ -67,6 +67,8 @@ export function createNodeFromContent(
       schemaToUse = new Schema({
         topNode: schema.spec.topNode,
         marks: schema.spec.marks,
+        // Prosemirror's schemas are executed such that: the last to execute, matches last
+        // This means that we can add a catch-all node at the end of the schema to catch any content that we don't know how to handle
         nodes: schema.spec.nodes.append({
           __tiptap__private__unknown__catch__all__node: {
             content: 'inline*',
@@ -75,6 +77,7 @@ export function createNodeFromContent(
               {
                 tag: '*',
                 getAttrs: () => {
+                  // If this is ever called, we know that the content has something that we don't know how to handle in the schema
                   hasInvalidContent = true
                   return null
                 },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,7 +39,16 @@ export type MaybeThisParameterType<T> = Exclude<T, Primitive> extends (...args: 
 export interface EditorEvents {
   beforeCreate: { editor: Editor }
   create: { editor: Editor }
-  contentError: { editor: Editor, error: Error }
+  contentError: {
+    editor: Editor,
+    error: Error,
+    /**
+     * If called, will re-initialize the editor with the collaboration extension removed.
+     * This will prevent syncing back deletions of content not present in the current schema.
+     * It may not exist if the editor already is constructed (like on `setContent`)
+     */
+    disableCollaboration?: () => void
+  }
   update: { editor: Editor; transaction: Transaction }
   selectionUpdate: { editor: Editor; transaction: Transaction }
   transaction: { editor: Editor; transaction: Transaction }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,9 +45,8 @@ export interface EditorEvents {
     /**
      * If called, will re-initialize the editor with the collaboration extension removed.
      * This will prevent syncing back deletions of content not present in the current schema.
-     * It may not exist if the editor already is constructed (like on `setContent`)
      */
-    disableCollaboration?: () => void
+    disableCollaboration: () => void
   }
   update: { editor: Editor; transaction: Transaction }
   selectionUpdate: { editor: Editor; transaction: Transaction }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,7 @@ export type MaybeThisParameterType<T> = Exclude<T, Primitive> extends (...args: 
 export interface EditorEvents {
   beforeCreate: { editor: Editor }
   create: { editor: Editor }
+  contentError: { editor: Editor, error: Error }
   update: { editor: Editor; transaction: Transaction }
   selectionUpdate: { editor: Editor; transaction: Transaction }
   transaction: { editor: Editor; transaction: Transaction }
@@ -67,8 +68,20 @@ export interface EditorOptions {
   enableInputRules: EnableRules
   enablePasteRules: EnableRules
   enableCoreExtensions: boolean
+  /**
+   * If `true`, the editor will check the content for errors on initialization.
+   * Emitting the `contentError` event if the content is invalid.
+   * Which can be used to show a warning or error message to the user.
+   * @default false
+   */
+  enableContentCheck: boolean
   onBeforeCreate: (props: EditorEvents['beforeCreate']) => void
   onCreate: (props: EditorEvents['create']) => void
+  /**
+   * Called when the editor encounters an error while parsing the content.
+   * Only enabled if `enableContentCheck` is `true`.
+   */
+  onContentError: (props: EditorEvents['contentError']) => void
   onUpdate: (props: EditorEvents['update']) => void
   onSelectionUpdate: (props: EditorEvents['selectionUpdate']) => void
   onTransaction: (props: EditorEvents['transaction']) => void

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -28,6 +28,7 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
     onSelectionUpdate,
     onTransaction,
     onUpdate,
+    onContentError,
   } = options
 
   const onBeforeCreateRef = useRef(onBeforeCreate)
@@ -38,6 +39,7 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
   const onSelectionUpdateRef = useRef(onSelectionUpdate)
   const onTransactionRef = useRef(onTransaction)
   const onUpdateRef = useRef(onUpdate)
+  const onContentErrorRef = useRef(onContentError)
 
   // This effect will handle updating the editor instance
   // when the event handlers change.
@@ -100,6 +102,13 @@ export const useEditor = (options: Partial<EditorOptions> = {}, deps: Dependency
       editorRef.current.on('update', onUpdate)
 
       onUpdateRef.current = onUpdate
+    }
+
+    if (onContentError) {
+      editorRef.current.off('contentError', onContentErrorRef.current)
+      editorRef.current.on('contentError', onContentError)
+
+      onContentErrorRef.current = onContentError
     }
   }, [onBeforeCreate, onBlur, onCreate, onDestroy, onFocus, onSelectionUpdate, onTransaction, onUpdate, editorRef.current])
 

--- a/tests/cypress/integration/core/createNodeFromContent.spec.ts
+++ b/tests/cypress/integration/core/createNodeFromContent.spec.ts
@@ -1,0 +1,167 @@
+/// <reference types="cypress" />
+
+import { createNodeFromContent, getSchemaByResolvedExtensions } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+
+describe('createNodeFromContent', () => {
+  it('creates a fragment from a schema and HTML content', () => {
+    const content = '<p>Example Text</p>'
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]))
+
+    expect(fragment.toJSON()).to.deep.eq([{
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }])
+  })
+
+  it('creates a fragment from a schema and JSON content', () => {
+    const content = {
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]))
+
+    expect(fragment.toJSON()).to.deep.eq({
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    })
+  })
+
+  it('creates a fragment from a schema and JSON array of content', () => {
+    const content = [{
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }, {
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'More Text',
+      }],
+    }]
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]))
+
+    expect(fragment.toJSON()).to.deep.eq([{
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }, {
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'More Text',
+      }],
+    }])
+  })
+
+  it('returns empty content when a schema does not have matching node types for JSON content', () => {
+    const content = {
+      type: 'non-existing-node-type',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]))
+
+    expect(fragment.toJSON()).to.deep.eq(null)
+  })
+
+  it('returns empty content when a schema does not have matching node types for HTML content', () => {
+    const content = '<non-existing-node-type>Example Text</non-existing-node-type>'
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]))
+
+    expect(fragment.toJSON()).to.deep.eq([{ type: 'text', text: 'Example Text' }])
+  })
+
+  it('if `errorOnInvalidContent` is true, will throw an error when a schema does not have matching node types for HTML content', () => {
+    const content = '<non-existing-node-type>Example Text</non-existing-node-type>'
+
+    expect(() => {
+      createNodeFromContent(content, getSchemaByResolvedExtensions([
+        Document,
+        Paragraph,
+        Text,
+      ]), { errorOnInvalidContent: true })
+    }).to.throw('[tiptap error]: Invalid HTML content')
+  })
+
+  it('if `errorOnInvalidContent` is true, will throw an error when a schema does not have matching node types for JSON content', () => {
+    const content = {
+      type: 'non-existing-node-type',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }
+
+    expect(() => {
+      createNodeFromContent(content, getSchemaByResolvedExtensions([
+        Document,
+        Paragraph,
+        Text,
+      ]), { errorOnInvalidContent: true })
+    }).to.throw('[tiptap error]: Invalid JSON content')
+  })
+
+  it('if `errorOnInvalidContent` is true, will throw an error when a schema does not have matching mark types for JSON content', () => {
+    const content = {
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+        marks: [{
+          type: 'non-existing-mark-type',
+        }],
+      }],
+    }
+
+    expect(() => {
+      createNodeFromContent(content, getSchemaByResolvedExtensions([
+        Document,
+        Paragraph,
+        Text,
+      ]), { errorOnInvalidContent: true })
+    }).to.throw('[tiptap error]: Invalid JSON content')
+  })
+})

--- a/tests/cypress/integration/core/createNodeFromContent.spec.ts
+++ b/tests/cypress/integration/core/createNodeFromContent.spec.ts
@@ -24,6 +24,24 @@ describe('createNodeFromContent', () => {
     }])
   })
 
+  it('if `errorOnInvalidContent` is true, creates a fragment from a schema and HTML content', () => {
+    const content = '<p>Example Text</p>'
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]), { errorOnInvalidContent: true })
+
+    expect(fragment.toJSON()).to.deep.eq([{
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }])
+  })
+
   it('creates a fragment from a schema and JSON content', () => {
     const content = {
       type: 'paragraph',
@@ -38,6 +56,30 @@ describe('createNodeFromContent', () => {
       Paragraph,
       Text,
     ]))
+
+    expect(fragment.toJSON()).to.deep.eq({
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    })
+  })
+
+  it('if `errorOnInvalidContent` is true, creates a fragment from a schema and JSON content', () => {
+    const content = {
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]), { errorOnInvalidContent: true })
 
     expect(fragment.toJSON()).to.deep.eq({
       type: 'paragraph',
@@ -68,6 +110,42 @@ describe('createNodeFromContent', () => {
       Paragraph,
       Text,
     ]))
+
+    expect(fragment.toJSON()).to.deep.eq([{
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }, {
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'More Text',
+      }],
+    }])
+  })
+
+  it('if `errorOnInvalidContent` is true, creates a fragment from a schema and JSON array of content', () => {
+    const content = [{
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'Example Text',
+      }],
+    }, {
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        text: 'More Text',
+      }],
+    }]
+
+    const fragment = createNodeFromContent(content, getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+    ]), { errorOnInvalidContent: true })
 
     expect(fragment.toJSON()).to.deep.eq([{
       type: 'paragraph',

--- a/tests/cypress/integration/core/onContentError.spec.ts
+++ b/tests/cypress/integration/core/onContentError.spec.ts
@@ -87,61 +87,7 @@ describe('onContentError', () => {
 
     expect(editor.getText()).to.eq('')
   })
-  it('emits a contentError on invalid content via setcontent', done => {
-    const json = {
-      invalid: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Example Text',
-            },
-          ],
-        },
-      ],
-    }
 
-    const editor = new Editor({
-      extensions: [Document, Paragraph, Text],
-      enableContentCheck: true,
-      onContentError: ({ error }) => {
-        expect(error.message).to.eq('[tiptap error]: Invalid JSON content')
-        done()
-      },
-    })
-
-    editor.commands.setContent(json)
-  })
-  it('emits a contentError on invalid content via setcontent with override', done => {
-    const json = {
-      invalid: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Example Text',
-            },
-          ],
-        },
-      ],
-    }
-
-    const editor = new Editor({
-      extensions: [Document, Paragraph, Text],
-      enableContentCheck: false,
-      onContentError: ({ error }) => {
-        expect(error.message).to.eq('[tiptap error]: Invalid JSON content')
-        done()
-      },
-    })
-
-    expect(editor.getText()).to.eq('')
-    editor.commands.setContent(json, false, {}, { errorOnInvalidContent: true })
-  })
   it('does not emit a contentError on valid content', () => {
     const json = {
       type: 'doc',

--- a/tests/cypress/integration/core/onContentError.spec.ts
+++ b/tests/cypress/integration/core/onContentError.spec.ts
@@ -1,0 +1,229 @@
+/// <reference types="cypress" />
+
+import { Editor, Extension } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+
+describe('onContentError', () => {
+  it('does not emit a contentError on invalid content (by default)', () => {
+    const json = {
+      invalid: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      content: json,
+      extensions: [Document, Paragraph, Text],
+      onContentError: () => {
+        expect(false).to.eq(true)
+      },
+    })
+
+    expect(editor.getText()).to.eq('')
+  })
+  it('does not emit a contentError on invalid content (when enableContentCheck = false)', () => {
+    const json = {
+      invalid: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      content: json,
+      extensions: [Document, Paragraph, Text],
+      enableContentCheck: false,
+      onContentError: () => {
+        expect(false).to.eq(true)
+      },
+    })
+
+    expect(editor.getText()).to.eq('')
+  })
+  it('emits a contentError on invalid content (when enableContentCheck = true)', done => {
+    const json = {
+      invalid: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      content: json,
+      extensions: [Document, Paragraph, Text],
+      enableContentCheck: true,
+      onContentError: ({ error }) => {
+        expect(error.message).to.eq('[tiptap error]: Invalid JSON content')
+        done()
+      },
+    })
+
+    expect(editor.getText()).to.eq('')
+  })
+  it('emits a contentError on invalid content via setcontent', done => {
+    const json = {
+      invalid: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      enableContentCheck: true,
+      onContentError: ({ error }) => {
+        expect(error.message).to.eq('[tiptap error]: Invalid JSON content')
+        done()
+      },
+    })
+
+    editor.commands.setContent(json)
+  })
+  it('emits a contentError on invalid content via setcontent with override', done => {
+    const json = {
+      invalid: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      enableContentCheck: false,
+      onContentError: ({ error }) => {
+        expect(error.message).to.eq('[tiptap error]: Invalid JSON content')
+        done()
+      },
+    })
+
+    expect(editor.getText()).to.eq('')
+    editor.commands.setContent(json, false, {}, { errorOnInvalidContent: true })
+  })
+  it('does not emit a contentError on valid content', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      content: json,
+      extensions: [Document, Paragraph, Text],
+      enableContentCheck: true,
+      onContentError: () => {
+        expect(false).to.eq(true)
+      },
+    })
+
+    expect(editor.getText()).to.eq('Example Text')
+  })
+  it('removes the collaboration extension when has invalid content (when enableContentCheck = true)', () => {
+    const json = {
+      invalid: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      content: json,
+      extensions: [Document, Paragraph, Text, Extension.create({ name: 'collaboration' })],
+      enableContentCheck: true,
+      onContentError: args => {
+        expect(args.editor.extensionManager.extensions.find(extension => extension.name === 'collaboration')).to.eq(undefined)
+      },
+    })
+
+    expect(editor.getText()).to.eq('')
+    expect(editor.extensionManager.extensions.find(extension => extension.name === 'collaboration')).to.eq(undefined)
+  })
+
+  it('does not remove the collaboration extension when has valid content (when enableContentCheck = true)', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const editor = new Editor({
+      content: json,
+      extensions: [Document, Paragraph, Text, Extension.create({ name: 'collaboration' })],
+      enableContentCheck: true,
+      onContentError: () => {
+        expect(true).to.eq(false)
+      },
+    })
+
+    expect(editor.getText()).to.eq('Example Text')
+    expect(editor.extensionManager.extensions.find(extension => extension.name === 'collaboration')).to.not.eq(undefined)
+  })
+})

--- a/tests/cypress/integration/core/onContentError.spec.ts
+++ b/tests/cypress/integration/core/onContentError.spec.ts
@@ -169,6 +169,7 @@ describe('onContentError', () => {
 
     expect(editor.getText()).to.eq('Example Text')
   })
+
   it('removes the collaboration extension when has invalid content (when enableContentCheck = true)', () => {
     const json = {
       invalid: 'doc',
@@ -190,6 +191,7 @@ describe('onContentError', () => {
       extensions: [Document, Paragraph, Text, Extension.create({ name: 'collaboration' })],
       enableContentCheck: true,
       onContentError: args => {
+        args.disableCollaboration()
         expect(args.editor.extensionManager.extensions.find(extension => extension.name === 'collaboration')).to.eq(undefined)
       },
     })


### PR DESCRIPTION
## Changes Overview

This PR introduces a basic primitive for handling schema errors. Giving the user a callback to know when the schema was given content that it cannot parse and should probably be read only.

## Implementation Approach

This change introduces two new top-level options to the editor: `enableContentCheck` & `onContentError` for dealing with content supplied that does not match the prosemirror schema generated by the set of tiptap extensions.

`enableContentCheck` allows the app developer to opt into the behavior to check for invalid schemas (this change is otherwise backwards compatible).
When true, this will try to parse the document, and any content that does not match the schema will emit a `contentError` which can be listened to via the `onContentError` callback.

## Testing Done

Added new tests for this, most tests were tested manually

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/pull/4641
