### PR TITLE
Add loading support for images

### DIFF
--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -37,9 +37,9 @@ declare module '@tiptap/core' {
        * @example
        * editor
        *   .commands
-       *   .setImage({ src: 'https://tiptap.dev/logo.png', alt: 'tiptap', title: 'tiptap logo' })
+       *   .setImage({ src: 'https://tiptap.dev/logo.png', alt: 'tiptap', title: 'tiptap logo', loading: 'lazy' })
        */
-      setImage: (options: { src: string, alt?: string, title?: string }) => ReturnType,
+      setImage: (options: { src: string, alt?: string, title?: string, loading?: string }) => ReturnType,
     }
   }
 }
@@ -82,6 +82,9 @@ export const Image = Node.create<ImageOptions>({
       alt: {
         default: null,
       },
+      loading: {
+        default: null,
+      },
       title: {
         default: null,
       },
@@ -119,9 +122,9 @@ export const Image = Node.create<ImageOptions>({
         find: inputRegex,
         type: this.type,
         getAttributes: match => {
-          const [,, alt, src, title] = match
+          const [,, alt, loading, src, title] = match
 
-          return { src, alt, title }
+          return { src, alt, loading, title }
         },
       }),
     ]


### PR DESCRIPTION
Nowadays images don't support the addition of the lazy attribute.

## Changes Overview
<!-- Briefly describe your changes. -->
There is an important attribute on Images that is used for performance but is not being supported by TipTap

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->
Just added the attribute in the Image node

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
