### PR TITLE
Do not log all files when you run the lint:fix command

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+**/.git
+**/.svn
+**/.hg
+**/node_modules
+
+.turbo
+.changeset
+.github/**/*
+
+demos/dist/**/*
+demos/node_modules/**/*
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "pnpm --prefix ./demos run start",
     "dev": "pnpm run start",
     "lint": "turbo run lint",
-    "lint:fix": "prettier . --write && eslint --fix --cache --quiet --no-error-on-unmatched-pattern ./",
+    "lint:fix": "prettier -w --log-level warn . && eslint --fix --cache --quiet --no-error-on-unmatched-pattern .",
     "lint:staged": "lint-staged",
     "test:open": "cypress open --project tests",
     "test:run": "cypress run --project tests",


### PR DESCRIPTION
## Changes Overview
Do not log all files that are analyzed by Prettier when you run the lint:fix command

Prevent prettier from formatting lockfiles

## Implementation Approach
Modify the lint:fix command

Add a .prettierignore file

## Testing Done
Run the lint:fix command

## Verification Steps
run the lint:fix command

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
