### PR TITLE
Strongly typed extension storage

### DIFF
--- a/.changeset/happy-squids-glow.md
+++ b/.changeset/happy-squids-glow.md
@@ -1,0 +1,8 @@
+---
+"@tiptap/core": minor
+"@tiptap/extension-character-count": minor
+"@tiptap/extension-collaboration": minor
+"@tiptap/extension-collaboration-cursor": minor
+---
+
+Allow the type of the extensionStorage field of the Editor class to be customizable

--- a/demos/src/Experiments/ExtensionStorage/React/CustomExtension.ts
+++ b/demos/src/Experiments/ExtensionStorage/React/CustomExtension.ts
@@ -4,6 +4,12 @@ type CustomStorage = {
   foo: number,
 }
 
+declare module '@tiptap/core' {
+  interface ExtensionStorage {
+    custom: CustomStorage;
+  }
+}
+
 export const CustomExtension = Extension.create<any, CustomStorage>({
   name: 'custom',
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -25,6 +25,7 @@ import { getTextSerializersFromSchema } from './helpers/getTextSerializersFromSc
 import { isActive } from './helpers/isActive.js'
 import { isNodeEmpty } from './helpers/isNodeEmpty.js'
 import { resolveFocusPosition } from './helpers/resolveFocusPosition.js'
+import { ExtensionStorage } from './index.js'
 import { NodePos } from './NodePos.js'
 import { style } from './style.js'
 import {
@@ -64,7 +65,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    */
   public isInitialized = false
 
-  public extensionStorage: Record<string, any> = {}
+  public extensionStorage: ExtensionStorage | Record<string, any> = {}
 
   public options: EditorOptions = {
     element: document.createElement('div'),
@@ -129,7 +130,7 @@ export class Editor extends EventEmitter<EditorEvents> {
   /**
    * Returns the editor storage.
    */
-  public get storage(): Record<string, any> {
+  public get storage(): ExtensionStorage | Record<string, any> {
     return this.extensionStorage
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,9 @@ export * from './utilities/index.js'
 export interface Commands<ReturnType = any> {}
 
 // eslint-disable-next-line
+export interface ExtensionStorage {}
+
+// eslint-disable-next-line
 export interface ExtensionConfig<Options = any, Storage = any> {}
 
 // eslint-disable-next-line

--- a/packages/extension-character-count/src/character-count.ts
+++ b/packages/extension-character-count/src/character-count.ts
@@ -47,6 +47,12 @@ export interface CharacterCountStorage {
   words: (options?: { node?: ProseMirrorNode }) => number
 }
 
+declare module '@tiptap/core' {
+  interface ExtensionStorage {
+    characterCount: CharacterCountStorage;
+  }
+}
+
 /**
  * This extension allows you to count the characters and words of your document.
  * @see https://tiptap.dev/api/extensions/character-count

--- a/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
+++ b/packages/extension-collaboration-cursor/src/collaboration-cursor.ts
@@ -76,6 +76,10 @@ declare module '@tiptap/core' {
       user: (attributes: Record<string, any>) => ReturnType,
     }
   }
+
+  interface ExtensionStorage {
+    collaborationCursor: CollaborationCursorStorage
+  }
 }
 
 const awarenessStatesToArray = (states: Map<number, Record<string, any>>) => {

--- a/packages/extension-collaboration/src/collaboration.ts
+++ b/packages/extension-collaboration/src/collaboration.ts
@@ -29,6 +29,10 @@ declare module '@tiptap/core' {
       redo: () => ReturnType;
     };
   }
+
+  interface ExtensionStorage {
+    collaboration: CollaborationStorage;
+  }
 }
 
 export interface CollaborationStorage {


### PR DESCRIPTION
## Changes Overview
Allow the type of the extensionStorage field of the Editor class to be customizable.

### Usage (Example with characterCount extension)

```ts
declare module '@tiptap/core' {
  interface ExtensionStorage {
    characterCount: CharacterCountStorage;
  }
}
```

## Implementation Approach

Create a new `ExtionsionStorage` interface in `@tiptap/core`. This type works very similar to the `Commands` interface: it can be extended and customized inside the extension code.

## Testing Done
The runtime code has not been changed. Only the types.

## Verification Steps
Check the types of the `Editor.extensionStorage` field.

## Additional Notes
This feature is a proposal and it is still under discussion so the maintainers might decide that it is not necessary. Tell me if you like it/hate it, feedback is welcome.

The type of the `Editor.extensionStorage` field is set to `ExtensionStorage | Record<string, any>` instead of `ExtensionStorage` so that it accounts for extensions where the types have not been set.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

[Discussion](https://github.com/ueberdosis/tiptap/discussions/6113)
