### PR TITLE
fix(extension-code): support safari versions 16.4 and older

### DIFF
--- a/.changeset/itchy-carrots-melt.md
+++ b/.changeset/itchy-carrots-melt.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-code": patch
+---
+
+Implement `inputRegex` and `pasteRegex` while avoiding lookbehind for compatibility with safari versions older than 16.4

--- a/packages/extension-code/src/code.ts
+++ b/packages/extension-code/src/code.ts
@@ -42,12 +42,12 @@ declare module '@tiptap/core' {
  *  This ensures that any text between backticks is formatted as code,
  *  regardless of the surrounding characters (exception being another backtick).
  */
-export const inputRegex = /(?<!`)`([^`]+)`(?!`)/
+export const inputRegex = /(^|[^`])`([^`]+)`(?!`)/
 
 /**
  * Matches inline code while pasting.
  */
-export const pasteRegex = /(?<!`)`([^`]+)`(?!`)/g
+export const pasteRegex = /(^|[^`])`([^`]+)`(?!`)/g
 
 /**
  * This extension allows you to mark text as inline code.


### PR DESCRIPTION
## Changes Overview
Rewrite the extension-code regex to avoid lookbehind to fix errors in safari versions 16.4 and older.

## Testing Done
I tested the regex in regex101 to ensure it continues to work as expected.

## Verification Steps
I checked to ensure that this actually works in older safari versions.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5889