### PR TITLE
fix(extension-link): update regex to allow numbers in URI

### DIFF
--- a/.changeset/three-crabs-beg.md
+++ b/.changeset/three-crabs-beg.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-link": patch
+---
+
+Added support for numbers in email addresses.

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -191,7 +191,7 @@ export function isAllowedUri(uri: string | undefined, protocols?: LinkOptions['p
       .match(
         new RegExp(
           // eslint-disable-next-line no-useless-escape
-          `^(?:(?:${allowedProtocols.join('|')}):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))`,
+          `^(?:(?:${allowedProtocols.join('|')}):|[^a-z]|[a-z0-9+.\-]+(?:[^a-z+.\-:]|$))`,
           'i',
         ),
       )


### PR DESCRIPTION
## Changes Overview
This PR allows numbers in links, especially in emails. Before something like test1@example.com did not work.