### PR TITLE
Update prosemirror-view & prosemirror-tables to most recent version

### DIFF
--- a/.changeset/cool-steaks-clean.md
+++ b/.changeset/cool-steaks-clean.md
@@ -1,0 +1,14 @@
+---
+"@tiptap/pm": patch
+---
+
+Because of an XSS vulnerability in the `prosemirror-model` package, we've updated all our prosemirror dependencies to the latest versions.
+
+**Upgraded packages**:
+
+- `prosemirror-model` from `^1.22.1` to `^1.22.2`
+- `prosemirror-tables` from `^1.3.7` to `^1.4.0`
+- `prosemirror-trailing-node` from `^2.0.8` to `^2.0.9`
+- `prosemirror-view` from `^1.33.8` to `^1.33.9`
+
+See https://discuss.prosemirror.net/t/heads-up-xss-risk-in-domserializer/6572

--- a/package-lock.json
+++ b/package-lock.json
@@ -13782,43 +13782,6 @@
         "prosemirror-view": "^1.27.0"
       }
     },
-    "node_modules/prosemirror-tables": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.3.7.tgz",
-      "integrity": "sha512-oEwX1wrziuxMtwFvdDWSFHVUWrFJWt929kVVfHvtTi8yvw+5ppxjXZkMG/fuTdFo+3DXyIPSKfid+Be1npKXDA==",
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.8.tgz",
-      "integrity": "sha512-ujRYhSuhQb1Jsarh1IHqb2KoSnRiD7wAMDGucP35DN7j5af6X7B18PfdPIrbwsPTqIAj0fyOvxbuPsWhNvylmA==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.19.0",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.31.2"
-      }
-    },
-    "node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/prosemirror-transform": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.9.0.tgz",
@@ -17889,159 +17852,159 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-blockquote": {
       "name": "@tiptap/extension-blockquote",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-bold": {
       "name": "@tiptap/extension-bold",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-bubble-menu": {
       "name": "@tiptap/extension-bubble-menu",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-bullet-list": {
       "name": "@tiptap/extension-bullet-list",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-character-count": {
       "name": "@tiptap/extension-character-count",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-code": {
       "name": "@tiptap/extension-code",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-code-block": {
       "name": "@tiptap/extension-code-block",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-code-block-lowlight": {
       "name": "@tiptap/extension-code-block-lowlight",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/extension-code-block": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/extension-code-block": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/extension-code-block": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/extension-code-block": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-collaboration": {
       "name": "@tiptap/extension-collaboration",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "y-prosemirror": "^1.2.9"
       },
       "funding": {
@@ -18049,17 +18012,17 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "y-prosemirror": "^1.2.6"
       }
     },
     "packages/extension-collaboration-cursor": {
       "name": "@tiptap/extension-collaboration-cursor",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
         "y-prosemirror": "^1.2.9"
       },
       "funding": {
@@ -18067,607 +18030,607 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
         "y-prosemirror": "^1.2.6"
       }
     },
     "packages/extension-color": {
       "name": "@tiptap/extension-color",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/extension-text-style": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/extension-text-style": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/extension-text-style": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/extension-text-style": "^2.5.5"
       }
     },
     "packages/extension-document": {
       "name": "@tiptap/extension-document",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-dropcursor": {
       "name": "@tiptap/extension-dropcursor",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-floating-menu": {
       "name": "@tiptap/extension-floating-menu",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-focus": {
       "name": "@tiptap/extension-focus",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-font-family": {
       "name": "@tiptap/extension-font-family",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/extension-text-style": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/extension-text-style": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/extension-text-style": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/extension-text-style": "^2.5.5"
       }
     },
     "packages/extension-gapcursor": {
       "name": "@tiptap/extension-gapcursor",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-hard-break": {
       "name": "@tiptap/extension-hard-break",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-heading": {
       "name": "@tiptap/extension-heading",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-highlight": {
       "name": "@tiptap/extension-highlight",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-history": {
       "name": "@tiptap/extension-history",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-horizontal-rule": {
       "name": "@tiptap/extension-horizontal-rule",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-image": {
       "name": "@tiptap/extension-image",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-italic": {
       "name": "@tiptap/extension-italic",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-link": {
       "name": "@tiptap/extension-link",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.1.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-list-item": {
       "name": "@tiptap/extension-list-item",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-list-keymap": {
       "name": "@tiptap/extension-list-keymap",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-mention": {
       "name": "@tiptap/extension-mention",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
-        "@tiptap/suggestion": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
+        "@tiptap/suggestion": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
-        "@tiptap/suggestion": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
+        "@tiptap/suggestion": "^2.5.5"
       }
     },
     "packages/extension-ordered-list": {
       "name": "@tiptap/extension-ordered-list",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-paragraph": {
       "name": "@tiptap/extension-paragraph",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-placeholder": {
       "name": "@tiptap/extension-placeholder",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-strike": {
       "name": "@tiptap/extension-strike",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-subscript": {
       "name": "@tiptap/extension-subscript",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-superscript": {
       "name": "@tiptap/extension-superscript",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-table": {
       "name": "@tiptap/extension-table",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-table-cell": {
       "name": "@tiptap/extension-table-cell",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-table-header": {
       "name": "@tiptap/extension-table-header",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-table-row": {
       "name": "@tiptap/extension-table-row",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-task-item": {
       "name": "@tiptap/extension-task-item",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/extension-task-list": {
       "name": "@tiptap/extension-task-list",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-text": {
       "name": "@tiptap/extension-text",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-text-align": {
       "name": "@tiptap/extension-text-align",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-text-style": {
       "name": "@tiptap/extension-text-style",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-typography": {
       "name": "@tiptap/extension-typography",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-underline": {
       "name": "@tiptap/extension-underline",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/extension-youtube": {
       "name": "@tiptap/extension-youtube",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4"
+        "@tiptap/core": "^2.5.5"
       }
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
         "zeed-dom": "^0.10.9"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/pm": {
       "name": "@tiptap/pm",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.2.1",
