### PR TITLE
Add clear mark parse rules to bold & italic marks

### DIFF
--- a/.changeset/calm-carpets-smile.md
+++ b/.changeset/calm-carpets-smile.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/extension-italic": patch
+"@tiptap/extension-bold": patch
+---
+
+Add parse rules that reset bold & italic marks

--- a/packages/extension-bold/src/bold.ts
+++ b/packages/extension-bold/src/bold.ts
@@ -76,6 +76,10 @@ export const Bold = Mark.create<BoldOptions>({
         getAttrs: node => (node as HTMLElement).style.fontWeight !== 'normal' && null,
       },
       {
+        style: 'font-weight=400',
+        clearMark: mark => mark.type.name === this.name,
+      },
+      {
         style: 'font-weight',
         getAttrs: value => /^(bold(er)?|[5-9]\d{2,})$/.test(value as string) && null,
       },

--- a/packages/extension-italic/src/italic.ts
+++ b/packages/extension-italic/src/italic.ts
@@ -79,6 +79,10 @@ export const Italic = Mark.create<ItalicOptions>({
         getAttrs: node => (node as HTMLElement).style.fontStyle !== 'normal' && null,
       },
       {
+        style: 'font-style=normal',
+        clearMark: mark => mark.type.name === this.name,
+      },
+      {
         style: 'font-style=italic',
       },
     ]


### PR DESCRIPTION
## Changes Overview
Resolves https://github.com/ueberdosis/tiptap/issues/5585

Adds parse rules to bold & italic that remove marks from their parent styles.

## Implementation Approach
This is a port of `prosemirror-schema-basic`. When parsing a `font-weight=400` or `font-style=normal` style, use the `clearMark` directive to clear the bold or italic marks respectively.

https://github.com/ProseMirror/prosemirror-schema-basic/commit/6521792c10edbaad4d2d10a0b21baa1b56364e82. 

## Testing Done
I tested my changes in the demo application. I asserted that HTML inserted into the editor are now parsed as expected, both from the clipboard & directly via `commands.setContent`

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

Ensure that HTML that nest `font-weight` & `font-style` tags are styled as expected.

**Input**
```html
<p style="font-weight: 700;">
  <span style="font-weight: 700;">I am Bold</span>
  <span style="font-weight: 400;">I am not Bold</span>
</p>
```

**Expectation**
```
doc(paragraph(bold("I am Bold "), "I am not Bold"))
```

**Input**
```html
<p style="font-style: italic">
  <span style="font-style: italic">I am Italic</span>
  <span style="font-style: normal">I am not Italic</span>
</p>
```

**Expectation**
```
doc(paragraph(italic("I am Italic "), "I am not Italic"))
```

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [X] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [X] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
