### PR TITLE
fix(core): dereference editor from DOM element on destroy #5654

### DIFF
--- a/.changeset/eighty-pandas-admire.md
+++ b/.changeset/eighty-pandas-admire.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+This plugs a memory leak where there is a circular reference between the view's DOM node and the editor instance, to resolve this, before destroying the view we need to delete the reference to the editor instance on the DOM node #5654

--- a/package-lock.json
+++ b/package-lock.json
@@ -18849,10 +18849,10 @@
     },
     "packages/core": {
       "name": "@tiptap/core",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18864,10 +18864,10 @@
     },
     "packages/extension-blockquote": {
       "name": "@tiptap/extension-blockquote",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18879,10 +18879,10 @@
     },
     "packages/extension-bold": {
       "name": "@tiptap/extension-bold",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18894,14 +18894,14 @@
     },
     "packages/extension-bubble-menu": {
       "name": "@tiptap/extension-bubble-menu",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18914,10 +18914,10 @@
     },
     "packages/extension-bullet-list": {
       "name": "@tiptap/extension-bullet-list",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18929,11 +18929,11 @@
     },
     "packages/extension-character-count": {
       "name": "@tiptap/extension-character-count",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18946,10 +18946,10 @@
     },
     "packages/extension-code": {
       "name": "@tiptap/extension-code",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18961,11 +18961,11 @@
     },
     "packages/extension-code-block": {
       "name": "@tiptap/extension-code-block",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -18978,12 +18978,12 @@
     },
     "packages/extension-code-block-lowlight": {
       "name": "@tiptap/extension-code-block-lowlight",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/extension-code-block": "^2.7.2",
-        "@tiptap/pm": "^2.7.2",
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/extension-code-block": "^2.7.3",
+        "@tiptap/pm": "^2.7.3",
         "lowlight": "^2 || ^3"
       },
       "funding": {
@@ -19000,11 +19000,11 @@
     },
     "packages/extension-collaboration": {
       "name": "@tiptap/extension-collaboration",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2",
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3",
         "y-prosemirror": "^1.2.12"
       },
       "funding": {
@@ -19019,10 +19019,10 @@
     },
     "packages/extension-collaboration-cursor": {
       "name": "@tiptap/extension-collaboration-cursor",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
+        "@tiptap/core": "^2.7.3",
         "y-prosemirror": "^1.2.12"
       },
       "funding": {
@@ -19086,11 +19086,11 @@
     },
     "packages/extension-color": {
       "name": "@tiptap/extension-color",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/extension-text-style": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/extension-text-style": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19103,10 +19103,10 @@
     },
     "packages/extension-document": {
       "name": "@tiptap/extension-document",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19118,11 +19118,11 @@
     },
     "packages/extension-dropcursor": {
       "name": "@tiptap/extension-dropcursor",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19135,14 +19135,14 @@
     },
     "packages/extension-floating-menu": {
       "name": "@tiptap/extension-floating-menu",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19155,11 +19155,11 @@
     },
     "packages/extension-focus": {
       "name": "@tiptap/extension-focus",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19172,11 +19172,11 @@
     },
     "packages/extension-font-family": {
       "name": "@tiptap/extension-font-family",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/extension-text-style": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/extension-text-style": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19189,11 +19189,11 @@
     },
     "packages/extension-gapcursor": {
       "name": "@tiptap/extension-gapcursor",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19206,10 +19206,10 @@
     },
     "packages/extension-hard-break": {
       "name": "@tiptap/extension-hard-break",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19221,10 +19221,10 @@
     },
     "packages/extension-heading": {
       "name": "@tiptap/extension-heading",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19236,10 +19236,10 @@
     },
     "packages/extension-highlight": {
       "name": "@tiptap/extension-highlight",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19251,11 +19251,11 @@
     },
     "packages/extension-history": {
       "name": "@tiptap/extension-history",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19268,11 +19268,11 @@
     },
     "packages/extension-horizontal-rule": {
       "name": "@tiptap/extension-horizontal-rule",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19285,10 +19285,10 @@
     },
     "packages/extension-image": {
       "name": "@tiptap/extension-image",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19300,10 +19300,10 @@
     },
     "packages/extension-italic": {
       "name": "@tiptap/extension-italic",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19315,14 +19315,14 @@
     },
     "packages/extension-link": {
       "name": "@tiptap/extension-link",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.1.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19335,10 +19335,10 @@
     },
     "packages/extension-list-item": {
       "name": "@tiptap/extension-list-item",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19350,10 +19350,10 @@
     },
     "packages/extension-list-keymap": {
       "name": "@tiptap/extension-list-keymap",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19365,12 +19365,12 @@
     },
     "packages/extension-mention": {
       "name": "@tiptap/extension-mention",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2",
-        "@tiptap/suggestion": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3",
+        "@tiptap/suggestion": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19384,10 +19384,10 @@
     },
     "packages/extension-ordered-list": {
       "name": "@tiptap/extension-ordered-list",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19399,10 +19399,10 @@
     },
     "packages/extension-paragraph": {
       "name": "@tiptap/extension-paragraph",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19414,11 +19414,11 @@
     },
     "packages/extension-placeholder": {
       "name": "@tiptap/extension-placeholder",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19431,10 +19431,10 @@
     },
     "packages/extension-strike": {
       "name": "@tiptap/extension-strike",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19446,10 +19446,10 @@
     },
     "packages/extension-subscript": {
       "name": "@tiptap/extension-subscript",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19461,10 +19461,10 @@
     },
     "packages/extension-superscript": {
       "name": "@tiptap/extension-superscript",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19476,11 +19476,11 @@
     },
     "packages/extension-table": {
       "name": "@tiptap/extension-table",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19493,10 +19493,10 @@
     },
     "packages/extension-table-cell": {
       "name": "@tiptap/extension-table-cell",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19508,10 +19508,10 @@
     },
     "packages/extension-table-header": {
       "name": "@tiptap/extension-table-header",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19523,10 +19523,10 @@
     },
     "packages/extension-table-row": {
       "name": "@tiptap/extension-table-row",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19538,11 +19538,11 @@
     },
     "packages/extension-task-item": {
       "name": "@tiptap/extension-task-item",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19555,10 +19555,10 @@
     },
     "packages/extension-task-list": {
       "name": "@tiptap/extension-task-list",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19570,10 +19570,10 @@
     },
     "packages/extension-text": {
       "name": "@tiptap/extension-text",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19585,10 +19585,10 @@
     },
     "packages/extension-text-align": {
       "name": "@tiptap/extension-text-align",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19600,10 +19600,10 @@
     },
     "packages/extension-text-style": {
       "name": "@tiptap/extension-text-style",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19615,10 +19615,10 @@
     },
     "packages/extension-typography": {
       "name": "@tiptap/extension-typography",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19630,10 +19630,10 @@
     },
     "packages/extension-underline": {
       "name": "@tiptap/extension-underline",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19645,10 +19645,10 @@
     },
     "packages/extension-youtube": {
       "name": "@tiptap/extension-youtube",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2"
+        "@tiptap/core": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19660,14 +19660,14 @@
     },
     "packages/html": {
       "name": "@tiptap/html",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "zeed-dom": "^0.15.1"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19709,7 +19709,7 @@
     },
     "packages/pm": {
       "name": "@tiptap/pm",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.2.1",
@@ -19738,18 +19738,18 @@
     },
     "packages/react": {
       "name": "@tiptap/react",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.7.2",
-        "@tiptap/extension-floating-menu": "^2.7.2",
+        "@tiptap/extension-bubble-menu": "^2.7.3",
+        "@tiptap/extension-floating-menu": "^2.7.3",
         "@types/use-sync-external-store": "^0.0.6",
         "fast-deep-equal": "^3",
         "use-sync-external-store": "^1.2.2"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2",
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "react": "^18.0.0",
@@ -19768,29 +19768,29 @@
     },
     "packages/starter-kit": {
       "name": "@tiptap/starter-kit",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/extension-blockquote": "^2.7.2",
-        "@tiptap/extension-bold": "^2.7.2",
-        "@tiptap/extension-bullet-list": "^2.7.2",
-        "@tiptap/extension-code": "^2.7.2",
-        "@tiptap/extension-code-block": "^2.7.2",
-        "@tiptap/extension-document": "^2.7.2",
-        "@tiptap/extension-dropcursor": "^2.7.2",
-        "@tiptap/extension-gapcursor": "^2.7.2",
-        "@tiptap/extension-hard-break": "^2.7.2",
-        "@tiptap/extension-heading": "^2.7.2",
-        "@tiptap/extension-history": "^2.7.2",
-        "@tiptap/extension-horizontal-rule": "^2.7.2",
-        "@tiptap/extension-italic": "^2.7.2",
-        "@tiptap/extension-list-item": "^2.7.2",
-        "@tiptap/extension-ordered-list": "^2.7.2",
-        "@tiptap/extension-paragraph": "^2.7.2",
-        "@tiptap/extension-strike": "^2.7.2",
-        "@tiptap/extension-text": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/extension-blockquote": "^2.7.3",
+        "@tiptap/extension-bold": "^2.7.3",
+        "@tiptap/extension-bullet-list": "^2.7.3",
+        "@tiptap/extension-code": "^2.7.3",
+        "@tiptap/extension-code-block": "^2.7.3",
+        "@tiptap/extension-document": "^2.7.3",
+        "@tiptap/extension-dropcursor": "^2.7.3",
+        "@tiptap/extension-gapcursor": "^2.7.3",
+        "@tiptap/extension-hard-break": "^2.7.3",
+        "@tiptap/extension-heading": "^2.7.3",
+        "@tiptap/extension-history": "^2.7.3",
+        "@tiptap/extension-horizontal-rule": "^2.7.3",
+        "@tiptap/extension-italic": "^2.7.3",
+        "@tiptap/extension-list-item": "^2.7.3",
+        "@tiptap/extension-ordered-list": "^2.7.3",
+        "@tiptap/extension-paragraph": "^2.7.3",
+        "@tiptap/extension-strike": "^2.7.3",
+        "@tiptap/extension-text": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19799,11 +19799,11 @@
     },
     "packages/suggestion": {
       "name": "@tiptap/suggestion",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2"
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3"
       },
       "funding": {
         "type": "github",
@@ -19816,16 +19816,16 @@
     },
     "packages/vue-2": {
       "name": "@tiptap/vue-2",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.7.2",
-        "@tiptap/extension-floating-menu": "^2.7.2",
+        "@tiptap/extension-bubble-menu": "^2.7.3",
+        "@tiptap/extension-floating-menu": "^2.7.3",
         "vue-ts-types": "^1.6.0"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2",
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3",
         "vue": "^2.6.0"
       },
       "funding": {
@@ -19876,15 +19876,15 @@
     },
     "packages/vue-3": {
       "name": "@tiptap/vue-3",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.7.2",
-        "@tiptap/extension-floating-menu": "^2.7.2"
+        "@tiptap/extension-bubble-menu": "^2.7.3",
+        "@tiptap/extension-floating-menu": "^2.7.3"
       },
       "devDependencies": {
-        "@tiptap/core": "^2.7.2",
-        "@tiptap/pm": "^2.7.2",
+        "@tiptap/core": "^2.7.3",
+        "@tiptap/pm": "^2.7.3",
         "vue": "^3.0.0"
       },
       "funding": {

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -568,6 +568,13 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.emit('destroy')
 
     if (this.view) {
+      // Cleanup our reference to prevent circular references which caused memory leaks
+      // @ts-ignore
+      const dom = this.view.dom as TiptapEditorHTMLElement
+
+      if (dom && dom.editor) {
+        delete dom.editor
+      }
       this.view.destroy()
     }
 


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
This plugs a memory leak where there is a circular reference between the view's DOM node and the editor instance, to resolve this, before destroying the view we need to delete the reference to the editor instance on the DOM node #5654
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
