### PR TITLE
Fix useEditor hook

### DIFF
--- a/.changeset/curly-buses-attend.md
+++ b/.changeset/curly-buses-attend.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+The optional deps argument to useEditor was not being respected for performance optimizations, now if deps are declared a new editor instance is created

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -98,17 +98,9 @@ export function useEditor(
 
   // This effect will handle creating/updating the editor instance
   useEffect(() => {
-    let editorInstance: Editor | null = editor
+    const newEditorInstance = new Editor(options)
 
-    if (!editorInstance) {
-      editorInstance = new Editor(options)
-      // instantiate the editor if it doesn't exist
-      // for ssr, this is the first time the editor is created
-      setEditor(editorInstance)
-    } else {
-      // if the editor does exist, update the editor options accordingly
-      editorInstance.setOptions(options)
-    }
+    setEditor(newEditorInstance)
   }, deps)
 
   const {

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -98,9 +98,23 @@ export function useEditor(
 
   // This effect will handle creating/updating the editor instance
   useEffect(() => {
-    const newEditorInstance = new Editor(options)
+    let editorInstance: Editor | null = editor
 
-    setEditor(newEditorInstance)
+    if (!editorInstance) {
+      editorInstance = new Editor(options)
+      // instantiate the editor if it doesn't exist
+      // for ssr, this is the first time the editor is created
+      setEditor(editorInstance)
+    } else if (Array.isArray(deps) && deps.length) {
+      // the deps array is used to re-initialize the editor instance
+      editorInstance = new Editor(options)
+
+      setEditor(editorInstance)
+    } else {
+      // if the editor does exist & deps are empty, we don't need to re-initialize the editor
+      // we can fast-path to update the editor options on the existing instance
+      editorInstance.setOptions(options)
+    }
   }, deps)
 
   const {


### PR DESCRIPTION
## Changes Overview

This PR changes the editor creation mechanism when dependencies change. Previously, the hook would try reusing an existing instance and applying new options if possible. Now, it always creates a new editor instance.

This fixes a bug where the content synchronisation mechanism wouldn't work in SPA apps when changing the content of the editor based on the client side route change. More specifically, it fixes a scenario where `/document/:id` page would contain a TipTap Collaboration editor and the user would

1. open `/document/1` and collaborate
2. open `/document/2` and collaborate

```ts
const editor = useEditor(
    {
      // NOTE: Disable immediate rendering to prevent SSR errors.
      immediatelyRender: false,
      extensions: [
        DocumentExtension.extend({
          content: 'heading block*',
        }),

        // ...

        // Collaboration
        CollaborationExtension.configure({ document: yDoc }),
        CommentsKit.configure({ provider: ttProvider }),
      ],
    },
    [yDoc, ttProvider],
  )
```

I expect that when user opens `/document/2` the content of the editor updates accordingly because `yDoc` and `ttProvider` changed. However, the content doesn't update unless I force reload a page or manually set the content as I'd do on initial render.

I think the issue lies in `EditorContent` not reinitialising when extensions change because the forwarded editor instance didn't change. Additionally, I tried manually changing the key property to force a reload, but because of the key management logic in `EditorContent.tsx` it didn't change the instance.

https://github.com/ueberdosis/tiptap/blob/a21a122759db1c4456c5d0a03f0154b44ea7a360/packages/react/src/EditorContent.tsx#L168

## Testing Done

I tested this locally via a `pnpm patch` and wanted to ask whether this breaks any crucial functionality. Moreover, I wanted to know whether this is a known issue and there exists a better solution for it before filing a final PR.

## Additional Notes

Running `npm run changeset` throws with the following error

![CleanShot 2024-07-15 at 23 19 12@2x](https://github.com/user-attachments/assets/0d412d91-cbfc-4ac1-960a-80644e0e872b)

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
