### PR TITLE
Improve accessibility on the editor DOM element

### DIFF
--- a/.changeset/soft-peaches-hang.md
+++ b/.changeset/soft-peaches-hang.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Added role and aria-label attributes to the contenteditable field for better screenreader support and mouseless controls

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -352,6 +352,14 @@ export class Editor extends EventEmitter<EditorEvents> {
       }),
     })
 
+    // add `role="textbox"` to the editor element
+    this.view.dom.setAttribute('role', 'textbox')
+
+    // add aria-label to the editor element
+    if (!this.view.dom.getAttribute('aria-label')) {
+      this.view.dom.setAttribute('aria-label', 'Rich-Text Editor')
+    }
+
     // `editor.view` is not yet available at this time.
     // Therefore we will add all plugins and node views directly afterwards.
     const newState = this.state.reconfigure({


### PR DESCRIPTION
## Changes Overview
This pull request focuses on improving accessibility for the contenteditable field in the editor by adding role and aria-label attributes. These changes enhance screen reader support and mouseless controls.

Accessibility improvements:

* [`packages/core/src/Editor.ts`](diffhunk://#diff-9b7c004a70a95a9e7b2b49f3761403a4abfe14fae1490e32c86306794017e27dR355-R362): Added `role="textbox"` and `aria-label="Rich-Text Editor"` attributes to the editor element to improve accessibility.

## Implementation Approach
I added two attributes to the editor's DOM element to allow more screenreaders to understand what kind of element the editor DOM element is. That should help with focus issues in a few instances.

## Testing Done
Testing was done locally

## Verification Steps
1. Use a screenreader (MacOS Voice Over or Windows Narrator for example)
2. Visit a demo locally and try to focus the editor

## Additional Notes
I was only able to fix issues in Firefox. Chrome whatsoever still causes issues for me but I think it's something wrong with my local setup.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
