### PR TITLE
Modify the TextAlign extension documentation so that the default value of the defaultAlignment option matches the code

### DIFF
--- a/.changeset/yellow-hairs-search.md
+++ b/.changeset/yellow-hairs-search.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-text-align": patch
+---
+
+Modify the documentation of the default value of defaultAlignment so that it matches the code

--- a/packages/extension-text-align/src/text-align.ts
+++ b/packages/extension-text-align/src/text-align.ts
@@ -17,7 +17,7 @@ export interface TextAlignOptions {
 
   /**
    * The default alignment.
-   * @default 'left'
+   * @default null
    * @example 'center'
    */
   defaultAlignment: string | null,


### PR DESCRIPTION
The default value of `defaultAlignment` is `null` in the code. Modify the documentation so that it matches the value in the code.

## Changes Overview
In the code of the TextAlign extension, the default value of the `defaultAlignment` property is `null`.

However, the documentation of the property says that its default value is `"left"`. The documentation does not match the code. By default, if the `defaultAlignment` property is not configured, the text alignment of a block is unset.

One might argue that, if the text alignment of a block is unset, its alignment is left in practice, but this is not always true. For example, if the parent element of the text editor has right text alignment, the text blocks will have right alignment too.

## Implementation Approach
Modify the documentation

## Testing Done
There were no changes to the code, only in the documentation. The testing consists in verifying that the documentation has changed.

## Verification Steps
Read the documentation of the `defaultAlignment` property

## Additional Notes
None

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
None
