### PR TITLE
fix: handleSelectionUpdate callback is triggered before the renderer is initialized.

### DIFF
--- a/.changeset/early-parrots-carry.md
+++ b/.changeset/early-parrots-carry.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Resolves #5870 by re-ordering executation of selectionUpdate handler

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -141,7 +141,6 @@ export class ReactNodeView<
     const { className = '' } = this.options
 
     this.handleSelectionUpdate = this.handleSelectionUpdate.bind(this)
-    this.editor.on('selectionUpdate', this.handleSelectionUpdate)
 
     this.renderer = new ReactRenderer(ReactNodeViewProvider, {
       editor: this.editor,
@@ -150,6 +149,7 @@ export class ReactNodeView<
       className: `node-${this.node.type.name} ${className}`.trim(),
     })
 
+    this.editor.on('selectionUpdate', this.handleSelectionUpdate)
     this.updateElementAttributes()
   }
 


### PR DESCRIPTION
## Changes Overview
This PR addresses a crash in the ReactNodeView implementation that occurs when the handleSelectionUpdate callback is triggered before the renderer is initialized. The issue arises due to the asynchronous nature of JavaScript, where the subscription to the selectionUpdate event (editor.on) is executed before the renderer initialization.

The proposed fix ensures that the renderer is initialized before subscribing to the selectionUpdate event, maintaining the intended execution order.

## Implementation Approach
The subscription to the selectionUpdate event was moved to occur after the initialization of the renderer. This ensures the callback does not execute prematurely and prevents the crash. The implementation adds no new functionality or logic but rearranges the code to avoid the race condition.

## Testing Done
The fix was tested by replicating the scenario that caused the crash:
	1.	Adding a new line before a tag.
	2.	Observing the behavior when the old node is destroyed, and a new node is created.

The changes successfully prevent the crash in these scenarios. Additionally, basic functionality was verified to ensure no regressions.

This normally occurs with editors built with tiptap, tippy and prosemirror. 

## Verification Steps
	1.	Open a document with the affected editor.
	2.	Add a new line before an existing tag and observe that no crash occurs.
	3.	Verify that the selectionUpdate events are properly handled without regressions in functionality.

## Additional Notes
This fix does not alter the functionality of the library; it only ensures proper execution order, and does not affect any other functionality, but avoids this condition that causes the crash

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5870