### PR TITLE
fix: bump priority of text-style extension fixes #4742

### DIFF
--- a/.changeset/loud-rockets-film.md
+++ b/.changeset/loud-rockets-film.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-text-style": patch
+---
+
+Give text-style extension a higher priority to have colors apply to things like underlines and strikethroughs

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -34,8 +34,8 @@ declare module '@tiptap/core' {
     /**
      * The priority of your extension. The higher, the later it will be called
      * and will take precedence over other extensions with a lower priority.
-     * @default 1000
-     * @example 1001
+     * @default 100
+     * @example 101
      */
     priority?: number
 

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -37,8 +37,8 @@ declare module '@tiptap/core' {
     /**
      * The priority of your extension. The higher, the later it will be called
      * and will take precedence over other extensions with a lower priority.
-     * @default 1000
-     * @example 1001
+     * @default 100
+     * @example 101
      */
     priority?: number
 

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -38,8 +38,8 @@ declare module '@tiptap/core' {
     /**
      * The priority of your extension. The higher, the later it will be called
      * and will take precedence over other extensions with a lower priority.
-     * @default 1000
-     * @example 1001
+     * @default 100
+     * @example 101
      */
     priority?: number
 

--- a/packages/extension-text-style/src/text-style.ts
+++ b/packages/extension-text-style/src/text-style.ts
@@ -33,6 +33,8 @@ declare module '@tiptap/core' {
 export const TextStyle = Mark.create<TextStyleOptions>({
   name: 'textStyle',
 
+  priority: 101,
+
   addOptions() {
     return {
       HTMLAttributes: {},


### PR DESCRIPTION
## Changes Overview
The text-style extension should be wrapping other elements like strikethroughs and underlines but because their priority was the same, the visuals would change based on extension order. So we modify the extension to have a slightly higher priority than the default

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->
I noticed that the JSDoc was incorrect on what the defaults were so I modified them to be accurate https://github.com/ueberdosis/tiptap/blob/2ef43e92515c0b9c93aa9471145fab62dfbc09ce/packages/core/src/ExtensionManager.ts#L97
## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
https://github.com/ueberdosis/tiptap/issues/4742