@@ -18680,18 +18643,37 @@
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-markdown": "^1.13.0",
         "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.22.1",
+        "prosemirror-model": "^1.22.2",
         "prosemirror-schema-basic": "^1.2.3",
         "prosemirror-schema-list": "^1.4.1",
         "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.3.7",
-        "prosemirror-trailing-node": "^2.0.8",
+        "prosemirror-tables": "^1.4.0",
+        "prosemirror-trailing-node": "^2.0.9",
         "prosemirror-transform": "^1.9.0",
-        "prosemirror-view": "^1.33.8"
+        "prosemirror-view": "^1.33.9"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "packages/pm/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/pm/node_modules/prosemirror-model": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.2.tgz",
+      "integrity": "sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
       }
     },
     "packages/pm/node_modules/prosemirror-schema-basic": {
@@ -18702,19 +18684,55 @@
         "prosemirror-model": "^1.19.0"
       }
     },
+    "packages/pm/node_modules/prosemirror-tables": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.4.0.tgz",
+      "integrity": "sha512-fxryZZkQG12fSCNuZDrYx6Xvo2rLYZTbKLRd8rglOPgNJGMKIS8uvTt6gGC38m7UCu/ENnXIP9pEz5uDaPc+cA==",
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
+    "packages/pm/node_modules/prosemirror-trailing-node": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.9.tgz",
+      "integrity": "sha512-YvyIn3/UaLFlFKrlJB6cObvUhmwFNZVhy1Q8OpW/avoTbD/Y7H5EcjK4AZFKhmuS6/N6WkGgt7gWtBWDnmFvHg==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "packages/pm/node_modules/prosemirror-view": {
+      "version": "1.33.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.9.tgz",
+      "integrity": "sha512-xV1A0Vz9cIcEnwmMhKKFAOkfIp8XmJRnaZoPqNXrPS7EK5n11Ov8V76KhR0RsfQd/SIzmWY+bg+M44A2Lx/Nnw==",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "packages/react": {
       "name": "@tiptap/react",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.5.4",
-        "@tiptap/extension-floating-menu": "^2.5.4",
+        "@tiptap/extension-bubble-menu": "^2.5.5",
+        "@tiptap/extension-floating-menu": "^2.5.5",
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.2.2"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "react": "^18.0.0",
@@ -18725,36 +18743,36 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/extension-blockquote": "^2.5.4",
-        "@tiptap/extension-bold": "^2.5.4",
-        "@tiptap/extension-bullet-list": "^2.5.4",
-        "@tiptap/extension-code": "^2.5.4",
-        "@tiptap/extension-code-block": "^2.5.4",
-        "@tiptap/extension-document": "^2.5.4",
-        "@tiptap/extension-dropcursor": "^2.5.4",
-        "@tiptap/extension-gapcursor": "^2.5.4",
-        "@tiptap/extension-hard-break": "^2.5.4",
-        "@tiptap/extension-heading": "^2.5.4",
-        "@tiptap/extension-history": "^2.5.4",
-        "@tiptap/extension-horizontal-rule": "^2.5.4",
-        "@tiptap/extension-italic": "^2.5.4",
-        "@tiptap/extension-list-item": "^2.5.4",
-        "@tiptap/extension-ordered-list": "^2.5.4",
-        "@tiptap/extension-paragraph": "^2.5.4",
-        "@tiptap/extension-strike": "^2.5.4",
-        "@tiptap/extension-text": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/extension-blockquote": "^2.5.5",
+        "@tiptap/extension-bold": "^2.5.5",
+        "@tiptap/extension-bullet-list": "^2.5.5",
+        "@tiptap/extension-code": "^2.5.5",
+        "@tiptap/extension-code-block": "^2.5.5",
+        "@tiptap/extension-document": "^2.5.5",
+        "@tiptap/extension-dropcursor": "^2.5.5",
+        "@tiptap/extension-gapcursor": "^2.5.5",
+        "@tiptap/extension-hard-break": "^2.5.5",
+        "@tiptap/extension-heading": "^2.5.5",
+        "@tiptap/extension-history": "^2.5.5",
+        "@tiptap/extension-horizontal-rule": "^2.5.5",
+        "@tiptap/extension-italic": "^2.5.5",
+        "@tiptap/extension-list-item": "^2.5.5",
+        "@tiptap/extension-ordered-list": "^2.5.5",
+        "@tiptap/extension-paragraph": "^2.5.5",
+        "@tiptap/extension-strike": "^2.5.5",
+        "@tiptap/extension-text": "^2.5.5"
       },
       "funding": {
         "type": "github",
@@ -18763,33 +18781,33 @@
     },
     "packages/suggestion": {
       "name": "@tiptap/suggestion",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4"
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5"
       }
     },
     "packages/vue-2": {
       "name": "@tiptap/vue-2",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.5.4",
-        "@tiptap/extension-floating-menu": "^2.5.4",
+        "@tiptap/extension-bubble-menu": "^2.5.5",
+        "@tiptap/extension-floating-menu": "^2.5.5",
         "vue-ts-types": "^1.6.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "vue": "^2.6.0"
       },
       "funding": {
@@ -18797,8 +18815,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "vue": "^2.6.0"
       }
     },
