### PR TITLE
Bdbch/reinstigate aria label

### DIFF
--- a/.changeset/few-lies-rule.md
+++ b/.changeset/few-lies-rule.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Reinstigated the aria-label to the editor DOM element

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -364,6 +364,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       attributes: {
         // add `role="textbox"` to the editor element
         role: 'textbox',
+        'aria-label': 'Rich-Text Editor',
         ...this.options.editorProps?.attributes,
       },
       dispatchTransaction: this.dispatchTransaction.bind(this),


### PR DESCRIPTION
## Changes Overview
We removed the aria-label a few versions ago, implemented a role to the editor but now needed the aria-label back by default. This PR reinstigates it.

## Implementation Approach
Very simple - added the aria-label attribute.

## Testing Done
Tested it locally

## Verification Steps
See above

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
