### PR TITLE
fix: check that view is not destroyed before creating node views in core Editor

### DIFF
--- a/.changeset/sixty-gifts-dream.md
+++ b/.changeset/sixty-gifts-dream.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Add a check beforecreateNodeViews so that view.setProps is not called when the view has already been destroyed

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -351,6 +351,10 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Creates all node views.
    */
   public createNodeViews(): void {
+    if (this.view.isDestroyed) {
+      return
+    }
+
     this.view.setProps({
       nodeViews: this.extensionManager.nodeViews,
     })


### PR DESCRIPTION
## Changes Overview
Adds a check before creating node views in the core editor so setProps is not called on a destroyed view.

## Implementation Approach
Added checks in `createNodeViews()` in `Editor.ts`.

## Additional Notes
This should be no-op for successful use cases. There should not be any reason to call `this.view.setProps` on a view that has been destroyed, and doing so should either be no-op or results in unexpected crashes. This PR fixes this behaviour.

Related to #5333.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable. (needs contribution)
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
