### PR TITLE
make sure rel attribute is set on html output for YouTube extension

### DIFF
--- a/tests/cypress/integration/html/generateHTML.spec.ts
+++ b/tests/cypress/integration/html/generateHTML.spec.ts
@@ -63,7 +63,7 @@ describe('generateHTML', () => {
     })
 
     expect(generateHTML(json, extensions)).to.equal(
-      '<p xmlns="http://www.w3.org/1999/xhtml">Tiptap now supports YouTube embeds! Awesome!</p><div xmlns="http://www.w3.org/1999/xhtml" data-youtube-video=""><iframe width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" src="https://www.youtube.com/embed/cqHqLQgVCgY" start="0"></iframe></div>',
+      '<p xmlns="http://www.w3.org/1999/xhtml">Tiptap now supports YouTube embeds! Awesome!</p><div xmlns="http://www.w3.org/1999/xhtml" data-youtube-video=""><iframe width="640" height="480" allowfullscreen="true" autoplay="false" disablekbcontrols="false" enableiframeapi="false" endtime="0" ivloadpolicy="0" loop="false" modestbranding="false" origin="" playlist="" rel="1" src="https://www.youtube.com/embed/cqHqLQgVCgY?rel=1" start="0"></iframe></div>',
     )
   })
 


### PR DESCRIPTION
## Changes Overview

This pull request updates a test case in `generateHTML.spec.ts` to reflect a change in the generated HTML for YouTube embeds. Specifically, it ensures that the `rel=1` parameter is included in the `src` URL of the YouTube iframe.

### Test case update:

* [`tests/cypress/integration/html/generateHTML.spec.ts`](diffhunk://#diff-5ca32de61aa3fd753a31a856ee237ba31065f1fcc55b54de13848e42f31296a3L66-R66): Modified the expected output of the `generateHTML` function to include the `rel=1` query parameter in the YouTube iframe `src` URL, ensuring consistent behavior with updated embed requirements.

## Implementation Approach

I updated the integration test for the generateHTML function to expect the new `rel=1` default.

## Testing Done

Ran the tests locally

## Verification Steps

N/A

## Additional Notes

N/A

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

