### PR TITLE
upgrade prosemirror-tables to 1.6.3

### DIFF
--- a/.changeset/tricky-apples-design.md
+++ b/.changeset/tricky-apples-design.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/pm": patch
+"tiptap-demos": patch
+---
+
+Upgraded prosemirror-tables to 1.6.3 to fix cells being resizable while the editor is uneditable

--- a/package-lock.json
+++ b/package-lock.json
@@ -15359,9 +15359,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.23.0.tgz",
-      "integrity": "sha512-Q/fgsgl/dlOAW9ILu4OOhYWQbc7TQd4BwKH/RwmUjyVf8682Be4zj3rOYdLnYEcGzyg8LL9Q5IWYKD8tdToreQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.24.1.tgz",
+      "integrity": "sha512-YM053N+vTThzlWJ/AtPtF1j0ebO36nvbmDy4U7qA2XQB8JVaQp1FmB9Jhrps8s+z+uxhhVTny4m20ptUvhk0Mg==",
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
@@ -15396,6 +15396,19 @@
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
         "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.6.3.tgz",
+      "integrity": "sha512-8B0X6PjAkXaHKntKndetNquxLIhWDDTybON1N4flKMY9Bq8/rm5k2ddW6X6LvFpqJBQeiKRp4yG3FqI/zOyQuA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.37.1"
       }
     },
     "node_modules/prosemirror-trailing-node": {
@@ -15435,9 +15448,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.37.0.tgz",
-      "integrity": "sha512-z2nkKI1sJzyi7T47Ji/ewBPuIma1RNvQCCYVdV+MqWBV7o4Sa1n94UJCJJ1aQRF/xRkFfyqLGlGFWitIcCOtbg==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.37.2.tgz",
+      "integrity": "sha512-ApcyrfV/cRcaL65on7TQcfWElwLyOgIjnIynfAuV+fIdlpbSvSWRwfuPaH7T5mo4AbO/FID29qOtjiDIKGWyog==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.20.0",
@@ -20470,7 +20483,7 @@
         "prosemirror-schema-basic": "^1.2.3",
         "prosemirror-schema-list": "^1.4.1",
         "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.1",
+        "prosemirror-tables": "^1.6.3",
         "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.2",
         "prosemirror-view": "^1.37.0"
@@ -20489,19 +20502,6 @@
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
         "prosemirror-model": "^1.20.0"
-      }
-    },
-    "packages/pm/node_modules/prosemirror-tables": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.6.1.tgz",
-      "integrity": "sha512-p8WRJNA96jaNQjhJolmbxTzd6M4huRE5xQ8OxjvMhQUP0Nzpo4zz6TztEiwk6aoqGBhz9lxRWR1yRZLlpQN98w==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
       }
     },
     "packages/react": {

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -140,7 +140,7 @@
     "prosemirror-schema-basic": "^1.2.3",
     "prosemirror-schema-list": "^1.4.1",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-tables": "^1.6.1",
+    "prosemirror-tables": "^1.6.3",
     "prosemirror-trailing-node": "^3.0.0",
     "prosemirror-transform": "^1.10.2",
     "prosemirror-view": "^1.37.0"


### PR DESCRIPTION
## Changes Overview
This PR upgrades prosemirror-tables to 1.6.3 to fix an issue with cells being resizable when the editor is uneditable.

### AI Summary

This pull request includes an upgrade to the `prosemirror-tables` dependency to address a specific issue with table cell resizing in the editor. The most important changes include updating the version of `prosemirror-tables` in the package file and documenting the upgrade in the changelog.

Dependency updates:

* [`packages/pm/package.json`](diffhunk://#diff-1ff088f5119ba6763199900bf03abb875b773a3a12c0cec1c463396b60d8243cL143-R143): Upgraded `prosemirror-tables` from version 1.6.1 to 1.6.3 to fix an issue where cells were resizable while the editor was uneditable.

Documentation:

* [`.changeset/tricky-apples-design.md`](diffhunk://#diff-c1379d108abe83650d91dd6076b202a656bcb9aa5c68508f6bc48231b3657f0fR1-R6): Added a changelog entry to document the upgrade of `prosemirror-tables` to version 1.6.3.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
