### PR TITLE
Trusted Types API violation fix

### DIFF
--- a/packages/core/src/utilities/createStyleTag.ts
+++ b/packages/core/src/utilities/createStyleTag.ts
@@ -12,7 +12,7 @@ export function createStyleTag(style: string, nonce?: string, suffix?: string): 
   }
 
   styleNode.setAttribute(`data-tiptap-style${suffix ? `-${suffix}` : ''}`, '')
-  styleNode.innerHTML = style
+  styleNode.textContent = style
   document.getElementsByTagName('head')[0].appendChild(styleNode)
 
   return styleNode

--- a/packages/core/src/utilities/elementFromString.ts
+++ b/packages/core/src/utilities/elementFromString.ts
@@ -14,9 +14,37 @@ const removeWhitespaces = (node: HTMLElement) => {
   return node
 }
 
+let policy = {
+  createHTML: (input: any) => input,
+  createScript: (input: any) => input,
+  createScriptURL: (input: any) => input,
+}
+
+try {
+  // @ts-ignore
+  // eslint-disable-next-line no-undef
+  policy = globalThis.trustedTypes.createPolicy('tiptap', {
+    createHTML: (input: any) => input,
+    createScript: (input: any) => input,
+    createScriptURL: (input: any) => input,
+  })
+} catch (error) {
+  // @ts-ignore
+  // eslint-disable-next-line no-undef
+  if (window.trustedTypes) {
+    // @ts-ignore
+    // eslint-disable-next-line no-undef
+    policy = window.trustedTypes.createPolicy('tiptap', {
+      createHTML: (input: any) => input,
+      createScript: (input: any) => input,
+      createScriptURL: (input: any) => input,
+    })
+  }
+}
+
 export function elementFromString(value: string): HTMLElement {
   // add a wrapper to preserve leading and trailing whitespace
-  const wrappedValue = `<body>${value}</body>`
+  const wrappedValue = policy.createHTML(`<body>${value}</body>`)
 
   const html = new window.DOMParser().parseFromString(wrappedValue, 'text/html').body
 


### PR DESCRIPTION
Fix for Trusted Types Issue with TipTap on YouTube
[YouTube recently enforced a stricter Content Security Policy with Trusted Types](https://developer.chrome.com/blog/trusted-types-on-youtube), causing TipTap to stop working in our Chrome extension. The issue arose because Trusted Types restrict certain operations like innerHTML, which TipTap relies on.

Solution:
We implemented a custom Trusted Types policy that allows TipTap to function correctly within YouTube's security framework. This fix involves defining and applying a policy that permits the necessary unsafe operations while maintaining security.

https://web.dev/articles/trusted-types#fix_the_violations