### PR TITLE
Update mention extension's priority

### DIFF
--- a/.changeset/lemon-onions-walk.md
+++ b/.changeset/lemon-onions-walk.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-mention": patch
+---
+
+Increase mention extension priority to allow mentions to be inserted in lists using the Enter key

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -77,6 +77,8 @@ export const MentionPluginKey = new PluginKey('mention')
 export const Mention = Node.create<MentionOptions>({
   name: 'mention',
 
+  priority: 101,
+
   addOptions() {
     return {
       HTMLAttributes: {},


### PR DESCRIPTION
## Changes Overview
Pressing Enter key when using the mention in a bullet list / ordered list would create a new list item instead of adding the mention. Updated the mention extension's priority to fix it.

## Implementation Approach
Update mention extension's priority to 101

## Additional Notes
### Preview
https://github.com/user-attachments/assets/0ea45fd8-8b4a-4644-9221-5f68fe3817f1

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
Fixes #5680 
