### PR TITLE
fix(core): allow unregistering multiple plugins

### DIFF
--- a/.changeset/lucky-bears-exercise.md
+++ b/.changeset/lucky-bears-exercise.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixes a bug where you could not unregister multiple plugins.

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -254,7 +254,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       const name = typeof nameOrPluginKey === 'string' ? `${nameOrPluginKey}$` : nameOrPluginKey.key
 
       // @ts-ignore
-      plugins = prevPlugins.filter(plugin => !plugin.key.startsWith(name))
+      plugins = plugins.filter(plugin => !plugin.key.startsWith(name))
     })
 
     if (prevPlugins.length === plugins.length) {


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
This resolves a minor logic bug, where passing an array of plugins to remove would only remove the last item in the list of plugins to remove.
## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->
This resolves the logic error by appropriately filtering out the array at each step (as opposed to continously filtering from the same starting array).
## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
Trivial to understand
## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->

This bug is also present in the `next` branch, but I choose to backport the fix & `next` can pull it in later
