### PR TITLE
fix: Address different behavior between `getHTML` and `generateHTML`

### DIFF
--- a/.changeset/serious-foxes-decide.md
+++ b/.changeset/serious-foxes-decide.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-task-item": patch
+---
+
+fix: Address different behavior between `getHTML` and `generateHTML`

--- a/.changeset/serious-foxes-decide.md
+++ b/.changeset/serious-foxes-decide.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-task-item": patch
 ---
 
-fix: Address different behavior between `getHTML` and `generateHTML`
+allow task items to be parsed when only having `<li data-checked` instead of only when `<li data-checked="true"`

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -68,7 +68,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
         parseHTML: element => {
           const dataChecked = element.getAttribute('data-checked')
 
-          return dataChecked != null && dataChecked !== 'false'
+          return dataChecked == null || dataChecked === 'true'
         },
         renderHTML: attributes => ({
           'data-checked': attributes.checked,

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -65,7 +65,11 @@ export const TaskItem = Node.create<TaskItemOptions>({
       checked: {
         default: false,
         keepOnSplit: false,
-        parseHTML: element => element.hasAttribute('data-checked') && element.getAttribute('data-checked') !== 'false',
+        parseHTML: element => {
+          const dataChecked = element.getAttribute('data-checked')
+
+          return dataChecked != null && dataChecked !== 'false'
+        },
         renderHTML: attributes => ({
           'data-checked': attributes.checked,
         }),

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -65,9 +65,9 @@ export const TaskItem = Node.create<TaskItemOptions>({
       checked: {
         default: false,
         keepOnSplit: false,
-        parseHTML: element => element.getAttribute('data-checked') === 'true',
+        parseHTML: element => element.hasAttribute('data-checked') && element.getAttribute('data-checked') !== 'false',
         renderHTML: attributes => ({
-          'data-checked': attributes.checked ? 'true' : undefined,
+          'data-checked': attributes.checked,
         }),
       },
     }

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -65,9 +65,9 @@ export const TaskItem = Node.create<TaskItemOptions>({
       checked: {
         default: false,
         keepOnSplit: false,
-        parseHTML: element => element.getAttribute('data-checked') !== 'false',
+        parseHTML: element => element.getAttribute('data-checked') === 'true',
         renderHTML: attributes => ({
-          'data-checked': attributes.checked,
+          'data-checked': attributes.checked ? 'true' : undefined,
         }),
       },
     }

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -65,9 +65,9 @@ export const TaskItem = Node.create<TaskItemOptions>({
       checked: {
         default: false,
         keepOnSplit: false,
-        parseHTML: element => element.getAttribute('data-checked') === 'true',
+        parseHTML: element => element.getAttribute('data-checked') !== 'false',
         renderHTML: attributes => ({
-          'data-checked': attributes.checked ? 'true' : undefined,
+          'data-checked': attributes.checked,
         }),
       },
     }

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -67,7 +67,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
         keepOnSplit: false,
         parseHTML: element => element.getAttribute('data-checked') === 'true',
         renderHTML: attributes => ({
-          'data-checked': attributes.checked,
+          'data-checked': attributes.checked ? 'true' : undefined,
         }),
       },
     }


### PR DESCRIPTION
## Changes Overview

Using `generateHTML` function from `@tiptap/html` package generates HTML like `<li data-checked data-type="taskItem">`.
However, in other parts of the code, the expected HTML is `<li data-checked="true" data-type="taskItem">`.
Due to this behavior, the selection state is lost when the HTML obtained using the `generateHTML` function is rendered again.

## Implementation Approach

The value set for the `data-checked` attribute can be either `true` or undefined.

## Testing Done

I manually tested both cases, using `generateHTML` and not using the `generateHTML` function, and confirmed that everything works correctly.

## Verification Steps

You can check out this repository to see how it works

https://github.com/baseballyama/tiptap-tasklist-bug-repl

## Additional Notes

N/A

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

N/A
