### PR TITLE
fix: do not consider text content as atoms resolve #5405

### DIFF
--- a/.changeset/lemon-files-thank.md
+++ b/.changeset/lemon-files-thank.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+This fixes a bug with inputrules not being able to resolve positions properly

--- a/packages/core/src/helpers/getTextContentFromNodes.ts
+++ b/packages/core/src/helpers/getTextContentFromNodes.ts
@@ -24,7 +24,7 @@ export const getTextContentFromNodes = ($from: ResolvedPos, maxMatch = 500) => {
         || node.textContent
         || '%leaf%'
 
-      textBefore += node.isAtom ? chunk : chunk.slice(0, Math.max(0, sliceEndPos - pos))
+      textBefore += node.isAtom && !node.isText ? chunk : chunk.slice(0, Math.max(0, sliceEndPos - pos))
     },
   )
 


### PR DESCRIPTION
## Changes Overview
This fixes a bug where text content was being considered in whole rather than just in slices when extracting the text content. This resolves a bug with input rules and a range error that could occur.
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
