### PR TITLE
Fix Slice import in DropPlugin

### DIFF
--- a/.changeset/rare-berries-sit.md
+++ b/.changeset/rare-berries-sit.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixed Slice import in DropPlugin

--- a/packages/core/src/plugins/DropPlugin.ts
+++ b/packages/core/src/plugins/DropPlugin.ts
@@ -1,5 +1,5 @@
+import { Slice } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
-import { Slice } from 'packages/pm/model'
 
 export const DropPlugin = (onDrop: (e: DragEvent, slice: Slice, moved: boolean) => void) => {
   return new Plugin({


### PR DESCRIPTION
## Changes Overview
Fix error "Cannot find module 'packages/pm/model' or its corresponding type declarations." by updating the import of Slice in DropPlugin.

## Implementation Approach
Use `@tiptap/pm/model` instead of `packages/pm/model`.

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
