### PR TITLE
fix(suggestion): add isLoading state to suggestion popup

### DIFF
--- a/.changeset/chilly-suits-flash.md
+++ b/.changeset/chilly-suits-flash.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/suggestion": patch
+---
+
+Exposes an `isLoading` prop to the Suggestion popup, returning a boolean that indicates if the items callback is a promise awaiting resolution

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -130,6 +130,11 @@ export interface SuggestionProps<I = any, TSelected = any> {
   items: I[]
 
   /**
+   * The state of loading items.
+   */
+  isLoading: boolean
+
+  /**
    * A function that is called when a suggestion is selected.
    * @param props The props object.
    * @returns void
@@ -215,6 +220,7 @@ export function Suggestion<I = any, TSelected = any>({
             query: state.query,
             text: state.text,
             items: [],
+            isLoading: false,
             command: commandProps => {
               return command({
                 editor,
@@ -247,9 +253,14 @@ export function Suggestion<I = any, TSelected = any>({
           }
 
           if (handleChange || handleStart) {
-            props.items = await items({
-              editor,
-              query: state.query,
+            props.isLoading = true
+            Promise.resolve(items({ editor, query: state.query })).then(result => {
+              if (props == null) {
+                return
+              }
+              props.isLoading = false
+              props.items = result
+              renderer?.onUpdate?.(props)
             })
           }
 


### PR DESCRIPTION
## Changes Overview
Fixes issue #5533 by exposing an `isLoading` prop for the suggestion popup.

## Implementation Approach
Not sure if this is the way to go, took the least resistant path. This re-renders the popup after resolving the `items` promise with the updated result.

## Testing Done
Here's a recording, though I'm not sure how it should be presented on the demo example.
https://www.loom.com/share/11fb168e6f0e4e6eb2853472b4f90842

## Verification Steps
As described in the video above.

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
