### PR TITLE
upgrade y-prosemirror

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -15,7 +15,7 @@
     "@lexical/react": "^0.11.3",
     "@lifeomic/attempt": "3.1.0",
     "@shikijs/core": "1.10.3",
-    "@tiptap/y-tiptap": "^2.0.0",
+    "@tiptap/y-tiptap": "^3.0.0-beta.3",
     "d3": "^7.9.0",
     "fast-glob": "^3.3.2",
     "highlight.js": "^11.11.1",

--- a/packages/extension-collaboration-caret/package.json
+++ b/packages/extension-collaboration-caret/package.json
@@ -33,12 +33,12 @@
   "devDependencies": {
     "@tiptap/core": "workspace:*",
     "@tiptap/pm": "workspace:*",
-    "@tiptap/y-tiptap": "^2.0.0"
+    "@tiptap/y-tiptap": "^3.0.0-beta.3"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:*",
     "@tiptap/pm": "workspace:*",
-    "@tiptap/y-tiptap": "^2.0.0"
+    "@tiptap/y-tiptap": "^3.0.0-beta.3"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -33,12 +33,12 @@
   "devDependencies": {
     "@tiptap/core": "workspace:*",
     "@tiptap/pm": "workspace:*",
-    "@tiptap/y-tiptap": "^2.0.0"
+    "@tiptap/y-tiptap": "^3.0.0-beta.3"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:*",
     "@tiptap/pm": "workspace:*",
-    "@tiptap/y-tiptap": "^2.0.0",
+    "@tiptap/y-tiptap": "^3.0.0-beta.3",
     "yjs": "^13"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: 1.10.3
         version: 1.10.3
       '@tiptap/y-tiptap':
-        specifier: ^2.0.0
-        version: 2.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.0-beta.3
+        version: 3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -481,8 +481,8 @@ importers:
         specifier: workspace:*
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^2.0.0
-        version: 2.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.0-beta.3
+        version: 3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-collaboration-caret:
     devDependencies:
@@ -493,8 +493,8 @@ importers:
         specifier: workspace:*
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^2.0.0
-        version: 2.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.0-beta.3
+        version: 3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-color:
     devDependencies:
@@ -2662,8 +2662,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@tiptap/y-tiptap@2.0.0':
-    resolution: {integrity: sha512-s/b2Xfz7CHjQgr4T0EPutHuFbKUyzJV1n7NVIkAW6/BseFfe0RgVWyPghan6ivdGYWVAHIiCocJYHQN2nedNNg==}
+  '@tiptap/y-tiptap@3.0.0-beta.3':
+    resolution: {integrity: sha512-1U/MTG7mpkc2VEIRzVueXqpHpawflF0DUuqkPwTezmBst6HPZ+NnZuDbJGay8dh//KSXcrS1Vtu1Wqa2Z/1HTw==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
       prosemirror-model: ^1.7.1
@@ -8594,7 +8594,7 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
-  '@tiptap/y-tiptap@2.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
+  '@tiptap/y-tiptap@3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
     dependencies:
       lib0: 0.2.104
       prosemirror-model: 1.24.1


### PR DESCRIPTION
This pull request updates the `@tiptap/y-tiptap` package to version `^3.0.0-beta.3` across multiple files and configurations. The update ensures compatibility with the latest features and improvements in the beta release of the package. Below are the key changes grouped by theme:

### Dependency Updates
* Updated `@tiptap/y-tiptap` from `^2.0.0` to `^3.0.0-beta.3` in `dependencies` of `demos/package.json`.
* Updated `@tiptap/y-tiptap` from `^2.0.0` to `^3.0.0-beta.3` in `devDependencies` and `peerDependencies` of `packages/extension-collaboration-caret/package.json`.
* Updated `@tiptap/y-tiptap` from `^2.0.0` to `^3.0.0-beta.3` in `devDependencies` and `peerDependencies` of `packages/extension-collaboration/package.json`.

### Lockfile Updates
* Updated the `specifier` and `version` of `@tiptap/y-tiptap` to `^3.0.0-beta.3` in multiple `importers` sections of `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL171-R172) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL484-R485) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL496-R497)
* Replaced the `@tiptap/y-tiptap` entry for version `2.0.0` with `3.0.0-beta.3` in the `packages` section of `pnpm-lock.yaml`.
* Updated the `snapshots` section in `pnpm-lock.yaml` to reflect the new version of `@tiptap/y-tiptap` and its dependencies.