### PR TITLE
Correct usages of `NodeViewRendererProps` type with `NodeViewProps` #5483

### DIFF
--- a/.changeset/large-donuts-lick.md
+++ b/.changeset/large-donuts-lick.md
@@ -1,0 +1,8 @@
+---
+"@tiptap/react": patch
+"@tiptap/vue-2": patch
+"@tiptap/vue-3": patch
+"@tiptap/core": patch
+---
+
+Removed `NodeViewRendererProps` type and replaces usages with `NodeViewProps`

--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -4,7 +4,7 @@ import { NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
 
 import { Editor as CoreEditor } from './Editor.js'
 import { Node } from './Node.js'
-import { DecorationWithType, NodeViewRendererOptions, NodeViewRendererProps } from './types.js'
+import { DecorationWithType, NodeViewProps, NodeViewRendererOptions } from './types.js'
 import { isAndroid } from './utilities/isAndroid.js'
 import { isiOS } from './utilities/isiOS.js'
 
@@ -33,7 +33,7 @@ export class NodeView<
 
   isDragging = false
 
-  constructor(component: Component, props: NodeViewRendererProps, options?: Partial<Options>) {
+  constructor(component: Component, props: NodeViewProps, options?: Partial<Options>) {
     this.component = component
     this.editor = props.editor as NodeEditor
     this.options = {
@@ -43,7 +43,7 @@ export class NodeView<
     } as Options
     this.extension = props.extension
     this.node = props.node
-    this.decorations = props.decorations as DecorationWithType[]
+    this.decorations = props.decorations
     this.getPos = props.getPos
     this.mount()
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -207,16 +207,7 @@ export interface NodeViewRendererOptions {
   contentDOMElementTag: string;
 }
 
-export type NodeViewRendererProps = {
-  editor: Editor;
-  node: ProseMirrorNode;
-  getPos: (() => number) | boolean;
-  HTMLAttributes: Record<string, any>;
-  decorations: Decoration[];
-  extension: Node;
-};
-
-export type NodeViewRenderer = (props: NodeViewRendererProps) => NodeView | {};
+export type NodeViewRenderer = (props: NodeViewProps) => NodeView | {};
 
 export type AnyCommands = Record<string, (...args: any[]) => Command>;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,6 +199,15 @@ export type NodeViewProps = {
   deleteNode: () => void;
 };
 
+export type NodeViewRendererProps = {
+  editor: Editor;
+  node: ProseMirrorNode;
+  getPos: (() => number) | boolean;
+  HTMLAttributes: Record<string, any>;
+  decorations: Decoration[];
+  extension: Node;
+};
+
 export interface NodeViewRendererOptions {
   stopEvent: ((props: { event: Event }) => boolean) | null;
   ignoreMutation:
@@ -207,7 +216,9 @@ export interface NodeViewRendererOptions {
   contentDOMElementTag: string;
 }
 
-export type NodeViewRenderer = (props: NodeViewProps) => NodeView | {};
+export type NodeViewRenderer = (props: NodeViewRendererProps) => NodeView | {};
+
+export type NodeViewRendererReactVue = (props: NodeViewProps) => NodeView | {};
 
 export type AnyCommands = Record<string, (...args: any[]) => Command>;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,6 +199,14 @@ export type NodeViewProps = {
   deleteNode: () => void;
 };
 
+export interface NodeViewRendererOptions {
+  stopEvent: ((props: { event: Event }) => boolean) | null;
+  ignoreMutation:
+    | ((props: { mutation: MutationRecord | { type: 'selection'; target: Element } }) => boolean)
+    | null;
+  contentDOMElementTag: string;
+}
+
 export type NodeViewRendererProps = {
   editor: Editor;
   node: ProseMirrorNode;
@@ -207,14 +215,6 @@ export type NodeViewRendererProps = {
   decorations: Decoration[];
   extension: Node;
 };
-
-export interface NodeViewRendererOptions {
-  stopEvent: ((props: { event: Event }) => boolean) | null;
-  ignoreMutation:
-    | ((props: { mutation: MutationRecord | { type: 'selection'; target: Element } }) => boolean)
-    | null;
-  contentDOMElementTag: string;
-}
 
 export type NodeViewRenderer = (props: NodeViewRendererProps) => NodeView | {};
 

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -5,7 +5,6 @@ import {
   NodeViewProps,
   NodeViewRenderer,
   NodeViewRendererOptions,
-  NodeViewRendererProps,
 } from '@tiptap/core'
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Decoration, NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
@@ -213,7 +212,7 @@ export function ReactNodeViewRenderer(
   component: any,
   options?: Partial<ReactNodeViewRendererOptions>,
 ): NodeViewRenderer {
-  return (props: NodeViewRendererProps) => {
+  return (props: NodeViewProps) => {
     // try to get the parent component
     // this is important for vue devtools to show the component hierarchy correctly
     // maybe it’s `undefined` because <editor-content> isn’t rendered yet

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -3,8 +3,8 @@ import {
   Editor,
   NodeView,
   NodeViewProps,
-  NodeViewRenderer,
   NodeViewRendererOptions,
+  NodeViewRendererReactVue,
 } from '@tiptap/core'
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Decoration, NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
@@ -211,8 +211,8 @@ class ReactNodeView extends NodeView<
 export function ReactNodeViewRenderer(
   component: any,
   options?: Partial<ReactNodeViewRendererOptions>,
-): NodeViewRenderer {
-  return (props: NodeViewProps) => {
+): NodeViewRendererReactVue {
+  return props => {
     // try to get the parent component
     // this is important for vue devtools to show the component hierarchy correctly
     // maybe it’s `undefined` because <editor-content> isn’t rendered yet

--- a/packages/vue-2/src/VueNodeViewRenderer.ts
+++ b/packages/vue-2/src/VueNodeViewRenderer.ts
@@ -2,8 +2,8 @@ import {
   DecorationWithType,
   NodeView,
   NodeViewProps,
-  NodeViewRenderer,
   NodeViewRendererOptions,
+  NodeViewRendererReactVue,
 } from '@tiptap/core'
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Decoration, NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
@@ -169,8 +169,8 @@ class VueNodeView extends NodeView<Vue | VueConstructor, Editor, VueNodeViewRend
 export function VueNodeViewRenderer(
   component: Vue | VueConstructor,
   options?: Partial<VueNodeViewRendererOptions>,
-): NodeViewRenderer {
-  return (props: NodeViewProps) => {
+): NodeViewRendererReactVue {
+  return props => {
     // try to get the parent component
     // this is important for vue devtools to show the component hierarchy correctly
     // maybe it’s `undefined` because <editor-content> isn’t rendered yet

--- a/packages/vue-2/src/VueNodeViewRenderer.ts
+++ b/packages/vue-2/src/VueNodeViewRenderer.ts
@@ -4,7 +4,6 @@ import {
   NodeViewProps,
   NodeViewRenderer,
   NodeViewRendererOptions,
-  NodeViewRendererProps,
 } from '@tiptap/core'
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Decoration, NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
@@ -171,7 +170,7 @@ export function VueNodeViewRenderer(
   component: Vue | VueConstructor,
   options?: Partial<VueNodeViewRendererOptions>,
 ): NodeViewRenderer {
-  return (props: NodeViewRendererProps) => {
+  return (props: NodeViewProps) => {
     // try to get the parent component
     // this is important for vue devtools to show the component hierarchy correctly
     // maybe it’s `undefined` because <editor-content> isn’t rendered yet

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -2,8 +2,8 @@ import {
   DecorationWithType,
   NodeView,
   NodeViewProps,
-  NodeViewRenderer,
   NodeViewRendererOptions,
+  NodeViewRendererReactVue,
 } from '@tiptap/core'
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Decoration, NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
@@ -212,8 +212,8 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
 export function VueNodeViewRenderer(
   component: Component,
   options?: Partial<VueNodeViewRendererOptions>,
-): NodeViewRenderer {
-  return (props: NodeViewProps) => {
+): NodeViewRendererReactVue {
+  return props => {
     // try to get the parent component
     // this is important for vue devtools to show the component hierarchy correctly
     // maybe it’s `undefined` because <editor-content> isn’t rendered yet

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -4,7 +4,6 @@ import {
   NodeViewProps,
   NodeViewRenderer,
   NodeViewRendererOptions,
-  NodeViewRendererProps,
 } from '@tiptap/core'
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Decoration, NodeView as ProseMirrorNodeView } from '@tiptap/pm/view'
@@ -214,7 +213,7 @@ export function VueNodeViewRenderer(
   component: Component,
   options?: Partial<VueNodeViewRendererOptions>,
 ): NodeViewRenderer {
-  return (props: NodeViewRendererProps) => {
+  return (props: NodeViewProps) => {
     // try to get the parent component
     // this is important for vue devtools to show the component hierarchy correctly
     // maybe it’s `undefined` because <editor-content> isn’t rendered yet


### PR DESCRIPTION
… `NodeViewProps` as well as removed unnecessary type assertions due to the new type.

## Changes Overview
~~Removed `NodeViewRendererProps` type and replaced all references to it with `NodeViewProps`.~~  _Added the `NodeViewRendererReactVue` type and updated references accordingly._ There were also some unnecessary type assertions that were seemingly trying to type cast their way around this object being the wrong type. The type now matches the available props mentioned in the [docs](https://tiptap.dev/docs/editor/extensions/custom-extensions/node-views/react#all-available-props). More info in the linked issue.

## Implementation Approach

## Testing Done

## Verification Steps

## Additional Notes

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5483
