### PR TITLE
refactor(core): update setContent command signature for better defaults

### DIFF
--- a/.changeset/moody-geckos-sort.md
+++ b/.changeset/moody-geckos-sort.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': major
+---
+
+`clearContent` command defaults to emitting updates now

--- a/.changeset/tidy-fireants-hang.md
+++ b/.changeset/tidy-fireants-hang.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': major
+---
+
+Change signature of `setContent` command to `(content, options)` and default to emitting updates

--- a/demos/src/Commands/SetContent/React/index.spec.js
+++ b/demos/src/Commands/SetContent/React/index.spec.js
@@ -47,12 +47,12 @@ context('/src/Commands/SetContent/React/', () => {
 
       editor.on('update', callback)
       // emit an update
-      editor.commands.setContent('Hello World.', true)
+      editor.commands.setContent('Hello World.', { emitUpdate: true })
       expect(updateCount).to.equal(1)
 
       updateCount = 0
       // do not emit an update
-      editor.commands.setContent('Hello World again.', false)
+      editor.commands.setContent('Hello World again.', { emitUpdate: false })
       expect(updateCount).to.equal(0)
       editor.off('update', callback)
     })
@@ -79,7 +79,7 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should keep newlines and tabs when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('<p>Hello\n\tworld\n\t\thow\n\t\t\tnice.</p>', false, { preserveWhitespace: 'full' })
+      editor.commands.setContent('<p>Hello\n\tworld\n\t\thow\n\t\t\tnice.</p>', { preserveWhitespace: 'full' })
       cy.get('.tiptap').should('contain.html', '<p>Hello\n\tworld\n\t\thow\n\t\t\tnice.</p>')
     })
   })
@@ -120,7 +120,7 @@ context('/src/Commands/SetContent/React/', () => {
   // This exists in insertContentAt as well
   it('should keep newlines and tabs between html fragments when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('<h1>Tiptap</h1>\n\t<p><strong>Hello World</strong></p>', false, {
+      editor.commands.setContent('<h1>Tiptap</h1>\n\t<p><strong>Hello World</strong></p>', {
         preserveWhitespace: 'full',
       })
       cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p>\n\t</p><p><strong>Hello World</strong></p>')
@@ -136,7 +136,7 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should allow inserting nothing when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('', false, { preserveWhitespace: 'full' })
+      editor.commands.setContent('', { preserveWhitespace: 'full' })
       cy.get('.tiptap').should('contain.html', '')
     })
   })
@@ -150,7 +150,7 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should allow inserting a partial HTML tag when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('<p>foo', false, { preserveWhitespace: 'full' })
+      editor.commands.setContent('<p>foo', { preserveWhitespace: 'full' })
       cy.get('.tiptap').should('contain.html', '<p>foo</p>')
     })
   })
@@ -166,7 +166,7 @@ context('/src/Commands/SetContent/React/', () => {
   // This exists in insertContentAt as well
   it('should allow inserting an incomplete HTML tag when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('foo<p', false, { preserveWhitespace: 'full' })
+      editor.commands.setContent('foo<p', { preserveWhitespace: 'full' })
       cy.get('.tiptap').should('contain.html', '<p>foo&lt;p</p>')
     })
   })
@@ -180,14 +180,14 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should allow inserting a list when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('<ul><li>ABC</li><li>123</li></ul>', false, { preserveWhitespace: 'full' })
+      editor.commands.setContent('<ul><li>ABC</li><li>123</li></ul>', { preserveWhitespace: 'full' })
       cy.get('.tiptap').should('contain.html', '<ul><li><p>ABC</p></li><li><p>123</p></li></ul>')
     })
   })
 
   it('should remove newlines and tabs when parseOptions.preserveWhitespace=false', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('\n<h1>Tiptap</h1><p><strong>Hello\n World</strong>\n</p>\n', false, {
+      editor.commands.setContent('\n<h1>Tiptap</h1><p><strong>Hello\n World</strong>\n</p>\n', {
         preserveWhitespace: false,
       })
       cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p><strong>Hello World</strong></p>')

--- a/demos/src/Commands/SetContent/React/index.spec.js
+++ b/demos/src/Commands/SetContent/React/index.spec.js
@@ -79,7 +79,9 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should keep newlines and tabs when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('<p>Hello\n\tworld\n\t\thow\n\t\t\tnice.</p>', { preserveWhitespace: 'full' })
+      editor.commands.setContent('<p>Hello\n\tworld\n\t\thow\n\t\t\tnice.</p>', {
+        parseOptions: { preserveWhitespace: 'full' },
+      })
       cy.get('.tiptap').should('contain.html', '<p>Hello\n\tworld\n\t\thow\n\t\t\tnice.</p>')
     })
   })
