### PR TITLE
fix(core): update tabindex on state change (#5231)

### DIFF
--- a/demos/src/GuideContent/ReadOnly/React/index.spec.js
+++ b/demos/src/GuideContent/ReadOnly/React/index.spec.js
@@ -15,6 +15,11 @@ context('/src/GuideContent/ReadOnly/React/', () => {
       cy.get('.tiptap').type('Edited: ')
 
       cy.get('.tiptap p:first').should('not.contain', 'Edited: ')
+
+      cy
+        .get('.tiptap')
+        .invoke('attr', 'tabindex')
+        .should('not.exist')
     })
   })
 
@@ -24,6 +29,11 @@ context('/src/GuideContent/ReadOnly/React/', () => {
       cy.get('.tiptap').type('Edited: ')
 
       cy.get('.tiptap p:first').should('contain', 'Edited: ')
+
+      cy
+        .get('.tiptap')
+        .invoke('attr', 'tabindex')
+        .should('eq', '0')
     })
   })
 })

--- a/packages/core/src/extensions/tabindex.ts
+++ b/packages/core/src/extensions/tabindex.ts
@@ -10,7 +10,7 @@ export const Tabindex = Extension.create({
       new Plugin({
         key: new PluginKey('tabindex'),
         props: {
-          attributes: this.editor.isEditable ? { tabindex: '0' } : {},
+          attributes: (): { [name: string]: string; } => (this.editor.isEditable ? { tabindex: '0' } : {}),
         },
       }),
     ]


### PR DESCRIPTION
## Changes Overview
This reverts the initial implementation by providing a method that sets `tabindex` on state change instead of the fixed object.

TypeScript was not happy with the derived return type, so I typed the function the same as in Prosemirror types.

Please check the issue with the detailed description of the problem: https://github.com/ueberdosis/tiptap/issues/5231

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
Manual testing + added automated tests.

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
