### PR TITLE
refactor(bubble-menu): always take the latest shouldShow callback, expose default implementation

### DIFF
--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -77,11 +77,18 @@ export class BubbleMenuView {
 
   private updateDebounceTimer: number | undefined
 
-  public shouldShow: Exclude<BubbleMenuPluginProps['shouldShow'], null> = ({
+  public shouldShow: Exclude<BubbleMenuPluginProps['shouldShow'], null>
+
+  /**
+   * The default `shouldShow` function.
+   */
+  public static shouldShow: Exclude<BubbleMenuPluginProps['shouldShow'], null> = ({
     view,
     state,
     from,
     to,
+    element,
+    editor,
   }) => {
     const { doc, selection } = state
     const { empty } = selection
@@ -94,11 +101,11 @@ export class BubbleMenuView {
     // When clicking on a element inside the bubble menu the editor "blur" event
     // is called and the bubble menu item is focussed. In this case we should
     // consider the menu as part of the editor and keep showing the menu
-    const isChildOfMenu = this.element.contains(document.activeElement)
+    const isChildOfMenu = element.contains(document.activeElement)
 
     const hasEditorFocus = view.hasFocus() || isChildOfMenu
 
-    if (!hasEditorFocus || empty || isEmptyTextBlock || !this.editor.isEditable) {
+    if (!hasEditorFocus || empty || isEmptyTextBlock || !editor.isEditable) {
       return false
     }
 
@@ -120,6 +127,8 @@ export class BubbleMenuView {
 
     if (shouldShow) {
       this.shouldShow = shouldShow
+    } else {
+      this.shouldShow = BubbleMenuView.shouldShow
     }
 
     this.element.addEventListener('mousedown', this.mousedownHandler, { capture: true })


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
Slight refactor to bubble menu, need to do the same for the floating menu, this allows us to always use the latest function for the shouldShow function
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->

Also done partially in https://github.com/ueberdosis/tiptap/pull/4295
