### PR TITLE
starter kit: add missing dependency

### DIFF
--- a/packages/starter-kit/package.json
+++ b/packages/starter-kit/package.json
@@ -45,6 +45,7 @@
     "@tiptap/extension-horizontal-rule": "^3.0.0-next.6",
     "@tiptap/extension-italic": "^3.0.0-next.6",
     "@tiptap/extension-link": "^3.0.0-next.6",
+    "@tiptap/extension-list": "^3.0.0-next.6",
     "@tiptap/extension-list-item": "^3.0.0-next.6",
     "@tiptap/extension-list-keymap": "^3.0.0-next.6",
     "@tiptap/extension-ordered-list": "^3.0.0-next.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,6 +841,9 @@ importers:
       '@tiptap/extension-link':
         specifier: ^3.0.0-next.6
         version: link:../extension-link
+      '@tiptap/extension-list':
+        specifier: ^3.0.0-next.6
+        version: link:../extension-list
       '@tiptap/extension-list-item':
         specifier: ^3.0.0-next.6
         version: link:../../packages-deprecated/extension-list-item


### PR DESCRIPTION
## Changes Overview
StarterKit fails to load b/c it's missing `extension-list`

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

