### PR TITLE
Prevent onBlur being trigged when task item is toggled

### DIFF
--- a/.changeset/slow-lies-promise.md
+++ b/.changeset/slow-lies-promise.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-task-item": patch
+---
+
+Prevent `onBlur` from being trigged when a task item is toggled

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -137,7 +137,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
 
       checkboxWrapper.contentEditable = 'false'
       checkbox.type = 'checkbox'
-      checkbox.addEventListener('mousedown', event => event.preventDefault());
+      checkbox.addEventListener('mousedown', event => event.preventDefault())
       checkbox.addEventListener('change', event => {
         // if the editor isn’t editable and we don't have a handler for
         // readonly checks we have to undo the latest change

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -137,6 +137,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
 
       checkboxWrapper.contentEditable = 'false'
       checkbox.type = 'checkbox'
+      checkbox.addEventListener('mousedown', event => event.preventDefault());
       checkbox.addEventListener('change', event => {
         // if the editor isn’t editable and we don't have a handler for
         // readonly checks we have to undo the latest change


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
Fixes https://github.com/ueberdosis/tiptap/issues/5519
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
