### PR TITLE
Add editorContainerProps to EditorProvider

### DIFF
--- a/.changeset/bright-apples-reflect.md
+++ b/.changeset/bright-apples-reflect.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Add editorContainerProps to EditorProvider. This allows for any HTML attributes to be added to the EditorContent when using EditorProvider

--- a/packages/react/src/Context.tsx
+++ b/packages/react/src/Context.tsx
@@ -34,7 +34,7 @@ export type EditorProviderProps = {
  * with `useCurrentEditor`.
  */
 export function EditorProvider({
-  children, slotAfter, slotBefore, editorContainerProps, ...editorOptions
+  children, slotAfter, slotBefore, editorContainerProps = {}, ...editorOptions
 }: EditorProviderProps) {
   const editor = useEditor(editorOptions)
 

--- a/packages/react/src/Context.tsx
+++ b/packages/react/src/Context.tsx
@@ -1,5 +1,7 @@
 import { Editor } from '@tiptap/core'
-import React, { createContext, ReactNode, useContext } from 'react'
+import React, {
+  createContext, HTMLAttributes, ReactNode, useContext,
+} from 'react'
 
 import { EditorContent } from './EditorContent.js'
 import { useEditor, UseEditorOptions } from './useEditor.js'
@@ -23,6 +25,7 @@ export type EditorProviderProps = {
   children?: ReactNode;
   slotBefore?: ReactNode;
   slotAfter?: ReactNode;
+  editorContainerProps?: HTMLAttributes<HTMLDivElement>;
 } & UseEditorOptions
 
 /**
@@ -31,7 +34,7 @@ export type EditorProviderProps = {
  * with `useCurrentEditor`.
  */
 export function EditorProvider({
-  children, slotAfter, slotBefore, ...editorOptions
+  children, slotAfter, slotBefore, editorContainerProps, ...editorOptions
 }: EditorProviderProps) {
   const editor = useEditor(editorOptions)
 
@@ -44,7 +47,7 @@ export function EditorProvider({
       {slotBefore}
       <EditorConsumer>
         {({ editor: currentEditor }) => (
-          <EditorContent editor={currentEditor} />
+          <EditorContent editor={currentEditor} {...editorContainerProps} />
         )}
       </EditorConsumer>
       {children}


### PR DESCRIPTION
## Changes Overview
Add `editorContainerProps` to EditorProvider. This will allow to pass HTML attributes to the EditorContent when using EditorProvider

## Additional Notes
### Preview
#### Code 
![image](https://github.com/user-attachments/assets/bb501c7d-6d47-4430-9734-f35e7818ccd6)
#### Output
![image](https://github.com/user-attachments/assets/2699ff58-31d5-4898-84b6-069e3627ff8c)

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
Related discussion - https://github.com/ueberdosis/tiptap/discussions/5656
