### PR TITLE
Rename focus extension default export from FocusClasses to Focus

### DIFF
--- a/.changeset/purple-wasps-jam.md
+++ b/.changeset/purple-wasps-jam.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-focus": patch
+---
+
+Rename focus extension default export from FocusClasses to Focus

--- a/packages/extension-focus/src/focus.ts
+++ b/packages/extension-focus/src/focus.ts
@@ -27,7 +27,7 @@ export interface FocusOptions {
  * This extension allows you to add a class to the focused node.
  * @see https://www.tiptap.dev/api/extensions/focus
  */
-export const FocusClasses = Extension.create<FocusOptions>({
+export const Focus = Extension.create<FocusOptions>({
   name: 'focus',
 
   addOptions() {

--- a/packages/extension-focus/src/index.ts
+++ b/packages/extension-focus/src/index.ts
@@ -1,5 +1,5 @@
-import { FocusClasses } from './focus.js'
+import { Focus } from './focus.js'
 
 export * from './focus.js'
 
-export default FocusClasses
+export default Focus


### PR DESCRIPTION
## Changes Overview
The Focus extension is exported as FocusClasses instead of Focus. This breaks autocomplete, so when I type "Focus" my code editor does not autocomplete the import as Focus extension. Instead, it autocompletes it as FocusClasses. Which contradicts the documentation.

## Implementation Approach
Rename the imports in the extension code.

## Testing Done
Run tests. Does not introduce new tests.

## Verification Steps
The default export is Focus instead of FocusClasses

## Additional Notes
The bug was found by user  @sparrow-chik-chrk in this PR: https://github.com/ueberdosis/tiptap-docs/pull/92

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap-docs/pull/92