### PR TITLE
fix(react): `useEditor` should not destroy instances that are still mounted

### DIFF
--- a/.changeset/clever-mice-search.md
+++ b/.changeset/clever-mice-search.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Fixes strict mode accidentally destroying the editor instance

--- a/demos/src/Examples/Performance/React/index.jsx
+++ b/demos/src/Examples/Performance/React/index.jsx
@@ -93,7 +93,7 @@ function EditorInstance({ shouldOptimizeRendering }) {
   )
 }
 
-export default () => {
+const EditorControls = () => {
   const [shouldOptimizeRendering, setShouldOptimizeRendering] = React.useState(true)
 
   return (
@@ -126,5 +126,13 @@ export default () => {
       </div>
       <EditorInstance shouldOptimizeRendering={shouldOptimizeRendering} />
     </>
+  )
+}
+
+export default () => {
+  return (
+    <React.StrictMode>
+      <EditorControls />
+    </React.StrictMode>
   )
 }


### PR DESCRIPTION
## Changes Overview

This forces the editor to re-use the editor instance that existed prior to an unmount and remount of the same component.
This fixes a bug in `React.StrictMode` introduced with the latest performance updates by PR #5161

<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
I made the Performance test playground run in StrictMode and was able to resolve the issue
## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->
Checked StrictMode and normal rendering and they seem fine
## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
