### PR TITLE
fix(core): configuring extensions should add to the parent's options not replace them

### DIFF
--- a/.changeset/clean-bugs-rush.md
+++ b/.changeset/clean-bugs-rush.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+There was a bug where doing a `.configure` on an extension, node or mark would overwrite the extensions options instead of being merged with the default options.

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -460,7 +460,7 @@ export class Extension<Options = any, Storage = any> {
     const extension = this.extend({
       ...this.config,
       addOptions: () => {
-        return mergeDeep(options, this.options as Record<string, any>) as Options
+        return mergeDeep(this.options as Record<string, any>, options) as Options
       },
     })
 

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -459,8 +459,8 @@ export class Extension<Options = any, Storage = any> {
     // with different calls of `configure`
     const extension = this.extend({
       ...this.config,
-      addOptions() {
-        return mergeDeep(this.parent?.() || {}, options) as Options
+      addOptions: () => {
+        return mergeDeep(options, this.options as Record<string, any>) as Options
       },
     })
 

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -592,7 +592,7 @@ export class Mark<Options = any, Storage = any> {
     const extension = this.extend({
       ...this.config,
       addOptions: () => {
-        return mergeDeep(options, this.options as Record<string, any>) as Options
+        return mergeDeep(this.options as Record<string, any>, options) as Options
       },
     })
 

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -591,8 +591,8 @@ export class Mark<Options = any, Storage = any> {
     // with different calls of `configure`
     const extension = this.extend({
       ...this.config,
-      addOptions() {
-        return mergeDeep(this.parent?.() || {}, options) as Options
+      addOptions: () => {
+        return mergeDeep(options, this.options as Record<string, any>) as Options
       },
     })
 

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -782,8 +782,8 @@ export class Node<Options = any, Storage = any> {
     // with different calls of `configure`
     const extension = this.extend({
       ...this.config,
-      addOptions() {
-        return mergeDeep(this.parent?.() || {}, options) as Options
+      addOptions: () => {
+        return mergeDeep(options, this.options as Record<string, any>) as Options
       },
     })
 

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -783,7 +783,7 @@ export class Node<Options = any, Storage = any> {
     const extension = this.extend({
       ...this.config,
       addOptions: () => {
-        return mergeDeep(options, this.options as Record<string, any>) as Options
+        return mergeDeep(this.options as Record<string, any>, options) as Options
       },
     })
 

--- a/tests/cypress/integration/core/extendExtensions.spec.ts
+++ b/tests/cypress/integration/core/extendExtensions.spec.ts
@@ -398,16 +398,17 @@ describe('extend extensions', () => {
           .create({
             name: 'parentExtension',
             addOptions() {
-              return { parent: 'exists' }
+              return { parent: 'exists', overwrite: 'parent' }
             },
           })
 
         const childExtension = parentExtension
-          .configure({ child: 'exists-too' })
+          .configure({ child: 'exists-too', overwrite: 'child' })
 
         expect(childExtension.options).to.deep.eq({
           parent: 'exists',
           child: 'exists-too',
+          overwrite: 'child',
         })
       })
 
@@ -416,15 +417,15 @@ describe('extend extensions', () => {
           .create({
             name: 'parentExtension',
             addOptions() {
-              return { defaultOptions: 'exists' }
+              return { defaultOptions: 'exists', overwrite: 'parent' }
             },
           })
 
         const childExtension = parentExtension
-          .configure({ configuredOptions: 'exists-too' }).extend({
+          .configure({ configuredOptions: 'exists-too', overwrite: 'configure' }).extend({
             name: 'childExtension',
             addOptions() {
-              return { ...this.parent?.(), additionalOptions: 'exist-too' }
+              return { ...this.parent?.(), additionalOptions: 'exist-too', overwrite: 'child' }
             },
           })
 
@@ -432,6 +433,7 @@ describe('extend extensions', () => {
           defaultOptions: 'exists',
           configuredOptions: 'exists-too',
           additionalOptions: 'exist-too',
+          overwrite: 'child',
         })
       })
     })

--- a/tests/cypress/integration/core/extendExtensions.spec.ts
+++ b/tests/cypress/integration/core/extendExtensions.spec.ts
@@ -393,12 +393,30 @@ describe('extend extensions', () => {
         })
       })
 
+      it('should configure to be in addition to the parent options', () => {
+        const parentExtension = Extendable
+          .create({
+            name: 'parentExtension',
+            addOptions() {
+              return { parent: 'exists' }
+            },
+          })
+
+        const childExtension = parentExtension
+          .configure({ child: 'exists-too' })
+
+        expect(childExtension.options).to.deep.eq({
+          parent: 'exists',
+          child: 'exists-too',
+        })
+      })
+
       it('should deeply merge options when extending a configured extension', () => {
         const parentExtension = Extendable
           .create({
             name: 'parentExtension',
             addOptions() {
-              return { defaultOptions: 'is-overwritten' }
+              return { defaultOptions: 'exists' }
             },
           })
 
@@ -411,6 +429,7 @@ describe('extend extensions', () => {
           })
 
         expect(childExtension.options).to.deep.eq({
+          defaultOptions: 'exists',
           configuredOptions: 'exists-too',
           additionalOptions: 'exist-too',
         })


### PR DESCRIPTION
## Changes Overview
There was a bug where doing a `.configure` on an extension, node or mark would overwrite the extensions options instead of being merged with the default options.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

Added tests

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
