### PR TITLE
Fix undo/redo still worked with isEditable false

### DIFF
--- a/packages/extension-history/src/history.ts
+++ b/packages/extension-history/src/history.ts
@@ -55,10 +55,12 @@ export const History = Extension.create<HistoryOptions>({
 
   addCommands() {
     return {
-      undo: () => ({ state, dispatch }) => {
+      undo: () => ({ editor, state, dispatch }) => {
+        if (!editor.isEditable) return false
         return undo(state, dispatch)
       },
-      redo: () => ({ state, dispatch }) => {
+      redo: () => ({ editor, state, dispatch }) => {
+        if (!editor.isEditable) return false
         return redo(state, dispatch)
       },
     }

--- a/packages/extension-history/src/history.ts
+++ b/packages/extension-history/src/history.ts
@@ -56,11 +56,15 @@ export const History = Extension.create<HistoryOptions>({
   addCommands() {
     return {
       undo: () => ({ editor, state, dispatch }) => {
-        if (!editor.isEditable) return false
+        if (!editor.isEditable) {
+          return false
+        }
         return undo(state, dispatch)
       },
       redo: () => ({ editor, state, dispatch }) => {
-        if (!editor.isEditable) return false
+        if (!editor.isEditable) {
+          return false
+        }
         return redo(state, dispatch)
       },
     }


### PR DESCRIPTION
## Changes Overview
Block undo/redo when `editable.isEditable` isn't truthy.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
None

## Verification Steps
None

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#5547
