### PR TITLE
fix(link): add backwards compat by deprecating validate and using isAllowedUri instead

### DIFF
--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -21,7 +21,7 @@ export default () => {
         autolink: true,
         defaultProtocol: 'https',
         protocols: ['http', 'https'],
-        validate: (url, ctx) => {
+        isAllowedUri: (url, ctx) => {
           try {
             // construct URL
             const parsedUrl = url.includes(':') ? new URL(url) : new URL(`${ctx.defaultProtocol}://${url}`)


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
As a follow up to this: https://github.com/ueberdosis/tiptap/pull/5808
Adds `isAllowedUri` which handles XSS protections,
deprecates `validate` in favor of the new `shouldAutoLink` which is a better name for what it does
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
