### PR TITLE
fix(extension-link): Fix the issue where a link cannot be pasted when…

### DIFF
--- a/packages/extension-link/src/helpers/pasteHandler.ts
+++ b/packages/extension-link/src/helpers/pasteHandler.ts
@@ -34,11 +34,9 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
           return false
         }
 
-        options.editor.commands.setMark(options.type, {
+        return options.editor.commands.setMark(options.type, {
           href: link.href,
         })
-
-        return true
       },
     },
   })


### PR DESCRIPTION
Fix the issue where a link cannot be pasted when the editor content is empty and the editor is in a 'select all' state. See details at [issue#5994](https://github.com/ueberdosis/tiptap/issues/5994)

## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->

https://github.com/ueberdosis/tiptap/issues/5994