### PR TITLE
add defaultType option to horizontal-rule

### DIFF
--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -9,7 +9,13 @@ export interface HorizontalRuleOptions {
    * @default {}
    * @example { class: 'foo' }
    */
-  HTMLAttributes: Record<string, any>
+  HTMLAttributes: Record<string, any>,
+  /**
+   * The default type to insert after the horizontal rule.
+   * @default "paragraph"
+   * @example "heading"
+   */
+  defaultType: string,
 }
 
 declare module '@tiptap/core' {
@@ -34,6 +40,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
   addOptions() {
     return {
       HTMLAttributes: {},
+      defaultType: "paragraph",
     }
   },
 
@@ -77,7 +84,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
           return (
             currentChain
               // set cursor after horizontal rule
-              .command(({ tr, dispatch }) => {
+              .command(({ state, tr, dispatch }) => {
                 if (dispatch) {
                   const { $to } = tr.selection
                   const posAfter = $to.end()
@@ -92,7 +99,7 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
                     }
                   } else {
                     // add node after horizontal rule if it’s the end of the document
-                    const node = $to.parent.type.contentMatch.defaultType?.create()
+                    const node = state.schema.nodes[this.options.defaultType].create()
 
                     if (node) {
                       tr.insert(posAfter, node)


### PR DESCRIPTION
## Changes Overview

This pull request adds a defaultType option to the horizontal-rule extension, enabling more precise behavior when inserting nodes in a document.

## Why This Change Is Necessary

Currently, when a custom `title` extension is defined as the first node of a document (`content: "title block+"`), inserting a `horizontal-rule` unexpectedly appends a `title` node to the end of the document. This behavior occurs because the default node is inferred from the document schema.

By introducing the `defaultType` option to `horizontal-rule`, we gain control over the default node type (e.g., `paragraph`) for insertion scenarios. This ensures predictable behavior, such as avoiding the unintended addition of a `title` node, and makes it easier to manage content structures.