### PR TITLE
fix: Text Formatting Effects Reset After Input Confirmation with Japanese IME on Mobile Browsers (Safari & Chrome)

### DIFF
--- a/.changeset/perfect-pillows-rhyme.md
+++ b/.changeset/perfect-pillows-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+fix(core): do not reset marks, or nodes when using IME on mobile devices

--- a/packages/core/src/extensions/keymap.ts
+++ b/packages/core/src/extensions/keymap.ts
@@ -104,6 +104,10 @@ export const Keymap = Extension.create({
       new Plugin({
         key: new PluginKey('clearDocument'),
         appendTransaction: (transactions, oldState, newState) => {
+          if (transactions.some(tr => tr.getMeta('composition'))) {
+            return
+          }
+
           const docChanges = transactions.some(transaction => transaction.docChanged)
             && !oldState.doc.eq(newState.doc)
 


### PR DESCRIPTION
# Changes Overview

Fixed the bug reported in #5733. On iOS Safari and WebView, when the document is empty and a decoration is applied, inputting and confirming text using Japanese IME or similar would reset the decoration. This issue has now been resolved.

## Implementation Approach

The clearDocument plugin is now configured not to execute while IME input is active.

## Testing Done

1. Clear the document.
2. Apply H1 decoration.
3. Use the iOS virtual keyboard to input text and confirm with the IME.
4. Verify that the decoration is not cleared.

## Verification Steps

1. Clear the document.
2. Apply H1 decoration.
3. Use the iOS virtual keyboard to input text and confirm with the IME.
4. Verify that the decoration is not cleared.

## Additional Notes

The decoration is now preserved as shown below.

https://github.com/user-attachments/assets/95207b8b-4405-40e6-8b5c-4e9d605941f3

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- #5733