### PR TITLE
fix(extension-code-block-lowlight): support for lowlight v3 aliases

### DIFF
--- a/.changeset/sweet-ants-lick.md
+++ b/.changeset/sweet-ants-lick.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-code-block-lowlight": patch
+---
+
+Add support for lowlight v3 aliases

--- a/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
+++ b/packages/extension-code-block-lowlight/src/lowlight-plugin.ts
@@ -49,7 +49,7 @@ function getDecorations({
     const language = block.node.attrs.language || defaultLanguage
     const languages = lowlight.listLanguages()
 
-    const nodes = language && (languages.includes(language) || registered(language))
+    const nodes = language && (languages.includes(language) || registered(language) || lowlight.registered?.(language))
       ? getHighlightNodes(lowlight.highlight(language, block.node.textContent))
       : getHighlightNodes(lowlight.highlightAuto(block.node.textContent))
 


### PR DESCRIPTION
## Changes Overview
Added support for lowlight v2+ method `registered`

## Implementation Approach
I tried not to remove support for earlier versions of lowlight that was implemented in #3155

## Testing Done
I checked that after entering ` ```javascript ` and ` ```jsx ` there was the same formatting result. It can be also checked on other aliases that are listed in [highlight.js Supported Languages](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md)

## Additional Notes
<img width="400" alt="Before" src="https://github.com/user-attachments/assets/533a5159-cfc7-483b-88fb-14eb4ef714a4">
<img width="400" alt="After" src="https://github.com/user-attachments/assets/47c4e7e8-80b8-4708-8c6a-a4ff35602f53">


## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#4651
