### PR TITLE
fix: add missing node view props to props type object

### DIFF
--- a/.changeset/silly-wolves-attack.md
+++ b/.changeset/silly-wolves-attack.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/vue-3": patch
+---
+
+update node view props to match `NodeViewProps` type

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -48,6 +48,18 @@ export const nodeViewProps = {
     type: Function as PropType<NodeViewProps['deleteNode']>,
     required: true as const,
   },
+  view: {
+    type: Object as PropType<NodeViewProps['view']>,
+    required: true as const,
+  },
+  innerDecorations: {
+    type: Object as PropType<NodeViewProps['innerDecorations']>,
+    required: true as const,
+  },
+  HTMLAttributes: {
+    type: Object as PropType<NodeViewProps['HTMLAttributes']>,
+    required: true as const,
+  },
 }
 
 export interface VueNodeViewRendererOptions extends NodeViewRendererOptions {


### PR DESCRIPTION
## Changes Overview

I was trying to follow the step from [render-a-vue-component](https://tiptap.dev/docs/editor/extensions/custom-extensions/node-views/vue#render-a-vue-component) section. Everything works except that there was a type error when I pass the customized component to `VueNodeViewRenderer`. After some searchs, now I think some props are missing. Thus adding them on could be a fix if the absence is not on purpose.

![image](https://github.com/user-attachments/assets/d7b8d188-6b23-40ea-abbd-42b75d26497f)

## Implementation Approach

add 3 missing props declaration to the `nodeViewProps` object

## Testing Done & Verification Steps

error resolved after the change

![image](https://github.com/user-attachments/assets/5fd71776-5771-47d5-bd15-760c73dc75f7)

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.
