### PR TITLE
docs(php): include note on livewire v2 and v3 differences

### DIFF
--- a/docs/installation/php.md
+++ b/docs/installation/php.md
@@ -24,6 +24,8 @@ We provide [an official PHP package to work with Tiptap content](/api/utilities/
   wire:poll.10000ms="autosave"
 ></x-editor>
 ```
+**Note**<br />
+The `.defer` modifier is no longer available in Livewire v3 as updating the state is deferred by default. Use the `.live` modifier if you need to update the state server-side as it changes.
 
 ### editor.blade.php
 ```html


### PR DESCRIPTION
## Changes Overview
Include minor note to the documentation due to livewire version update.

## Testing Done
Works on Laravel Livewire v3.4.12.
