### PR TITLE
fix: don't hide tabs in previews when only one lang is available

### DIFF
--- a/demos/preview/Demo.vue
+++ b/demos/preview/Demo.vue
@@ -4,29 +4,24 @@
     :src="currentIframeUrl"
     :key="currentIframeUrl"
   />
-  <div class="antialiased" v-else>
-    <div v-if="showTabs">
+  <div class="overflow-hidden antialiased rounded-lg" v-else>
+    <div class="px-3 py-1 bg-black flex items-center gap-0.5" v-if="showTabs">
       <button
         v-for="(language, index) in sortedTabs"
         :key="index"
         @click="setTab(language.name)"
-        class="px-4 py-2 text-xs font-bold tracking-wide uppercase rounded-t-lg"
+        class="px-3 py-2 text-sm text-white leading-[125%] font-semibold rounded-[0.625rem] transition-all"
         :class="[currentTab === language.name
-          ? 'bg-black text-white'
-          : 'text-black'
+          ? 'opacity-100 bg-[#1C1917]'
+          : 'opacity-50 bg-transparent hover:opacity-100 hover:bg-[#1C1917]'
         ]"
       >
         {{ language.name }}
       </button>
     </div>
-    <div class="overflow-hidden rounded-b-xl">
+    <div class="overflow-hidden">
       <div
-        class="bg-white border-black border-3 last:rounded-b-xl"
-        :class="[
-          showTabs && firstTabSelected
-            ? 'rounded-tr-xl'
-            : 'rounded-t-xl',
-        ]"
+        class="bg-white"
       >
         <demo-frame
           :src="currentIframeUrl"

--- a/demos/preview/Demo.vue
+++ b/demos/preview/Demo.vue
@@ -5,7 +5,7 @@
     :key="currentIframeUrl"
   />
   <div class="overflow-hidden antialiased rounded-lg" v-else>
-    <div class="px-3 py-1 bg-black flex items-center gap-0.5" v-if="showTabs">
+    <div class="px-3 py-1 bg-black flex items-center gap-0.5">
       <button
         v-for="(language, index) in sortedTabs"
         :key="index"
@@ -117,10 +117,6 @@ export default {
   },
 
   computed: {
-    showTabs() {
-      return this.sortedTabs.length > 1
-    },
-
     currentIframeUrl() {
       return `/src/${this.name}/${this.currentTab}/`
     },


### PR DESCRIPTION
## Changes Overview
In our new demo preview frames, the tabs for languages should **always** be visible - even if only one language is available as a demo.