### PR TITLE
Fix invalid editor.isDestroyed value

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -718,7 +718,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Check if the editor is already destroyed.
    */
   public get isDestroyed(): boolean {
-    return !this.editorView?.isDestroyed
+    return this.editorView?.isDestroyed || false
   }
 
   public $node(selector: string, attributes?: { [key: string]: any }): NodePos | null {

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -718,7 +718,6 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Check if the editor is already destroyed.
    */
   public get isDestroyed(): boolean {
-    console.log(this.editorView?.isDestroyed)
     return this.editorView?.isDestroyed ?? true
   }
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -718,7 +718,8 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Check if the editor is already destroyed.
    */
   public get isDestroyed(): boolean {
-    return this.editorView?.isDestroyed || true
+    console.log(this.editorView?.isDestroyed)
+    return this.editorView?.isDestroyed ?? true
   }
 
   public $node(selector: string, attributes?: { [key: string]: any }): NodePos | null {

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -718,7 +718,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Check if the editor is already destroyed.
    */
   public get isDestroyed(): boolean {
-    return this.editorView?.isDestroyed || false
+    return this.editorView?.isDestroyed || true
   }
 
   public $node(selector: string, attributes?: { [key: string]: any }): NodePos | null {


### PR DESCRIPTION
## Changes Overview
This PR fixes an infinite loop caused by #6233 which lead to an invalid `editor.isDestroyed` value as the `editorView.isDestroyed` value was wrongfully negated.

## Implementation Approach
Removed the negation to make sure `editor.isDestroyed` returns the correct state as otherwise renderers will try to re-create the editor forever.

## Testing Done
- Did a manual test on my device

## Verification Steps
- see above

## Additional Notes
- N/A

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
