### PR TITLE
Fix getMarkRange not finding marks when at the start of a mark

### DIFF
--- a/.changeset/sweet-masks-smash.md
+++ b/.changeset/sweet-masks-smash.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixed an issue with getMarkRange not returning the correct range when cursor is at the start of the specified mark

--- a/packages/core/src/helpers/getMarkRange.ts
+++ b/packages/core/src/helpers/getMarkRange.ts
@@ -29,17 +29,20 @@ export function getMarkRange(
   if (!$pos || !type) {
     return
   }
-
   let start = $pos.parent.childAfter($pos.parentOffset)
 
-  if ($pos.parentOffset === start.offset && start.offset !== 0) {
+  // If the cursor is at the start of a text node that does not have the mark, look backward
+  if (!start.node || !start.node.marks.some(mark => mark.type === type)) {
     start = $pos.parent.childBefore($pos.parentOffset)
   }
 
-  if (!start.node) {
+  // If there is no text node with the mark even backward, return undefined
+  if (!start.node || !start.node.marks.some(mark => mark.type === type)) {
     return
   }
 
+  // We now know that the cursor is either at the start, middle or end of a text node with the specified mark
+  // so we can look it up on the targeted mark
   const mark = findMarkInSet([...start.node.marks], type, attributes)
 
   if (!mark) {

--- a/tests/cypress/integration/core/getMarkRange.spec.ts
+++ b/tests/cypress/integration/core/getMarkRange.spec.ts
@@ -1,0 +1,87 @@
+/// <reference types="cypress" />
+
+import {
+  getMarkRange,
+  getSchemaByResolvedExtensions,
+} from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Link from '@tiptap/extension-link'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { Node } from '@tiptap/pm/model'
+
+describe('getMarkRange', () => {
+  const document = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'This is a ' },
+          { type: 'text', text: 'linked', marks: [{ type: 'link', attrs: { href: 'https://tiptap.dev' } }] },
+          { type: 'text', text: ' text.' },
+        ],
+      },
+    ],
+  }
+
+  const schema = getSchemaByResolvedExtensions([
+    Document,
+    Paragraph,
+    Text,
+    Link.configure({ openOnClick: false }),
+  ])
+
+  it('gets the correct range for a position inside the mark', () => {
+    const doc = Node.fromJSON(schema, document)
+    const $pos = doc.resolve(14)
+    const range = getMarkRange($pos, schema.marks.link)
+
+    expect(range).to.deep.eq({
+      from: 11,
+      to: 17,
+    })
+
+    // eslint-disable-next-line no-console
+    console.log(range)
+  })
+
+  it('gets the correct range for a position at the start of the mark', () => {
+    const doc = Node.fromJSON(schema, document)
+    const $pos = doc.resolve(11)
+    const range = getMarkRange($pos, schema.marks.link)
+
+    expect(range).to.deep.eq({
+      from: 11,
+      to: 17,
+    })
+
+    // eslint-disable-next-line no-console
+    console.log(range)
+  })
+
+  it('gets the correct range for a position at the end of the mark', () => {
+    const doc = Node.fromJSON(schema, document)
+    const $pos = doc.resolve(17)
+    const range = getMarkRange($pos, schema.marks.link)
+
+    expect(range).to.deep.eq({
+      from: 11,
+      to: 17,
+    })
+
+    // eslint-disable-next-line no-console
+    console.log(range)
+  })
+
+  it('gets undefined if a mark is not found', () => {
+    const doc = Node.fromJSON(schema, document)
+    const $pos = doc.resolve(6)
+    const range = getMarkRange($pos, schema.marks.link)
+
+    expect(range).to.eq(undefined)
+
+    // eslint-disable-next-line no-console
+    console.log(range)
+  })
+})

--- a/tests/cypress/integration/core/getMarkRange.spec.ts
+++ b/tests/cypress/integration/core/getMarkRange.spec.ts
@@ -55,9 +55,6 @@ describe('getMarkRange', () => {
       from: 11,
       to: 17,
     })
-
-    // eslint-disable-next-line no-console
-    console.log(range)
   })
 
   it('gets the correct range for a position at the end of the mark', () => {
@@ -69,9 +66,6 @@ describe('getMarkRange', () => {
       from: 11,
       to: 17,
     })
-
-    // eslint-disable-next-line no-console
-    console.log(range)
   })
 
   it('gets undefined if a mark is not found', () => {
@@ -80,8 +74,5 @@ describe('getMarkRange', () => {
     const range = getMarkRange($pos, schema.marks.link)
 
     expect(range).to.eq(undefined)
-
-    // eslint-disable-next-line no-console
-    console.log(range)
   })
 })

