### PR TITLE
use @beta for publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
         uses: changesets/action@v1
         with:
           createGithubReleases: false
-          publish: pnpm run publish --tag ${{ github.ref_name == 'next' && 'next'  || 'latest' }}
+          publish: pnpm run publish --tag ${{ github.ref_name == 'next' && 'beta'  || 'latest' }}
           version: pnpm run version
           title: ${{ github.ref_name == 'main' && 'Publish a new stable version'  || 'Publish a new pre-release version' }}
           commit: >-


### PR DESCRIPTION
This PR changes the NPM tag of the `next` release to use `beta` as a tag. That way people can easily install the latest beta version via `@tiptap/pkg@beta` for example

```
pnpm i @tiptap/core@beta
```