### PR TITLE
Add element to shouldShow in BubbleMenuPlugin

### DIFF
--- a/.changeset/five-mice-turn.md
+++ b/.changeset/five-mice-turn.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-bubble-menu": patch
+---
+
+Add `element: HTMLElement` to `shouldShow` options within the BubbleMenu options.

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -46,6 +46,7 @@ export interface BubbleMenuPluginProps {
   shouldShow?:
     | ((props: {
         editor: Editor
+        element: HTMLElement
         view: EditorView
         state: EditorState
         oldState?: EditorState
@@ -238,6 +239,7 @@ export class BubbleMenuView {
 
     const shouldShow = this.shouldShow?.({
       editor: this.editor,
+      element: this.element,
       view,
       state,
       oldState,


### PR DESCRIPTION
## Changes Overview
The internal implementation of `shouldShow` is using `this.element`.
The user cannot reuse the internal implementation and add some logic, because the `element` parameter is missing.

## Implementation Approach
Add the `element` parameter to `shouldShow`.

## Testing Done
Not really tested.

## Verification Steps
Implements your own `shouldShow`:
```ts
import { isTextSelection } from "@tiptap/core";
import { BubbleMenuPluginProps } from "@tiptap/extension-bubble-menu";

export const bubbleMenuShouldShow: Exclude<BubbleMenuPluginProps["shouldShow"], null> =
  ({ editor, element, view, state, from, to }) => {
  const { doc, selection } = state;
  const { empty } = selection;

  const isEmptyTextBlock = !doc.textBetween(from, to).length && isTextSelection(state.selection);

  const isChildOfMenu = element.contains(document.activeElement);

  const hasEditorFocus = view.hasFocus() || isChildOfMenu;

  return hasEditorFocus && !empty && !isEmptyTextBlock && editor.isEditable;
};
```

## Additional Notes
N/A

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
N/A