### PR TITLE
fix(react): always cleanup old editor instances

### DIFF
--- a/.changeset/red-suns-allow.md
+++ b/.changeset/red-suns-allow.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Resolve a bug an editor could be instantiated but not destroyed. This was causing issues with multiple instances of plugins still being active and interfering with each other

--- a/demos/src/Examples/Performance/React/index.jsx
+++ b/demos/src/Examples/Performance/React/index.jsx
@@ -26,6 +26,9 @@ function EditorInstance({ shouldOptimizeRendering }) {
       A highly optimized editor that only re-renders when it’s necessary.
     </p>
     `,
+    onBeforeCreate: () => {
+      console.log('onBeforeCreate')
+    },
   })
   /**
    * This hook allows us to select the editor state we want to use in our component.

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,6 +1,7 @@
 import { EditorOptions } from '@tiptap/core'
 import {
-  DependencyList, useDebugValue, useEffect, useRef, useState,
+  DependencyList, MutableRefObject,
+  useDebugValue, useEffect, useRef, useState,
 } from 'react'
 
 import { Editor } from './Editor.js'
@@ -30,6 +31,25 @@ export type UseEditorOptions = Partial<EditorOptions> & {
 };
 
 /**
+ * Create a new editor instance. And attach event listeners.
+ */
+function createEditor(options: MutableRefObject<UseEditorOptions>): Editor {
+  const editor = new Editor(options.current)
+
+  editor.on('beforeCreate', (...args) => options.current.onBeforeCreate?.(...args))
+  editor.on('blur', (...args) => options.current.onBlur?.(...args))
+  editor.on('create', (...args) => options.current.onCreate?.(...args))
+  editor.on('destroy', (...args) => options.current.onDestroy?.(...args))
+  editor.on('focus', (...args) => options.current.onFocus?.(...args))
+  editor.on('selectionUpdate', (...args) => options.current.onSelectionUpdate?.(...args))
+  editor.on('transaction', (...args) => options.current.onTransaction?.(...args))
+  editor.on('update', (...args) => options.current.onUpdate?.(...args))
+  editor.on('contentError', (...args) => options.current.onContentError?.(...args))
+
+  return editor
+}
+
+/**
  * This hook allows you to create an editor instance.
  * @param options The editor options
  * @param deps The dependencies to watch for changes
@@ -57,6 +77,7 @@ export function useEditor(
   options: UseEditorOptions = {},
   deps: DependencyList = [],
 ): Editor | null {
+  const mostRecentOptions = useRef(options)
   const [editor, setEditor] = useState(() => {
     if (options.immediatelyRender === undefined) {
       if (isSSR || isNext) {
@@ -76,7 +97,7 @@ export function useEditor(
       }
 
       // Default to immediately rendering when client-side rendering
-      return new Editor(options)
+      return createEditor(mostRecentOptions)
     }
 
     if (options.immediatelyRender && isSSR && isDev) {
@@ -87,7 +108,7 @@ export function useEditor(
     }
 
     if (options.immediatelyRender) {
-      return new Editor(options)
+      return createEditor(mostRecentOptions)
     }
 
     return null
@@ -100,7 +121,7 @@ export function useEditor(
 
   // This effect will handle creating/updating the editor instance
   useEffect(() => {
-    const cleanup = (editorInstance: Editor | null) => {
+    const destroyUnusedEditor = (editorInstance: Editor | null) => {
       if (editorInstance) {
         // We need to destroy the editor asynchronously to avoid memory leaks
         // because the editor instance is still being used in the component.
@@ -115,135 +136,31 @@ export function useEditor(
       }
     }
 
-    let editorInstance = editor
+    let editorInstance = mostRecentEditor.current
 
     if (!editorInstance) {
-      editorInstance = new Editor(options)
+      editorInstance = createEditor(mostRecentOptions)
       setEditor(editorInstance)
-      return () => cleanup(editorInstance)
+      return () => destroyUnusedEditor(editorInstance)
     }
 
-    if (Array.isArray(deps) && deps.length) {
-      // We need to destroy the editor instance and re-initialize it
-      // when the deps array changes
-      editorInstance.destroy()
+    if (!Array.isArray(deps) || deps.length === 0) {
+      // if the editor does exist & deps are empty, we don't need to re-initialize the editor
+      // we can fast-path to update the editor options on the existing instance
+      editorInstance.setOptions(options)
 
-      // the deps array is used to re-initialize the editor instance
-      editorInstance = new Editor(options)
-      setEditor(editorInstance)
-      return () => cleanup(editorInstance)
+      return () => destroyUnusedEditor(editorInstance)
     }
 
-    // if the editor does exist & deps are empty, we don't need to re-initialize the editor
-    // we can fast-path to update the editor options on the existing instance
-    editorInstance.setOptions(options)
+    // We need to destroy the editor instance and re-initialize it
+    // when the deps array changes
+    editorInstance.destroy()
 
-    return () => cleanup(editorInstance)
+    // the deps array is used to re-initialize the editor instance
+    editorInstance = createEditor(mostRecentOptions)
+    setEditor(editorInstance)
+    return () => destroyUnusedEditor(editorInstance)
   }, deps)
-
-  const {
-    onBeforeCreate,
-    onBlur,
-    onCreate,
-    onDestroy,
-    onFocus,
-    onSelectionUpdate,
-    onTransaction,
-    onUpdate,
-    onContentError,
-  } = options
-
-  const onBeforeCreateRef = useRef(onBeforeCreate)
-  const onBlurRef = useRef(onBlur)
-  const onCreateRef = useRef(onCreate)
-  const onDestroyRef = useRef(onDestroy)
-  const onFocusRef = useRef(onFocus)
-  const onSelectionUpdateRef = useRef(onSelectionUpdate)
-  const onTransactionRef = useRef(onTransaction)
-  const onUpdateRef = useRef(onUpdate)
-  const onContentErrorRef = useRef(onContentError)
-
-  // This effect will handle updating the editor instance
-  // when the event handlers change.
-  useEffect(() => {
-    if (!editor) {
-      return
-    }
-
-    if (onBeforeCreate) {
-      editor.off('beforeCreate', onBeforeCreateRef.current)
-      editor.on('beforeCreate', onBeforeCreate)
-
-      onBeforeCreateRef.current = onBeforeCreate
-    }
-
-    if (onBlur) {
-      editor.off('blur', onBlurRef.current)
-      editor.on('blur', onBlur)
-
-      onBlurRef.current = onBlur
-    }
-
-    if (onCreate) {
-      editor.off('create', onCreateRef.current)
-      editor.on('create', onCreate)
-
-      onCreateRef.current = onCreate
-    }
-
-    if (onDestroy) {
-      editor.off('destroy', onDestroyRef.current)
-      editor.on('destroy', onDestroy)
-
-      onDestroyRef.current = onDestroy
-    }
-
-    if (onFocus) {
-      editor.off('focus', onFocusRef.current)
-      editor.on('focus', onFocus)
-
-      onFocusRef.current = onFocus
-    }
-
-    if (onSelectionUpdate) {
-      editor.off('selectionUpdate', onSelectionUpdateRef.current)
-      editor.on('selectionUpdate', onSelectionUpdate)
-
-      onSelectionUpdateRef.current = onSelectionUpdate
-    }
-
-    if (onTransaction) {
-      editor.off('transaction', onTransactionRef.current)
-      editor.on('transaction', onTransaction)
-
-      onTransactionRef.current = onTransaction
-    }
-
-    if (onUpdate) {
-      editor.off('update', onUpdateRef.current)
-      editor.on('update', onUpdate)
-
-      onUpdateRef.current = onUpdate
-    }
-
-    if (onContentError) {
-      editor.off('contentError', onContentErrorRef.current)
-      editor.on('contentError', onContentError)
-
-      onContentErrorRef.current = onContentError
-    }
-  }, [
-    onBeforeCreate,
-    onBlur,
-    onCreate,
-    onDestroy,
-    onFocus,
-    onSelectionUpdate,
-    onTransaction,
-    onUpdate,
-    onContentError,
-    editor,
-  ])
 
   // The default behavior is to re-render on each transaction
   // This is legacy behavior that will be removed in future versions


### PR DESCRIPTION
## Changes Overview
React in strict mode can re-render the editor very quickly without unmounting, this makes it so that there cannot be two initalized editor instances active at the same time.

This was causing issues with the collaboration cursor which would infinitely send awareness updates while the editor was focused
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
