### PR TITLE
hotfix(vue-3): backwards compatibility ref exposed methods

### DIFF
--- a/packages/vue-3/src/VueRenderer.ts
+++ b/packages/vue-3/src/VueRenderer.ts
@@ -22,8 +22,6 @@ interface RenderedComponent {
  * This class is used to render Vue components inside the editor.
  */
 export class VueRenderer {
-  id: string
-
   renderedComponent!: RenderedComponent
 
   editor: ExtendedEditor
@@ -35,7 +33,6 @@ export class VueRenderer {
   props: Record<string, any>
 
   constructor(component: Component, { props = {}, editor }: VueRendererOptions) {
-    this.id = Math.floor(Math.random() * 0xFFFFFFFF).toString()
     this.editor = editor as ExtendedEditor
     this.component = markRaw(component)
     this.el = document.createElement('div')
@@ -45,6 +42,10 @@ export class VueRenderer {
 
   get element(): Element | null {
     return this.renderedComponent.el
+  }
+
+  get ref(): any {
+    return this.renderedComponent.vNode?.component?.exposed
   }
 
   renderComponent() {


### PR DESCRIPTION
## Changes Overview
return to using `renderedComponent`'s `ref` method to bind the methods exposed by the component and preserve the compontability of interfacing

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
