### PR TITLE
fix: revert type changes introduced with 2.10 #5859

### DIFF
--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -61,7 +61,7 @@ declare module '@tiptap/core' {
      */
     addOptions?: (this: {
       name: string
-      parent: ParentConfig<ExtensionConfig<Options, Storage>>['addOptions']
+      parent: Exclude<ParentConfig<ExtensionConfig<Options, Storage>>['addOptions'], undefined>
     }) => Options
 
     /**
@@ -76,7 +76,7 @@ declare module '@tiptap/core' {
     addStorage?: (this: {
       name: string
       options: Options
-      parent: ParentConfig<ExtensionConfig<Options, Storage>>['addStorage']
+      parent: Exclude<ParentConfig<ExtensionConfig<Options, Storage>>['addStorage'], undefined>
     }) => Storage
 
     /**

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -474,9 +474,9 @@ export class Extension<Options = any, Storage = any> {
   }
 
   extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<ExtensionConfig<Partial<ExtendedOptions>, Partial<ExtendedStorage>>> = {},
+    extendedConfig: Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>> = {},
   ) {
-    const extension = new Extension<ExtendedOptions, ExtendedStorage>({ ...this.config, ...extendedConfig } as ExtensionConfig)
+    const extension = new Extension<ExtendedOptions, ExtendedStorage>({ ...this.config, ...extendedConfig })
 
     extension.parent = this
 

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -64,7 +64,7 @@ declare module '@tiptap/core' {
      */
     addOptions?: (this: {
       name: string
-      parent: ParentConfig<MarkConfig<Options, Storage>>['addOptions']
+      parent: Exclude<ParentConfig<MarkConfig<Options, Storage>>['addOptions'], undefined>
     }) => Options
 
     /**
@@ -79,7 +79,7 @@ declare module '@tiptap/core' {
     addStorage?: (this: {
       name: string
       options: Options
-      parent: ParentConfig<MarkConfig<Options, Storage>>['addStorage']
+      parent: Exclude<ParentConfig<MarkConfig<Options, Storage>>['addStorage'], undefined>
     }) => Storage
 
     /**

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -606,9 +606,9 @@ export class Mark<Options = any, Storage = any> {
   }
 
   extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<MarkConfig<Partial<ExtendedOptions>, Partial<ExtendedStorage>>> = {},
+    extendedConfig: Partial<MarkConfig<ExtendedOptions, ExtendedStorage>> = {},
   ) {
-    const extension = new Mark<ExtendedOptions, ExtendedStorage>(extendedConfig as MarkConfig)
+    const extension = new Mark<ExtendedOptions, ExtendedStorage>(extendedConfig)
 
     extension.parent = this
 

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -816,9 +816,9 @@ export class Node<Options = any, Storage = any> {
   }
 
   extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<NodeConfig<Partial<ExtendedOptions>, Partial<ExtendedStorage>>> = {},
+    extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>> = {},
   ) {
-    const extension = new Node<ExtendedOptions, ExtendedStorage>(extendedConfig as NodeConfig)
+    const extension = new Node<ExtendedOptions, ExtendedStorage>(extendedConfig)
 
     extension.parent = this
 

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -65,7 +65,7 @@ declare module '@tiptap/core' {
      */
     addOptions?: (this: {
       name: string
-      parent: ParentConfig<NodeConfig<Options, Storage>>['addOptions']
+      parent: Exclude<ParentConfig<NodeConfig<Options, Storage>>['addOptions'], undefined>
     }) => Options
 
     /**
@@ -80,7 +80,7 @@ declare module '@tiptap/core' {
     addStorage?: (this: {
       name: string
       options: Options
-      parent: ParentConfig<NodeConfig<Options, Storage>>['addStorage']
+      parent: Exclude<ParentConfig<NodeConfig<Options, Storage>>['addStorage'], undefined>
     }) => Storage
 
     /**


### PR DESCRIPTION
## Changes Overview

It seems that updating types is a catch-22 and I don't have the time to be resolving this, will reopen #5768 and let someone else implement this at another time

- **revert: "fix(core): update the typings to be that options and storage are partials on an extended config #5852 (#5854)"**
- **revert: "fix(core): update the typing of `addOptions`, `addStorage` to have an optional parent #5768 (#5770)"**

<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
