### PR TITLE
fix(bubble-menu): add focusout handler for floating element

### DIFF
--- a/.changeset/twelve-turtles-cry.md
+++ b/.changeset/twelve-turtles-cry.md
@@ -1,0 +1,8 @@
+---
+"@tiptap/extension-bubble-menu": patch
+"@tiptap/react": patch
+"@tiptap/vue-2": patch
+"@tiptap/vue-3": patch
+---
+
+Fix the bug where the bubble menu does not hide

--- a/.changeset/twelve-turtles-cry.md
+++ b/.changeset/twelve-turtles-cry.md
@@ -5,4 +5,4 @@
 "@tiptap/vue-3": patch
 ---
 
-Fix the bug where the bubble menu does not hide
+Added a `focusout` event listener to handle blur events on the bubble menu element, ensuring the menu closes properly when blurred.

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -123,6 +123,7 @@ export class BubbleMenuView {
     }
 
     this.element.addEventListener('mousedown', this.mousedownHandler, { capture: true })
+    this.element.addEventListener('focusout', this.floatingFocusoutHandler)
     this.view.dom.addEventListener('dragstart', this.dragstartHandler)
     this.editor.on('focus', this.focusHandler)
     this.editor.on('blur', this.blurHandler)
@@ -130,6 +131,10 @@ export class BubbleMenuView {
     // Detaches menu content from its current parent
     this.element.remove()
     this.element.style.visibility = 'visible'
+  }
+
+  floatingFocusoutHandler = (event: FocusEvent) => {
+    this.blurHandler({ event })
   }
 
   mousedownHandler = () => {
@@ -303,6 +308,7 @@ export class BubbleMenuView {
     }
     this.tippy?.destroy()
     this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
+    this.element.removeEventListener('focusout', this.floatingFocusoutHandler)
     this.view.dom.removeEventListener('dragstart', this.dragstartHandler)
     this.editor.off('focus', this.focusHandler)
     this.editor.off('blur', this.blurHandler)

--- a/packages/react/src/BubbleMenu.tsx
+++ b/packages/react/src/BubbleMenu.tsx
@@ -50,7 +50,7 @@ export const BubbleMenu = (props: BubbleMenuProps) => {
   }, [props.editor, currentEditor, element])
 
   return (
-    <div ref={setElement} className={props.className} style={{ visibility: 'hidden' }}>
+    <div ref={setElement} tabIndex={-1} className={props.className} style={{ visibility: 'hidden' }}>
       {props.children}
     </div>
   )

--- a/packages/vue-2/src/BubbleMenu.ts
+++ b/packages/vue-2/src/BubbleMenu.ts
@@ -61,7 +61,7 @@ export const BubbleMenu: Component = {
   },
 
   render(this: BubbleMenuInterface, createElement: CreateElement) {
-    return createElement('div', { style: { visibility: 'hidden' } }, this.$slots.default)
+    return createElement('div', { style: { visibility: 'hidden' }, attrs: { tabIndex: -1 } }, this.$slots.default)
   },
 
   beforeDestroy(this: BubbleMenuInterface) {

--- a/packages/vue-3/src/BubbleMenu.ts
+++ b/packages/vue-3/src/BubbleMenu.ts
@@ -66,6 +66,6 @@ export const BubbleMenu = defineComponent({
       editor.unregisterPlugin(pluginKey)
     })
 
-    return () => h('div', { ref: root }, slots.default?.())
+    return () => h('div', { ref: root, tabindex: -1 }, slots.default?.())
   },
 })


### PR DESCRIPTION
## Changes Overview

Fix the bug where the bubble menu does not hide

## Implementation Approach

Add an additional focusout event handler to the floating element.

Also, set tabIndex to -1 for the bubble menu to ensure that clicking on an empty block in the bubble menu does not result in the parentNode being null.

## Testing Done

Test on a local

## Verification Steps

Add input into bubble-menu demo
Open BubbleMenu
Click on the input
Click outside the editor

## Additional Notes

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#578 
