### PR TITLE
fix: remove unused spec for font family extension

### DIFF
--- a/demos/src/Extensions/FontFamily/React/index.jsx
+++ b/demos/src/Extensions/FontFamily/React/index.jsx
@@ -41,7 +41,7 @@ export default () => {
             Inter
           </button>
           <button
-            onClick={() => editor.chain().focus().setFontFamily('Comic Sans MS, Comic Sans').run()}
+            onClick={() => editor.chain().focus().setFontFamily('"Comic Sans MS", "Comic Sans"').run()}
             className={
               editor.isActive('textStyle', { fontFamily: '"Comic Sans MS", "Comic Sans"' })
                 ? 'is-active'

--- a/demos/src/Extensions/FontFamily/React/index.spec.js
+++ b/demos/src/Extensions/FontFamily/React/index.spec.js
@@ -29,15 +29,6 @@ context('/src/Extensions/FontFamily/React/', () => {
     cy.get('.tiptap span').should('not.exist')
   })
 
-  it('should work with font-family that have spaces in them', () => {
-    cy.get('[data-test-id="comic-sans"]')
-      .should('not.have.class', 'is-active')
-      .click()
-      .should('have.class', 'is-active')
-
-    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: Comic Sans MS, Comic Sans')
-  })
-
   it('should allow CSS variables as a font-family', () => {
     cy.get('[data-test-id="css-variable"]')
       .should('not.have.class', 'is-active')

--- a/demos/src/Extensions/FontFamily/React/index.spec.js
+++ b/demos/src/Extensions/FontFamily/React/index.spec.js
@@ -37,6 +37,16 @@ context('/src/Extensions/FontFamily/React/', () => {
 
     cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: var(--title-font-family)')
   })
+
+  it('should allow fonts containing multiple font families', () => {
+    cy.get('[data-test-id="comic-sans"]')
+      .should('not.have.class', 'is-active')
+      .click()
+      .should('have.class', 'is-active')
+
+    cy.get('.tiptap').find('span').should('have.attr', 'style', 'font-family: "Comic Sans MS", "Comic Sans"')
+  })
+
   it('should allow fonts containing a space and number as a font-family', () => {
     cy.get('[data-test-id="exo2"]')
       .should('not.have.class', 'is-active')


### PR DESCRIPTION
## Changes Overview

Remove an unused test since we do already check for font family with spaces in a previous test and we already have a documentation pointing out how you should expect the font family to be checked

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

`N/A`

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

`N/A`

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

`N/A`

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

`N/A`

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->

https://github.com/ueberdosis/tiptap-docs/pull/71
https://github.com/ueberdosis/tiptap/pull/5880
