### PR TITLE
Add Node linebreakReplacement support and enable on hardBreak nodes

### DIFF
--- a/.changeset/shy-pigs-exercise.md
+++ b/.changeset/shy-pigs-exercise.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/core": patch
+"@tiptap/extension-hard-break": patch
+---
+
+Add Node `linebreakReplacement` support and enable on hard-break nodes

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -596,6 +596,25 @@ declare module '@tiptap/core' {
         }) => NodeSpec['whitespace'])
 
     /**
+     * Allows a **single** node to be set as linebreak equivalent (e.g. hardBreak).
+     * When converting between block types that have whitespace set to "pre"
+     * and don't support the linebreak node (e.g. codeBlock) and other block types
+     * that do support the linebreak node (e.g. paragraphs) - this node will be used
+     * as the linebreak instead of stripping the newline.
+     *
+     * See [linebreakReplacement](https://prosemirror.net/docs/ref/#model.NodeSpec.linebreakReplacement).
+     */
+    linebreakReplacement?:
+      | NodeSpec['linebreakReplacement']
+      | ((this: {
+          name: string
+          options: Options
+          storage: Storage
+          parent: ParentConfig<NodeConfig<Options, Storage>>['linebreakReplacement']
+          editor?: Editor
+        }) => NodeSpec['linebreakReplacement'])
+
+    /**
      * When enabled, enables both
      * [`definingAsContext`](https://prosemirror.net/docs/ref/#model.NodeSpec.definingAsContext) and
      * [`definingForContent`](https://prosemirror.net/docs/ref/#model.NodeSpec.definingForContent).

--- a/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
+++ b/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
@@ -78,6 +78,7 @@ export function getSchemaByResolvedExtensions(extensions: Extensions, editor?: E
         ),
         code: callOrReturn(getExtensionField<NodeConfig['code']>(extension, 'code', context)),
         whitespace: callOrReturn(getExtensionField<NodeConfig['whitespace']>(extension, 'whitespace', context)),
+        linebreakReplacement: callOrReturn(getExtensionField<NodeConfig['linebreakReplacement']>(extension, 'linebreakReplacement', context)),
         defining: callOrReturn(
           getExtensionField<NodeConfig['defining']>(extension, 'defining', context),
         ),

--- a/packages/extension-hard-break/src/hard-break.ts
+++ b/packages/extension-hard-break/src/hard-break.ts
@@ -48,6 +48,8 @@ export const HardBreak = Node.create<HardBreakOptions>({
 
   selectable: false,
 
+  linebreakReplacement: true,
+
   parseHTML() {
     return [
       { tag: 'br' },


### PR DESCRIPTION
## Changes Overview
- Support the [linebreakReplacement](https://prosemirror.net/docs/ref/#model.NodeSpec.linebreakReplacement) property on Nodes
- Set the `hardBreak` node as the `linebreakReplacement` node, by default.

## Implementation Approach
- Followed the way other properties are defined, such as `whitespace`

## Testing Done

- Added the property to hardBreak and verified in the local React CodeBlock example (http://localhost:3000/preview/Nodes/CodeBlock) that toggling from a codeBlock to a normal paragraph visually keeps the line breaks.

**Before:**

https://github.com/user-attachments/assets/4de1753d-6268-402b-b2ff-c8920a5a5f9f

**After:**

https://github.com/user-attachments/assets/cd0177e8-1586-498a-bdf6-09cd672ab20d


## Verification Steps

- In the CodeBlock example (`tiptap/demos/src/Nodes/CodeBlock/React/index.jsx`) add the `HardBreak` extension
- Run and load the example - http://localhost:3000/preview/Nodes/CodeBlock
- Verify that toggling off the codeBlock maintains the line breaks


## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

