### PR TITLE
fix(core): getMarkRange match only the current mark of a type #3872

### DIFF
--- a/.changeset/wicked-meals-shop.md
+++ b/.changeset/wicked-meals-shop.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+getMarkRange would greedily match more content than it should have if it was the same type of mark, now it will match only the mark at the position #3872

--- a/tests/cypress/integration/core/getMarkRange.spec.ts
+++ b/tests/cypress/integration/core/getMarkRange.spec.ts
@@ -140,4 +140,38 @@ describe('getMarkRange', () => {
       to: 39,
     })
   })
+  it('can distinguish mark boundaries', () => {
+    const testDocument = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'This is a text with a ' },
+            { type: 'text', text: 'link.', marks: [{ type: 'link', attrs: { href: 'https://tiptap.dev' } }] },
+            { type: 'text', text: 'another link', marks: [{ type: 'link', attrs: { href: 'https://tiptap.dev/invalid' } }] },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'This is a text without a link.' },
+          ],
+        },
+      ],
+    }
+
+    const doc = Node.fromJSON(schema, testDocument)
+    const $pos = doc.resolve(27)
+    const range = getMarkRange($pos, schema.marks.link, { href: 'https://tiptap.dev' })
+
+    expect(range).to.deep.eq({
+      from: 23,
+      to: 28,
+    })
+
+    const nextRange = getMarkRange(doc.resolve(28), schema.marks.link)
+
+    expect(nextRange).to.deep.eq({ from: 28, to: 40 })
+  })
 })


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
getMarkRange would greedily match more content than it should have if it was the same type of mark, now it will match only the mark at the position #3872
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
