### PR TITLE
fix: Uncaught TypeError on renderer tiptap react issue #5870

### DIFF
--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -193,13 +193,13 @@ export class ReactNodeView<
     }
 
     if (from <= pos && to >= pos + this.node.nodeSize) {
-      if (this.renderer.props.selected) {
+      if (this?.renderer?.props?.selected) {
         return
       }
 
       this.selectNode()
     } else {
-      if (!this.renderer.props.selected) {
+      if (!this?.renderer?.props?.selected) {
         return
       }
 


### PR DESCRIPTION
## Changes Overview
Adds null coalescing operators to `this.renderer.props.selected` in order to handle intermittent cases where the renderer might be undefined due to lifecycle issues

## Implementation Approach
Simple null coalescing operators

## Testing Done
Attempted to replicate the crash in https://github.com/ueberdosis/tiptap/issues/5870 after applying the changes

## Verification Steps
Crash should no longer be reproducible.

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
 https://github.com/ueberdosis/tiptap/issues/5870
