### PR TITLE
Fix/remove empty text style extension

### DIFF
--- a/.changeset/green-students-serve.md
+++ b/.changeset/green-students-serve.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-text-style": minor
+---
+
+fix: #4311 - update the logic of removeEmptyTextStyle to manually handle the selection of all of the nodes within the selection to check for their marks independently to fix an issue where unsetting the font family on a selection would remove all applied text style marks from the selection as well

--- a/packages/extension-text-style/src/text-style.ts
+++ b/packages/extension-text-style/src/text-style.ts
@@ -1,5 +1,4 @@
 import {
-  getMarkAttributes,
   Mark,
   mergeAttributes,
 } from '@tiptap/core'
@@ -64,15 +63,34 @@ export const TextStyle = Mark.create<TextStyleOptions>({
 
   addCommands() {
     return {
-      removeEmptyTextStyle: () => ({ state, commands }) => {
-        const attributes = getMarkAttributes(state, this.type)
-        const hasStyles = Object.entries(attributes).some(([, value]) => !!value)
+      removeEmptyTextStyle: () => ({ tr }) => {
 
-        if (hasStyles) {
-          return true
-        }
+        const { selection } = tr
 
-        return commands.unsetMark(this.name)
+        // Gather all of the nodes within the selection range.
+        // We would need to go through each node individually
+        // to check if it has any inline style attributes.
+        // Otherwise, calling commands.unsetMark(this.name)
+        // removes everything from all the nodes
+        // within the selection range.
+        tr.doc.nodesBetween(selection.from, selection.to, (node, pos) => {
+
+          // Check if it's a paragraph element, if so, skip this node as we apply
+          // the text style to inline text nodes only (span).
+          if (node.isTextblock) {
+            return true
+          }
+
+          // Check if the node has no inline style attributes.
+          // Filter out non-`textStyle` marks.
+          if (
+            !node.marks.filter(mark => mark.type === this.type).some(mark => Object.values(mark.attrs).some(value => !!value))) {
+            // Proceed with the removal of the `textStyle` mark for this node only
+            tr.removeMark(pos, pos + node.nodeSize, this.type)
+          }
+        })
+
+        return true
       },
     }
   },


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

We were handling incorrectly the removal of styles by calling `command.unsetMark(this.name)` at the `removeEmptyTextStyle`. This was causing the removal of all of the marks from the node itself and all their descendants and this was causing the loss of all of the inline styles that were applied across the selection.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

In order to fix this issue, we were in the need to manually and properly handle the selection and all of the nodes within the selection and check their marks independently to make sure we're not throwing away inline styles that were not related to unsetting the font family or any other unset of marks.

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

https://github.com/user-attachments/assets/88c1302d-e44e-4837-8b4c-c9f1697e5b71

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

1. Pull the branch.
2. Access `demos/Extensions/FontFamily/React/index.jsx`
3. Paste the attached content that includes `colors` to check other cases of inline style removal
4. Run the dev server
5. Access the given demo and play around with colors and font families
6. Everything should work as expected

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

Demo JSX component

```jsx
import './styles.scss'

import { Color } from '@tiptap/extension-color'
import Document from '@tiptap/extension-document'
import FontFamily from '@tiptap/extension-font-family'
import Paragraph from '@tiptap/extension-paragraph'
import Text from '@tiptap/extension-text'
import TextStyle from '@tiptap/extension-text-style'
import { EditorContent, useEditor } from '@tiptap/react'
import React from 'react'

export default () => {
  const editor = useEditor({
    extensions: [Document, Paragraph, Text, TextStyle, FontFamily, Color],
    content: `
        <p><span style="font-family: Inter;">Did you know that Inter is a really nice font for interfaces?</span></p>
        <p><span style="font-family: Comic Sans MS, Comic Sans">It doesn’t look as professional as Comic Sans.</span></p>
        <p><span style="font-family: serif">Serious people use serif fonts anyway.</span></p>
        <p><span style="font-family: monospace">The cool kids can apply monospace fonts aswell.</span></p>
        <p><span style="font-family: cursive">But hopefully we all can agree, that cursive fonts are the best.</span></p>
        <p><span style="font-family: var(--title-font-family)">Then there are CSS variables, the new hotness.</span></p>
        <p><span style="font-family: 'Exo 2'">TipTap even can handle exotic fonts as Exo 2.</span></p>
      `,
  })

  if (!editor) {
    return null
  }

  return (
    <>
      <link
        href="https://fonts.googleapis.com/css2?family=Exo+2:ital,wght@0,100..900;1,100..900&display=swap"
        rel="stylesheet"/>
      <div className="control-group">
        <div className="button-group">
          <button
            onClick={() => editor.chain().focus().setFontFamily('Inter').run()}
            className={editor.isActive('textStyle', { fontFamily: 'Inter' }) ? 'is-active' : ''}
            data-test-id="inter"
          >
            Inter
          </button>
          <button
            onClick={() => editor.chain().focus().setFontFamily('"Comic Sans MS", "Comic Sans"').run()}
            className={
              editor.isActive('textStyle', { fontFamily: '"Comic Sans MS", "Comic Sans"' })
                ? 'is-active'
                : ''
            }
            data-test-id="comic-sans"
          >
            Comic Sans
          </button>
          <button
            onClick={() => editor.chain().focus().setFontFamily('serif').run()}
            className={editor.isActive('textStyle', { fontFamily: 'serif' }) ? 'is-active' : ''}
            data-test-id="serif"
          >
            Serif
          </button>
          <button
            onClick={() => editor.chain().focus().setFontFamily('monospace').run()}
            className={editor.isActive('textStyle', { fontFamily: 'monospace' }) ? 'is-active' : ''}
            data-test-id="monospace"
          >
            Monospace
          </button>
          <button
            onClick={() => editor.chain().focus().setFontFamily('cursive').run()}
            className={editor.isActive('textStyle', { fontFamily: 'cursive' }) ? 'is-active' : ''}
            data-test-id="cursive"
          >
            Cursive
          </button>
          <button
            onClick={() => editor.chain().focus().setFontFamily('var(--title-font-family)').run()}
            className={editor.isActive('textStyle', { fontFamily: 'var(--title-font-family)' }) ? 'is-active' : ''}
            data-test-id="css-variable"
          >
            CSS variable
          </button>
          <button
            onClick={() => editor.chain().focus().setFontFamily('"Exo 2"').run()}
            className={editor.isActive('textStyle', { fontFamily: '"Exo 2"' }) ? 'is-active' : ''}
            data-test-id="exo2"
          >
            Exo 2
          </button>
          <button onClick={() => editor.chain().focus().unsetFontFamily().run()}
                  data-test-id="unsetFontFamily">
            Unset font family
          </button>
          <button onClick={() => editor.chain().focus().setColor('#663399').run()}>
            Set Rebecapurple color
          </button>
          <button onClick={() => editor.chain().focus().setColor('#ff6347').run()}>
            Set Tomato color
          </button>
          <button onClick={() => editor.chain().focus().unsetColor().run()}>
            Unset color
          </button>
        </div>
      </div>
      <EditorContent editor={editor}/>
    </>
  )
}

```

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->

https://github.com/ueberdosis/tiptap/issues/4311
