### PR TITLE
fix(react): resolves React NodeView performance issues

### DIFF
--- a/.changeset/rotten-beers-protect.md
+++ b/.changeset/rotten-beers-protect.md
@@ -1,0 +1,12 @@
+---
+"@tiptap/react": minor
+"@tiptap/core": minor
+---
+
+This PR significantly improves the performance of React NodeViews in a couple of ways:
+
+- It now uses useSyncExternalStore to synchronize changes between React & the editor instance
+- It dramatically reduces the number of re-renders by re-using instances of React portals that have already been initialized and unaffected by the change made in the editor
+
+We were seeing performance problems with React NodeViews because a change to one of them would cause a re-render to all instances of node views. For an application that heavily relies on node views in React, this was quite expensive.
+This should dramatically cut down on the number of instances that have to re-render, and, making each of those re-renders much less costly.

--- a/demos/src/Examples/CustomParagraph/React/Paragraph.jsx
+++ b/demos/src/Examples/CustomParagraph/React/Paragraph.jsx
@@ -6,7 +6,6 @@ import {
 } from '@tiptap/react'
 
 const ParagraphComponent = ({ node }) => {
-  console.count('render')
   return (
     <NodeViewWrapper style={{ position: 'relative' }}>
       <span contentEditable={false} className="label" style={{

--- a/demos/src/Examples/CustomParagraph/React/Paragraph.jsx
+++ b/demos/src/Examples/CustomParagraph/React/Paragraph.jsx
@@ -6,6 +6,7 @@ import {
 } from '@tiptap/react'
 
 const ParagraphComponent = ({ node }) => {
+  console.count('render')
   return (
     <NodeViewWrapper style={{ position: 'relative' }}>
       <span contentEditable={false} className="label" style={{

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -57,6 +57,8 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   public isFocused = false
 
+  public isInitialized = false
+
   public extensionStorage: Record<string, any> = {}
 
   public options: EditorOptions = {
@@ -111,6 +113,7 @@ export class Editor extends EventEmitter<EditorEvents> {
 
       this.commands.focus(this.options.autofocus)
       this.emit('create', { editor: this })
+      this.isInitialized = true
     }, 0)
   }
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -57,6 +57,9 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   public isFocused = false
 
+  /**
+   * The editor is considered initialized after the `create` event has been emitted.
+   */
   public isInitialized = false
 
   public extensionStorage: Record<string, any> = {}

--- a/packages/react/src/Editor.ts
+++ b/packages/react/src/Editor.ts
@@ -1,4 +1,5 @@
 import { Editor as CoreEditor } from '@tiptap/core'
+import React from 'react'
 
 import { ReactRenderer } from './ReactRenderer.js'
 
@@ -6,8 +7,8 @@ type ContentComponent = {
   setRenderer(id: string, renderer: ReactRenderer): void;
   removeRenderer(id: string): void;
   subscribe: (callback: () => void) => () => void;
-  getSnapshot: () => Record<string, ReactRenderer>;
-  getServerSnapshot: () => Record<string, ReactRenderer>;
+  getSnapshot: () => Record<string, React.ReactPortal>;
+  getServerSnapshot: () => Record<string, React.ReactPortal>;
 }
 
 export class Editor extends CoreEditor {

--- a/packages/react/src/Editor.ts
+++ b/packages/react/src/Editor.ts
@@ -1,12 +1,13 @@
 import { Editor as CoreEditor } from '@tiptap/core'
-import React from 'react'
 
-import { EditorContentProps, EditorContentState } from './EditorContent.js'
 import { ReactRenderer } from './ReactRenderer.js'
 
-type ContentComponent = React.Component<EditorContentProps, EditorContentState> & {
+type ContentComponent = {
   setRenderer(id: string, renderer: ReactRenderer): void;
   removeRenderer(id: string): void;
+  subscribe: (callback: () => void) => () => void;
+  getSnapshot: () => Record<string, ReactRenderer>;
+  getServerSnapshot: () => Record<string, ReactRenderer>;
 }
 
 export class Editor extends CoreEditor {

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -1,7 +1,8 @@
 import React, {
   ForwardedRef, forwardRef, HTMLProps, LegacyRef, MutableRefObject,
+  useSyncExternalStore,
 } from 'react'
-import ReactDOM, { flushSync } from 'react-dom'
+import ReactDOM from 'react-dom'
 
 import { Editor } from './Editor.js'
 import { ReactRenderer } from './ReactRenderer.js'
@@ -20,7 +21,9 @@ const mergeRefs = <T extends HTMLDivElement>(
   }
 }
 
-const Portals: React.FC<{ renderers: Record<string, ReactRenderer> }> = ({ renderers }) => {
+const Portals: React.FC<{ contentComponent: Exclude<Editor['contentComponent'], null> }> = ({ contentComponent }) => {
+  const renderers = useSyncExternalStore(contentComponent.subscribe, contentComponent.getSnapshot, contentComponent.getServerSnapshot)
+
   return (
     <>
       {Object.entries(renderers).map(([key, renderer]) => {
@@ -35,14 +38,52 @@ export interface EditorContentProps extends HTMLProps<HTMLDivElement> {
   innerRef?: ForwardedRef<HTMLDivElement | null>;
 }
 
-export interface EditorContentState {
-  renderers: Record<string, ReactRenderer>;
+function getInstance(): Exclude<Editor['contentComponent'], null> {
+
+  const subscribers = new Set<() => void>()
+  let renderers: Record<string, ReactRenderer<unknown, unknown>> = {}
+
+  return {
+    /**
+     * Subscribe to the editor instance's changes.
+     */
+    subscribe(callback: () => void) {
+      subscribers.add(callback)
+      return () => {
+        subscribers.delete(callback)
+      }
+    },
+    getSnapshot() {
+      return renderers
+    },
+    getServerSnapshot() {
+      // TODO figure out if this is valid
+      return renderers
+    },
+    setRenderer(id: string, renderer: ReactRenderer) {
+      renderers = {
+        ...renderers,
+        [id]: renderer,
+      }
+
+      subscribers.forEach(subscriber => subscriber())
+    },
+    removeRenderer(id: string) {
+      const nextRenderers = { ...renderers }
+
+      delete nextRenderers[id]
+      renderers = nextRenderers
+      subscribers.forEach(subscriber => subscriber())
+    },
+  }
 }
 
-export class PureEditorContent extends React.Component<EditorContentProps, EditorContentState> {
+export class PureEditorContent extends React.Component<EditorContentProps, {hasContentComponentInitialized: boolean}> {
   editorContentRef: React.RefObject<any>
 
   initialized: boolean
+
+  unsubscribeToContentComponent?: () => void
 
   constructor(props: EditorContentProps) {
     super(props)
@@ -50,7 +91,7 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
     this.initialized = false
 
     this.state = {
-      renderers: {},
+      hasContentComponentInitialized: Boolean(props.editor?.contentComponent),
     }
   }
 
@@ -78,47 +119,29 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
         element,
       })
 
-      editor.contentComponent = this
+      editor.contentComponent = getInstance()
+
+      if (!this.state.hasContentComponentInitialized) {
+        this.unsubscribeToContentComponent = editor.contentComponent.subscribe(() => {
+          this.setState(prevState => {
+            if (!prevState.hasContentComponentInitialized) {
+              return {
+                hasContentComponentInitialized: true,
+              }
+            }
+            return prevState
+          })
+
+          if (this.unsubscribeToContentComponent) {
+            this.unsubscribeToContentComponent()
+          }
+        })
+      }
 
       editor.createNodeViews()
 
       this.initialized = true
     }
-  }
-
-  maybeFlushSync(fn: () => void) {
-    // Avoid calling flushSync until the editor is initialized.
-    // Initialization happens during the componentDidMount or componentDidUpdate
-    // lifecycle methods, and React doesn't allow calling flushSync from inside
-    // a lifecycle method.
-    if (this.initialized) {
-      flushSync(fn)
-    } else {
-      fn()
-    }
-  }
-
-  setRenderer(id: string, renderer: ReactRenderer) {
-    this.maybeFlushSync(() => {
-      this.setState(({ renderers }) => ({
-        renderers: {
-          ...renderers,
-          [id]: renderer,
-        },
-      }))
-    })
-  }
-
-  removeRenderer(id: string) {
-    this.maybeFlushSync(() => {
-      this.setState(({ renderers }) => {
-        const nextRenderers = { ...renderers }
-
-        delete nextRenderers[id]
-
-        return { renderers: nextRenderers }
-      })
-    })
   }
 
   componentWillUnmount() {
@@ -134,6 +157,10 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
       editor.view.setProps({
         nodeViews: {},
       })
+    }
+
+    if (this.unsubscribeToContentComponent) {
+      this.unsubscribeToContentComponent()
     }
 
     editor.contentComponent = null
@@ -158,7 +185,7 @@ export class PureEditorContent extends React.Component<EditorContentProps, Edito
       <>
         <div ref={mergeRefs(innerRef, this.editorContentRef)} {...rest} />
         {/* @ts-ignore */}
-        <Portals renderers={this.state.renderers} />
+        {editor?.contentComponent && <Portals contentComponent={editor.contentComponent} />}
       </>
     )
   }

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -21,15 +21,20 @@ const mergeRefs = <T extends HTMLDivElement>(
   }
 }
 
+/**
+ * This component renders all of the editor's node views.
+ */
 const Portals: React.FC<{ contentComponent: Exclude<Editor['contentComponent'], null> }> = ({
   contentComponent,
 }) => {
+  // For performance reasons, we render the node view portals on state changes only
   const renderers = useSyncExternalStore(
     contentComponent.subscribe,
     contentComponent.getSnapshot,
     contentComponent.getServerSnapshot,
   )
 
+  // This allows us to directly render the portals without any additional wrapper
   return (
     <>
       {Object.values(renderers)}
@@ -62,6 +67,9 @@ function getInstance(): Exclude<Editor['contentComponent'], null> {
     getServerSnapshot() {
       return renderers
     },
+    /**
+     * Adds a new NodeView Renderer to the editor.
+     */
     setRenderer(id: string, renderer: ReactRenderer) {
       renderers = {
         ...renderers,
@@ -70,6 +78,9 @@ function getInstance(): Exclude<Editor['contentComponent'], null> {
 
       subscribers.forEach(subscriber => subscriber())
     },
+    /**
+     * Removes a NodeView Renderer from the editor.
+     */
     removeRenderer(id: string) {
       const nextRenderers = { ...renderers }
 
@@ -126,7 +137,9 @@ export class PureEditorContent extends React.Component<
 
       editor.contentComponent = getInstance()
 
+      // Has the content component been initialized?
       if (!this.state.hasContentComponentInitialized) {
+        // Subscribe to the content component
         this.unsubscribeToContentComponent = editor.contentComponent.subscribe(() => {
           this.setState(prevState => {
             if (!prevState.hasContentComponentInitialized) {
@@ -137,6 +150,7 @@ export class PureEditorContent extends React.Component<
             return prevState
           })
 
+          // Unsubscribe to previous content component
           if (this.unsubscribeToContentComponent) {
             this.unsubscribeToContentComponent()
           }

--- a/packages/react/src/NodeViewWrapper.tsx
+++ b/packages/react/src/NodeViewWrapper.tsx
@@ -12,6 +12,7 @@ export const NodeViewWrapper: React.FC<NodeViewWrapperProps> = React.forwardRef(
   const Tag = props.as || 'div'
 
   return (
+    // @ts-ignore
     <Tag
       {...props}
       ref={ref}

--- a/packages/react/src/NodeViewWrapper.tsx
+++ b/packages/react/src/NodeViewWrapper.tsx
@@ -7,7 +7,6 @@ export interface NodeViewWrapperProps {
   as?: React.ElementType,
 }
 
-// TODO not sure that we need all of this, I feel like it could just be a hook that spreads props onto a user's top-level component
 export const NodeViewWrapper: React.FC<NodeViewWrapperProps> = React.forwardRef((props, ref) => {
   const { onDragStart } = useReactNodeView()
   const Tag = props.as || 'div'

--- a/packages/react/src/NodeViewWrapper.tsx
+++ b/packages/react/src/NodeViewWrapper.tsx
@@ -7,6 +7,7 @@ export interface NodeViewWrapperProps {
   as?: React.ElementType,
 }
 
+// TODO not sure that we need all of this, I feel like it could just be a hook that spreads props onto a user's top-level component
 export const NodeViewWrapper: React.FC<NodeViewWrapperProps> = React.forwardRef((props, ref) => {
   const { onDragStart } = useReactNodeView()
   const Tag = props.as || 'div'

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -66,6 +66,8 @@ class ReactNodeView extends NodeView<
     }
     const context = { onDragStart, nodeViewContentRef }
     const Component = this.component
+    // For performance reasons, we memoize the provider component
+    // And all of the things it requires are declared outside of the component, so it doesn't need to re-render
     const ReactNodeViewProvider: React.FunctionComponent = React.memo(componentProps => {
       return (
         <ReactNodeViewContext.Provider value={context}>

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -58,25 +58,21 @@ class ReactNodeView extends NodeView<
       this.component.displayName = capitalizeFirstChar(this.extension.name)
     }
 
-    const ReactNodeViewProvider: React.FunctionComponent = componentProps => {
-      const Component = this.component
-      const onDragStart = this.onDragStart.bind(this)
-      const nodeViewContentRef: ReactNodeViewContextProps['nodeViewContentRef'] = element => {
-        if (element && this.contentDOMElement && element.firstChild !== this.contentDOMElement) {
-          element.appendChild(this.contentDOMElement)
-        }
+    const onDragStart = this.onDragStart.bind(this)
+    const nodeViewContentRef: ReactNodeViewContextProps['nodeViewContentRef'] = element => {
+      if (element && this.contentDOMElement && element.firstChild !== this.contentDOMElement) {
+        element.appendChild(this.contentDOMElement)
       }
-
-      return (
-        <>
-          {/* @ts-ignore */}
-          <ReactNodeViewContext.Provider value={{ onDragStart, nodeViewContentRef }}>
-            {/* @ts-ignore */}
-            <Component {...componentProps} />
-          </ReactNodeViewContext.Provider>
-        </>
-      )
     }
+    const context = { onDragStart, nodeViewContentRef }
+    const Component = this.component
+    const ReactNodeViewProvider: React.FunctionComponent = React.memo(componentProps => {
+      return (
+        <ReactNodeViewContext.Provider value={context}>
+          {React.createElement(Component, componentProps)}
+        </ReactNodeViewContext.Provider>
+      )
+    })
 
     ReactNodeViewProvider.displayName = 'ReactNodeView'
 

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -143,7 +143,7 @@ export class ReactRenderer<R = unknown, P = unknown> {
       }
     }
 
-    this.reactElement = <Component {...props } />
+    this.reactElement = React.createElement(Component, props)
 
     this.editor?.contentComponent?.setRenderer(this.id, this)
   }

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -1,5 +1,6 @@
 import { Editor } from '@tiptap/core'
 import React from 'react'
+import { flushSync } from 'react-dom'
 
 import { Editor as ExtendedEditor } from './Editor.js'
 
@@ -71,6 +72,8 @@ type ComponentType<R, P> =
   React.FunctionComponent<P> |
   React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<R>>;
 
+let first = true
+
 /**
  * The ReactRenderer class. It's responsible for rendering React components inside the editor.
  * @example
@@ -121,7 +124,20 @@ export class ReactRenderer<R = unknown, P = unknown> {
       })
     }
 
-    this.render()
+    if (first) {
+      // TODO this is totally a hack, on the first render of the editor (parent editor)
+      // We need to delay the rendering of the ReactRenderer components (because it would render before the editor is ready)
+      // setTimeout(() => {
+      this.render()
+      first = false
+      // }, 100)
+    } else {
+      // On first render, we need to flush the render synchronously
+      // Renders afterwards can be async, but this fixes a cursor positioning issue
+      flushSync(() => {
+        this.render()
+      })
+    }
   }
 
   render(): void {

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -72,8 +72,6 @@ type ComponentType<R, P> =
   React.FunctionComponent<P> |
   React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<R>>;
 
-let first = true
-
 /**
  * The ReactRenderer class. It's responsible for rendering React components inside the editor.
  * @example
@@ -124,19 +122,14 @@ export class ReactRenderer<R = unknown, P = unknown> {
       })
     }
 
-    if (first) {
-      // TODO this is totally a hack, on the first render of the editor (parent editor)
-      // We need to delay the rendering of the ReactRenderer components (because it would render before the editor is ready)
-      // setTimeout(() => {
-      this.render()
-      first = false
-      // }, 100)
-    } else {
+    if (this.editor.isInitialized) {
       // On first render, we need to flush the render synchronously
       // Renders afterwards can be async, but this fixes a cursor positioning issue
       flushSync(() => {
         this.render()
       })
+    } else {
+      this.render()
     }
   }
 


### PR DESCRIPTION
## Changes Overview

This PR significantly improves the performance of React NodeViews in a couple of ways:

 - It uses `useSyncExternalStore` to synchronize changes between React & the editor instance
 - It dramatically reduces the number of re-renders by re-using instances of React portals that have already been initialized and unaffected by the change made in the editor

We were seeing performance problems with React NodeViews because a change to one of them would cause a re-render to all instances of node views, for an application that heavily relies on node views in React, this is expensive. This should dramatically cut down on the number of instances that have to re-render as well as making each of those re-renders much less costly.

## Implementation Approach

Similar to the performance updates for Tiptap 2.5, React has it's own lifecycle for components and it really does not like when you try to force it to be synchronous (since it would prefer to batch renders together). Now we can have the best of both worlds by forcing a synchronous render on initialization, but updates afterward can be done on React's normal lifecycle (i.e. without a flushSync)

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

Lots of manual testing with tons of custom react node views. Much faster than before, but hard to write tests for.

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have renamed my PR according to the naming conventions. (e.g. `feat: Implement new feature` or `chore(deps): Update dependencies`)
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
https://github.com/ueberdosis/tiptap/issues/3976
https://github.com/ueberdosis/tiptap/issues/3580
