### PR TITLE
fix(collaboration): update y-prosemirror, respect `onFirstRender`

### DIFF
--- a/.changeset/yellow-rice-collect.md
+++ b/.changeset/yellow-rice-collect.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/extension-collaboration-cursor": patch
+"@tiptap/extension-collaboration": patch
+---
+
+This updates y-prosemirror to a version that no longer has syncing problems and extension collaboration now respects the onFirstRender option

--- a/demos/package.json
+++ b/demos/package.json
@@ -20,7 +20,7 @@
     "remixicon": "^2.5.0",
     "shiki": "^1.10.3",
     "simplify-js": "^1.2.4",
-    "y-prosemirror": "^1.2.9",
+    "y-prosemirror": "^1.2.11",
     "y-webrtc": "^10.3.0",
     "yjs": "^13.6.18"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "remixicon": "^2.5.0",
         "shiki": "^1.10.3",
         "simplify-js": "^1.2.4",
-        "y-prosemirror": "^1.2.9",
+        "y-prosemirror": "^1.2.11",
         "y-webrtc": "^10.3.0",
         "yjs": "^13.6.18"
       },
@@ -789,6 +789,29 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "demos/node_modules/y-prosemirror": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.11.tgz",
+      "integrity": "sha512-MUGMYyokOb9DpBRHr4Cadob2KheDCKW2LHceAM2yrWp9dfX+3HZZUNEubEPd4zszq4DF2fGCFhE3N66zOTLoxA==",
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "demos/node_modules/yallist": {
@@ -17741,29 +17764,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/y-prosemirror": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.9.tgz",
-      "integrity": "sha512-fThGIVmSqrqnG/ckywEGlHM9ElfILC4TcMZd5zxWPe/i+UuP97TEr4swsopRKG3Y+KHBVt4Y/5NVBC3AAsUoUg==",
-      "dependencies": {
-        "lib0": "^0.2.42"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.7.1",
-        "prosemirror-state": "^1.2.3",
-        "prosemirror-view": "^1.9.10",
-        "y-protocols": "^1.0.1",
-        "yjs": "^13.5.38"
-      }
-    },
     "node_modules/y-protocols": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
@@ -18068,7 +18068,7 @@
       "devDependencies": {
         "@tiptap/core": "^2.5.8",
         "@tiptap/pm": "^2.5.8",
-        "y-prosemirror": "^1.2.9"
+        "y-prosemirror": "^1.2.11"
       },
       "funding": {
         "type": "github",
@@ -18077,7 +18077,7 @@
       "peerDependencies": {
         "@tiptap/core": "^2.5.8",
         "@tiptap/pm": "^2.5.8",
-        "y-prosemirror": "^1.2.6"
+        "y-prosemirror": "^1.2.11"
       }
     },
     "packages/extension-collaboration-cursor": {
@@ -18086,7 +18086,7 @@
       "license": "MIT",
       "devDependencies": {
         "@tiptap/core": "^2.5.8",
-        "y-prosemirror": "^1.2.9"
+        "y-prosemirror": "^1.2.11"
       },
       "funding": {
         "type": "github",
@@ -18094,7 +18094,55 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.5.8",
-        "y-prosemirror": "^1.2.6"
+        "y-prosemirror": "^1.2.11"
+      }
+    },
+    "packages/extension-collaboration-cursor/node_modules/y-prosemirror": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.11.tgz",
+      "integrity": "sha512-MUGMYyokOb9DpBRHr4Cadob2KheDCKW2LHceAM2yrWp9dfX+3HZZUNEubEPd4zszq4DF2fGCFhE3N66zOTLoxA==",
+      "dev": true,
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
+      }
+    },
+    "packages/extension-collaboration/node_modules/y-prosemirror": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.11.tgz",
+      "integrity": "sha512-MUGMYyokOb9DpBRHr4Cadob2KheDCKW2LHceAM2yrWp9dfX+3HZZUNEubEPd4zszq4DF2fGCFhE3N66zOTLoxA==",
+      "dev": true,
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "packages/extension-color": {

--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -30,11 +30,11 @@
   ],
   "devDependencies": {
     "@tiptap/core": "^2.5.8",
-    "y-prosemirror": "^1.2.9"
+    "y-prosemirror": "^1.2.11"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.5.8",
-    "y-prosemirror": "^1.2.6"
+    "y-prosemirror": "^1.2.11"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
+++ b/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
@@ -127,6 +127,9 @@ export const CollaborationCursor = Extension.create<CollaborationCursorOptions, 
     if (this.options.onUpdate !== defaultOnUpdate) {
       console.warn('[tiptap warn]: DEPRECATED: The "onUpdate" option is deprecated. Please use `editor.storage.collaborationCursor.users` instead. Read more: https://tiptap.dev/api/extensions/collaboration-cursor')
     }
+    if (!this.options.provider) {
+      throw new Error('The "provider" option is required for the CollaborationCursor extension')
+    }
   },
 
   addStorage() {

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -31,12 +31,12 @@
   "devDependencies": {
     "@tiptap/core": "^2.5.8",
     "@tiptap/pm": "^2.5.8",
-    "y-prosemirror": "^1.2.9"
+    "y-prosemirror": "^1.2.11"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.5.8",
     "@tiptap/pm": "^2.5.8",
-    "y-prosemirror": "^1.2.6"
+    "y-prosemirror": "^1.2.11"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/src/collaboration.ts
+++ b/packages/extension-collaboration/src/collaboration.ts
@@ -167,8 +167,8 @@ export const Collaboration = Extension.create<CollaborationOptions>({
     }
 
     const ySyncPluginOptions: YSyncOpts = {
-      ...(this.options.ySyncOptions ? { ...this.options.ySyncOptions } : {}),
-      ...(this.options.onFirstRender ? { ...this.options.onFirstRender } : {}),
+      ...this.options.ySyncOptions,
+      onFirstRender: this.options.onFirstRender,
     }
 
     const ySyncPluginInstance = ySyncPlugin(fragment, ySyncPluginOptions)


### PR DESCRIPTION
## Changes Overview
`onFirstRender` was never actually able to be called, this option is now respected.
This updates `y-prosemirror` which shipped a bug in a patch version that caused some documents to fail to sync due to a nodeSize error
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
