### PR TITLE
fix(task-item): fix read only checked handling

### DIFF
--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -163,7 +163,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
 
               if (!editor.isEditable && this.options.onReadOnlyChecked) {
                 // Reset state if onReadOnlyChecked returns false
-                if (!this.options.onReadOnlyChecked(currentNode, checked)) {
+                if (!currentNode || !this.options.onReadOnlyChecked(currentNode, checked)) {
                   checkbox.checked = !checkbox.checked
                   return false
                 }

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -149,7 +149,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
 
         const { checked } = event.target as any
 
-        if (editor.isEditable && typeof getPos === 'function') {
+        if (typeof getPos === 'function') {
           editor
             .chain()
             .focus(undefined, { scrollIntoView: false })
@@ -161,6 +161,14 @@ export const TaskItem = Node.create<TaskItemOptions>({
               }
               const currentNode = tr.doc.nodeAt(position)
 
+              if (!editor.isEditable && this.options.onReadOnlyChecked) {
+                // Reset state if onReadOnlyChecked returns false
+                if (!this.options.onReadOnlyChecked(currentNode, checked)) {
+                  checkbox.checked = !checkbox.checked
+                  return false
+                }
+              }
+
               tr.setNodeMarkup(position, undefined, {
                 ...currentNode?.attrs,
                 checked,
@@ -169,12 +177,6 @@ export const TaskItem = Node.create<TaskItemOptions>({
               return true
             })
             .run()
-        }
-        if (!editor.isEditable && this.options.onReadOnlyChecked) {
-          // Reset state if onReadOnlyChecked returns false
-          if (!this.options.onReadOnlyChecked(node, checked)) {
-            checkbox.checked = !checkbox.checked
-          }
         }
       })
 


### PR DESCRIPTION
Fixes #3676

## Changes Overview

`onReadOnlyChecked` allows you to determine whether the checking/unchecking the task item should apply the change, or not.

It did not work because:
- it only ever passed the original node to the function, not the current node
- even if you returned true it would not apply the change to the document

## Implementation Approach

Now it runs the logic inside the transaction where we have access to the current node, and we can either abort it as before if it returns `false`, or allow it to proceed with the transaction if it returns `true`.

## Testing Done

Only manual testing whilst clicking in a browser.

## Verification Steps

Configure your editor like this:

```js

new Editor({
    editable: false,
    // + other options
    extensions: [
        TaskItem.configure({
            // Allow checking/unchecking when in read only mode
            onReadOnlyChecked: () => true,
        }),
        // + other extensions
    ]
})    
```

Then, ideally, open a couple of windows with a collaborative session running, and notice that you can check/uncheck the box in one window, but the change is not propagated to the other.

Additionally, if you want to have more logic (e.g. the kind of logic in https://github.com/ueberdosis/tiptap/issues/4521 - where the node descendent are checked for matching), it should be possible to observe the node is now the correct node, and can be matched if desired:

```js
onReadOnlyChecked: (node, checked) => {
  editor.state.doc.descendants((subnode, pos) => {
    if (node.eq(subnode)) {
      const { tr } = editor!.state;
      tr.setNodeMarkup(pos, undefined, {
        ...node.attrs,
        checked: checked,
      });
      editor.view.dispatch(tr);
    }
  });
  return true;
},
```

## Additional Notes

There is also another bug, in the update method because it uses `checkbox.setAttribute('checked', 'checked')` and `checkbox.removeAttribute('checked')` which is not the correct way to change the state of a checkbox, should just be `checkbox.checked = checked`.

Should I add a fix to this PR? Maybe best in another one....

Update: I submitted a separate PR for that https://github.com/ueberdosis/tiptap/pull/5953

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/3676
https://github.com/ueberdosis/tiptap/issues/4521
