### PR TITLE
fix(bubble-menu): avoid bluring if event is on the editor #3471

### DIFF
--- a/.changeset/pink-avocados-stare.md
+++ b/.changeset/pink-avocados-stare.md
@@ -1,0 +1,9 @@
+---
+"@tiptap/extension-floating-menu": patch
+"@tiptap/extension-bubble-menu": patch
+"@tiptap/react": patch
+"@tiptap/vue-2": patch
+"@tiptap/vue-3": patch
+---
+
+Fixes an issue where the bubble and flaoting menus on blur would remount

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -156,6 +156,12 @@ export class BubbleMenuView {
       return
     }
 
+    if (
+      event?.relatedTarget === this.editor.view.dom
+    ) {
+      return
+    }
+
     this.hide()
   }
 

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -123,6 +123,12 @@ export class FloatingMenuView {
       return
     }
 
+    if (
+      event?.relatedTarget === this.editor.view.dom
+    ) {
+      return
+    }
+
     this.hide()
   }
 


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
Fixes an issue where the bubble and flaoting menus on blur would remount
https://github.com/ueberdosis/tiptap/issues/3471

Although I do question this one: https://github.com/ueberdosis/tiptap/issues/3471#issuecomment-1782622093

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
