### PR TITLE
Allow setting HTML tags other than <span> for "as" in MarkViewContent

### DIFF
--- a/.changeset/quiet-falcons-study.md
+++ b/.changeset/quiet-falcons-study.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Allow setting HTML tags other than <span> for "as" in MarkViewContent

--- a/packages/react/src/ReactMarkViewRenderer.tsx
+++ b/packages/react/src/ReactMarkViewRenderer.tsx
@@ -16,16 +16,18 @@ export const ReactMarkViewContext = React.createContext<MarkViewContextProps>({
 })
 
 export type MarkViewContentProps<T extends keyof React.JSX.IntrinsicElements = 'span'> = {
-  as?: NoInfer<T>
-} & React.ComponentProps<T>
+  as?: T
+} & Omit<React.ComponentProps<T>, 'as'>
 
-export const MarkViewContent: React.FC<MarkViewContentProps> = props => {
-  const Tag = props.as || 'span'
+export const MarkViewContent = <T extends keyof React.JSX.IntrinsicElements = 'span'>(
+  props: MarkViewContentProps<T>,
+) => {
+  const { as: Tag = 'span', ...rest } = props
   const { markViewContentRef } = React.useContext(ReactMarkViewContext)
 
   return (
     // @ts-ignore
-    <Tag {...props} ref={markViewContentRef} data-mark-view-content="" />
+    <Tag {...rest} ref={markViewContentRef} data-mark-view-content="" />
   )
 }
 


### PR DESCRIPTION
## Changes Overview
I modified the type of MarkViewContent to allow specifying any HTML element, as it previously only accepted span and undefined.

<!-- Briefly describe your changes. -->

## Implementation Approach
Fixed MarkViewContentProps as type to use T instead of passing NoInfer<T>.

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
All tests passed locally.

I have confirmed that tsc passes in local.
However, I could not find a Cypress test for this fix.

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/discussions/6323#discussioncomment-13105496

<!-- Link any related issues here -->
