### PR TITLE
fix: extension link object replacement caracter sanitization

### DIFF
--- a/.changeset/unlucky-ravens-build.md
+++ b/.changeset/unlucky-ravens-build.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-link": patch
 ---
 
-object replacement character sanitization
+fix: #5679 - perform string sanitization to remove unwanted "object replacement characters" from the before performing link detection

--- a/.changeset/unlucky-ravens-build.md
+++ b/.changeset/unlucky-ravens-build.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-link": patch
+---
+
+object replacement character sanitization

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -299,9 +299,6 @@ export const Link = Mark.create<LinkOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
-
-    // console.log('renderHTML: ', HTMLAttributes)
-
     // prevent XSS attacks
     if (
       !this.options.isAllowedUri(HTMLAttributes.href, {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -299,6 +299,9 @@ export const Link = Mark.create<LinkOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
+
+    // console.log('renderHTML: ', HTMLAttributes)
+
     // prevent XSS attacks
     if (
       !this.options.isAllowedUri(HTMLAttributes.href, {
@@ -351,7 +354,12 @@ export const Link = Mark.create<LinkOptions>({
 
           if (text) {
             const { protocols, defaultProtocol } = this.options
-            const links = find(text).filter(
+            // Prosemirror replaces zero-width non-joiner characters
+            // with Object Replacement Character from unicode.
+            // Therefore, linkifyjs does not recognize the
+            // link properly. We replace these characters
+            // with regular spaces to fix this issue.
+            const links = find(text.replaceAll('\uFFFC', ' ')).filter(
               item => item.isLink
                 && this.options.isAllowedUri(item.value, {
                   defaultValidate: href => !!isAllowedUri(href, protocols),


### PR DESCRIPTION
## Changes Overview

Prosemirror replaces zero-width non-joiner characters with Object Replacement Character from unicode. Therefore, linkifyjs does not recognize the link properly. We replace these characters with regular spaces to fix this issue.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

Special Character Replacement

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

Tested within the demo with the provided content that produced the issue

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

`N/A`

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

`N/A`

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->

https://github.com/ueberdosis/tiptap/issues/5679