### PR TITLE
fix(core): isNodeEmpty no longer considers attributes for it's checks

### DIFF
--- a/.changeset/smart-rockets-divide.md
+++ b/.changeset/smart-rockets-divide.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/core": patch
+"@tiptap/extension-placeholder": patch
+---
+
+This addresses an issue with `isNodeEmpty` function where it was also comparing node attributes and finding mismatches on actually empty nodes. This helps placeholders find empty content correctly

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -39,6 +39,7 @@ import { isFunction } from './utilities/isFunction.js'
 
 export * as extensions from './extensions/index.js'
 
+// @ts-ignore
 export interface TiptapEditorHTMLElement extends HTMLElement {
   editor?: Editor
 }
@@ -340,6 +341,7 @@ export class Editor extends EventEmitter<EditorEvents> {
 
     // Let’s store the editor instance in the DOM element.
     // So we’ll have access to it for tests.
+    // @ts-ignore
     const dom = this.view.dom as TiptapEditorHTMLElement
 
     dom.editor = this

--- a/packages/core/src/helpers/isNodeEmpty.ts
+++ b/packages/core/src/helpers/isNodeEmpty.ts
@@ -1,11 +1,41 @@
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 
-export function isNodeEmpty(node: ProseMirrorNode): boolean {
-  const defaultContent = node.type.createAndFill(node.attrs)
+/**
+ * Returns true if the given node is empty.
+ * When `checkChildren` is true (default), it will also check if all children are empty.
+ */
+export function isNodeEmpty(
+  node: ProseMirrorNode,
+  { checkChildren }: { checkChildren: boolean } = { checkChildren: true },
+): boolean {
+  if (node.isText) {
+    return !node.text
+  }
 
-  if (!defaultContent) {
+  if (node.content.childCount === 0) {
+    return true
+  }
+
+  if (node.isLeaf) {
     return false
   }
 
-  return node.eq(defaultContent)
+  if (checkChildren) {
+    let hasSameContent = true
+
+    node.content.forEach(childNode => {
+      if (hasSameContent === false) {
+        // Exit early for perf
+        return
+      }
+
+      if (!isNodeEmpty(childNode)) {
+        hasSameContent = false
+      }
+    })
+
+    return hasSameContent
+  }
+
+  return false
 }


### PR DESCRIPTION
## Changes Overview

This addresses a bug with `isNodeEmpty` where it was also considering attributes on the node for it's emptiness check.

## Implementation Approach
To address it, I went with a different approach of actually visiting each node to check for emptiness. This is both more performant and will be more accurate since it does not compare other properties like marks & attributes which do not determine emptiness.

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
I added a bunch of tests to ensure that the implementation not only passes for the previous cases but also considers the different attributes case.

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
