### PR TITLE
fix: findDuplicates - use Array.from when converting Set

### DIFF
--- a/.changeset/early-singers-begin.md
+++ b/.changeset/early-singers-begin.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+fix(core): findDuplicates - use Array.from when converting Set

--- a/packages/core/src/utilities/findDuplicates.ts
+++ b/packages/core/src/utilities/findDuplicates.ts
@@ -1,5 +1,5 @@
 export function findDuplicates(items: any[]): any[] {
   const filtered = items.filter((el, index) => items.indexOf(el) !== index)
 
-  return [...new Set(filtered)]
+  return Array.from(new Set(filtered))
 }


### PR DESCRIPTION
## Changes Overview

I was getting a duplicate extension warning in Chrome because the duplicates array would contain an empty Set object:
```
[tiptap warn]: Duplicate extension names found: ['[object Set]']. This can lead to issues.
```
For whatever reason spreading the Set as a new array isn't always working as intended and causes a false positive regarding duplicates. The issue disappears when using `Array.from`.

## Implementation Approach

Switch from `[...new Set(filtered)]` to `Array.from(new Set(filtered))`

## Testing Done

I tested this on my local project. It's pretty straightforward change, so didn't overthink testing here.

## Verification Steps

Ensure that the duplicate extension warning is not being logged.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.