### PR TITLE
Fix for #5490 - Adds `preventClearDocument` meta + makes it easier to disable specific core plugins.

### DIFF
--- a/.changeset/chatty-pumas-cross.md
+++ b/.changeset/chatty-pumas-cross.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": minor
+---
+
+Fixes #5490. The `preventClearDocument` meta tag can now be used to prevent the `clearDocument` plugin in the core keymap extension from modifying transactions that appear to clear the document (but might be clearing it for other reasons).

--- a/.changeset/rich-waves-study.md
+++ b/.changeset/rich-waves-study.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": minor
+---
+
+An object can now be passed to `enableCoreExtensions` to allow disabling only specific core extensions.

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -261,7 +261,12 @@ export class Editor extends EventEmitter<EditorEvents> {
       FocusEvents,
       Keymap,
       Tabindex,
-    ] : []
+    ].filter(ext => {
+      if (typeof this.options.enableCoreExtensions === 'object') {
+        return this.options.enableCoreExtensions[ext.name as keyof typeof this.options.enableCoreExtensions] !== false
+      }
+      return true
+    }) : []
     const allExtensions = [...coreExtensions, ...this.options.extensions].filter(extension => {
       return ['extension', 'node', 'mark'].includes(extension?.type)
     })

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -106,7 +106,9 @@ export const Keymap = Extension.create({
           const docChanges = transactions.some(transaction => transaction.docChanged)
             && !oldState.doc.eq(newState.doc)
 
-          if (!docChanges) {
+          const ignoreTr = transactions.some(transaction => transaction.getMeta('preventClearDocument'))
+
+          if (!docChanges || ignoreTr) {
             return
           }
 

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -3,6 +3,7 @@ import { Plugin, PluginKey, Selection } from '@tiptap/pm/state'
 import { CommandManager } from '../CommandManager.js'
 import { Extension } from '../Extension.js'
 import { createChainableState } from '../helpers/createChainableState.js'
+import { isNodeEmpty } from '../helpers/isNodeEmpty.js'
 import { isiOS } from '../utilities/isiOS.js'
 import { isMacOS } from '../utilities/isMacOS.js'
 
@@ -121,7 +122,7 @@ export const Keymap = Extension.create({
             return
           }
 
-          const isEmpty = newState.doc.textBetween(0, newState.doc.content.size, ' ', ' ').length === 0
+          const isEmpty = isNodeEmpty(newState.doc)
 
           if (!isEmpty) {
             return

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,7 +79,24 @@ export interface EditorOptions {
   };
   enableInputRules: EnableRules;
   enablePasteRules: EnableRules;
-  enableCoreExtensions: boolean;
+  /**
+   * Determines whether core extensions are enabled.
+   *
+   * If set to `false`, all core extensions will be disabled.
+   * To disable specific core extensions, provide an object where the keys are the extension names and the values are `false`.
+   * Extensions not listed in the object will remain enabled.
+   *
+   * @example
+   * // Disable all core extensions
+   * enabledCoreExtensions: false
+   *
+   * @example
+   * // Disable only the keymap core extension
+   * enabledCoreExtensions: { keymap: false }
+   *
+   * @default true
+   */
+  enableCoreExtensions: boolean | Record<'editable' | 'clipboardTextSerializer' | 'commands' | 'focusEvents' | 'keymap' | 'tabindex', false>;
   /**
    * If `true`, the editor will check the content for errors on initialization.
    * Emitting the `contentError` event if the content is invalid.


### PR DESCRIPTION
## Changes Overview
- Adds `preventClearDocument` to the clearDocument plugin to fix the main issue in #5490.
- Allows `enableCoreExtensions` to be an object disabling certain core extensions.
- Replaces the nodesBetween empty doc check with isNodeEmpty as requested.

## Implementation Approach
Regarding the disabling of core extensions, @nperez0111, you suggested using `coreExtensionOptions`, but I thought this made a bit more sense. It's only a bit weird in that passing something like `enableCoreExtensions: { keymap: true }` still enables everything. Only passing `false` will disable an extension (leaving others enabled). But I think that would be the most common use case.

Otherwise what sort of interface did you have in mind?

## Testing Done
I'm having a bit of issues running cypress locally. But I see the PRs have github actions.

I also tested it with my app to see everything was getting properly ignore/disabled.

## Verification Steps
- clearDocument should still work as usual unless one sets `preventClearDocument` on the transaction. My reproduction in #5490 shows the issue clearly.
- enableCoreExtensions should work normally, unless an object is passed, and then only core extensions set to false are disabled. Others stay enabled.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
Am awaiting the github actions results, but otherwise no.
- [x] My changes do not break the library. 
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
