### PR TITLE
fix(react): preserve editable option across renders

### DIFF
--- a/.changeset/loud-maps-work.md
+++ b/.changeset/loud-maps-work.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+preserve editable option across re-renders #5547

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -199,7 +199,10 @@ class EditorInstanceManager {
       if (this.editor && !this.editor.isDestroyed && deps.length === 0) {
         // if the editor does exist & deps are empty, we don't need to re-initialize the editor
         // we can fast-path to update the editor options on the existing instance
-        this.editor.setOptions(this.options.current)
+        this.editor.setOptions({
+          ...this.options.current,
+          editable: this.editor.isEditable,
+        })
       } else {
         // When the editor:
         // - does not yet exist


### PR DESCRIPTION
## Changes Overview
Updated editable option to be preserved across re-renders

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5547
