### PR TITLE
feat(core): introduce new mounting system for SSR

### DIFF
--- a/.changeset/red-ants-wonder.md
+++ b/.changeset/red-ants-wonder.md
@@ -1,0 +1,66 @@
+---
+'@tiptap/core': minor
+---
+
+This introduces a new behavior for the editor, the ability to be safely run on the server-side (without rendering).
+
+`prosemirror-view` encapsulates all view (& DOM) related code, and cannot safely be SSR'd, but, the majority of the editor instance itself is in plain JS that does not require DOM APIs (unless your content is specified in HTML).
+
+But, we have so many convenient methods available for manipulating content. So, it is a shame that they could not be used on the server side too. With this change, the editor can be rendered on the server-side and will use a stub for select prosemirror-view methods. If accessing unsupported methods or values on the `editor.view`, you will encounter runtime errors, so it is important for you to test to see if the methods you call actually work.
+
+This is a step towards being able to server-side render content, but, it is not completely supported yet. This does not mean that you can render an editor instance on the server and expect it to just output any HTML.
+
+## Usage
+
+If you pass `element: null` to your editor options:
+
+- the `editor.view` will not be initialized
+- the editor will not emit it's `'create'` event
+- the focus will not be initialized to it's first position
+
+You can however, later use the new `mount` function on the instance, which will mount the editor view to a DOM element. This obviously will not be allowed on the server which has no document object.
+
+Therefore, this will work on the server:
+
+```ts
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+const editor = new Editor({
+  element: null,
+  content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello, World!' }] }] },
+  extensions: [StarterKit],
+})
+
+editor
+  .chain()
+  .selectAll()
+  .setContent({ type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'XYZ' }] }] })
+  .run()
+
+console.log(editor.state.doc.toJSON())
+// { type: 'doc', content: [ { type: 'paragraph', content: [ { type: 'text', text: 'XYZ' } ] } ] }
+```
+
+Any of these things will not work on the server, and result in a runtime error:
+
+```ts
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+const editor = new Editor({
+  // document will not be defined in a server environment
+  element: document.createElement('div'),
+  content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello, World!' }] }] },
+  extensions: [StarterKit],
+})
+
+editor
+  .chain()
+  // focus is a command which depends on the editor-view, so it will not work in a server environment
+  .focus()
+  .run()
+
+console.log(editor.getHTML())
+// getHTML relies on the editor-view, so it will not work in a server environment
+```

