### PR TITLE
[ReactRenderer] Support lazy & dynamic (NextJs) components

### DIFF
--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -29,6 +29,21 @@ function isForwardRefComponent(Component: any) {
   )
 }
 
+/**
+ * Check if a component is a lazy loaded
+ * @param Component
+ * @returns {boolean}
+ */
+function isLazyComponent(Component: any) {
+  const isLazy = typeof Component === 'object'
+    && Component.$$typeof?.toString() === 'Symbol(react.lazy)'
+
+  const isNextDynamic = typeof Component === 'function'
+    && Component.prototype.constructor.displayName === 'LoadableComponent'
+
+  return isLazy || isNextDynamic
+}
+
 export interface ReactRendererOptions {
   /**
    * The editor instance.
@@ -136,7 +151,13 @@ export class ReactRenderer<R = unknown, P extends Record<string, any> = object> 
       }
     }
 
-    this.reactElement = <Component {...props} />
+    this.reactElement = isLazyComponent(Component) ? (
+      <React.Suspense>
+        <Component {...props} />
+      </React.Suspense>
+    ) : (
+      <Component {...props} />
+    )
 
     editor?.contentComponent?.setRenderer(this.id, this)
   }


### PR DESCRIPTION
## Changes Overview
Support React.lazy and NextJS's dynamic components in ReactRenderer

## Implementation Approach
- `isLazyComponent` helper function in ReactRender - Checks if the passed component is either React lazy object  or NextJS `LoadableComponent` (dynamic import)
- If the component is lazy wrap it into React.Suspense (No fallback)

## Testing Done
[CodeSandbox](https://codesandbox.io/p/sandbox/tip-tap-react-renderer-dynamic-vmqw86)

## Verification Steps
* Create dynamic or react lazy component
* Create new react render 
```
      currentComponent = new ReactRenderer(Component, {
        editor,
      });
````
* The component should be rendered properly

## Additional Notes
Supporting dynamic elements is important especially when the bundle size is a consideration.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

N/A
