### PR TITLE
fix(selection): skip decorations for node selection and non editable editor

### DIFF
--- a/.changeset/smooth-carrots-beam.md
+++ b/.changeset/smooth-carrots-beam.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extensions': minor
+---
+
+skip decorations for node selection and non editable editor

--- a/packages/extensions/src/selection/selection.ts
+++ b/packages/extensions/src/selection/selection.ts
@@ -1,4 +1,4 @@
-import { Extension } from '@tiptap/core'
+import { Extension, isNodeSelection } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 
@@ -32,7 +32,7 @@ export const Selection = Extension.create({
         key: new PluginKey('selection'),
         props: {
           decorations(state) {
-            if (state.selection.empty || editor.isFocused) {
+            if (state.selection.empty || editor.isFocused || !editor.isEditable || isNodeSelection(state.selection)) {
               return null
             }
 


### PR DESCRIPTION
## Changes Overview
Skip inline decorations when the editor is not editable or a node is selected. This prevents unwanted behavior caused by the `selection` class, such as child elements under custom nodes being selected.

## Implementation Approach

## Testing Done

## Verification Steps

## Additional Notes

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
Unwanted selection behaviour occured [Issue](https://github.com/Aslam97/shadcn-minimal-tiptap/issues/78)
Node selection 
![IMG_0306 PNG](https://github.com/user-attachments/assets/380f2bde-ac10-4599-93bd-ebc6e56428c2)
