### PR TITLE
Font-family extension: Prevent removal of quotes in parseHTML

### DIFF
--- a/.changeset/tiny-buckets-behave.md
+++ b/.changeset/tiny-buckets-behave.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-font-family": patch
+---
+
+Font-family extension: Prevent removal of quotes in parseHTML

--- a/demos/src/Extensions/FontFamily/React/index.jsx
+++ b/demos/src/Extensions/FontFamily/React/index.jsx
@@ -18,6 +18,7 @@ export default () => {
         <p><span style="font-family: monospace">The cool kids can apply monospace fonts aswell.</span></p>
         <p><span style="font-family: cursive">But hopefully we all can agree, that cursive fonts are the best.</span></p>
         <p><span style="font-family: var(--title-font-family)">Then there are CSS variables, the new hotness.</span></p>
+        <p><span style="font-family: 'Exo 2'">TipTap even can handle exotic fonts as Exo 2.</span></p>
       `,
   })
 
@@ -27,6 +28,9 @@ export default () => {
 
   return (
     <>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Exo+2:ital,wght@0,100..900;1,100..900&display=swap"
+        rel="stylesheet"/>
       <div className="control-group">
         <div className="button-group">
           <button
@@ -82,12 +86,20 @@ export default () => {
           >
             Comic Sans quoted
           </button>
-          <button onClick={() => editor.chain().focus().unsetFontFamily().run()} data-test-id="unsetFontFamily">
+          <button
+            onClick={() => editor.chain().focus().setFontFamily('"Exo 2"').run()}
+            className={editor.isActive('textStyle', { fontFamily: '"Exo 2"' }) ? 'is-active' : ''}
+            data-test-id="exo2"
+          >
+            Exo 2
+          </button>
+          <button onClick={() => editor.chain().focus().unsetFontFamily().run()}
+                  data-test-id="unsetFontFamily">
             Unset font family
           </button>
         </div>
       </div>
-      <EditorContent editor={editor} />
+      <EditorContent editor={editor}/>
     </>
   )
 }

--- a/demos/src/Extensions/FontFamily/React/index.spec.js
+++ b/demos/src/Extensions/FontFamily/React/index.spec.js
@@ -46,4 +46,12 @@ context('/src/Extensions/FontFamily/React/', () => {
 
     cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: var(--title-font-family)')
   })
+  it('should allow fonts containing a space and number as a font-family', () => {
+    cy.get('[data-test-id="exo2"]')
+      .should('not.have.class', 'is-active')
+      .click()
+      .should('have.class', 'is-active')
+
+    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: "Exo 2"')
+  })
 })

--- a/packages/extension-font-family/src/font-family.ts
+++ b/packages/extension-font-family/src/font-family.ts
@@ -49,7 +49,7 @@ export const FontFamily = Extension.create<FontFamilyOptions>({
         attributes: {
           fontFamily: {
             default: null,
-            parseHTML: element => element.style.fontFamily?.replace(/['"]+/g, ''),
+            parseHTML: element => element.style.fontFamily,
             renderHTML: attributes => {
               if (!attributes.fontFamily) {
                 return {}


### PR DESCRIPTION
## Changes Overview
Font-family extension: Prevent removal of quotes in `parseHTML`

Removing quotes in `font-family` parsing can result in invalid HTML when using font names that contain both spaces and numbers (e.g., "Exo 2").


## Implementation Approach
Initially attempted to add quotes in `renderHTML`, but realized the issue originated in `parseHTML`, where quotes were being removed automatically. Addressed this issue in https://github.com/ueberdosis/tiptap/commit/1af78299247e967a76b400f5db8adf8e28c5e5f2  The reason for this behavior in `parseHTML` is unclear, so further investigation may be required.

## Testing Done
All existing tests pass. Added a new test specifically for `font-family` values with both spaces and numbers.

## Verification Steps
Run the test suite to confirm no regressions.
Verify that fonts with spaces and numbers in their names, like "Exo 2", are correctly parsed without removing quotes.

## Additional Notes
This pull request is related to https://github.com/ueberdosis/tiptap/pull/4545 

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
