### PR TITLE
feat: support global attributes for all nodes & marks

### DIFF
--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -108,8 +108,9 @@ declare module '@tiptap/core' {
       name: string
       options: Options
       storage: Storage
+      extensions: (Node | Mark)[]
       parent: ParentConfig<ExtensionConfig<Options, Storage>>['addGlobalAttributes']
-    }) => GlobalAttributes | {}
+    }) => GlobalAttributes
 
     /**
      * This function adds commands to the editor

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -111,8 +111,9 @@ declare module '@tiptap/core' {
       name: string
       options: Options
       storage: Storage
+      extensions: (Node | Mark)[]
       parent: ParentConfig<MarkConfig<Options, Storage>>['addGlobalAttributes']
-    }) => GlobalAttributes | {}
+    }) => GlobalAttributes
 
     /**
      * This function adds commands to the editor

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -7,6 +7,7 @@ import { Editor } from './Editor.js'
 import { getExtensionField } from './helpers/getExtensionField.js'
 import { NodeConfig } from './index.js'
 import { InputRule } from './InputRule.js'
+import { Mark } from './Mark.js'
 import { PasteRule } from './PasteRule.js'
 import {
   AnyConfig,
@@ -111,8 +112,9 @@ declare module '@tiptap/core' {
       name: string
       options: Options
       storage: Storage
+      extensions: (Node | Mark)[]
       parent: ParentConfig<NodeConfig<Options, Storage>>['addGlobalAttributes']
-    }) => GlobalAttributes | {}
+    }) => GlobalAttributes
 
     /**
      * This function adds commands to the editor

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -57,7 +57,7 @@ declare module '@tiptap/core' {
 }
 
 const isFragment = (nodeOrFragment: ProseMirrorNode | Fragment): nodeOrFragment is Fragment => {
-  return nodeOrFragment.toString().startsWith('<')
+  return !('type' in nodeOrFragment)
 }
 
 export const insertContentAt: RawCommands['insertContentAt'] = (position, value, options) => ({ tr, dispatch, editor }) => {

--- a/packages/core/src/helpers/getAttributesFromExtensions.ts
+++ b/packages/core/src/helpers/getAttributesFromExtensions.ts
@@ -5,7 +5,6 @@ import {
   Attributes,
   ExtensionAttribute,
   Extensions,
-  GlobalAttributes,
 } from '../types.js'
 import { getExtensionField } from './getExtensionField.js'
 import { splitExtensions } from './splitExtensions.js'
@@ -32,6 +31,7 @@ export function getAttributesFromExtensions(extensions: Extensions): ExtensionAt
       name: extension.name,
       options: extension.options,
       storage: extension.storage,
+      extensions: nodeAndMarkExtensions,
     }
 
     const addGlobalAttributes = getExtensionField<AnyConfig['addGlobalAttributes']>(
@@ -44,8 +44,7 @@ export function getAttributesFromExtensions(extensions: Extensions): ExtensionAt
       return
     }
 
-    // TODO: remove `as GlobalAttributes`
-    const globalAttributes = addGlobalAttributes() as GlobalAttributes
+    const globalAttributes = addGlobalAttributes()
 
     globalAttributes.forEach(globalAttribute => {
       globalAttribute.types.forEach(type => {

--- a/packages/core/src/helpers/isNodeEmpty.ts
+++ b/packages/core/src/helpers/isNodeEmpty.ts
@@ -1,8 +1,11 @@
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 
 export function isNodeEmpty(node: ProseMirrorNode): boolean {
-  const defaultContent = node.type.createAndFill()?.toJSON()
-  const content = node.toJSON()
+  const defaultContent = node.type.createAndFill()
 
-  return JSON.stringify(defaultContent) === JSON.stringify(content)
+  if (!defaultContent) {
+    return false
+  }
+
+  return node.eq(defaultContent)
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,7 +152,13 @@ export type ExtensionAttribute = {
 }
 
 export type GlobalAttributes = {
+  /**
+   * The node & mark types this attribute should be applied to.
+   */
   types: string[]
+  /**
+   * The attributes to add to the node or mark types.
+   */
   attributes: {
     [key: string]: Attribute
   }


### PR DESCRIPTION
## Changes Overview

This adds all of the applied node & mark extensions as available on the `this` binding for the `addGlobalAttributes` function. This is helpful to be able to apply attributes to all installed extensions for example.

Other optimizations that I saw along the way were applied too:
 - Use the much faster `.eq` method for determining equality of whether a node is considered empty
 - Use a simpler & much faster check to determine if something is a fragment

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
