### PR TITLE
Fix broken React unmount because of non-existing view on unmount

### DIFF
--- a/.changeset/shaggy-hats-rescue.md
+++ b/.changeset/shaggy-hats-rescue.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Fixed a bug in the EditorContent component that caused a crash in Firefox based browsers because of the editor view not being available when an uninitialized editor is unmounted (for example via Strict mode)

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -164,10 +164,14 @@ export class PureEditorContent extends React.Component<
 
     this.initialized = false
 
-    if (!editor.isDestroyed) {
-      editor.view.setProps({
-        nodeViews: {},
-      })
+    try {
+      if (!editor.isDestroyed) {
+        editor.view.setProps({
+          nodeViews: {},
+        })
+      }
+    } catch {
+      // ignore error as we can't set props on a non-existing view
     }
 
     if (this.unsubscribeToContentComponent) {


### PR DESCRIPTION
## Changes Overview

This pull request addresses a bug fix in the `EditorContent` component of the `@tiptap/react` package. The fix prevents a crash in Firefox browsers caused by attempting to set properties on an uninitialized editor view when the editor is unmounted, such as during React's Strict Mode.

### Bug Fixes:

* [`.changeset/shaggy-hats-rescue.md`](diffhunk://#diff-7ad48e49078f41227d545319e8c06e2d578d95efa8e230312797b7fbc20be5c6R1-R5): Added a patch-level changeset entry describing the bug fix for the `EditorContent` component crash in Firefox browsers.
* [`packages/react/src/EditorContent.tsx`](diffhunk://#diff-c1d83c0fa32f3b18f2d8e5b3eb81f9d951c0d6de903191d495d169d248188ceeR167-R175): Wrapped the `editor.view.setProps` call in a `try-catch` block to handle cases where the editor view is not initialized, preventing errors during unmounting.

## Implementation Approach

Added a simple try-catch block around the `editor.view.setProps()` call as the view could not be available yet.

## Testing Done

Tested on Gecko and Chromium browsers if the error still occurs.

## Verification Steps

See above

## Additional Notes

N/A

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
