### PR TITLE
fix(core): check schema's nesting rules on contentCheck (#5500)

### DIFF
--- a/.changeset/mean-pets-unite.md
+++ b/.changeset/mean-pets-unite.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+fix: check for schema's nesting rules on contentCheck

--- a/packages/core/src/helpers/createNodeFromContent.ts
+++ b/packages/core/src/helpers/createNodeFromContent.ts
@@ -45,7 +45,13 @@ export function createNodeFromContent(
         return Fragment.fromArray(content.map(item => schema.nodeFromJSON(item)))
       }
 
-      return schema.nodeFromJSON(content)
+      const node = schema.nodeFromJSON(content)
+
+      if (options.errorOnInvalidContent) {
+        node.check()
+      }
+
+      return node
     } catch (error) {
       if (options.errorOnInvalidContent) {
         throw new Error('[tiptap error]: Invalid JSON content', { cause: error as Error })

--- a/tests/cypress/integration/core/createNodeFromContent.spec.ts
+++ b/tests/cypress/integration/core/createNodeFromContent.spec.ts
@@ -242,4 +242,25 @@ describe('createNodeFromContent', () => {
       ]), { errorOnInvalidContent: true })
     }).to.throw('[tiptap error]: Invalid JSON content')
   })
+
+  it('if `errorOnInvalidContent` is true, will throw an error, when the JSON content does not follow the nesting rules of the schema', () => {
+    const content = {
+      type: 'paragraph',
+      content: [{
+        type: 'paragraph',
+        content: [{
+          type: 'text',
+          text: 'Example Text',
+        }],
+      }],
+    }
+
+    expect(() => {
+      createNodeFromContent(content, getSchemaByResolvedExtensions([
+        Document,
+        Paragraph,
+        Text,
+      ]), { errorOnInvalidContent: true })
+    }).to.throw('[tiptap error]: Invalid JSON content')
+  })
 })


### PR DESCRIPTION
## Changes Overview
An error will be thrown when the JSON content doesn't match the schema nesting rules, and `contentCheck` is set to true.

## Implementation Approach
I added [check](https://prosemirror.net/docs/ref/#model.Node.check) in `createNodeFromContent`

## Testing Done
I added a the test `if 'errorOnInvalidContent' is true, will throw an error, when the JSON content does not follow the nesting rules of the schema`

## Verification Steps

## Additional Notes

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
[#5500](https://github.com/ueberdosis/tiptap/issues/5500#issue-2467718220)
