### PR TITLE
feat(text-style): add `toggleTextStyle` command

### DIFF
--- a/.changeset/orange-spoons-rescue.md
+++ b/.changeset/orange-spoons-rescue.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-text-style': minor
+---
+
+Add `toggleTextStyle` command and add typings for the commands parameters based on the installed extensions that include `textStyle`

--- a/packages/extension-color/src/color.ts
+++ b/packages/extension-color/src/color.ts
@@ -30,6 +30,12 @@ declare module '@tiptap/core' {
   }
 }
 
+declare module '@tiptap/extension-text-style' {
+  interface TextStyleAttributes {
+    color?: string | null
+  }
+}
+
 /**
  * This extension allows you to color your text.
  * @see https://tiptap.dev/api/extensions/color

--- a/packages/extension-font-family/src/font-family.ts
+++ b/packages/extension-font-family/src/font-family.ts
@@ -29,6 +29,12 @@ declare module '@tiptap/core' {
   }
 }
 
+declare module '@tiptap/extension-text-style' {
+  interface TextStyleAttributes {
+    fontFamily?: string | null
+  }
+}
+
 /**
  * This extension allows you to set a font family for text.
  * @see https://www.tiptap.dev/api/extensions/font-family

--- a/packages/extension-font-size/src/font-size.ts
+++ b/packages/extension-font-size/src/font-size.ts
@@ -29,6 +29,12 @@ declare module '@tiptap/core' {
   }
 }
 
+declare module '@tiptap/extension-text-style' {
+  interface TextStyleAttributes {
+    fontSize?: string | null
+  }
+}
+
 /**
  * This extension allows you to set a font size for text.
  * @see https://www.tiptap.dev/api/extensions/font-size

--- a/packages/extension-text-style/src/text-style.ts
+++ b/packages/extension-text-style/src/text-style.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
 import { Mark, mergeAttributes } from '@tiptap/core'
 
 export interface TextStyleOptions {
@@ -17,6 +18,11 @@ export interface TextStyleOptions {
   mergeNestedSpanStyles: boolean
 }
 
+/**
+ * The available text style attributes.
+ */
+export interface TextStyleAttributes extends Record<string, any> {}
+
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     textStyle: {
@@ -25,6 +31,12 @@ declare module '@tiptap/core' {
        * @example editor.commands.removeEmptyTextStyle()
        */
       removeEmptyTextStyle: () => ReturnType
+      /**
+       * Toggle a text style
+       * @param attributes The text style attributes
+       * @example editor.commands.toggleTextStyle({ fontWeight: 'bold' })
+       */
+      toggleTextStyle: (attributes?: TextStyleAttributes) => ReturnType
     }
   }
 }
@@ -49,7 +61,7 @@ const mergeNestedSpanStyles = (element: HTMLElement) => {
 
 /**
  * This extension allows you to create text styles. It is required by default
- * for the `textColor` and `backgroundColor` extensions.
+ * for the `text-color` and `font-family` extensions.
  * @see https://www.tiptap.dev/api/marks/text-style
  */
 export const TextStyle = Mark.create<TextStyleOptions>({
@@ -92,6 +104,11 @@ export const TextStyle = Mark.create<TextStyleOptions>({
 
   addCommands() {
     return {
+      toggleTextStyle:
+        attributes =>
+        ({ commands }) => {
+          return commands.toggleMark(this.name, attributes)
+        },
       removeEmptyTextStyle:
         () =>
         ({ tr }) => {


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
This adds a `toggleTextStyle` command which can toggle between a text style. It also adds the typing for the command's argument based on other extensions using the `textStyle` mark
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
