### PR TITLE
feat(starter-kit): enable more extensions in the starter-kit for easier onboarding

### DIFF
--- a/.changeset/weak-books-eat.md
+++ b/.changeset/weak-books-eat.md
@@ -1,0 +1,7 @@
+---
+"@tiptap/starter-kit": major
+---
+
+We have now added the Link, ListKeymap, and Underline extensions to the starter kit for a smoother onboarding experience
+
+If you have theses extensions in your project, you can remove them from your project and use the ones from the starter kit instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4730,10 +4730,6 @@
         "vite": "^4.0.0"
       }
     },
-    "node_modules/@tiptap-shared/rollup-config": {
-      "resolved": "shared/rollup-config",
-      "link": true
-    },
     "node_modules/@tiptap/core": {
       "resolved": "packages/core",
       "link": true
@@ -17411,11 +17407,14 @@
         "@tiptap/extension-history": "^3.0.0-next.0",
         "@tiptap/extension-horizontal-rule": "^3.0.0-next.0",
         "@tiptap/extension-italic": "^3.0.0-next.0",
+        "@tiptap/extension-link": "^3.0.0-next.0",
         "@tiptap/extension-list-item": "^3.0.0-next.0",
+        "@tiptap/extension-list-keymap": "^3.0.0-next.0",
         "@tiptap/extension-ordered-list": "^3.0.0-next.0",
         "@tiptap/extension-paragraph": "^3.0.0-next.0",
         "@tiptap/extension-strike": "^3.0.0-next.0",
-        "@tiptap/extension-text": "^3.0.0-next.0"
+        "@tiptap/extension-text": "^3.0.0-next.0",
+        "@tiptap/extension-underline": "^3.0.0-next.0"
       },
       "funding": {
         "type": "github",
@@ -17508,7 +17507,8 @@
       }
     },
     "shared/rollup-config": {
-      "name": "@tiptap-shared/rollup-config"
+      "name": "@tiptap-shared/rollup-config",
+      "extraneous": true
     }
   }
 }

--- a/packages/starter-kit/package.json
+++ b/packages/starter-kit/package.json
@@ -43,9 +43,12 @@
     "@tiptap/extension-horizontal-rule": "^3.0.0-next.0",
     "@tiptap/extension-italic": "^3.0.0-next.0",
     "@tiptap/extension-list-item": "^3.0.0-next.0",
+    "@tiptap/extension-list-keymap": "^3.0.0-next.0",
+    "@tiptap/extension-link": "^3.0.0-next.0",
     "@tiptap/extension-ordered-list": "^3.0.0-next.0",
     "@tiptap/extension-paragraph": "^3.0.0-next.0",
     "@tiptap/extension-strike": "^3.0.0-next.0",
+    "@tiptap/extension-underline": "^3.0.0-next.0",
     "@tiptap/extension-text": "^3.0.0-next.0"
   },
   "repository": {

--- a/packages/starter-kit/src/starter-kit.ts
+++ b/packages/starter-kit/src/starter-kit.ts
@@ -12,11 +12,14 @@ import { Heading, HeadingOptions } from '@tiptap/extension-heading'
 import { History, HistoryOptions } from '@tiptap/extension-history'
 import { HorizontalRule, HorizontalRuleOptions } from '@tiptap/extension-horizontal-rule'
 import { Italic, ItalicOptions } from '@tiptap/extension-italic'
+import { Link, LinkOptions } from '@tiptap/extension-link'
 import { ListItem, ListItemOptions } from '@tiptap/extension-list-item'
+import { ListKeymap, ListKeymapOptions } from '@tiptap/extension-list-keymap'
 import { OrderedList, OrderedListOptions } from '@tiptap/extension-ordered-list'
 import { Paragraph, ParagraphOptions } from '@tiptap/extension-paragraph'
 import { Strike, StrikeOptions } from '@tiptap/extension-strike'
 import { Text } from '@tiptap/extension-text'
+import { Underline, UnderlineOptions } from '@tiptap/extension-underline'
 
 export interface StarterKitOptions {
   /**
@@ -104,6 +107,18 @@ export interface StarterKitOptions {
   listItem: Partial<ListItemOptions> | false,
 
   /**
+   * If set to false, the listItemKeymap extension will not be registered
+   * @example listKeymap: false
+   */
+  listKeymap: Partial<ListKeymapOptions> | false,
+
+  /**
+   * If set to false, the link extension will not be registered
+   * @example link: false
+   */
+  link: Partial<LinkOptions> | false,
+
+  /**
    * If set to false, the orderedList extension will not be registered
    * @example orderedList: false
    */
@@ -126,6 +141,12 @@ export interface StarterKitOptions {
    * @example text: false
    */
   text: false,
+
+  /**
+   * If set to false, the underline extension will not be registered
+   * @example underline: false
+   */
+  underline: Partial<UnderlineOptions> | false,
 }
 
 /**
@@ -195,6 +216,14 @@ export const StarterKit = Extension.create<StarterKitOptions>({
       extensions.push(ListItem.configure(this.options?.listItem))
     }
 
+    if (this.options.listKeymap !== false) {
+      extensions.push(ListKeymap.configure(this.options?.listKeymap))
+    }
+
+    if (this.options.link !== false) {
+      extensions.push(Link.configure(this.options?.link))
+    }
+
     if (this.options.orderedList !== false) {
       extensions.push(OrderedList.configure(this.options?.orderedList))
     }
@@ -209,6 +238,10 @@ export const StarterKit = Extension.create<StarterKitOptions>({
 
     if (this.options.text !== false) {
       extensions.push(Text.configure(this.options?.text))
+    }
+
+    if (this.options.underline !== false) {
+      extensions.push(Underline.configure(this.options?.underline))
     }
 
     return extensions


### PR DESCRIPTION
## Changes Overview

I went ahead and enabled more extensions that I felt made sense in a generic starter kit, I added links, underlines and the list keymap extension since I felt this was core to the tiptap experience
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
