### PR TITLE
Update `getPos` type inside `NodeViewRendererProps` to reflect actual functionality

### DIFF
--- a/.changeset/green-wolves-arrive.md
+++ b/.changeset/green-wolves-arrive.md
@@ -1,0 +1,9 @@
+---
+"@tiptap/core": major
+---
+
+Fix `getPos` type in `NodeViewRendererProps` to potentially be `undefined`
+
+Breaking change: Types may flag uses of getPos where an `undefined` possibility isn't handled.
+Why this change was made: To ensure the type reflects the real functionality of this function.
+How to update: Ensure that the return value of `getPos` exists before making use of the value.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -236,7 +236,7 @@ export type NodeViewRendererProps = {
   // pass-through from prosemirror
   node: Parameters<NodeViewConstructor>[0];
   view: Parameters<NodeViewConstructor>[1];
-  getPos: () => number; // TODO getPos was incorrectly typed before, change to `Parameters<NodeViewConstructor>[2];` in the next major version
+  getPos: Parameters<NodeViewConstructor>[2];
   decorations: Parameters<NodeViewConstructor>[3];
   innerDecorations: Parameters<NodeViewConstructor>[4];
   // tiptap-specific


### PR DESCRIPTION
## Changes Overview
The type for `getPos` inside of `NodeViewRendererProps` was incorrectly typed to indicate that it always returns a number, when this is not the actual case. It can also return `undefined`.

As per the ProseMirror documentation:
> The third argument getPos is a function that can be called to get the node's current position, which can be useful when creating transactions to update it. **Note that if the node is not in the document, the position returned by this function will be undefined**.

Trusting this function to always return a number has lead to some stability issues in our application, so I believe it's best that the type reflects the actual functionality, even if this may cause some headaches to handle `undefined` cases. 

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->
Update the type to point towards `Parameters<NodeViewConstructor>[2]`, which I believe inherits off `pm/view`.

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
- Ran test suite, including cypress tests. All passing.

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->
- Try to use `getPos` inside of a `NodeView`.

## Additional Notes
I'd consider this a breaking change, as it could flare up people's type checks if they're not handling the possibility of the return value being `undefined`,  so I have marked it as needing a major version bump in the changeset.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/3823
