### PR TITLE
Fix NodePos logic for child position calculation and attribute changes

### DIFF
--- a/.changeset/nervous-bats-film.md
+++ b/.changeset/nervous-bats-film.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixed an issue while updating attributes on a NodePos that was not a text

--- a/.changeset/sweet-feet-dream.md
+++ b/.changeset/sweet-feet-dream.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixed issues with NodePos child positions causing wrong positions when used on non-text atoms

--- a/packages/core/src/NodePos.ts
+++ b/packages/core/src/NodePos.ts
@@ -236,12 +236,13 @@ export class NodePos {
   }
 
   setAttribute(attributes: { [key: string]: any }) {
-    const { selection } = this.editor.state
+    const { tr } = this.editor.state
 
-    this.editor.chain()
-      .setTextSelection(this.from)
-      .updateAttributes(this.node.type.name, attributes)
-      .setTextSelection(selection.from)
-      .run()
+    tr.setNodeMarkup(this.from, undefined, {
+      ...this.node.attrs,
+      ...attributes,
+    })
+
+    this.editor.view.dispatch(tr)
   }
 }

--- a/packages/core/src/NodePos.ts
+++ b/packages/core/src/NodePos.ts
@@ -135,8 +135,9 @@ export class NodePos {
 
     this.node.content.forEach((node, offset) => {
       const isBlock = node.isBlock && !node.isTextblock
+      const isNonTextAtom = node.isAtom && !node.isText
 
-      const targetPos = this.pos + offset + 1
+      const targetPos = this.pos + offset + (isNonTextAtom ? 0 : 1)
       const $pos = this.resolvedPos.doc.resolve(targetPos)
 
       if (!isBlock && $pos.depth <= this.depth) {
@@ -235,9 +236,12 @@ export class NodePos {
   }
 
   setAttribute(attributes: { [key: string]: any }) {
-    const oldSelection = this.editor.state.selection
+    const { selection } = this.editor.state
 
-    this.editor.chain().setTextSelection(this.from).updateAttributes(this.node.type.name, attributes).setTextSelection(oldSelection.from)
+    this.editor.chain()
+      .setTextSelection(this.from)
+      .updateAttributes(this.node.type.name, attributes)
+      .setTextSelection(selection.from)
       .run()
   }
 }


### PR DESCRIPTION
## Changes Overview

This pull request addresses several issues in the `@tiptap/core` package, particularly focusing on fixing problems related to `NodePos` attributes and child positions. The main changes include bug fixes to ensure correct handling of non-text atoms and improvements to the attribute update mechanism.

Bug fixes:

* [`.changeset/nervous-bats-film.md`](diffhunk://#diff-1424d192cc57f5c8573055e8638e1147fd04a613f075b992926e31b64f3b46beR1-R5): Fixed an issue while updating attributes on a `NodePos` that was not a text.
* [`.changeset/sweet-feet-dream.md`](diffhunk://#diff-2b81d02a2b19bd5bae65c933f5e1d881c1ab8286511bad9e7421b5011885a779R1-R5): Fixed issues with `NodePos` child positions causing wrong positions when used on non-text atoms.

Changes:

* [`packages/core/src/NodePos.ts`](diffhunk://#diff-deab15d8918868fc71b9ad8ee3afa808f6b4be07c48e915fd0aed512493fd90cR138-R140): Modified the calculation of `targetPos` to correctly handle non-text atoms by adjusting the offset conditionally.
* [`packages/core/src/NodePos.ts`](diffhunk://#diff-deab15d8918868fc71b9ad8ee3afa808f6b4be07c48e915fd0aed512493fd90cL238-R246): Refactored the `setAttribute` method to use a transaction (`tr`) for setting node markup and dispatching the update, improving the attribute update mechanism.

## Implementation Approach

- Added a new check if the current NodePos child position is a non-text atom (the offset will be 0 then)
- Added direct PM logic to update attributes on a NodePos node

## Testing Done
- Ran tests locally
- Ran tests on CI
- Tested my changes locally on a local demo

## Verification Steps
That's my demo:

```jsx
import './styles.scss'

import Image from '@tiptap/extension-image'
import { EditorContent, useEditor } from '@tiptap/react'
import StarterKit from '@tiptap/starter-kit'
import React, { useMemo } from 'react'

export default () => {
  const editor = useEditor({
    extensions: [
      StarterKit,
      Image,
    ],
    content: `
      <p>This is my demo</p>
      <img src="https://picsum.photos/200/300" alt="test">
    `,
  })

  const imagePos = useMemo(() => {
    let pos = 0

    editor.state.doc.descendants((node, nodePosition) => {
      if (node.type.name === 'image') {
        pos = nodePosition
      }
    })
    return pos
  }, [editor])

  return (
    <>
      <div>
        <button onClick={() => editor.$node('image').setAttribute({ src: 'https://picsum.photos/500/500' })}>Change Image</button>
      </div>
      <EditorContent editor={editor} />
      <div>
        <div>NodePos Pos: {editor.$node('image').pos}</div>
        <div>PM Pos: {imagePos}</div>
      </div>
    </>
  )
}
```

## Additional Notes
Nothing

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
This PR should fix #5672 and fix #5671
