### PR TITLE
Flip the order of useEditorState's overloads

### DIFF
--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -95,11 +95,11 @@ function makeEditorStateInstance<TEditor extends Editor | null = Editor | null>(
 }
 
 export function useEditorState<TSelectorResult>(
-  options: UseEditorStateOptions<TSelectorResult, Editor | null>
-): TSelectorResult | null;
-export function useEditorState<TSelectorResult>(
   options: UseEditorStateOptions<TSelectorResult, Editor>
 ): TSelectorResult;
+export function useEditorState<TSelectorResult>(
+  options: UseEditorStateOptions<TSelectorResult, Editor | null>
+): TSelectorResult | null;
 
 export function useEditorState<TSelectorResult>(
   options: UseEditorStateOptions<TSelectorResult, Editor> | UseEditorStateOptions<TSelectorResult, Editor | null>,


### PR DESCRIPTION
So that TypeScript will resolve the non-nullable one first, unless the editor is nullable, in which case the other one will resolve.

Related to discussion in #5161 @nperez0111 
