### PR TITLE
fix(link): change type HTMLLinkElement to HTMLAnchorElement

### DIFF
--- a/packages/extension-link/src/helpers/clickHandler.ts
+++ b/packages/extension-link/src/helpers/clickHandler.ts
@@ -32,7 +32,7 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
         }
 
         const attrs = getAttributes(view.state, options.type.name)
-        const link = (event.target as HTMLLinkElement)
+        const link = (event.target as HTMLAnchorElement)
 
         const href = link?.href ?? attrs.href
         const target = link?.target ?? attrs.target


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

Fix the type assertion of file [packages/extension-link/src/helpers/clickHandler.ts](https://github.com/ueberdosis/tiptap/blob/87d63d8d1761138add50e05d584e6f24d99daf9c/packages/extension-link/src/helpers/clickHandler.ts#L35)

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

> The HTMLLinkElement interface represents reference information for external resources and the relationship of those resources to a document and vice versa (corresponds to [link](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link) element; not to be confused with [a](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a), which is represented by [HTMLAnchorElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement)). This object inherits all of the properties and methods of the [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) interface.

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
