### PR TITLE
fix(task-item): fix updating checked status

### DIFF
--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -202,12 +202,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
             return false
           }
 
-          listItem.dataset.checked = updatedNode.attrs.checked
-          if (updatedNode.attrs.checked) {
-            checkbox.setAttribute('checked', 'checked')
-          } else {
-            checkbox.removeAttribute('checked')
-          }
+          checkbox.checked = listItem.dataset.checked = updatedNode.attrs.checked
 
           return true
         },


### PR DESCRIPTION
## Changes Overview

The code currently uses `setAttribute` / `removeAttribute` to update the checked status of the checkbox, this is the incorrect method to use. Checkboxes have a `checked` property that can be set.

See https://aileenrae.co.uk/blog/programatically-check-uncheck-checkbox-javascript/

## Implementation Approach

Switch to setting `checkbox.checked` property

## Testing Done

Manually in browser.

## Verification Steps

Open a collaborative session with task item extension available.

In one window check/uncheck the box a few times, then in the other window do the same.

Notice that the update _appears_ to no longer propagate, the checkbox state does not change in the other window.

It _is_ actually changing the attribute on the document node correctly, which you can see if have styling applied such as this (on the task item):

```scss
li[data-checked='true'] {
    text-decoration: line-through;
}
```

With the fix, it works again!

## Additional Notes


## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

I couldn't find an existing issue for it, which I thought was surprising, but maybe I didn't look well enough.
