### PR TITLE
fix(vue-3): custom node views when using class components

### DIFF
--- a/.changeset/three-snakes-wink.md
+++ b/.changeset/three-snakes-wink.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/vue-3": patch
+---
+
+fix vue3 class components not working as node views

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -221,7 +221,12 @@ export function VueNodeViewRenderer(
     if (!(props.editor as Editor).contentComponent) {
       return {}
     }
+    // check for class-component and normalize if neccessary
+    const normalizedComponent = typeof component === 'function' && '__vccOpts' in component
+      // eslint-disable-next-line no-underscore-dangle
+      ? component.__vccOpts as Component
+      : component
 
-    return new VueNodeView(component, props, options) as unknown as ProseMirrorNodeView
+    return new VueNodeView(normalizedComponent, props, options) as unknown as ProseMirrorNodeView
   }
 }


### PR DESCRIPTION
## Changes Overview
Enables using Vue 3 class-based components as node views. 

## Implementation Approach
Because of the way `VueNodeView` extends a custom node view,  a class-based component needs to be "unwrapped" before it can be used – a good opportunity to do this seems to be in the `VueNodeViewRenderer` function where the `VueNodeView` is constructed.

Checking and unwrapping is done using the same approach as in the vuejs implementation, see [runtime-core/src/component.ts#L1174](https://github.com/vuejs/core/blob/e0b2975ef65ae6a0be0aa0a0df43fb887c665251/packages/runtime-core/src/component.ts#L1174) for the check and [runtime-core/src/vnode.ts#L580](https://github.com/vuejs/core/blob/e0b2975ef65ae6a0be0aa0a0df43fb887c665251/packages/runtime-core/src/vnode.ts#L580) for the unwrapping code.

## Testing Done
Is in use and working in my app.

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
