### PR TITLE
Fix/insert content at block insertions

### DIFF
--- a/.changeset/lazy-needles-train.md
+++ b/.changeset/lazy-needles-train.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": major
+---
+
+`insertContent` and `insertContentAt` commands should not split text nodes like paragraphs into multiple nodes when the inserted content is at the beginning of the text to avoid empty nodes being created

--- a/demos/src/Commands/InsertContent/React/index.jsx
+++ b/demos/src/Commands/InsertContent/React/index.jsx
@@ -1,11 +1,12 @@
 import './styles.scss'
 
 import { Color } from '@tiptap/extension-color'
+import { Image } from '@tiptap/extension-image'
 import ListItem from '@tiptap/extension-list-item'
 import TextStyle from '@tiptap/extension-text-style'
 import { EditorProvider, useCurrentEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 const htmlContent = `
   <h1><a href="https://tiptap.dev/">Tiptap</a></h1>
@@ -24,6 +25,12 @@ And more lines`
 const MenuBar = () => {
   const { editor } = useCurrentEditor()
 
+  const insertImage = useCallback(() => {
+    const url = prompt('Enter an image URL')
+
+    editor.chain().insertContent(`<img src="${url}" alt="Example image" />`).focus().run()
+  }, [editor])
+
   if (!editor) {
     return null
   }
@@ -40,12 +47,14 @@ const MenuBar = () => {
         <button data-test-id="text-content" onClick={() => editor.chain().insertContent(textContent).focus().run()}>
           Insert text content
         </button>
+        <button data-test-id="image-content" onClick={insertImage}>Insert image</button>
       </div>
     </div>
   )
 }
 
 const extensions = [
+  Image,
   Color.configure({ types: [TextStyle.name, ListItem.name] }),
   TextStyle.configure({ types: [ListItem.name] }),
   StarterKit.configure({

--- a/demos/src/Commands/InsertContent/React/index.spec.js
+++ b/demos/src/Commands/InsertContent/React/index.spec.js
@@ -11,7 +11,7 @@ context('/src/Commands/InsertContent/React/', () => {
     cy.get('button[data-test-id="html-content"]').click()
 
     // check if the content html is correct
-    cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p><strong>Hello World</strong></p><p>This is a paragraph<br>with a break.</p><p>And this is some additional string content.</p>')
+    cy.get('.tiptap').should('contain.html', '<h1><a target="_blank" rel="noopener noreferrer nofollow" href="https://tiptap.dev/">Tiptap</a></h1><p><strong>Hello World</strong></p><p>This is a paragraph<br>with a break.</p><p>And this is some additional string content.</p>')
   })
 
   it('should keep spaces inbetween tags in html content', () => {
@@ -91,4 +91,21 @@ context('/src/Commands/InsertContent/React/', () => {
     })
   })
 
+  it('should split content when image is inserted inbetween text', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.commands.insertContent('<p>HelloWorld</p>')
+      editor.commands.setTextSelection(6)
+      editor.commands.insertContent('<img src="https://example.image/1" alt="This is an example" />')
+      cy.get('.tiptap').should('contain.html', '<p>Hello</p><img src="https://example.image/1" alt="This is an example" contenteditable="false" draggable="true"><p>World</p>')
+    })
+  })
+
+  it('should not split content when image is inserted at beginning of text', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.commands.insertContent('<p>HelloWorld</p>')
+      editor.commands.setTextSelection(1)
+      editor.commands.insertContent('<img src="https://example.image/1" alt="This is an example" />')
+      cy.get('.tiptap').should('contain.html', '<img src="https://example.image/1" alt="This is an example" contenteditable="false" draggable="true"><p>HelloWorld</p>')
+    })
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
     },
     "demos": {
       "name": "tiptap-demos",
-      "version": "2.4.2",
+      "version": "3.0.0-next.0",
       "dependencies": {
         "@hocuspocus/provider": "2.13.5",
         "@lexical/react": "^0.11.1",
@@ -18439,57 +18439,57 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-blockquote": {
       "name": "@tiptap/extension-blockquote",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-bold": {
       "name": "@tiptap/extension-bold",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-bubble-menu": {
       "name": "@tiptap/extension-bubble-menu",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
@@ -18497,82 +18497,82 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-bullet-list": {
       "name": "@tiptap/extension-bullet-list",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-character-count": {
       "name": "@tiptap/extension-character-count",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-code": {
       "name": "@tiptap/extension-code",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-code-block": {
       "name": "@tiptap/extension-code-block",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-code-block-lowlight": {
       "name": "@tiptap/extension-code-block-lowlight",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/extension-code-block": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/extension-code-block": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "lowlight": "^2 || ^3"
       },
       "funding": {
@@ -18580,20 +18580,20 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/extension-code-block": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/extension-code-block": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "highlight.js": "^11",
         "lowlight": "^2 || ^3"
       }
     },
     "packages/extension-collaboration": {
       "name": "@tiptap/extension-collaboration",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "y-prosemirror": "^1.2.9"
       },
       "funding": {
@@ -18601,17 +18601,17 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "y-prosemirror": "^1.2.6"
       }
     },
     "packages/extension-collaboration-cursor": {
       "name": "@tiptap/extension-collaboration-cursor",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
         "y-prosemirror": "^1.2.9"
       },
       "funding": {
@@ -18619,67 +18619,67 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
         "y-prosemirror": "^1.2.6"
       }
     },
     "packages/extension-color": {
       "name": "@tiptap/extension-color",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/extension-text-style": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/extension-text-style": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/extension-text-style": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/extension-text-style": "^3.0.0-next.1"
       }
     },
     "packages/extension-document": {
       "name": "@tiptap/extension-document",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-dropcursor": {
       "name": "@tiptap/extension-dropcursor",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-floating-menu": {
       "name": "@tiptap/extension-floating-menu",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
@@ -18687,538 +18687,538 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-focus": {
       "name": "@tiptap/extension-focus",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-font-family": {
       "name": "@tiptap/extension-font-family",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/extension-text-style": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/extension-text-style": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/extension-text-style": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/extension-text-style": "^3.0.0-next.1"
       }
     },
     "packages/extension-gapcursor": {
       "name": "@tiptap/extension-gapcursor",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-hard-break": {
       "name": "@tiptap/extension-hard-break",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-heading": {
       "name": "@tiptap/extension-heading",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-highlight": {
       "name": "@tiptap/extension-highlight",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-history": {
       "name": "@tiptap/extension-history",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-horizontal-rule": {
       "name": "@tiptap/extension-horizontal-rule",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-image": {
       "name": "@tiptap/extension-image",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-italic": {
       "name": "@tiptap/extension-italic",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-link": {
       "name": "@tiptap/extension-link",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.1.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-list-item": {
       "name": "@tiptap/extension-list-item",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-list-keymap": {
       "name": "@tiptap/extension-list-keymap",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-mention": {
       "name": "@tiptap/extension-mention",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
-        "@tiptap/suggestion": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
+        "@tiptap/suggestion": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
-        "@tiptap/suggestion": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
+        "@tiptap/suggestion": "^3.0.0-next.1"
       }
     },
     "packages/extension-ordered-list": {
       "name": "@tiptap/extension-ordered-list",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-paragraph": {
       "name": "@tiptap/extension-paragraph",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-placeholder": {
       "name": "@tiptap/extension-placeholder",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-strike": {
       "name": "@tiptap/extension-strike",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-subscript": {
       "name": "@tiptap/extension-subscript",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-superscript": {
       "name": "@tiptap/extension-superscript",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-table": {
       "name": "@tiptap/extension-table",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-table-cell": {
       "name": "@tiptap/extension-table-cell",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-table-header": {
       "name": "@tiptap/extension-table-header",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-table-row": {
       "name": "@tiptap/extension-table-row",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-task-item": {
       "name": "@tiptap/extension-task-item",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/extension-task-list": {
       "name": "@tiptap/extension-task-list",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-text": {
       "name": "@tiptap/extension-text",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-text-align": {
       "name": "@tiptap/extension-text-align",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-text-style": {
       "name": "@tiptap/extension-text-style",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-typography": {
       "name": "@tiptap/extension-typography",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-underline": {
       "name": "@tiptap/extension-underline",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/extension-youtube": {
       "name": "@tiptap/extension-youtube",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1"
       }
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "zeed-dom": "^0.10.9"
       },
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/pm": {
       "name": "@tiptap/pm",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.2.1",
