### PR TITLE
fix: Use undefined for type attribute default

### DIFF
--- a/.changeset/ordered-list-type-attr-undefined.md
+++ b/.changeset/ordered-list-type-attr-undefined.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-ordered-list": patch
+---
+
+fix: Use undefined for type attribute default

--- a/packages/extension-ordered-list/src/ordered-list.ts
+++ b/packages/extension-ordered-list/src/ordered-list.ts
@@ -85,7 +85,7 @@ export const OrderedList = Node.create<OrderedListOptions>({
         },
       },
       type: {
-        default: null,
+        default: undefined,
         parseHTML: element => element.getAttribute('type'),
       },
     }


### PR DESCRIPTION
## Changes Overview

#5344 introduced a type attribute for ordered lists. The default value is set to `null` which causes a change in the outputted document when using `editor.getJSON()`. If the user is using strict backend validation of the document, this will cause validation to fail.

Changing to `undefined` removes it from the JSON document, matching previous behaviour.

#### Pre v2.6.1

```json
{
  "type": "orderedList",
  "attrs": {
    "start": 1,
  },
  "content": [],
}
```

#### Since v2.6.1

```json
{
  "type": "orderedList",
  "attrs": {
    "start": 1,
    "type": null,
  },
  "content": [],
}
```

## Implementation Approach

## Testing Done

## Verification Steps

## Additional Notes

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

#5344