### PR TITLE
feat(pm): bundle prosemirror packages into the pm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4310,7 +4310,8 @@
     "node_modules/@remirror/core-constants": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ==",
+      "dev": true
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "6.0.4",
@@ -6970,7 +6971,8 @@
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -11614,6 +11616,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -12482,6 +12485,7 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -12497,12 +12501,14 @@
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -12519,7 +12525,8 @@
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/meow": {
       "version": "12.1.1",
@@ -13739,6 +13746,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.2.1.tgz",
       "integrity": "sha512-J7msc6wbxB4ekDFj+n9gTW/jav/p53kdlivvuppHsrZXCaQdVgRghoZbSS3kwrRyAstRVQ4/+u5k7YfLgkkQvQ==",
+      "dev": true,
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
       }
@@ -13747,6 +13755,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
       "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "dev": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0"
       }
@@ -13755,6 +13764,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.6.0.tgz",
       "integrity": "sha512-xn1U/g36OqXn2tn5nGmvnnimAj/g1pUx2ypJJIe8WkVX83WyJVC5LTARaxZa2AtQRwntu9Jc5zXs9gL9svp/mg==",
+      "dev": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -13796,6 +13806,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.1.tgz",
       "integrity": "sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==",
+      "dev": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -13806,6 +13817,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
       "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+      "dev": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -13817,6 +13829,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
       "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+      "dev": true,
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -13828,6 +13841,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.4.0.tgz",
       "integrity": "sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==",
+      "dev": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -13837,6 +13851,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.2.tgz",
       "integrity": "sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==",
+      "dev": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -13846,6 +13861,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.0.tgz",
       "integrity": "sha512-UziddX3ZYSYibgx8042hfGKmukq5Aljp2qoBiJRejD/8MH70siQNz5RB1TrdTPheqLMy4aCe4GYNF10/3lQS5g==",
