### PR TITLE
use @tiptap/y-tiptap instead of y-prosemirror

### DIFF
--- a/.changeset/eighty-gifts-matter.md
+++ b/.changeset/eighty-gifts-matter.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-collaboration-cursor': major
+'@tiptap/extension-collaboration': major
+---
+
+Replaced y-prosemirror with @tiptap/y-tiptap

--- a/demos/package.json
+++ b/demos/package.json
@@ -15,6 +15,7 @@
     "@lexical/react": "^0.11.3",
     "@lifeomic/attempt": "3.1.0",
     "@shikijs/core": "1.10.3",
+    "@tiptap/y-tiptap": "^1.0.0",
     "d3": "^7.9.0",
     "fast-glob": "^3.3.2",
     "highlight.js": "^11.11.1",
@@ -41,7 +42,6 @@
     "prosemirror-view": "^1.37.1",
     "remixicon": "^2.5.0",
     "shiki": "^1.25.1",
-    "y-prosemirror": "^1.2.15",
     "y-webrtc": "10.3.0",
     "yjs": "13.6.23"
   },

--- a/demos/src/Experiments/CollaborationAnnotation/Vue/extension/AnnotationState.ts
+++ b/demos/src/Experiments/CollaborationAnnotation/Vue/extension/AnnotationState.ts
@@ -1,6 +1,10 @@
 import { EditorState, Transaction } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
-import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, ySyncPluginKey } from 'y-prosemirror'
+import {
+  absolutePositionToRelativePosition,
+  relativePositionToAbsolutePosition,
+  ySyncPluginKey,
+} from '@tiptap/y-tiptap'
 import * as Y from 'yjs'
 
 import { AnnotationItem } from './AnnotationItem.js'

--- a/demos/src/Experiments/MultipleEditors/Vue/index.vue
+++ b/demos/src/Experiments/MultipleEditors/Vue/index.vue
@@ -38,7 +38,7 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Dropcursor } from '@tiptap/extensions'
 import { Editor, EditorContent } from '@tiptap/vue-3'
