### PR TITLE
feat(CharacterCount): Add counter function to `CharacterCount` extension.

### DIFF
--- a/.changeset/calm-bottles-shout.md
+++ b/.changeset/calm-bottles-shout.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-character-count": minor
+---
+
+Make counter function accessible from outside character-count extension

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -16,6 +16,18 @@ export interface CharacterCountOptions {
    * @example 'textSize'
    */
   mode: 'textSize' | 'nodeSize'
+  /**
+ * The text counter function to use. Defaults to a simple character count.
+ * @default (text) => text.length
+ * @example (text) => [...new Intl.Segmenter().segment(text)].length
+ */
+  textCounter: (text: string) => number
+  /**
+   * The word counter function to use. Defaults to a simple word count.
+   * @default (text) => text.split(' ').filter(word => word !== '').length
+   * @example (text) => text.split(/\s+/).filter(word => word !== '').length
+   */
+  wordCounter: (text: string) => number
 }
 
 export interface CharacterCountStorage {
@@ -46,6 +58,8 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
     return {
       limit: null,
       mode: 'textSize',
+      textCounter: text => text.length,
+      wordCounter: text => text.split(' ').filter(word => word !== '').length,
     }
   },
 
@@ -64,7 +78,7 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
       if (mode === 'textSize') {
         const text = node.textBetween(0, node.content.size, undefined, ' ')
 
-        return text.length
+        return this.options.textCounter(text)
       }
 
       return node.nodeSize
@@ -73,9 +87,8 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
     this.storage.words = options => {
       const node = options?.node || this.editor.state.doc
       const text = node.textBetween(0, node.content.size, ' ', ' ')
-      const words = text.split(' ').filter(word => word !== '')
 
-      return words.length
+      return this.options.wordCounter(text)
     }
   },
 


### PR DESCRIPTION
## Changes Overview
Made `CharacterCount`'s text and word counting logic to accessible from outside, which can solve issues with string containing emoji.

## Implementation Approach
I've just added these two options
```tsx
export interface CharacterCountOptions {
  /**
   * The text counter function to use. Defaults to a simple character count.
   * @default (text) => text.length
   * @example (text) => [...new Intl.Segmenter().segment(text)].length
   */
  textCounter: (text: string) => number
  /**
   * The word counter function to use. Defaults to a simple word count.
   * @default (text) => text.split(' ').filter(word => word !== '').length
   * @example (text) => text.split(/\s+/).filter(word => word !== '').length
   */
  wordCounter: (text: string) => number
}
```
and default options
```ts
      textCounter: text => text.length,
      wordCounter: text => text.split(' ').filter(word => word !== '').length,
```

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