+      "dev": true,
       "dependencies": {
         "markdown-it": "^14.0.0",
         "prosemirror-model": "^1.20.0"
@@ -13855,6 +13871,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.4.tgz",
       "integrity": "sha512-S/bXlc0ODQup6aiBbWVsX/eM+xJgCTAfMq/nLqaO5ID/am4wS0tTCIkzwytmao7ypEtjj39i7YbJjAgO20mIqA==",
+      "dev": true,
       "dependencies": {
         "crelt": "^1.0.0",
         "prosemirror-commands": "^1.0.0",
@@ -13874,6 +13891,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.3.tgz",
       "integrity": "sha512-h+H0OQwZVqMon1PNn0AG9cTfx513zgIG2DY00eJ00Yvgb3UD+GQ/VlWW5rcaxacpCGT1Yx8nuhwXk4+QbXUfJA==",
+      "dev": true,
       "dependencies": {
         "prosemirror-model": "^1.19.0"
       }
@@ -13882,6 +13900,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.4.1.tgz",
       "integrity": "sha512-jbDyaP/6AFfDfu70VzySsD75Om2t3sXTOdl5+31Wlxlg62td1haUpty/ybajSfJ1pkGadlOfwQq9kgW5IMo1Rg==",
+      "dev": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -13902,6 +13921,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.4.0.tgz",
       "integrity": "sha512-fxryZZkQG12fSCNuZDrYx6Xvo2rLYZTbKLRd8rglOPgNJGMKIS8uvTt6gGC38m7UCu/ENnXIP9pEz5uDaPc+cA==",
+      "dev": true,
       "dependencies": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -13914,6 +13934,7 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.9.tgz",
       "integrity": "sha512-YvyIn3/UaLFlFKrlJB6cObvUhmwFNZVhy1Q8OpW/avoTbD/Y7H5EcjK4AZFKhmuS6/N6WkGgt7gWtBWDnmFvHg==",
+      "dev": true,
       "dependencies": {
         "@remirror/core-constants": "^2.0.2",
         "escape-string-regexp": "^4.0.0"
@@ -13928,6 +13949,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13994,6 +14016,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -14767,7 +14790,8 @@
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
-      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "dev": true
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -16500,7 +16524,8 @@
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -16981,7 +17006,8 @@
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true
     },
     "node_modules/watchpack": {
       "version": "2.4.1",
@@ -17518,141 +17544,141 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-blockquote": {
       "name": "@tiptap/extension-blockquote",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-bold": {
       "name": "@tiptap/extension-bold",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-bubble-menu": {
       "name": "@tiptap/extension-bubble-menu",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-bullet-list": {
       "name": "@tiptap/extension-bullet-list",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-character-count": {
       "name": "@tiptap/extension-character-count",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-code": {
       "name": "@tiptap/extension-code",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-code-block": {
       "name": "@tiptap/extension-code-block",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-code-block-lowlight": {
       "name": "@tiptap/extension-code-block-lowlight",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/extension-code-block": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/extension-code-block": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "lowlight": "^2 || ^3"
       },
       "funding": {
@@ -17660,20 +17686,20 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/extension-code-block": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/extension-code-block": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "highlight.js": "^11",
         "lowlight": "^2 || ^3"
       }
     },
     "packages/extension-collaboration": {
       "name": "@tiptap/extension-collaboration",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "y-prosemirror": "^1.2.11"
       },
       "funding": {
@@ -17681,17 +17707,17 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "y-prosemirror": "^1.2.11"
       }
     },
     "packages/extension-collaboration-cursor": {
       "name": "@tiptap/extension-collaboration-cursor",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
         "y-prosemirror": "^1.2.11"
       },
       "funding": {
@@ -17699,609 +17725,609 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
         "y-prosemirror": "^1.2.11"
       }
     },
     "packages/extension-color": {
       "name": "@tiptap/extension-color",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/extension-text-style": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/extension-text-style": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/extension-text-style": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/extension-text-style": "^2.6.4"
       }
     },
     "packages/extension-document": {
       "name": "@tiptap/extension-document",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-dropcursor": {
       "name": "@tiptap/extension-dropcursor",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-floating-menu": {
       "name": "@tiptap/extension-floating-menu",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-focus": {
       "name": "@tiptap/extension-focus",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-font-family": {
       "name": "@tiptap/extension-font-family",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/extension-text-style": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/extension-text-style": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/extension-text-style": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/extension-text-style": "^2.6.4"
       }
     },
     "packages/extension-gapcursor": {
       "name": "@tiptap/extension-gapcursor",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-hard-break": {
       "name": "@tiptap/extension-hard-break",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-heading": {
       "name": "@tiptap/extension-heading",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-highlight": {
       "name": "@tiptap/extension-highlight",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-history": {
       "name": "@tiptap/extension-history",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-horizontal-rule": {
       "name": "@tiptap/extension-horizontal-rule",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-image": {
       "name": "@tiptap/extension-image",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-italic": {
       "name": "@tiptap/extension-italic",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-link": {
       "name": "@tiptap/extension-link",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.1.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-list-item": {
       "name": "@tiptap/extension-list-item",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-list-keymap": {
       "name": "@tiptap/extension-list-keymap",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-mention": {
       "name": "@tiptap/extension-mention",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
-        "@tiptap/suggestion": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
+        "@tiptap/suggestion": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
-        "@tiptap/suggestion": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
+        "@tiptap/suggestion": "^2.6.4"
       }
     },
     "packages/extension-ordered-list": {
       "name": "@tiptap/extension-ordered-list",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-paragraph": {
       "name": "@tiptap/extension-paragraph",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-placeholder": {
       "name": "@tiptap/extension-placeholder",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-strike": {
       "name": "@tiptap/extension-strike",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-subscript": {
       "name": "@tiptap/extension-subscript",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-superscript": {
       "name": "@tiptap/extension-superscript",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-table": {
       "name": "@tiptap/extension-table",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-table-cell": {
       "name": "@tiptap/extension-table-cell",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-table-header": {
       "name": "@tiptap/extension-table-header",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-table-row": {
       "name": "@tiptap/extension-table-row",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-task-item": {
       "name": "@tiptap/extension-task-item",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/extension-task-list": {
       "name": "@tiptap/extension-task-list",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-text": {
       "name": "@tiptap/extension-text",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-text-align": {
       "name": "@tiptap/extension-text-align",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-text-style": {
       "name": "@tiptap/extension-text-style",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-typography": {
       "name": "@tiptap/extension-typography",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-underline": {
       "name": "@tiptap/extension-underline",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/extension-youtube": {
       "name": "@tiptap/extension-youtube",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0"
+        "@tiptap/core": "^2.6.4"
       }
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "zeed-dom": "^0.10.9"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/pm": {
       "name": "@tiptap/pm",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "prosemirror-changeset": "^2.2.1",
         "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.5.2",