@@ -19247,17 +19247,17 @@
     },
     "packages/react": {
       "name": "@tiptap/react",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^3.0.0-next.0",
-        "@tiptap/extension-floating-menu": "^3.0.0-next.0",
+        "@tiptap/extension-bubble-menu": "^3.0.0-next.1",
+        "@tiptap/extension-floating-menu": "^3.0.0-next.1",
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.2.2"
       },
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "react": "^18.0.0",
@@ -19268,40 +19268,40 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/extension-blockquote": "^3.0.0-next.0",
-        "@tiptap/extension-bold": "^3.0.0-next.0",
-        "@tiptap/extension-bullet-list": "^3.0.0-next.0",
-        "@tiptap/extension-code": "^3.0.0-next.0",
-        "@tiptap/extension-code-block": "^3.0.0-next.0",
-        "@tiptap/extension-document": "^3.0.0-next.0",
-        "@tiptap/extension-dropcursor": "^3.0.0-next.0",
-        "@tiptap/extension-gapcursor": "^3.0.0-next.0",
-        "@tiptap/extension-hard-break": "^3.0.0-next.0",
-        "@tiptap/extension-heading": "^3.0.0-next.0",
-        "@tiptap/extension-history": "^3.0.0-next.0",
-        "@tiptap/extension-horizontal-rule": "^3.0.0-next.0",
-        "@tiptap/extension-italic": "^3.0.0-next.0",
-        "@tiptap/extension-link": "^3.0.0-next.0",
-        "@tiptap/extension-list-item": "^3.0.0-next.0",
-        "@tiptap/extension-list-keymap": "^3.0.0-next.0",
-        "@tiptap/extension-ordered-list": "^3.0.0-next.0",
-        "@tiptap/extension-paragraph": "^3.0.0-next.0",
-        "@tiptap/extension-strike": "^3.0.0-next.0",
-        "@tiptap/extension-text": "^3.0.0-next.0",
-        "@tiptap/extension-underline": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/extension-blockquote": "^3.0.0-next.1",
+        "@tiptap/extension-bold": "^3.0.0-next.1",
+        "@tiptap/extension-bullet-list": "^3.0.0-next.1",
+        "@tiptap/extension-code": "^3.0.0-next.1",
+        "@tiptap/extension-code-block": "^3.0.0-next.1",
+        "@tiptap/extension-document": "^3.0.0-next.1",
+        "@tiptap/extension-dropcursor": "^3.0.0-next.1",
+        "@tiptap/extension-gapcursor": "^3.0.0-next.1",
+        "@tiptap/extension-hard-break": "^3.0.0-next.1",
+        "@tiptap/extension-heading": "^3.0.0-next.1",
+        "@tiptap/extension-history": "^3.0.0-next.1",
+        "@tiptap/extension-horizontal-rule": "^3.0.0-next.1",
+        "@tiptap/extension-italic": "^3.0.0-next.1",
+        "@tiptap/extension-link": "^3.0.0-next.1",
+        "@tiptap/extension-list-item": "^3.0.0-next.1",
+        "@tiptap/extension-list-keymap": "^3.0.0-next.1",
+        "@tiptap/extension-ordered-list": "^3.0.0-next.1",
+        "@tiptap/extension-paragraph": "^3.0.0-next.1",
+        "@tiptap/extension-strike": "^3.0.0-next.1",
+        "@tiptap/extension-text": "^3.0.0-next.1",
+        "@tiptap/extension-underline": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
@@ -19310,33 +19310,33 @@
     },
     "packages/suggestion": {
       "name": "@tiptap/suggestion",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0"
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1"
       }
     },
     "packages/vue-2": {
       "name": "@tiptap/vue-2",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^3.0.0-next.0",
-        "@tiptap/extension-floating-menu": "^3.0.0-next.0",
+        "@tiptap/extension-bubble-menu": "^3.0.0-next.1",
+        "@tiptap/extension-floating-menu": "^3.0.0-next.1",
         "vue-ts-types": "^1.6.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "vue": "^2.6.0"
       },
       "funding": {
@@ -19344,8 +19344,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "vue": "^2.6.0"
       }
     },
