### PR TITLE
Prevent selection deletions at the end of list items from joining lists

### DIFF
--- a/.changeset/four-islands-chew.md
+++ b/.changeset/four-islands-chew.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-list-keymap": patch
+---
+
+Improve selected text deletion at the end of list items

--- a/packages/extension-list-keymap/src/listHelpers/handleDelete.ts
+++ b/packages/extension-list-keymap/src/listHelpers/handleDelete.ts
@@ -16,6 +16,15 @@ export const handleDelete = (editor: Editor, name: string) => {
     return false
   }
 
+  // if the selection is not collapsed, or not within a single node
+  // do nothing and proceed
+  const { selection } = editor.state
+  const { $from, $to } = selection
+
+  if (!selection.empty && $from.sameParent($to)) {
+    return false
+  }
+
   // check if the next node is a list with a deeper depth
   if (nextListIsDeeper(name, editor.state)) {
     return editor


### PR DESCRIPTION


## Changes Overview

- Delete text, instead of joining lists, if the selection is:
    - At the end of the list item
    - Not collapsed
    - Within a single list item

Previously the text wasn't being deleted, but the following list item was being joined (see the testing videos within Verification Steps)


NOTE: The fix might be better suited to the `isAtEndOfNode` function from `@tiptap/core` - however because that's exposed it might result in unintended regressions out in the wild.

## Implementation Approach

Traced the ListKeymap delete handlers and debugged guard statements that were trying to avoid the `joinItemForward` command.

## Testing Done

All initial tests passed & performed manual testing of the `http://localhost:3000/preview/Extensions/ListKeymap` demo.

## Verification Steps

Attempted a deletion of text, starting from the end of a node - then going backwards, before & after the change:

**Before**

https://github.com/user-attachments/assets/02a0ab77-38e8-4fe1-aa30-8b04eb33b65f

**After**

https://github.com/user-attachments/assets/d927492f-f491-4644-b632-47832afb7608

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

