### PR TITLE
fix(core): fix focus issue introduced in v2.11.0

### DIFF
--- a/.changeset/thirty-deers-attend.md
+++ b/.changeset/thirty-deers-attend.md
@@ -2,4 +2,4 @@
 "@tiptap/core": minor
 ---
 
-Focus synchronously only if on iOS or Android
+Focus synchronously only if on iOS or Android #4448

--- a/.changeset/thirty-deers-attend.md
+++ b/.changeset/thirty-deers-attend.md
@@ -2,4 +2,4 @@
 "@tiptap/core": minor
 ---
 
-Scope view.dom.focus() to iOS and Android
+Focus synchronously only if on iOS or Android

--- a/.changeset/thirty-deers-attend.md
+++ b/.changeset/thirty-deers-attend.md
@@ -1,5 +1,5 @@
 ---
-"@tiptap/core": minor
+"@tiptap/core": patch
 ---
 
 Focus synchronously only if on iOS or Android #4448

--- a/.changeset/thirty-deers-attend.md
+++ b/.changeset/thirty-deers-attend.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": minor
+---
+
+Scope view.dom.focus() to iOS and Android

--- a/packages/core/src/commands/focus.ts
+++ b/packages/core/src/commands/focus.ts
@@ -1,6 +1,8 @@
 import { isTextSelection } from '../helpers/isTextSelection.js'
 import { resolveFocusPosition } from '../helpers/resolveFocusPosition.js'
 import { FocusPosition, RawCommands } from '../types.js'
+import { isiOS } from '../utilities/isiOS.js';
+import { isAndroid } from '../utilities/isAndroid.js';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -42,7 +44,11 @@ export const focus: RawCommands['focus'] = (position = null, options = {}) => ({
   }
 
   const delayedFocus = () => {
-    (view.dom as HTMLElement).focus()
+    // focus within `requestAnimationFrame` breaks focus on iOS and Android
+    // so we have to call this
+    if (isiOS() || isAndroid()) {
+      (view.dom as HTMLElement).focus()
+    }
 
     // For React we have to focus asynchronously. Otherwise wild things happen.
     // see: https://github.com/ueberdosis/tiptap/issues/1520

--- a/packages/core/src/commands/focus.ts
+++ b/packages/core/src/commands/focus.ts
@@ -1,8 +1,8 @@
 import { isTextSelection } from '../helpers/isTextSelection.js'
 import { resolveFocusPosition } from '../helpers/resolveFocusPosition.js'
 import { FocusPosition, RawCommands } from '../types.js'
-import { isiOS } from '../utilities/isiOS.js';
-import { isAndroid } from '../utilities/isAndroid.js';
+import { isAndroid } from '../utilities/isAndroid.js'
+import { isiOS } from '../utilities/isiOS.js'
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {


### PR DESCRIPTION
## Changes Overview
A change was introduced in v2.11.0 to [fix losing text selection/focus when using the `focus` command on Android](https://github.com/ueberdosis/tiptap/pull/4448/files). This PR effectively reverts this change, while updating the conditional logic to be more narrowly scoped to solve the issue for Android as originally intended.

## Implementation Approach
The previous logic in this function was scoped to just iOS, so I simply added an Android check in the same `if` statement. The removal of the `if` statement altogether introduced new behavior to all implementors of `focus`, which in my case (Chrome, web) led to undesirable behavior of the page jumping to the top of the editor.

## Testing Done
No testing done -- no devices to test with

## Verification Steps
No verification done

## Additional Notes
I think this is a pretty simple solution when you compare the previous and current logic implemented in this code block. Admittedly I have no real way to verify this other than the change introduced to my app when I installed `@tiptap/core v2.11.0`. Hoping someone else can take it from here, given the small size of the change requested.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/5992