@@ -19380,15 +19380,15 @@
     },
     "packages/vue-3": {
       "name": "@tiptap/vue-3",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^3.0.0-next.0",
-        "@tiptap/extension-floating-menu": "^3.0.0-next.0"
+        "@tiptap/extension-bubble-menu": "^3.0.0-next.1",
+        "@tiptap/extension-floating-menu": "^3.0.0-next.1"
       },
       "devDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "vue": "^3.0.0"
       },
       "funding": {
@@ -19396,8 +19396,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0-next.0",
-        "@tiptap/pm": "^3.0.0-next.0",
+        "@tiptap/core": "^3.0.0-next.1",
+        "@tiptap/pm": "^3.0.0-next.1",
         "vue": "^3.0.0"
       }
     }

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -71,6 +71,7 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
     }
 
     let content: Fragment | ProseMirrorNode
+    const { selection } = editor.state
 
     try {
       content = createNodeFromContent(value, editor.schema, {
@@ -139,6 +140,13 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
       tr.insertText(newContent, from, to)
     } else {
       newContent = content
+
+      const fromSelectionAtStart = selection.$from.parentOffset === 0
+      const isTextSelection = selection.$from.node().isText || selection.$from.node().isTextblock
+
+      if (fromSelectionAtStart && isTextSelection) {
+        from = Math.max(0, from - 1)
+      }
 
       tr.replaceWith(from, to, newContent)
     }


### PR DESCRIPTION
## Changes Overview
This PR fixes an issue that was brought up by a community member about how the `insertContent` and `insertContentAt` commands always split text nodes when **the selection starts at the beginning of the text**. This would always lead to the inserted content having an empty paragraph inserted above it.

In the following example I'll try to point out the issue more

```html
<p>Hello World</p>
```

Let's say your cursor right now is at the start of `Hello World` and you would insert an image, the resulting HTML previously would return

```html
<!-- This paragraph was created because Tiptap was -->
<!-- trying to insert the node literally into the --> 
<!-- paragraph at position 1 which won't work so it splits it -->
<p></p>
<img src="https://image.domain/path.jpg" alt="My image" />
<p>Hello World</p>
```

After this fix the HTML will result to this:

```html
<img src="https://image.domain/path.jpg" alt="My image" />
<p>Hello World</p>
```

When the content is inserted between existing text, it will just work as usual via splitting the paragraph/text node apart.

## Implementation Approach
Before we run the actual inserting of block node content, I added a check to see if

1. The cursor is currently at the start of it's parent node
2. The cursor is inside a text or textblock node

If both requirements are met, we jump out of the node via `from =- 1` to prepend said node before the current text block.

## Testing Done
I added two test cases for those scenarios and both run valid + did manual tests.

## Verification Steps
1. Check the tests (should run through)
2. Clone manually if needed & open the `insertContent` demo

## Additional Notes
This is a **major** change as it could break existing insertContent usages.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

