### PR TITLE
fix: add zero-width space to resolve cursor selection issue

### DIFF
--- a/.changeset/serious-coins-fail.md
+++ b/.changeset/serious-coins-fail.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-mention": patch
+---
+
+add zero-width space to resolve cursor selection issue

--- a/demos/src/Nodes/Mention/React/styles.scss
+++ b/demos/src/Nodes/Mention/React/styles.scss
@@ -10,5 +10,8 @@
     box-decoration-break: clone;
     color: var(--purple);
     padding: 0.1rem 0.3rem;
+    &::after {
+      content: "\200B";
+    }
   }
 }


### PR DESCRIPTION
## Changes Overview
Implemented a zero-width space (\u200B) after `.mention` elements to improve cursor positioning and prevent selection issues.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
