### PR TITLE
fix(vue-3): provide app global

### DIFF
--- a/packages/vue-3/src/VueRenderer.ts
+++ b/packages/vue-3/src/VueRenderer.ts
@@ -50,6 +50,9 @@ export class VueRenderer {
   renderComponent() {
     let vNode: ExtendedVNode = h(this.component as DefineComponent, this.props)
 
+    if (this.editor.appContext) {
+      vNode.appContext = this.editor.appContext
+    }
     if (typeof document !== 'undefined' && this.el) { render(vNode, this.el) }
 
     const destroy = () => {


### PR DESCRIPTION
## Changes Overview
In refacto's work to improve rendering performance of vue-3 components we attached appContext to `EditorContent` but forgot to bind it to the rendered vNode.
https://github.com/ueberdosis/tiptap/pull/5206

## Implementation Approach
We bind appContext on the rendered vNode

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5323