@@ -18829,15 +18847,15 @@
     },
     "packages/vue-3": {
       "name": "@tiptap/vue-3",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.5.4",
-        "@tiptap/extension-floating-menu": "^2.5.4"
+        "@tiptap/extension-bubble-menu": "^2.5.5",
+        "@tiptap/extension-floating-menu": "^2.5.5"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "vue": "^3.0.0"
       },
       "funding": {
@@ -18845,8 +18863,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.5.4",
-        "@tiptap/pm": "^2.5.4",
+        "@tiptap/core": "^2.5.5",
+        "@tiptap/pm": "^2.5.5",
         "vue": "^3.0.0"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13755,11 +13755,19 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.1.tgz",
-      "integrity": "sha512-gMrxal+F3higDFxCkBK5iQXckRVYvIu/3dopERJ6b20xfwZ9cbYvQvuldqaN+v/XytNPGyURYUpUU23kBRxWCQ==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.2.tgz",
+      "integrity": "sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==",
       "dependencies": {
         "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.3.tgz",
+      "integrity": "sha512-h+H0OQwZVqMon1PNn0AG9cTfx513zgIG2DY00eJ00Yvgb3UD+GQ/VlWW5rcaxacpCGT1Yx8nuhwXk4+QbXUfJA==",
+      "dependencies": {
+        "prosemirror-model": "^1.19.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -13782,6 +13790,43 @@
         "prosemirror-view": "^1.27.0"
       }
     },
+    "node_modules/prosemirror-tables": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.4.0.tgz",
+      "integrity": "sha512-fxryZZkQG12fSCNuZDrYx6Xvo2rLYZTbKLRd8rglOPgNJGMKIS8uvTt6gGC38m7UCu/ENnXIP9pEz5uDaPc+cA==",
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.9.tgz",
+      "integrity": "sha512-YvyIn3/UaLFlFKrlJB6cObvUhmwFNZVhy1Q8OpW/avoTbD/Y7H5EcjK4AZFKhmuS6/N6WkGgt7gWtBWDnmFvHg==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prosemirror-transform": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.9.0.tgz",
@@ -13791,9 +13836,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.33.8",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.8.tgz",
-      "integrity": "sha512-4PhMr/ufz2cdvFgpUAnZfs+0xij3RsFysreeG9V/utpwX7AJtYCDVyuRxzWoMJIEf4C7wVihuBNMPpFLPCiLQw==",
+      "version": "1.33.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.9.tgz",
+      "integrity": "sha512-xV1A0Vz9cIcEnwmMhKKFAOkfIp8XmJRnaZoPqNXrPS7EK5n11Ov8V76KhR0RsfQd/SIzmWY+bg+M44A2Lx/Nnw==",
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -18655,69 +18700,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "packages/pm/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/pm/node_modules/prosemirror-model": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.2.tgz",
-      "integrity": "sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==",
-      "dependencies": {
-        "orderedmap": "^2.0.0"
-      }
-    },
-    "packages/pm/node_modules/prosemirror-schema-basic": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.3.tgz",
-      "integrity": "sha512-h+H0OQwZVqMon1PNn0AG9cTfx513zgIG2DY00eJ00Yvgb3UD+GQ/VlWW5rcaxacpCGT1Yx8nuhwXk4+QbXUfJA==",
-      "dependencies": {
-        "prosemirror-model": "^1.19.0"
-      }
-    },
-    "packages/pm/node_modules/prosemirror-tables": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.4.0.tgz",
-      "integrity": "sha512-fxryZZkQG12fSCNuZDrYx6Xvo2rLYZTbKLRd8rglOPgNJGMKIS8uvTt6gGC38m7UCu/ENnXIP9pEz5uDaPc+cA==",
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
-    "packages/pm/node_modules/prosemirror-trailing-node": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.9.tgz",
-      "integrity": "sha512-YvyIn3/UaLFlFKrlJB6cObvUhmwFNZVhy1Q8OpW/avoTbD/Y7H5EcjK4AZFKhmuS6/N6WkGgt7gWtBWDnmFvHg==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
-      }
-    },
-    "packages/pm/node_modules/prosemirror-view": {
-      "version": "1.33.9",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.9.tgz",
-      "integrity": "sha512-xV1A0Vz9cIcEnwmMhKKFAOkfIp8XmJRnaZoPqNXrPS7EK5n11Ov8V76KhR0RsfQd/SIzmWY+bg+M44A2Lx/Nnw==",
-      "dependencies": {
-        "prosemirror-model": "^1.20.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0"
       }
     },
     "packages/react": {

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -136,14 +136,14 @@
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-markdown": "^1.13.0",
     "prosemirror-menu": "^1.2.4",
-    "prosemirror-model": "^1.22.1",
+    "prosemirror-model": "^1.22.2",
     "prosemirror-schema-basic": "^1.2.3",
     "prosemirror-schema-list": "^1.4.1",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-tables": "^1.3.7",
-    "prosemirror-trailing-node": "^2.0.8",
+    "prosemirror-tables": "^1.4.0",
+    "prosemirror-trailing-node": "^2.0.9",
     "prosemirror-transform": "^1.9.0",
-    "prosemirror-view": "^1.33.8"
+    "prosemirror-view": "^1.33.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes Overview
Updated prosemirror-views & prosemirror-tables to most recent version

## Implementation Approach
Actually I was looking for the prosemirror-model update because there was an XSS issue with version 1.22.0 and below (see https://discuss.prosemirror.net/t/heads-up-xss-risk-in-domserializer/6572) - but it seems we already updated it.

While we're at it why not just bump the other prosemirror versions too.

## Testing Done
I ran the tests locally + went through the demos manually to see if any functionality is broken (specially tables).

## Verification Steps
See above

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

