### PR TITLE
Fix: Adding empty td tag inside table throws RangeError

### DIFF
--- a/.changeset/warm-yaks-speak.md
+++ b/.changeset/warm-yaks-speak.md
@@ -2,4 +2,4 @@
 "@tiptap/core": minor
 ---
 
-fix parsing of empty html table in insertContentAt func
+add slice option to insertContentAt and insertContent function

--- a/.changeset/warm-yaks-speak.md
+++ b/.changeset/warm-yaks-speak.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": minor
+---
+
+fix parsing of empty html table in insertContentAt func

--- a/demos/src/Examples/Tables/React/index.spec.js
+++ b/demos/src/Examples/Tables/React/index.spec.js
@@ -121,4 +121,20 @@ context('/src/Examples/Tables/React/', () => {
       expect(elements[1].innerText).to.equal('Column 2')
     })
   })
+
+  it('should use parse function', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.commands.insertContentAt(0, '<table><tr><td></td></tr></table>', {
+        applyInputRules: true,
+        slice: false, // to use parse function
+      })
+
+      cy.get('.tiptap table').should('exist').within(() => {
+        cy.get('colgroup').should('exist')
+        cy.get('tbody').should('exist')
+        cy.get('tr').should('exist')
+        cy.get('td').should('exist')
+      })
+    })
+  })
 })

--- a/packages/core/src/commands/insertContent.ts
+++ b/packages/core/src/commands/insertContent.ts
@@ -31,6 +31,12 @@ declare module '@tiptap/core' {
           updateSelection?: boolean;
           applyInputRules?: boolean;
           applyPasteRules?: boolean;
+
+          /**
+           * Whether to use parseSlice function to parse the content.
+           * @default true
+           */
+          slice?: boolean
         }
       ) => ReturnType;
     };

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -74,6 +74,7 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
 
     try {
       content = createNodeFromContent(value, editor.schema, {
+        slice: false,
         parseOptions: {
           preserveWhitespace: 'full',
           ...options.parseOptions,

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -50,6 +50,12 @@ declare module '@tiptap/core' {
            * Whether to throw an error if the content is invalid.
            */
           errorOnInvalidContent?: boolean
+
+          /**
+           * Whether to use parseSlice function to parse the content.
+           * @default true
+           */
+          slice?: boolean
         },
       ) => ReturnType
     }
@@ -67,6 +73,7 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
       updateSelection: true,
       applyInputRules: false,
       applyPasteRules: false,
+      slice: true,
       ...options,
     }
 
@@ -74,7 +81,7 @@ export const insertContentAt: RawCommands['insertContentAt'] = (position, value,
 
     try {
       content = createNodeFromContent(value, editor.schema, {
-        slice: false,
+        slice: options.slice,
         parseOptions: {
           preserveWhitespace: 'full',
           ...options.parseOptions,


### PR DESCRIPTION
## Changes Overview
Closes: #6237 

By default we using `DOMParser.parseSlice` (this function is not parsing the full node.), and no option to disable it 
so, I created an option `useParseSlice`,  

https://discuss.prosemirror.net/t/domparser-parseslice-not-parsing-correctly-empty-table-cell/5510 

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
