### PR TITLE
fix(core): address enableContentCheck insertion bug

### DIFF
--- a/.changeset/tiny-walls-shave.md
+++ b/.changeset/tiny-walls-shave.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixes a bug where if `enableContentCheck` was true, inserting content as JSON nodes would fail. This was because the node that was being created technically had a different schema than the content being inserted, so it would fail to generate the correct content value


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

To insert a node/mark in prosemirror, the schemas needed to be the same instance to be able to create the correct type from raw JSON. This removes a perf optimization & uses the dummy schema only to check for content errors but then recreates the same node afterwards with the editor's schema.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
