### PR TITLE
Prevent null pointer exception in `BubbleMenu`

### DIFF
--- a/.changeset/seven-hats-thank.md
+++ b/.changeset/seven-hats-thank.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-bubble-menu": patch
+---
+
+Fix a potential null pointer exception

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -268,11 +268,11 @@ export class BubbleMenuView {
 
             if (node) {
               const nodeViewWrapper = node.dataset.nodeViewWrapper ? node : node.querySelector('[data-node-view-wrapper]')
-              
+
               if (nodeViewWrapper) {
                 node = nodeViewWrapper.firstChild as HTMLElement
               }
-              
+
               if (node) {
                 return node.getBoundingClientRect()
               }

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -266,14 +266,16 @@ export class BubbleMenuView {
           if (isNodeSelection(state.selection)) {
             let node = view.nodeDOM(from) as HTMLElement
 
-            const nodeViewWrapper = node.dataset.nodeViewWrapper ? node : node.querySelector('[data-node-view-wrapper]')
-
-            if (nodeViewWrapper) {
-              node = nodeViewWrapper.firstChild as HTMLElement
-            }
-
             if (node) {
-              return node.getBoundingClientRect()
+              const nodeViewWrapper = node.dataset.nodeViewWrapper ? node : node.querySelector('[data-node-view-wrapper]')
+              
+              if (nodeViewWrapper) {
+                node = nodeViewWrapper.firstChild as HTMLElement
+              }
+              
+              if (node) {
+                return node.getBoundingClientRect()
+              }
             }
           }
 


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

Our sentry is full of "Cannot read properties of null (reading 'dataset')" which point to [this place](https://github.com/ueberdosis/tiptap/blob/2ea807d1db03c44a2af8fea9d176e9cbb5b71800/packages/extension-bubble-menu/src/bubble-menu-plugin.ts#L269) in the `getReferenceClientRect` for tippy in the `BubbleMenu` extension. This PR just adds an additional nullability check.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
