### PR TITLE
fix(core): respect the editor's parseOptions

### DIFF
--- a/.changeset/blue-poems-camp.md
+++ b/.changeset/blue-poems-camp.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+insertContentAt, setContent, and insertContent commands now respect the editor's pre-defined parseOptions configuration if the command does not specify it's own parseOptions

--- a/demos/src/Commands/InsertContent/React/index.spec.js
+++ b/demos/src/Commands/InsertContent/React/index.spec.js
@@ -91,4 +91,28 @@ context('/src/Commands/InsertContent/React/', () => {
     })
   })
 
+  it('should respect editor.options.parseOptions if defined to be `false`', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.options.parseOptions = { preserveWhitespace: false }
+      editor.commands.insertContent('\n<h1>Tiptap</h1><p><strong>Hello\n World</strong>\n</p>\n')
+      cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p><strong>Hello World</strong></p>')
+    })
+  })
+
+  it('should respect editor.options.parseOptions if defined to be `full`', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.options.parseOptions = { preserveWhitespace: 'full' }
+      editor.commands.insertContent('\n<h1>Tiptap</h1><p><strong>Hello\n World</strong>\n</p>\n')
+      cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p><strong>Hello\n World</strong></p>')
+    })
+  })
+
+  it('should respect editor.options.parseOptions if defined to be `true`', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.options.parseOptions = { preserveWhitespace: true }
+      editor.commands.insertContent('<h1>Tiptap</h1><p><strong>Hello\n World</strong>\n</p>')
+      cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p><strong>Hello  World</strong></p>')
+    })
+  })
+
 })

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -63,7 +63,7 @@ const isFragment = (nodeOrFragment: ProseMirrorNode | Fragment): nodeOrFragment 
 export const insertContentAt: RawCommands['insertContentAt'] = (position, value, options) => ({ tr, dispatch, editor }) => {
   if (dispatch) {
     options = {
-      parseOptions: {},
+      parseOptions: editor.options.parseOptions,
       updateSelection: true,
       applyInputRules: false,
       applyPasteRules: false,


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
insertContentAt, setContent, and insertContent commands now respect the editor's pre-defined parseOptions configuration if the command does not specify it's own parseOptions
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
Added Tests
## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
