### PR TITLE
 fix(suggestion): dropdown can't be closed with `Esc` (#4380)

### DIFF
--- a/.changeset/tender-items-visit.md
+++ b/.changeset/tender-items-visit.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/suggestion": patch
+---
+
+Dropdowns from the suggestion utility couldn't be closed with the `Esc` key

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -197,7 +197,7 @@ export function Suggestion<I = any, TSelected = any>({
 
           const handleStart = started || (moved && changed)
           const handleChange = changed || moved
-          const handleExit = stopped
+          const handleExit = stopped || (moved && changed)
 
           // Cancel when suggestion isn't active
           if (!handleStart && !handleChange && !handleExit) {


### PR DESCRIPTION
## Changes Overview
See discussion here: https://github.com/ueberdosis/tiptap/pull/4380#issuecomment-2306513901

## Implementation Approach

Suggested by @nperez0111.

## Testing Done
I checked that this works with the single room collaboration demo opened in different browsers, and manually tested all the small issues for which I recorded small videos in the commented linked above.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.