### PR TITLE
fix(react): update the types to reflect true options #5459

### DIFF
--- a/.changeset/dry-cycles-sleep.md
+++ b/.changeset/dry-cycles-sleep.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Updates the typings to `useEditor` and `EditorProvider` to not conflict with the core Editor type

--- a/packages/react/src/Context.tsx
+++ b/packages/react/src/Context.tsx
@@ -1,6 +1,7 @@
+import { Editor } from '@tiptap/core'
 import React, { createContext, ReactNode, useContext } from 'react'
 
-import { Editor } from './Editor.js'
+import { Editor as ReactEditor } from './Editor.js'
 import { EditorContent } from './EditorContent.js'
 import { useEditor, UseEditorOptions } from './useEditor.js'
 
@@ -44,7 +45,7 @@ export function EditorProvider({
       {slotBefore}
       <EditorConsumer>
         {({ editor: currentEditor }) => (
-          <EditorContent editor={currentEditor} />
+          <EditorContent editor={currentEditor as ReactEditor} />
         )}
       </EditorConsumer>
       {children}

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,4 +1,4 @@
-import { EditorOptions } from '@tiptap/core'
+import { type EditorOptions, Editor } from '@tiptap/core'
 import {
   DependencyList,
   MutableRefObject,
@@ -9,7 +9,6 @@ import {
 } from 'react'
 import { useSyncExternalStore } from 'use-sync-external-store/shim'
 
-import { Editor } from './Editor.js'
 import { useEditorState } from './useEditorState.js'
 
 const isDev = process.env.NODE_ENV !== 'production'

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -1,7 +1,6 @@
+import type { Editor } from '@tiptap/core'
 import { useDebugValue, useEffect, useState } from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
-
-import type { Editor } from './Editor.js'
 
 export type EditorStateSnapshot<TEditor extends Editor | null = Editor | null> = {
   editor: TEditor;


### PR DESCRIPTION
## Changes Overview
This updates the typings so that the outer exposed types are from @tiptap/core and the inner types are from @tiptap/react
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5459
