### PR TITLE
fix(core): use correct position for getMarksBetween

### DIFF
--- a/.changeset/real-kiwis-double.md
+++ b/.changeset/real-kiwis-double.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+This fixes a discrepency between `getMarksBetween` and `isActive(markName)` where the position used for getMarksBetween was off by one

--- a/packages/core/src/helpers/getMarksBetween.ts
+++ b/packages/core/src/helpers/getMarksBetween.ts
@@ -12,7 +12,7 @@ export function getMarksBetween(from: number, to: number, doc: ProseMirrorNode):
       .resolve(from)
       .marks()
       .forEach(mark => {
-        const $pos = doc.resolve(from - 1)
+        const $pos = doc.resolve(from)
         const range = getMarkRange($pos, mark.type)
 
         if (!range) {


### PR DESCRIPTION
## Changes Overview
See issue #5401
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
Tested with this & checked that the cursor position was the same as expected
```diff
diff --git a/demos/src/Marks/Link/React/index.jsx b/demos/src/Marks/Link/React/index.jsx
index 452bb5b4b..99b071c26 100644
--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -1,5 +1,6 @@
 import './styles.scss'
 
+import { getMarksBetween } from '@tiptap/core'
 import Code from '@tiptap/extension-code'
 import Document from '@tiptap/extension-document'
 import Link from '@tiptap/extension-link'
@@ -30,6 +31,13 @@ export default () => {
           By default every link will get a <code>rel="noopener noreferrer nofollow"</code> attribute. It’s configurable though.
         </p>
       `,
+    onTransaction: ctx => {
+      console.log(getMarksBetween(
+        ctx.editor.state.selection.from,
+        ctx.editor.state.selection.to,
+        ctx.editor.state.doc,
+      ))
+    },
   })
 
   const setLink = useCallback(() => {
```

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
