### PR TITLE
fix: whiteSpace style of NodeViewContent should be set to break-spaces

### DIFF
--- a/packages/vue-2/src/NodeViewContent.ts
+++ b/packages/vue-2/src/NodeViewContent.ts
@@ -15,7 +15,7 @@ export const NodeViewContent: Component = {
   render(this: NodeViewContentInterface, createElement: CreateElement) {
     return createElement(this.as, {
       style: {
-        whiteSpace: 'pre-wrap',
+        whiteSpace: 'break-spaces',
       },
       attrs: {
         'data-node-view-content': '',


### PR DESCRIPTION
## Changes Overview
Changed whitespace from pre-wrap to break-spaces which allows the whitespace to be preserved and word re

## Implementation Approach
Replaced pre-wrap with break-spaces

## Testing Done
Tested locally to check for whitespacing and breaks.

## Verification Steps

## Additional Notes

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
#5587 
