### PR TITLE
fix(react): useLayoutEffect instead of useEffect to cut down on reflow

### DIFF
--- a/.changeset/long-pears-wash.md
+++ b/.changeset/long-pears-wash.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+This changes useEditorState to use the useLayoutEffect hook instead of the useEffect hook, so that state that might render to the page can be committed in one pass instead of two.

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -1,6 +1,6 @@
 import type { Editor } from '@tiptap/core'
 import deepEqual from 'fast-deep-equal/es6/react'
-import { useDebugValue, useEffect, useState } from 'react'
+import { useDebugValue, useLayoutEffect, useState } from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
 
 export type EditorStateSnapshot<TEditor extends Editor | null = Editor | null> = {
@@ -164,7 +164,7 @@ export function useEditorState<TSelectorResult>(
     options.equalityFn ?? deepEqual,
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     return editorStateManager.watch(options.editor)
   }, [options.editor, editorStateManager])
 


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
useLayoutEffect instead of useEffect, to commit changes to page in one pass instead of two
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
