### PR TITLE
upgrade prosemirror-tables to 1.6.4 (fixes #6074)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15398,19 +15398,6 @@
         "prosemirror-view": "^1.27.0"
       }
     },
-    "node_modules/prosemirror-tables": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.6.3.tgz",
-      "integrity": "sha512-8B0X6PjAkXaHKntKndetNquxLIhWDDTybON1N4flKMY9Bq8/rm5k2ddW6X6LvFpqJBQeiKRp4yG3FqI/zOyQuA==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.37.1"
-      }
-    },
     "node_modules/prosemirror-trailing-node": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
@@ -20483,7 +20470,7 @@
         "prosemirror-schema-basic": "^1.2.3",
         "prosemirror-schema-list": "^1.4.1",
         "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.3",
+        "prosemirror-tables": "^1.6.4",
         "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.2",
         "prosemirror-view": "^1.37.0"
@@ -20502,6 +20489,19 @@
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
         "prosemirror-model": "^1.20.0"
+      }
+    },
+    "packages/pm/node_modules/prosemirror-tables": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.6.4.tgz",
+      "integrity": "sha512-TkDY3Gw52gRFRfRn2f4wJv5WOgAOXLJA2CQJYIJ5+kdFbfj3acR4JUW6LX2e1hiEBiUwvEhzH5a3cZ5YSztpIA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.37.2"
       }
     },
     "packages/react": {

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -140,7 +140,7 @@
     "prosemirror-schema-basic": "^1.2.3",
     "prosemirror-schema-list": "^1.4.1",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-tables": "^1.6.3",
+    "prosemirror-tables": "^1.6.4",
     "prosemirror-trailing-node": "^3.0.0",
     "prosemirror-transform": "^1.10.2",
     "prosemirror-view": "^1.37.0"


### PR DESCRIPTION
## Changes Overview

Just a dependency upgrade to fix a bug with tables - #6074.

PR in prosemirror-tables:
https://github.com/ProseMirror/prosemirror-tables/pull/267