-import { yDocToProsemirrorJSON } from 'y-prosemirror'
+import { yDocToProsemirrorJSON } from '@tiptap/y-tiptap'
 import * as Y from 'yjs'
 
 const HeadingDocument = Document.extend({

--- a/packages/extension-collaboration-cursor/package.json
+++ b/packages/extension-collaboration-cursor/package.json
@@ -33,12 +33,12 @@
   "devDependencies": {
     "@tiptap/core": "^3.0.0-next.4",
     "@tiptap/pm": "^3.0.0-next.4",
-    "y-prosemirror": "^1.2.15"
+    "@tiptap/y-tiptap": "^1.0.0"
   },
   "peerDependencies": {
     "@tiptap/core": "^3.0.0-next.3",
     "@tiptap/pm": "^3.0.0-next.3",
-    "y-prosemirror": "^1.2.6"
+    "@tiptap/y-tiptap": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
+++ b/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
 import { DecorationAttrs } from '@tiptap/pm/view'
-import { defaultSelectionBuilder, yCursorPlugin } from 'y-prosemirror'
+import { defaultSelectionBuilder, yCursorPlugin } from '@tiptap/y-tiptap'
 
 type CollaborationCursorStorage = {
   users: { clientId: number; [key: string]: any }[]

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -33,12 +33,12 @@
   "devDependencies": {
     "@tiptap/core": "^3.0.0-next.4",
     "@tiptap/pm": "^3.0.0-next.4",
-    "y-prosemirror": "^1.2.15"
+    "@tiptap/y-tiptap": "^1.0.0"
   },
   "peerDependencies": {
     "@tiptap/core": "^3.0.0-next.1",
     "@tiptap/pm": "^3.0.0-next.1",
-    "y-prosemirror": "^1.2.6",
+    "@tiptap/y-tiptap": "^1.0.0",
     "yjs": "^13"
   },
   "repository": {

--- a/packages/extension-collaboration/src/collaboration.ts
+++ b/packages/extension-collaboration/src/collaboration.ts
@@ -1,7 +1,7 @@
 import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { EditorView } from '@tiptap/pm/view'
-import { redo, undo, ySyncPlugin, yUndoPlugin, yUndoPluginKey, yXmlFragmentToProsemirrorJSON } from 'y-prosemirror'
+import { redo, undo, ySyncPlugin, yUndoPlugin, yUndoPluginKey, yXmlFragmentToProsemirrorJSON } from '@tiptap/y-tiptap'
 import { Doc, UndoManager, XmlFragment } from 'yjs'
 
 type YSyncOpts = Parameters<typeof ySyncPlugin>[1]

--- a/packages/extension-collaboration/src/helpers/isChangeOrigin.ts
+++ b/packages/extension-collaboration/src/helpers/isChangeOrigin.ts
@@ -1,5 +1,5 @@
 import { Transaction } from '@tiptap/pm/state'
-import { ySyncPluginKey } from 'y-prosemirror'
+import { ySyncPluginKey } from '@tiptap/y-tiptap'
 
 /**
  * Checks if a transaction was originated from a Yjs change.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@shikijs/core':
         specifier: 1.10.3
         version: 1.10.3
+      '@tiptap/y-tiptap':
+        specifier: ^1.0.0
+        version: 1.0.0(@tiptap/pm@packages+pm)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -224,9 +227,6 @@ importers:
       shiki:
         specifier: ^1.25.1
         version: 1.29.1
-      y-prosemirror:
-        specifier: ^1.2.15
-        version: 1.2.15(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.37.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
       y-webrtc:
         specifier: 10.3.0
         version: 10.3.0(yjs@13.6.23)
@@ -387,9 +387,9 @@ importers:
       '@tiptap/pm':
         specifier: ^3.0.0-next.4
         version: link:../pm
-      y-prosemirror:
-        specifier: ^1.2.15
-        version: 1.2.15(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.37.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+      '@tiptap/y-tiptap':
+        specifier: ^1.0.0
+        version: 1.0.0(@tiptap/pm@packages+pm)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-collaboration-cursor:
     devDependencies:
@@ -399,9 +399,9 @@ importers:
       '@tiptap/pm':
         specifier: ^3.0.0-next.4
         version: link:../pm
-      y-prosemirror:
-        specifier: ^1.2.15
-        version: 1.2.15(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.37.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+      '@tiptap/y-tiptap':
+        specifier: ^1.0.0
+        version: 1.0.0(@tiptap/pm@packages+pm)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-color:
     devDependencies:
@@ -2438,6 +2438,14 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@tiptap/y-tiptap@1.0.0':
+    resolution: {integrity: sha512-Gr4zBSZAOqUAbWSQ/4AfTWX9rXuAkPmM5406vg6X4rB0hToVbmCHXvbxzh7uLMW0Rlwpe+Eo6jMam2ZC3p1BgA==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      '@tiptap/pm': ^2.11.3
+      y-protocols: ^1.0.1
+      yjs: ^13.5.38
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -6136,16 +6144,6 @@ packages:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
 
-  y-prosemirror@1.2.15:
-    resolution: {integrity: sha512-XDdrytq2M5bIy3qusQvfRclLu2eWZYPA+BbGWAb9FFWEhOB5FCrnzez2vsA+gvAd0FJTAcr89mjJ5g45r0j7TQ==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
-    peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
-      y-protocols: ^1.0.1
-      yjs: ^13.5.38
-
   y-protocols@1.0.6:
     resolution: {integrity: sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
@@ -7926,6 +7924,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@tiptap/y-tiptap@1.0.0(@tiptap/pm@packages+pm)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
+    dependencies:
+      '@tiptap/pm': link:packages/pm
+      lib0: 0.2.99
+      y-protocols: 1.0.6(yjs@13.6.23)
+      yjs: 13.6.23
 
   '@types/aria-query@5.0.4': {}
 
@@ -12056,15 +12061,6 @@ snapshots:
   ws@8.18.0: {}
 
   xml-name-validator@4.0.0: {}
-
-  y-prosemirror@1.2.15(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.37.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23):
-    dependencies:
-      lib0: 0.2.99
-      prosemirror-model: 1.24.1
-      prosemirror-state: 1.4.3
-      prosemirror-view: 1.37.1
-      y-protocols: 1.0.6(yjs@13.6.23)
-      yjs: 13.6.23
 
   y-protocols@1.0.6(yjs@13.6.23):
     dependencies:


### PR DESCRIPTION
## AI Summary

This pull request focuses on replacing the `y-prosemirror` package with the `@tiptap/y-tiptap` package across various files and configurations. The changes ensure consistency and compatibility with the updated package.

### Package Replacement:

* [`demos/package.json`](diffhunk://#diff-2759f93cee6a28002b544bc4f705b4890d72bbb85eea0d7ff670da00277e70f4R18): Added `@tiptap/y-tiptap` and removed `y-prosemirror`. [[1]](diffhunk://#diff-2759f93cee6a28002b544bc4f705b4890d72bbb85eea0d7ff670da00277e70f4R18) [[2]](diffhunk://#diff-2759f93cee6a28002b544bc4f705b4890d72bbb85eea0d7ff670da00277e70f4L44)
* [`packages/extension-collaboration-cursor/package.json`](diffhunk://#diff-c973c19872ef6828b7fa6f3c72e514c0b787c0dc3aeddbb00fca92b442f85a02L36-R41): Replaced `y-prosemirror` with `@tiptap/y-tiptap` in both `devDependencies` and `peerDependencies`.
* [`packages/extension-collaboration/package.json`](diffhunk://#diff-eb960c703ad1fedab0ab673c2aa94fcd4afcfd79742407083e99aa9aa52e09b3L36-R41): Replaced `y-prosemirror` with `@tiptap/y-tiptap` in both `devDependencies` and `peerDependencies`.

### Import Statement Updates:

* [`demos/src/Experiments/CollaborationAnnotation/Vue/extension/AnnotationState.ts`](diffhunk://#diff-ce99f37aa956aed0f3497acf0d57b1c11b5da53c7b2a6aa970e7830a3dd88451L3-R7): Updated import statements to use `@tiptap/y-tiptap`.
* [`demos/src/Experiments/MultipleEditors/Vue/index.vue`](diffhunk://#diff-1724b99537baee9d4847d55c3fa34dfe0d0baa58512f0b1a6f76f3254267741cL41-R41): Updated import statements to use `@tiptap/y-tiptap`.
* [`packages/extension-collaboration-cursor/src/collaboration-cursor.ts`](diffhunk://#diff-b21ce82aceb85fefdaea2e6ac2db22122df97504a0318c436d68e6366d8cd343L3-R3): Updated import statements to use `@tiptap/y-tiptap`.
* [`packages/extension-collaboration/src/collaboration.ts`](diffhunk://#diff-55494469bf2776f1b238660c1492cc307a94eaa58e0c6522f57d6a8e743b12cdL4-R4): Updated import statements to use `@tiptap/y-tiptap`.
* [`packages/extension-collaboration/src/helpers/isChangeOrigin.ts`](diffhunk://#diff-d82f6d5debc378d0214a2b1a01dfff729a068a963e3b4937405ec0690a6f256dL2-R2): Updated import statements to use `@tiptap/y-tiptap`.

### Configuration Updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR149-R151): Added `@tiptap/y-tiptap` and removed `y-prosemirror` from various sections, ensuring the lockfile reflects the updated dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR149-R151) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL227-L229) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL390-R392) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL402-R404) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2442-R2449) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6139-L6148) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7928-R7934) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12060-L12068)

## Implementation Approach
This is a 1:1 drop-in replacement for y-prosemirror so I didn't need to do any specific implementations.

## Testing Done
I made sure that all tests are still successful and tested it locally on my collaboration demos.

## Verification Steps
See above 

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
