### PR TITLE
List Keymap: Fix backspace behavior when selection is not collapsed

### DIFF
--- a/.changeset/chatty-monkeys-hear.md
+++ b/.changeset/chatty-monkeys-hear.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-list-keymap": patch
+---
+
+Fix backspace behavior when selection is not collapsed

--- a/packages/extension-list-keymap/src/listHelpers/handleBackspace.ts
+++ b/packages/extension-list-keymap/src/listHelpers/handleBackspace.ts
@@ -12,6 +12,12 @@ export const handleBackspace = (editor: Editor, name: string, parentListTypes: s
     return true
   }
 
+  // if the selection is not collapsed
+  // we can rely on the default backspace behavior
+  if (editor.state.selection.from !== editor.state.selection.to) {
+    return false
+  }
+
   // if the current item is NOT inside a list item &
   // the previous item is a list (orderedList or bulletList)
   // move the cursor into the list and delete the current item


### PR DESCRIPTION
## Changes Overview
Fixes #4368

## Implementation Approach
I figured that just checking if selection's `to` and `from` doesn't match, default backspace behavior will result in expected behavior. So I added check to [handleBackspace.ts](https://github.com/ueberdosis/tiptap/pull/5810/files#diff-15ca0926de038c0b181f99b43c4af4614ecb69b3fe559da219a9001d606bf750R17).

## Testing Done
N/A

## Verification Steps
1. Start development environment and navigate to `/preview/Extensions/ListKeymap`. 
2. Create a list with one or multiple list items, and paragraph underneath. 
3. Select all and hit backspace.

If you created list with one list item there will be no error in console. If you created list with multiple list items, the behavior will be as expected. Compare this with previous behavior either of tiptap's `develop` or [live example](https://tiptap.dev/docs/editor/extensions/functionality/listkeymap)


## Checklist
- [X] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [X] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues
#4368
