### PR TITLE
fix: placeholders now check for empty content compared to their "true" empty state

### DIFF
--- a/.changeset/mean-cooks-cheer.md
+++ b/.changeset/mean-cooks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-placeholder": patch
+---
+
+Placeholders can now handle more complex default content

--- a/packages/extension-placeholder/src/placeholder.ts
+++ b/packages/extension-placeholder/src/placeholder.ts
@@ -1,4 +1,4 @@
-import { Editor, Extension } from '@tiptap/core'
+import { Editor, Extension, isNodeEmpty } from '@tiptap/core'
 import { Node as ProsemirrorNode } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
@@ -30,15 +30,6 @@ export interface PlaceholderOptions {
         hasAnchor: boolean
       }) => string)
     | string
-
-  /**
-   * **Used for empty check on the document.**
-   *
-   * If true, any node that is not a leaf or atom will be considered for empty check.
-   * If false, only default nodes (paragraphs) will be considered for empty check.
-   * @default false
-   */
-  considerAnyAsEmpty: boolean
 
   /**
    * **Checks if the placeholder should be only shown when the editor is editable.**
@@ -82,7 +73,6 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
       emptyNodeClass: 'is-empty',
       placeholder: 'Write something …',
       showOnlyWhenEditable: true,
-      considerAnyAsEmpty: false,
       showOnlyCurrent: true,
       includeChildren: false,
     }
@@ -102,21 +92,11 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
               return null
             }
 
-            // only calculate isEmpty once due to its performance impacts (see issue #3360)
-            const { firstChild } = doc.content
-            const isLeaf = firstChild && firstChild.type.isLeaf
-            const isAtom = firstChild && firstChild.isAtom
-            const isValidNode = this.options.considerAnyAsEmpty
-              ? true
-              : firstChild && firstChild.type.name === doc.type.contentMatch.defaultType?.name
-            const isEmptyDoc = doc.content.childCount <= 1
-              && firstChild
-              && isValidNode
-              && (firstChild.nodeSize <= 2 && (!isLeaf || !isAtom))
+            const isEmptyDoc = this.editor.isEmpty
 
             doc.descendants((node, pos) => {
               const hasAnchor = anchor >= pos && anchor <= pos + node.nodeSize
-              const isEmpty = !node.isLeaf && !node.childCount
+              const isEmpty = !node.isLeaf && isNodeEmpty(node)
 
               if ((hasAnchor || !this.options.showOnlyCurrent) && isEmpty) {
                 const classes = [this.options.emptyNodeClass]


### PR DESCRIPTION
## Changes Overview
This resolves a bug where the placeholder extension was not counting a document that contains more complex default content

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->
I did some testing with the placeholder extension, couldn't be bothered to write whole new tests for it:
```diff
diff --git a/demos/src/Extensions/Placeholder/React/index.jsx b/demos/src/Extensions/Placeholder/React/index.jsx
index 970353980..9d5ae3389 100644
--- a/demos/src/Extensions/Placeholder/React/index.jsx
+++ b/demos/src/Extensions/Placeholder/React/index.jsx
@@ -1,5 +1,7 @@
 import './styles.scss'
 
+import { Node } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
 import Placeholder from '@tiptap/extension-placeholder'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -8,7 +10,19 @@ import React from 'react'
 export default () => {
   const editor = useEditor({
     extensions: [
-      StarterKit,
+      Node.create({
+        name: 'page',
+        content: 'block+',
+        renderHTML({ HTMLAttributes }) {
+          return ['p', HTMLAttributes, 0]
+        },
+      }),
+      Document.extend({
+        content: 'page+',
+      }),
+      StarterKit.configure({
+        document: false,
+      }),
       Placeholder.configure({
         // Use a placeholder:
         placeholder: 'Write something …',

```

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
^ above
## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
