### PR TITLE
fix: use null in ordered list's default type value

### DIFF
--- a/.changeset/shiny-rabbits-invite.md
+++ b/.changeset/shiny-rabbits-invite.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-ordered-list": patch
+---
+
+Use null in ordered list's default type value for better schema extension support

--- a/packages/extension-ordered-list/src/ordered-list.ts
+++ b/packages/extension-ordered-list/src/ordered-list.ts
@@ -85,7 +85,7 @@ export const OrderedList = Node.create<OrderedListOptions>({
         },
       },
       type: {
-        default: undefined,
+        default: null,
         parseHTML: element => element.getAttribute('type'),
       },
     }


### PR DESCRIPTION
## Changes Overview

Use `null` for the default type value, instead of `undefined`.

This has no implication on the usual flows, but fixes an issue when exporting & importing the schema as JSON, as `undefined` is not a valid value in JSON.

It would lead to "RangeError: No value supplied for attribute type" when using the exported schema e.g. in `prosemirrorJSONToYDoc` from y-prosemirror.

## Testing Done

Used the patched OrderedList in my projects & I've seen no changes in behaviour or issues.

## Verification Steps

Tested the schema export via this script:

```
const spec = {
  nodes: {},
  marks: {},
};
schema.spec.nodes.forEach((key, value) => (spec.nodes[key] = value));
schema.spec.marks.forEach((key, value) => (spec.marks[key] = value));
exportedSchema = JSON.stringify(spec);
```

Which now exports the schema correctly & I can use it for e.g. the function `prosemirrorJSONToYDoc` from y-prosemirror to parse document JSONs that include ordered lists. 

This failed before with "RangeError: No value supplied for attribute type"

I used this workaround which replaces undefined values with null, before adding the patch of this PR:
```
exportedSchema = JSON.stringify(spec, function (k, v) {
    return v === undefined ? null : v;
  })
```

This fixes my issue as well, but I thought a patch to the package would be beneficial.


## Additional Notes

Maybe I'm missing something that this change could have a downstream impact on. Any thoughts of an experienced tiptap maintainer would be very welcome!

