### PR TITLE
fix(core): editor.commands.setContent setting document attributes

### DIFF
--- a/.changeset/wise-oranges-deny.md
+++ b/.changeset/wise-oranges-deny.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixes editor.command.setContent not setting attributes on the Document Node.

--- a/packages/core/src/commands/setContent.ts
+++ b/packages/core/src/commands/setContent.ts
@@ -58,6 +58,10 @@ export const setContent: RawCommands['setContent'] = (content, emitUpdate = fals
 
     if (dispatch) {
       tr.replaceWith(0, doc.content.size, document).setMeta('preventUpdate', !emitUpdate)
+
+      Object.entries(document.attrs).forEach(([key, value]) => {
+        tr.setDocAttribute(key, value)
+      })
     }
     return true
   }


### PR DESCRIPTION
Related to #5813. Fixes editor.command.setContent not setting attribute on document.

## Changes Overview

Related to #5813. Fixes editor.command.setContent not setting attribute on document.

## Implementation Approach

As ProseMirror doesn't seem to be replacing the document attributes, we now do that manually.

## Testing Done

Manually, but feel free to recommend me. Also see #5813

## Verification Steps

```ts
import { Editor } from '../tiptap/packages/core'
import Document from '../tiptap/packages/extension-document'
import Paragraph from '../tiptap/packages/extension-paragraph'
import Text from '../tiptap/packages/extension-text'


const editor = new Editor({
    element: document.querySelector('.element'),
    extensions: [
        Document.extend({
            addAttributes() {
                return {
                    ...this?.parent?.(),
                    testAttr1: { default: 'DEFAULT' }
                }
            }
        }),
        Paragraph.extend({
            addAttributes() {
                return {
                    ...this?.parent?.(),
                    testAttr2: { default: 'DEFAULT' }
                }
            }
        }),,
        Text
    ],
    content: '<p>Default content</p>',
})

editor.commands.setContent({ 
    type: "doc", 
    attrs: { testAttr1: "Not default" },
    content: [
        {
            type: "paragraph",
            attrs: { testAttr2: "Not default" },
            content: [
                { type: "text", text: "Updated content" }
            ]
        }
    ]
})

console.log(editor.state.doc.attrs); // { testAttr1: "Not default" }
console.log(editor.state.doc.content.firstChild.attrs); // { testAttr2: "Not default" }
```

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#5813