### PR TITLE
Allow default behaviour in stopEvent/ignoreMutation overrides

### DIFF
--- a/.changeset/warm-kids-repair.md
+++ b/.changeset/warm-kids-repair.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Allow default behaviour in stopEvent/ignoreMutation overrides

--- a/packages/core/src/NodeView.ts
+++ b/packages/core/src/NodeView.ts
@@ -121,7 +121,11 @@ export class NodeView<
     }
 
     if (typeof this.options.stopEvent === 'function') {
-      return this.options.stopEvent({ event })
+      const shouldStopEvent = this.options.stopEvent({ event })
+
+      if (shouldStopEvent !== null) {
+        return shouldStopEvent
+      }
     }
 
     const target = event.target as HTMLElement
@@ -215,7 +219,11 @@ export class NodeView<
     }
 
     if (typeof this.options.ignoreMutation === 'function') {
-      return this.options.ignoreMutation({ mutation })
+      const shouldIgnoreMutation = this.options.ignoreMutation({ mutation })
+
+      if (shouldIgnoreMutation !== null) {
+        return shouldIgnoreMutation
+      }
     }
 
     // a leaf/atom node is like a black box for ProseMirror

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -586,8 +586,8 @@ export interface NodeViewProps extends NodeViewRendererProps {
 }
 
 export interface NodeViewRendererOptions {
-  stopEvent: ((props: { event: Event }) => boolean) | null
-  ignoreMutation: ((props: { mutation: ViewMutationRecord }) => boolean) | null
+  stopEvent: ((props: { event: Event }) => boolean | null) | null
+  ignoreMutation: ((props: { mutation: ViewMutationRecord }) => boolean | null) | null
   contentDOMElementTag: string
 }
 


### PR DESCRIPTION
## Changes Overview
In my case, I needed to override `stopEvent`, but only for a specific case. Otherwise I'd like for it to have a default behaviour. To do this, I'd have to recreate all the checks from default `stopEvent` in my override. This PR addresses this inconvenience.

## Implementation Approach
`stopEvent` ignores override only if you explicitly return a `null`. This should minimize a breaking change for existing usages.

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
#257 