@@ -18328,17 +18354,17 @@
     },
     "packages/react": {
       "name": "@tiptap/react",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.6.0",
-        "@tiptap/extension-floating-menu": "^2.6.0",
+        "@tiptap/extension-bubble-menu": "^2.6.4",
+        "@tiptap/extension-floating-menu": "^2.6.4",
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.2.2"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "react": "^18.0.0",
@@ -18349,37 +18375,37 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/extension-blockquote": "^2.6.0",
-        "@tiptap/extension-bold": "^2.6.0",
-        "@tiptap/extension-bullet-list": "^2.6.0",
-        "@tiptap/extension-code": "^2.6.0",
-        "@tiptap/extension-code-block": "^2.6.0",
-        "@tiptap/extension-document": "^2.6.0",
-        "@tiptap/extension-dropcursor": "^2.6.0",
-        "@tiptap/extension-gapcursor": "^2.6.0",
-        "@tiptap/extension-hard-break": "^2.6.0",
-        "@tiptap/extension-heading": "^2.6.0",
-        "@tiptap/extension-history": "^2.6.0",
-        "@tiptap/extension-horizontal-rule": "^2.6.0",
-        "@tiptap/extension-italic": "^2.6.0",
-        "@tiptap/extension-list-item": "^2.6.0",
-        "@tiptap/extension-ordered-list": "^2.6.0",
-        "@tiptap/extension-paragraph": "^2.6.0",
-        "@tiptap/extension-strike": "^2.6.0",
-        "@tiptap/extension-text": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/extension-blockquote": "^2.6.4",
+        "@tiptap/extension-bold": "^2.6.4",
+        "@tiptap/extension-bullet-list": "^2.6.4",
+        "@tiptap/extension-code": "^2.6.4",
+        "@tiptap/extension-code-block": "^2.6.4",
+        "@tiptap/extension-document": "^2.6.4",
+        "@tiptap/extension-dropcursor": "^2.6.4",
+        "@tiptap/extension-gapcursor": "^2.6.4",
+        "@tiptap/extension-hard-break": "^2.6.4",
+        "@tiptap/extension-heading": "^2.6.4",
+        "@tiptap/extension-history": "^2.6.4",
+        "@tiptap/extension-horizontal-rule": "^2.6.4",
+        "@tiptap/extension-italic": "^2.6.4",
+        "@tiptap/extension-list-item": "^2.6.4",
+        "@tiptap/extension-ordered-list": "^2.6.4",
+        "@tiptap/extension-paragraph": "^2.6.4",
+        "@tiptap/extension-strike": "^2.6.4",
+        "@tiptap/extension-text": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
@@ -18388,33 +18414,33 @@
     },
     "packages/suggestion": {
       "name": "@tiptap/suggestion",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0"
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4"
       }
     },
     "packages/vue-2": {
       "name": "@tiptap/vue-2",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.6.0",
-        "@tiptap/extension-floating-menu": "^2.6.0",
+        "@tiptap/extension-bubble-menu": "^2.6.4",
+        "@tiptap/extension-floating-menu": "^2.6.4",
         "vue-ts-types": "^1.6.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "vue": "^2.6.0"
       },
       "funding": {
@@ -18422,8 +18448,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "vue": "^2.6.0"
       }
     },
@@ -18459,15 +18485,15 @@
     },
     "packages/vue-3": {
       "name": "@tiptap/vue-3",
-      "version": "2.6.0",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.6.0",
-        "@tiptap/extension-floating-menu": "^2.6.0"
+        "@tiptap/extension-bubble-menu": "^2.6.4",
+        "@tiptap/extension-floating-menu": "^2.6.4"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "vue": "^3.0.0"
       },
       "funding": {
@@ -18475,8 +18501,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.6.0",
-        "@tiptap/pm": "^2.6.0",
+        "@tiptap/core": "^2.6.4",
+        "@tiptap/pm": "^2.6.4",
         "vue": "^3.0.0"
       }
     },

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -125,7 +125,7 @@
     "transform/**",
     "view/**"
   ],
-  "dependencies": {
+  "devDependencies": {
     "prosemirror-changeset": "^2.2.1",
     "prosemirror-collab": "^1.3.1",
     "prosemirror-commands": "^1.5.2",

--- a/packages/pm/tsup.config.ts
+++ b/packages/pm/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig(options => {
     dts: true,
     splitting: true,
     clean: true,
+    noExternal: [/^prosemirror/],
     format: [
       'esm',
       'cjs',


### PR DESCRIPTION
## Changes Overview
This is more of an experiment than anything, if we bundle all of the prosemirror packages instead of relying on dependencies to be resolved properly, we would fix CDN importing of tiptap as well as guaranteeing that a known set of good prosemirror packages work together.
The only issue is when people would want to use prosemirror packages separately from tiptap, because it is now a completely different instance things can break if they don't import from @tiptap/pm.
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/4873