--- a/tests/cypress/integration/core/getMarkRange.spec.ts
+++ b/tests/cypress/integration/core/getMarkRange.spec.ts
@@ -41,9 +41,6 @@ describe('getMarkRange', () => {
       from: 11,
       to: 17,
     })
-
-    // eslint-disable-next-line no-console
-    console.log(range)
   })
 
   it('gets the correct range for a position at the start of the mark', () => {
@@ -74,5 +71,73 @@ describe('getMarkRange', () => {
     const range = getMarkRange($pos, schema.marks.link)
 
     expect(range).to.eq(undefined)
+  })
+
+  it('doesnt cross node boundaries on backward check', () => {
+    const testDocument = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'This is a text with a ' },
+            { type: 'text', text: 'link.', marks: [{ type: 'link', attrs: { href: 'https://tiptap.dev' } }] },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'This is a text without a link.' },
+          ],
+        },
+      ],
+    }
+
+    const doc = Node.fromJSON(schema, testDocument)
+    const $pos = doc.resolve(28)
+    const range = getMarkRange($pos, schema.marks.link)
+
+    expect(range).to.deep.eq({
+      from: 23,
+      to: 28,
+    })
+
+    const nextRange = getMarkRange(doc.resolve(30), schema.marks.link)
+
+    expect(nextRange).to.eq(undefined)
+  })
+
+  it('doesnt cross node boundaries on forward check', () => {
+    const testDocument = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'This is a text without a link.' },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'A link', marks: [{ type: 'link', attrs: { href: 'https://tiptap.dev' } }] },
+            { type: 'text', text: ' is at the start of this paragraph.' },
+          ],
+        },
+      ],
+    }
+    const doc = Node.fromJSON(schema, testDocument)
+
+    const range = getMarkRange(doc.resolve(32), schema.marks.link)
+
+    expect(range).to.eq(undefined)
+
+    const $pos = doc.resolve(33)
+    const nextRange = getMarkRange($pos, schema.marks.link)
+
+    expect(nextRange).to.deep.eq({
+      from: 33,
+      to: 39,
+    })
   })
 })


### PR DESCRIPTION
## Changes Overview

This pull request addresses an issue in the `@tiptap/core` package where the `getMarkRange` function did not return the correct range when the cursor was at the start of the specified mark. The changes involve both documentation and code modifications to ensure accurate behavior.

### Bug Fix:

* [`packages/core/src/helpers/getMarkRange.ts`](diffhunk://#diff-e265670b2c081e4c8486eb69ad5c34a81f449ba84871895b072de287ed55ab4bL32-R45): Updated the `getMarkRange` function to correctly handle cases where the cursor is at the start of a text node without the mark, ensuring it looks backward and returns the appropriate range.

## Implementation Approach
You can find out more about my implementation from the comments in code. I basically added a forward, then backward check for marks on the current nodes parent with the parent offset.

## Testing Done
Tested it locally on my machine in a demo I build. (See below)

## Verification Steps
My demo:

```
import './styles.scss'

import Document from '@tiptap/extension-document'
import Link from '@tiptap/extension-link'
import Paragraph from '@tiptap/extension-paragraph'
import Text from '@tiptap/extension-text'
import { EditorContent, getMarkRange, useEditor } from '@tiptap/react'
import React, { useCallback } from 'react'

export default () => {
  const editor = useEditor({
    extensions: [
      Document,
      Paragraph,
      Text,
      Link.configure({ openOnClick: false }),
    ],
    content: `
      <p>
        This is a radically reduced version of Tiptap. It has support for a document, with paragraphs and text. That’s it. It’s probably too much for real minimalists though.
      </p>
      <p>
        This is a <a href="#">Link</a> with some text afterwards.
      </p>
      <p>
        The paragraph extension is not really required, but you need at least one node. Sure, that node can be something different.
      </p>
    `,
  })

  const handleClick = useCallback(() => {
    const range = getMarkRange(
      editor.state.selection.$from,
      editor.schema.marks.link,
    )

    console.log(editor.state.selection.from, range)
  }, [editor])

  return (
    <div>
      <div>
        <button onClick={handleClick}>Expand selection to mark</button>
      </div>
      <EditorContent editor={editor} />
    </div>
  )
}
```

## Additional Notes
Nothing to add here

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
Fixes #5715
