### PR TITLE
fix: allow task items to be parsed when only having `<li data-checked` instead of only when `<li data-checked="true"` (re-fix of #5366)

### DIFF
--- a/.changeset/wise-beers-reflect.md
+++ b/.changeset/wise-beers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-task-item": patch
+---
+
+allow task items to be parsed when only having `<li data-checked` instead of only when `<li data-checked="true"` (re-fix of #5366)

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -68,7 +68,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
         parseHTML: element => {
           const dataChecked = element.getAttribute('data-checked')
 
-          return dataChecked == null || dataChecked === 'true'
+          return dataChecked === '' || dataChecked === 'true'
         },
         renderHTML: attributes => ({
           'data-checked': attributes.checked,


### PR DESCRIPTION
## Changes Overview

When I modified the code in response to [the comments](https://github.com/ueberdosis/tiptap/pull/5366#discussion_r1682594145) in PR #5366, somehow I made the wrong modification. I am very sorry.🙏🙏🙏 @nperez0111 

This PR will be correctly amended according to this comment.
I have confirmed that it works correctly with both the REPL created in #5366 and my own product code.

I will take care to avoid similar carelessness.🙏

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
I tested it by manual. 

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/pull/5366