--- a/demos/src/Extensions/CollaborationWithMenus/React/index.spec.js
+++ b/demos/src/Extensions/CollaborationWithMenus/React/index.spec.js
@@ -12,8 +12,8 @@ context('/src/Extensions/CollaborationWithMenus/React/', () => {
   })
 
   it('should have menu plugins initiated', () => {
+    cy.wait(700)
     cy.get('.tiptap').then(async ([{ editor }]) => {
-      await cy.wait(100)
       const bubbleMenuPlugin = editor.view.state.plugins.find(plugin => plugin.spec.key?.key === 'bubbleMenu$')
       const floatingMenuPlugin = editor.view.state.plugins.find(plugin => plugin.spec.key?.key === 'floatingMenu$')
       const hasBothMenuPluginsLoaded = !!bubbleMenuPlugin && !!floatingMenuPlugin

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -142,6 +142,11 @@ export class Editor extends EventEmitter<EditorEvents> {
   }
 
   public mount(el: NonNullable<EditorOptions['element']> & {}) {
+    if (typeof document === 'undefined') {
+      throw new Error(
+        `[tiptap error]: The editor cannot be mounted because there is no 'document' defined in this environment.`,
+      )
+    }
     this.createView(el)
 
     window.setTimeout(() => {
@@ -266,7 +271,7 @@ export class Editor extends EventEmitter<EditorEvents> {
 
           // We throw an error here, because we know the view is not available
           throw new Error(
-            `[Tiptap Editor]: The editor view is not available. Cannot access view['${key as string}']. The editor may not be mounted yet.`,
+            `[tiptap error]: The editor view is not available. Cannot access view['${key as string}']. The editor may not be mounted yet.`,
           )
         },
       },

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -264,7 +264,11 @@ export class Editor extends EventEmitter<EditorEvents> {
         editable: true,
       } as EditorView,
       {
-        get(obj, key) {
+        get: (obj, key) => {
+          // Specifically always return the most recent editorState
+          if (key === 'state') {
+            return this.editorState
+          }
           if (key in obj) {
             return Reflect.get(obj, key)
           }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -225,8 +225,10 @@ export type EnableRules = (AnyExtension | string)[] | boolean
 export interface EditorOptions {
   /**
    * The element or selector to bind the editor to
+   * If `null` is passed, the editor will not be mounted automatically
+   * If a function is passed, it will be called with the editor's root element
    */
-  element: Element
+  element: Element | null
   /**
    * The content of the editor (HTML, JSON, or a JSON array)
    */

--- a/packages/core/src/utilities/elementFromString.ts
+++ b/packages/core/src/utilities/elementFromString.ts
@@ -15,6 +15,9 @@ const removeWhitespaces = (node: HTMLElement) => {
 }
 
 export function elementFromString(value: string): HTMLElement {
+  if (typeof window === 'undefined') {
+    throw new Error('[tiptap error]: there is no window object available, so this function cannot be used')
+  }
   // add a wrapper to preserve leading and trailing whitespace
   const wrappedValue = `<body>${value}</body>`
 

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -175,10 +175,11 @@ export class PureEditorContent extends React.Component<
 
     editor.contentComponent = null
 
-    if (!editor.options.element.firstChild) {
+    if (!editor.options.element?.firstChild) {
       return
     }
 
+    // TODO using the new editor.mount method might allow us to remove this
     const newElement = document.createElement('div')
 
     newElement.append(...editor.options.element.childNodes)

--- a/packages/vue-2/src/EditorContent.ts
+++ b/packages/vue-2/src/EditorContent.ts
@@ -24,7 +24,7 @@ export const EditorContent: Component = {
           this.$nextTick(() => {
             const element = this.$el
 
-            if (!element || !editor.options.element.firstChild) {
+            if (!element || !editor.options.element?.firstChild) {
               return
             }
 
@@ -61,10 +61,11 @@ export const EditorContent: Component = {
 
     editor.contentComponent = null
 
-    if (!editor.options.element.firstChild) {
+    if (!editor.options.element?.firstChild) {
       return
     }
 
+    // TODO using the new editor.mount method might allow us to remove this
     const newElement = document.createElement('div')
 
     newElement.append(...editor.options.element.childNodes)

--- a/packages/vue-3/src/EditorContent.ts
+++ b/packages/vue-3/src/EditorContent.ts
@@ -32,10 +32,11 @@ export const EditorContent = defineComponent({
 
       if (editor && editor.options.element && rootEl.value) {
         nextTick(() => {
-          if (!rootEl.value || !editor.options.element.firstChild) {
+          if (!rootEl.value || !editor.options.element?.firstChild) {
             return
           }
 
+          // TODO using the new editor.mount method might allow us to remove this
           const element = unref(rootEl.value)
 
           rootEl.value.append(...editor.options.element.childNodes)


### PR DESCRIPTION
## Changes Overview

This introduces a new behavior for the editor. The ability to be safely run on the server-side (without rendering).

prosemirror-view encapsulates all view related code, and cannot safely be SSR'd, but, the majority of the editor instance itself is in plain JS that does not require DOM APIs (unless your content is specified in HTML).

But, we have so many convenient methods available for manipulating content, that it is a shame that they could not be used on the server side too. With this update, the editor can be rendered on the server-side and will use a stub for prosemirror-view methods. If accessing certain functions on the view, you will encounter runtime errors, so it is important for you to test to see if the methods you call actually work.

This is a step towards being able to server-side render content, but, it is not completely supported yet. This does not mean that you can render an editor instance on the server and expect it to just output any HTML.

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

If you pass `element: null` to your editor options:
 - the editor view will not be initialized
 - the editor will not emit it's `create` event
 - the focus will not move to it's first position

UNTIL, the `mount` function is called on the instance, which will mount the editor view to a DOM element. This obviously will not be allowed on the server which has no document object.

Therefore, this will work on the server:
```ts
import { Editor } from '@tiptap/core'
import StarterKit from '@tiptap/starter-kit'

const editor = new Editor({
  element: null,
  content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello, World!' }] }] },
  extensions: [StarterKit],
})

editor
  .chain()
  .selectAll()
  .setContent({ type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'XYZ' }] }] })
  .run()

console.log(editor.state.doc.toJSON())
// { type: 'doc', content: [ { type: 'paragraph', content: [ { type: 'text', text: 'XYZ' } ] } ] }
```
Any of these things will not work on the server, and result in a runtime error:
```ts
import { Editor } from '@tiptap/core'
import StarterKit from '@tiptap/starter-kit'

const editor = new Editor({
  // document will not be defined in a server environment
  element: document.createElement('div'),
  content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello, World!' }] }] },
  extensions: [StarterKit],
})

editor
  .chain()
  // focus is a command which depends on the editor-view, so it will not work in a server environment
  .focus()
  .run()

console.log(editor.getHTML())
// getHTML relies on the editor-view, so it will not work in a server environment
```

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
