### PR TITLE
fix: add extension-text-style as a dep of @tiptap/starter-kit #5691

### DIFF
--- a/.changeset/thirty-apes-boil.md
+++ b/.changeset/thirty-apes-boil.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/starter-kit": patch
+---
+
+Adds @tiptap/extension-text-style to @tiptap/starter-kit deps but does not install the extension, since it is only to resolve a peer dep install for list-items

--- a/package-lock.json
+++ b/package-lock.json
@@ -19798,6 +19798,7 @@
         "@tiptap/extension-paragraph": "^2.8.0",
         "@tiptap/extension-strike": "^2.8.0",
         "@tiptap/extension-text": "^2.8.0",
+        "@tiptap/extension-text-style": "^2.8.0",
         "@tiptap/pm": "^2.8.0"
       },
       "funding": {

--- a/packages/starter-kit/package.json
+++ b/packages/starter-kit/package.json
@@ -48,6 +48,7 @@
     "@tiptap/extension-paragraph": "^2.8.0",
     "@tiptap/extension-strike": "^2.8.0",
     "@tiptap/extension-text": "^2.8.0",
+    "@tiptap/extension-text-style": "^2.8.0",
     "@tiptap/pm": "^2.8.0"
   },
   "repository": {


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
Adds @tiptap/extension-text-style to @tiptap/starter-kit deps but does not install the extension, since it is only to resolve a peer dep install for list-items
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
#5691
