### PR TITLE
Fixed Link extension's commands not respecting XSS prevention via unallowed protocols

### DIFF
--- a/.changeset/empty-seals-join.md
+++ b/.changeset/empty-seals-join.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-link": patch
+---
+
+Added checks for allowed protocols in link commands & exported isValidUri helper for manual checks outside of the extension

--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -105,8 +105,12 @@ export default () => {
     }
 
     // update link
-    editor.chain().focus().extendMarkRange('link').setLink({ href: url })
-      .run()
+    try {
+      editor.chain().focus().extendMarkRange('link').setLink({ href: url })
+        .run()
+    } catch (e) {
+      alert(e.message)
+    }
   }, [editor])
 
   if (!editor) {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -160,7 +160,7 @@ declare module '@tiptap/core' {
 // eslint-disable-next-line no-control-regex
 const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
 
-function isAllowedUri(uri: string | undefined, protocols?: LinkOptions['protocols']) {
+export function isAllowedUri(uri: string | undefined, protocols?: LinkOptions['protocols']) {
   const allowedProtocols: string[] = [
     'http',
     'https',
@@ -322,11 +322,23 @@ export const Link = Mark.create<LinkOptions>({
     return {
       setLink:
         attributes => ({ chain }) => {
+          const { href } = attributes
+
+          if (!isAllowedUri(href, this.options.protocols)) {
+            throw new Error('Invalid protocol')
+          }
+
           return chain().setMark(this.name, attributes).setMeta('preventAutolink', true).run()
         },
 
       toggleLink:
         attributes => ({ chain }) => {
+          const { href } = attributes
+
+          if (!isAllowedUri(href, this.options.protocols)) {
+            throw new Error('Invalid protocol')
+          }
+
           return chain()
             .toggleMark(this.name, attributes, { extendEmptyMarkRange: true })
             .setMeta('preventAutolink', true)

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -324,8 +324,12 @@ export const Link = Mark.create<LinkOptions>({
         attributes => ({ chain }) => {
           const { href } = attributes
 
-          if (!isAllowedUri(href, this.options.protocols)) {
-            throw new Error('Invalid protocol')
+          if (!this.options.isAllowedUri(href, {
+            defaultValidate: url => !!isAllowedUri(url, this.options.protocols),
+            protocols: this.options.protocols,
+            defaultProtocol: this.options.defaultProtocol,
+          })) {
+            return false
           }
 
           return chain().setMark(this.name, attributes).setMeta('preventAutolink', true).run()
@@ -335,8 +339,12 @@ export const Link = Mark.create<LinkOptions>({
         attributes => ({ chain }) => {
           const { href } = attributes
 
-          if (!isAllowedUri(href, this.options.protocols)) {
-            throw new Error('Invalid protocol')
+          if (!this.options.isAllowedUri(href, {
+            defaultValidate: url => !!isAllowedUri(url, this.options.protocols),
+            protocols: this.options.protocols,
+            defaultProtocol: this.options.defaultProtocol,
+          })) {
+            return false
           }
 
           return chain()


### PR DESCRIPTION
This pull request includes changes to improve error handling and validation for links in the `Link` extension. The most important changes include adding error handling in the React component, exporting the `isAllowedUri` function, and validating link protocols before setting or toggling links.

## Implementation Approach
I added checks inside the `setLink` and `toggleLink` commands to see if the link being tried to set is actually valid. If not, we throw an error so the developer can implement error handling outside of the extension.

```js
try {
  editor.chain().setLink('javascript:alert("Hello world")').focus().run()
} catch (e) {
  if (e.message === 'Invalid protocol') {
    alert('Please don\'t put XSS injections into our content please.')
  }
}
```

## Testing Done
1. Tested it locally on the Link demo (where I also added said check + error handler)
2. Used the already existing test that will check if insertion of unwanted protocols works or not

## Verification Steps
See above

## Additional Notes
Because people can potentially also override said commands, I added an export for the `isValidUri` function to make it easy for people to add said checks themselves.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
