### PR TITLE
fix(jsx): list jsx-dev-runtime in package.json in files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,8 @@
   "files": [
     "src",
     "dist",
-    "jsx-runtime"
+    "jsx-runtime",
+    "jsx-dev-runtime"
   ],
   "devDependencies": {
     "@tiptap/pm": "workspace:*"


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

Fixes #6389

This PR adds missing entry `jsx-dev-runtime` (introduced in #5558) to `@tiptap/core` package.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

I have added `jsx-dev-runtime` to the `files` list in `package.json`. The directory is currently excluded from the distro because of it.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

I did manual testing via `npm publish --dry-run --tag next` to make sure the directory is included in the output.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