@@ -121,7 +123,9 @@ context('/src/Commands/SetContent/React/', () => {
   it('should keep newlines and tabs between html fragments when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
       editor.commands.setContent('<h1>Tiptap</h1>\n\t<p><strong>Hello World</strong></p>', {
-        preserveWhitespace: 'full',
+        parseOptions: {
+          preserveWhitespace: 'full',
+        },
       })
       cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p>\n\t</p><p><strong>Hello World</strong></p>')
     })
@@ -136,7 +140,7 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should allow inserting nothing when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('', { preserveWhitespace: 'full' })
+      editor.commands.setContent('', { parseOptions: { preserveWhitespace: 'full' } })
       cy.get('.tiptap').should('contain.html', '')
     })
   })
@@ -150,7 +154,7 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should allow inserting a partial HTML tag when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('<p>foo', { preserveWhitespace: 'full' })
+      editor.commands.setContent('<p>foo', { parseOptions: { preserveWhitespace: 'full' } })
       cy.get('.tiptap').should('contain.html', '<p>foo</p>')
     })
   })
@@ -166,7 +170,7 @@ context('/src/Commands/SetContent/React/', () => {
   // This exists in insertContentAt as well
   it('should allow inserting an incomplete HTML tag when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('foo<p', { preserveWhitespace: 'full' })
+      editor.commands.setContent('foo<p', { parseOptions: { preserveWhitespace: 'full' } })
       cy.get('.tiptap').should('contain.html', '<p>foo&lt;p</p>')
     })
   })
@@ -180,7 +184,7 @@ context('/src/Commands/SetContent/React/', () => {
 
   it('should allow inserting a list when preserveWhitespace = full', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
-      editor.commands.setContent('<ul><li>ABC</li><li>123</li></ul>', { preserveWhitespace: 'full' })
+      editor.commands.setContent('<ul><li>ABC</li><li>123</li></ul>', { parseOptions: { preserveWhitespace: 'full' } })
       cy.get('.tiptap').should('contain.html', '<ul><li><p>ABC</p></li><li><p>123</p></li></ul>')
     })
   })
