### PR TITLE
Added optional custom uri validator in link extension

### DIFF
--- a/tests/cypress/integration/extensions/link.spec.ts
+++ b/tests/cypress/integration/extensions/link.spec.ts
@@ -27,6 +27,7 @@ describe('extension-link', () => {
     '../relative.html',
     'mailto:info@example.com',
     'ftp://info@example.com',
+    // 'currentdir/image.png', should work?
   ]
 
   it('does output href tag for valid JSON schemas', () => {
@@ -262,6 +263,31 @@ describe('extension-link', () => {
             Paragraph,
             Link.configure({
               protocols: ['custom', { scheme: 'another-custom' }],
+            }),
+          ],
+          content: `<p><a href="${url}">hello world!</a></p>`,
+        })
+
+        expect(editor.getHTML()).to.include(url)
+        expect(JSON.stringify(editor.getJSON())).to.include(url)
+
+        editor?.destroy()
+        getEditorEl()?.remove()
+      })
+    })
+  })
+  describe('custom uri validator', () => {
+    it('allows using an optional custom uri validator function', () => {
+
+      ['currentdir/page.html', ...validUrls].forEach(url => {
+        editor = new Editor({
+          element: createEditorEl(),
+          extensions: [
+            Document,
+            Text,
+            Paragraph,
+            Link.configure({
+              customUriValidator: uri => (/^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i).test(uri),
             }),
           ],
           content: `<p><a href="${url}">hello world!</a></p>`,


### PR DESCRIPTION
## Changes Overview
Added custom url validation to link extension

## Implementation Approach
Added an optional custom url validation to provide full control over (in)valid uri's

## Testing Done
Added test 

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
[[Bug]: Expose an API to overwrite the default link validation](https://github.com/ueberdosis/tiptap/issues/5564)

