### PR TITLE
fix: Adjust the `splitBlock` command to return `false` when it was unsuccessful

### DIFF
--- a/.changeset/eleven-needles-argue.md
+++ b/.changeset/eleven-needles-argue.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Adjust the `splitBlock` command to return `false` when it was unsuccessful.


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
Fix the `splitBlock` command so that it returns `true` when it successfully split a block & `false` when it does not. Allows for consumers to determine if the command was successful & act accordingly.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->
`splitBlock` already determined if a split was possible & saved those results to a `can` variable. This change returns the `can` variable, both when `dispatch` is defined & undefined.

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
[I altered the `CustomDocument` example](https://github.com/mgreystone/tiptap/commit/3d762be990c08eeae0970b4f1d9c2a0948817154) to only allow a single block by setting `content: heading block`. I then added a custom Enter keyboard shortcut to log if `splitBlock` returned false. Pushing the enter key anywhere in the document will now log "success".

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->
* Create a schema where splitting a block is impossible--for example, setting `content: 'block'` on a document. Call `editor.commands.splitBlock()` & ensure it returns `false`.
* Adjust the schema to allow for blocks to be split--for example, setting `content: 'block+'`. Ensure that `editor.commands.splitBlock()` now returns `true`.

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [X] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [X] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues
Fixes: https://github.com/ueberdosis/tiptap/issues/5363