@@ -188,7 +192,9 @@ context('/src/Commands/SetContent/React/', () => {
   it('should remove newlines and tabs when parseOptions.preserveWhitespace=false', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
       editor.commands.setContent('\n<h1>Tiptap</h1><p><strong>Hello\n World</strong>\n</p>\n', {
-        preserveWhitespace: false,
+        parseOptions: {
+          preserveWhitespace: false,
+        },
       })
       cy.get('.tiptap').should('contain.html', '<h1>Tiptap</h1><p><strong>Hello World</strong></p>')
     })

--- a/demos/src/GuideContent/ExportHTML/React/index.jsx
+++ b/demos/src/GuideContent/ExportHTML/React/index.jsx
@@ -37,7 +37,6 @@ export default () => {
           It’s 19871. You can’t turn on a radio, or go to a mall without hearing Olivia Newton-John’s hit song, Physical.
         </p>
       `,
-      true,
     )
 
     // It’s likely that you’d like to focus the Editor after most commands.

--- a/demos/src/GuideContent/ExportJSON/React/index.jsx
+++ b/demos/src/GuideContent/ExportJSON/React/index.jsx
@@ -31,23 +31,20 @@ export default () => {
 
   const setContent = useCallback(() => {
     // You can pass a JSON document to the editor.
-    editor.commands.setContent(
-      {
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: 'It’s 19871. You can’t turn on a radio, or go to a mall without hearing Olivia Newton-John’s hit song, Physical.',
-              },
-            ],
-          },
-        ],
-      },
-      true,
-    )
+    editor.commands.setContent({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'It’s 19871. You can’t turn on a radio, or go to a mall without hearing Olivia Newton-John’s hit song, Physical.',
+            },
+          ],
+        },
+      ],
+    })
 
     // It’s likely that you’d like to focus the Editor after most commands.
     editor.commands.focus()

--- a/demos/src/GuideContent/ExportJSON/Vue/index.vue
+++ b/demos/src/GuideContent/ExportJSON/Vue/index.vue
@@ -63,23 +63,20 @@ export default {
   methods: {
     setContent() {
       // You can pass a JSON document to the editor.
-      this.editor.commands.setContent(
-        {
-          type: 'doc',
-          content: [
-            {
-              type: 'paragraph',
-              content: [
-                {
-                  type: 'text',
-                  text: 'It’s 19871. You can’t turn on a radio, or go to a mall without hearing Olivia Newton-John’s hit song, Physical.',
-                },
-              ],
-            },
-          ],
-        },
-        true,
-      )
+      this.editor.commands.setContent({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'It’s 19871. You can’t turn on a radio, or go to a mall without hearing Olivia Newton-John’s hit song, Physical.',
+              },
+            ],
+          },
+        ],
+      })
 
       // It’s likely that you’d like to focus the Editor after most commands.
       this.editor.commands.focus()

--- a/demos/src/GuideContent/ReadOnly/React/index.spec.js
+++ b/demos/src/GuideContent/ReadOnly/React/index.spec.js
@@ -21,8 +21,8 @@ context('/src/GuideContent/ReadOnly/React/', () => {
   })
 
   it('should be editable', () => {
-    cy.get('.tiptap').then(([{ editor }]) => {
-      editor.setEditable(true)
+    cy.get('#editable').click()
+    cy.get('.tiptap').then(() => {
       cy.get('.tiptap').type('Edited: ')
 
       cy.get('.tiptap p:first').should('contain', 'Edited: ')

--- a/demos/src/GuideContent/ReadOnly/Vue/index.spec.js
+++ b/demos/src/GuideContent/ReadOnly/Vue/index.spec.js
@@ -19,8 +19,8 @@ context('/src/GuideContent/ReadOnly/Vue/', () => {
   })
 
   it('should be editable', () => {
-    cy.get('.tiptap').then(([{ editor }]) => {
-      editor.setEditable(true)
+    cy.get('#editable').click()
+    cy.get('.tiptap').then(() => {
       cy.get('.tiptap').type('Edited: ')
 
       cy.get('.tiptap p:first').should('contain', 'Edited: ')

--- a/demos/src/GuideGettingStarted/VModel/Vue/Editor.vue
+++ b/demos/src/GuideGettingStarted/VModel/Vue/Editor.vue
@@ -38,7 +38,7 @@ export default {
         return
       }
 
-      this.editor.commands.setContent(value, false)
+      this.editor.commands.setContent(value)
     },
   },
 

--- a/packages/core/src/commands/clearContent.ts
+++ b/packages/core/src/commands/clearContent.ts
@@ -5,16 +5,21 @@ declare module '@tiptap/core' {
     clearContent: {
       /**
        * Clear the whole document.
-       * @param emitUpdate Whether to emit an update event.
        * @example editor.commands.clearContent()
        */
-      clearContent: (emitUpdate?: boolean) => ReturnType
+      clearContent: (
+        /**
+         * Whether to emit an update event.
+         * @default true
+         */
+        emitUpdate?: boolean,
+      ) => ReturnType
     }
   }
 }
 
 export const clearContent: RawCommands['clearContent'] =
-  (emitUpdate = false) =>
+  (emitUpdate = true) =>
   ({ commands }) => {
-    return commands.setContent('', emitUpdate)
+    return commands.setContent('', { emitUpdate })
   }

--- a/packages/core/src/commands/setContent.ts
+++ b/packages/core/src/commands/setContent.ts
@@ -20,24 +20,25 @@ declare module '@tiptap/core' {
         content: Content | Fragment | ProseMirrorNode,
 
         /**
-         * Whether to emit an update event.
-         * @default false
-         */
-        emitUpdate?: boolean,
-
-        /**
-         * Options for parsing the content.
-         * @default {}
-         */
-        parseOptions?: ParseOptions,
-        /**
          * Options for `setContent`.
          */
         options?: {
           /**
+           * Options for parsing the content.
+           * @default {}
+           */
+          parseOptions?: ParseOptions
+
+          /**
            * Whether to throw an error if the content is invalid.
            */
           errorOnInvalidContent?: boolean
+
+          /**
+           * Whether to emit an update event.
+           * @default true
+           */
+          emitUpdate?: boolean
         },
       ) => ReturnType
     }
@@ -45,7 +46,7 @@ declare module '@tiptap/core' {
 }
 
 export const setContent: RawCommands['setContent'] =
-  (content, emitUpdate = false, parseOptions = {}, options = {}) =>
+  (content, { errorOnInvalidContent, emitUpdate = true, parseOptions = {} } = {}) =>
   ({ editor, tr, dispatch, commands }) => {
     const { doc } = tr
 
@@ -53,7 +54,7 @@ export const setContent: RawCommands['setContent'] =
     // TODO remove this in the next major version
     if (parseOptions.preserveWhitespace !== 'full') {
       const document = createDocument(content, editor.schema, parseOptions, {
-        errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
+        errorOnInvalidContent: errorOnInvalidContent ?? editor.options.enableContentCheck,
       })
 
       if (dispatch) {
@@ -68,6 +69,6 @@ export const setContent: RawCommands['setContent'] =
 
     return commands.insertContentAt({ from: 0, to: doc.content.size }, content, {
       parseOptions,
-      errorOnInvalidContent: options.errorOnInvalidContent ?? editor.options.enableContentCheck,
+      errorOnInvalidContent: errorOnInvalidContent ?? editor.options.enableContentCheck,
     })
   }


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
The current setContent command signature was a bit strange, why would it default to NOT emitting updates? Why was the signature a bunch of options as separate arguments.

This cleans up the function signature and uses a better default
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
