### PR TITLE
chore: Use proper types for `configure` methods (Extension/Mark/Node)

### DIFF
--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -457,7 +457,7 @@ export class Extension<Options = any, Storage = any> {
   configure(options: Partial<Options> = {}) {
     // return a new instance so we can use the same extension
     // with different calls of `configure`
-    const extension = this.extend({
+    const extension = this.extend<Options, Storage>({
       ...this.config,
       addOptions: () => {
         return mergeDeep(this.options as Record<string, any>, options) as Options

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -589,7 +589,7 @@ export class Mark<Options = any, Storage = any> {
   configure(options: Partial<Options> = {}) {
     // return a new instance so we can use the same extension
     // with different calls of `configure`
-    const extension = this.extend({
+    const extension = this.extend<Options, Storage>({
       ...this.config,
       addOptions: () => {
         return mergeDeep(this.options as Record<string, any>, options) as Options

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -780,7 +780,7 @@ export class Node<Options = any, Storage = any> {
   configure(options: Partial<Options> = {}) {
     // return a new instance so we can use the same extension
     // with different calls of `configure`
-    const extension = this.extend({
+    const extension = this.extend<Options, Storage>({
       ...this.config,
       addOptions: () => {
         return mergeDeep(this.options as Record<string, any>, options) as Options


### PR DESCRIPTION
## Changes Overview

Our [Typist](https://typist.doist.dev/) package (based on Tiptap) is still using `v2.3.0` for now, and while attempting a quick upgrade to the latest version, some type checks started to fail ([ref](https://github.com/Doist/typist/actions/runs/10148455201/job/28061425917?pr=773)).

One of the issues is that calling `Extension.create().configure()` returns `Node<any, any>`, whereas before it would return `Node<Options, Storage>`. This PR fixes that by making sure that when `.configure()` is called for an `Extension`, `Node`, or `Mark`, the correct type is returned.

Would love it if this could be reviewed, merged, and release soon, so that we can upgrade our Tiptap version.

## Testing Done

Built Tiptap locally and checked the generated `.d.ts` files, the expected types were there.

## Verification Steps

Same as above. Build Tiptap, and check that the `.d.ts` files are generated with the currect types for the `.configure()` method.

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.