### PR TITLE
feat(text-align): add toggle command

### DIFF
--- a/.changeset/spotty-cobras-shake.md
+++ b/.changeset/spotty-cobras-shake.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-text-align": major
+---
+
+Add command `toggleTextAlign`

--- a/.changeset/spotty-cobras-shake.md
+++ b/.changeset/spotty-cobras-shake.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-text-align": major
 ---
 
-Add command `toggleTextAlign`
+Added new `toggleTextAlign` command to TextAlign extension to make toggling text alignments easier to handle

--- a/demos/src/Extensions/TextAlign/React/index.jsx
+++ b/demos/src/Extensions/TextAlign/React/index.jsx
@@ -62,6 +62,12 @@ export default () => {
             Unset text align
           </button>
           <button
+            onClick={() => editor.chain().focus().toggleTextAlign('right').run()}
+            className={editor.isActive({ textAlign: 'right' }) ? 'is-active' : ''}
+          >
+            Toggle Right
+          </button>
+          <button
             onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
             className={editor.isActive({ level: 1 }) ? 'is-active' : ''}
           >

--- a/demos/src/Extensions/TextAlign/React/index.spec.js
+++ b/demos/src/Extensions/TextAlign/React/index.spec.js
@@ -89,6 +89,14 @@ context('/src/Extensions/TextAlign/React/', () => {
     cy.get('.tiptap').find('p').should('not.have.css', 'text-align', 'left')
   })
 
+  it('toggle the text to right on the 6rd button', () => {
+    cy.get('button:nth-child(6)').click()
+    cy.get('.tiptap').find('p').should('not.have.css', 'text-align', 'right')
+
+    cy.get('button:nth-child(6)').click()
+    cy.get('.tiptap').find('p').should('not.have.css', 'text-align', 'left')
+  })
+
   it('aligns the text left when pressing the keyboard shortcut', () => {
     cy.get('.tiptap')
       .trigger('keydown', { modKey: true, shiftKey: true, key: 'l' })

--- a/demos/src/Extensions/TextAlign/Vue/index.spec.js
+++ b/demos/src/Extensions/TextAlign/Vue/index.spec.js
@@ -104,6 +104,22 @@ context('/src/Extensions/TextAlign/Vue/', () => {
       .should('not.have.css', 'text-align', 'left')
   })
 
+  it('toggle the text to right on the 6rd button', () => {
+    cy.get('button:nth-child(6)')
+      .click()
+
+    cy.get('.tiptap')
+      .find('p')
+      .should('have.css', 'text-align', 'right')
+
+    cy.get('button:nth-child(6)')
+      .click()
+
+    cy.get('.tiptap')
+      .find('p')
+      .should('have.css', 'text-align', 'left')
+  })
+
   it('aligns the text left when pressing the keyboard shortcut', () => {
     cy.get('.tiptap')
       .trigger('keydown', { modKey: true, shiftKey: true, key: 'l' })

--- a/demos/src/Extensions/TextAlign/Vue/index.vue
+++ b/demos/src/Extensions/TextAlign/Vue/index.vue
@@ -17,6 +17,9 @@
         <button @click="editor.chain().focus().unsetTextAlign().run()">
           Unset text align
         </button>
+        <button @click="editor.chain().focus().toggleTextAlign('right').run()" :class="{ 'is-active': editor.isActive({ textAlign: 'right' }) }">
+          Toggle Right
+        </button>
       </div>
     </div>
     <editor-content :editor="editor" />

--- a/packages/extension-text-align/src/text-align.ts
+++ b/packages/extension-text-align/src/text-align.ts
@@ -37,6 +37,12 @@ declare module '@tiptap/core' {
        * @example editor.commands.unsetTextAlign()
        */
       unsetTextAlign: () => ReturnType,
+      /**
+       * Toggle the text align attribute
+       * @param alignment The alignment
+       * @example editor.commands.toggleTextAlign('right')
+       */
+      toggleTextAlign: (alignment: string) => ReturnType,
     }
   }
 }
@@ -97,6 +103,17 @@ export const TextAlign = Extension.create<TextAlignOptions>({
         return this.options.types
           .map(type => commands.resetAttributes(type, 'textAlign'))
           .every(response => response)
+      },
+
+      toggleTextAlign: alignment => ({ editor, commands }) => {
+        if (!this.options.alignments.includes(alignment)) {
+          return false
+        }
+
+        if (editor.isActive({ textAlign: alignment })) {
+          return commands.unsetTextAlign()
+        }
+        return commands.setTextAlign(alignment)
       },
     }
   },


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

when I write a toolbar component. I found most format can use togglexxx to switch format state. but text align need manual judgment and setting. I add `toggleTextAlign` that can switch align state easily

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
