### PR TITLE
fix: take atom content in full

### DIFF
--- a/.changeset/atom-text-content-in-full.md
+++ b/.changeset/atom-text-content-in-full.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+fix: take atom content in full

--- a/.changeset/atom-text-content-in-full.md
+++ b/.changeset/atom-text-content-in-full.md
@@ -2,4 +2,4 @@
 "@tiptap/core": patch
 ---
 
-fix: take atom content in full
+Make sure that atoms are used in-full without cutting the content. Node size for atoms is 1 which causes text to be cut unexpectedly.

--- a/packages/core/src/helpers/getTextContentFromNodes.ts
+++ b/packages/core/src/helpers/getTextContentFromNodes.ts
@@ -24,7 +24,7 @@ export const getTextContentFromNodes = ($from: ResolvedPos, maxMatch = 500) => {
         || node.textContent
         || '%leaf%'
 
-      textBefore += chunk.slice(0, Math.max(0, sliceEndPos - pos))
+      textBefore += node.isAtom ? chunk : chunk.slice(0, Math.max(0, sliceEndPos - pos))
     },
   )
 

--- a/tests/cypress/integration/core/getTextContentFromNodes.spec.ts
+++ b/tests/cypress/integration/core/getTextContentFromNodes.spec.ts
@@ -1,0 +1,41 @@
+/// <reference types="cypress" />
+
+import {
+  getSchemaByResolvedExtensions, getTextContentFromNodes,
+} from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Mention from '@tiptap/extension-mention'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { Node } from '@tiptap/pm/model'
+
+describe(getTextContentFromNodes.name, () => {
+  it('gets text', () => {
+    const schema = getSchemaByResolvedExtensions([
+      Document,
+      Paragraph,
+      Text,
+      Mention.configure({ renderText: ({ node }) => `@${node.attrs.label ?? 'Unknown'}` }),
+    ])
+
+    const doc = Node.fromJSON(schema, {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Start ' },
+            { type: 'mention', attrs: { id: 1, label: 'Mention' } },
+            { type: 'text', text: ' End' },
+          ],
+        },
+      ],
+    })
+
+    const pos = doc.resolve(12)
+
+    const text = getTextContentFromNodes(pos)
+
+    expect(text).to.eq('Start @Mention End')
+  })
+})


### PR DESCRIPTION
## Changes Overview
Make sure that atoms are used in-full without cutting the content. Node size for atoms is 1 which causes text to be cut unexpectedly.

## Implementation Approach
Just made sure I handle the one exception for not cutting content – atom.

## Testing Done
Automated tests for new functionality. Unfortunately there are no existing tests so regression testing is manual.

## Verification Steps
Try adding atom nodes and copy text. Content should contain full atom content.

## Additional Notes

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5298
