### PR TITLE
Fix off by one error for images (and probably other atomic nodes)

### DIFF
--- a/packages/core/src/NodePos.ts
+++ b/packages/core/src/NodePos.ts
@@ -136,7 +136,7 @@ export class NodePos {
     this.node.content.forEach((node, offset) => {
       const isBlock = node.isBlock && !node.isTextblock
 
-      const targetPos = this.pos + offset + 1
+      const targetPos = this.pos + offset + (node.isAtom ? 0 : 1)
       const $pos = this.resolvedPos.doc.resolve(targetPos)
 
       if (!isBlock && $pos.depth <= this.depth) {


### PR DESCRIPTION
## Changes Overview
Fixes NodePos miscalculation for images

## Implementation Approach
Reverts the spirit, but not letter, of the approach that was used before the regression occurred: https://github.com/ueberdosis/tiptap/pull/5038/files#diff-deab15d8918868fc71b9ad8ee3afa808f6b4be07c48e915fd0aed512493fd90cL139

## Testing Done
**TESTING WAS NOT DONE**

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
@masylum your help confirming this PR works as intended would be greatly appreciated

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
#5314
