### PR TITLE
fix(react): always attempt to cleanup editor instances, starting from creation #5492

### DIFF
--- a/.changeset/funny-terms-do.md
+++ b/.changeset/funny-terms-do.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Resolves a bug where `useEditor` may not properly cleanup an instance created when in React's StrictMode #5492

--- a/demos/src/Extensions/CollaborationCursor/React/index.jsx
+++ b/demos/src/Extensions/CollaborationCursor/React/index.jsx
@@ -14,7 +14,7 @@ import * as Y from 'yjs'
 const ydoc = new Y.Doc()
 const provider = new WebrtcProvider('tiptap-collaboration-cursor-extension', ydoc)
 
-export default () => {
+function Component() {
   const editor = useEditor({
     extensions: [
       Document,
@@ -39,3 +39,11 @@ export default () => {
 
   return <EditorContent editor={editor} />
 }
+
+function App() {
+  const useStrictMode = true
+
+  return useStrictMode ? <React.StrictMode><Component /></React.StrictMode> : <Component />
+}
+
+export default App

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -78,6 +78,7 @@ class EditorInstanceManager {
     this.options = options
     this.subscriptions = new Set<() => void>()
     this.setEditor(this.getInitialEditor())
+    this.scheduleDestroy()
 
     this.getEditor = this.getEditor.bind(this)
     this.getServerSnapshot = this.getServerSnapshot.bind(this)
@@ -253,10 +254,10 @@ class EditorInstanceManager {
     const currentInstanceId = this.instanceId
     const currentEditor = this.editor
 
-    // Wait a tick to see if the component is still mounted
+    // Wait two ticks to see if the component is still mounted
     this.scheduledDestructionTimeout = setTimeout(() => {
       if (this.isComponentMounted && this.instanceId === currentInstanceId) {
-        // If still mounted on the next tick, with the same instanceId, do not destroy the editor
+        // If still mounted on the following tick, with the same instanceId, do not destroy the editor
         if (currentEditor) {
           // just re-apply options as they might have changed
           currentEditor.setOptions(this.options.current)
@@ -269,7 +270,9 @@ class EditorInstanceManager {
           this.setEditor(null)
         }
       }
-    }, 0)
+      // This allows the effect to run again between ticks
+      // which may save us from having to re-create the editor
+    }, 1)
   }
 }
 


### PR DESCRIPTION
## Changes Overview
`React.StrictMode` has made the way that we create editor instances very strange. There is a tension where React wants for us to create side-effects only within a `useEffect` so the lifecycle that StrictMode goes through is very strange:
 - A render pass
 - A render pass
 - Call useEffects
 - Call cleanup on useEffects
 - Call useEffects again

This is meant to understand whether the functions are indeed memory safe, which I can appreciate but it is very different behavior from what it actually does at runtime:

 - A render pass
 - Call useEffects
 - Call cleanup on useEffects
 - A render pass
 - Call useEffects
 - Call cleanup on useEffects

So this change makes it safe to run useEditor in StrictMode, our test suite was not previously set up to test StrictMode behavior so it was missed in original development.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

The core of the change ended up being quite simple, because we can create the editor within the first render, we need to already schedule it's destruction.
Scheduling a destruction, ensures that an instance that was created in that first render pass can be cleaned up.
Waiting one more tick than before ensures that we don't accidentally destroy an editor instance that could actually be valid in the next render pass.

In StrictMode, there will be two editor instances created, the first will be created & quickly destroyed in 2 ticks.
In Normal React, there will only ever be 1 instance created and destroyed only on unmount.

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
Lots of manual testing and console logging, we are not set up in a way to test React rendering behavior so tests could not be written

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->
Collaboration Cursors are a great way to test this, because if two instances are active attached to the same ydoc, their clientids will be the same and it will constantly try to send awareness updates even though they are attached to the same instance.
This manifests itself visually too by constantly flickering.

The silver lining with the original bug is that when React was running in normal mode (like in prod), the behavior was actually working properly, it was only an issue in StrictMode

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5492
