### PR TITLE
Fix issue where inserting an image below an existing image #6401

### DIFF
--- a/.changeset/wet-rice-suffer.md
+++ b/.changeset/wet-rice-suffer.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixed an issue where images placed into an empty paragraph right after an existing image would replace the existing image instead

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -163,8 +163,9 @@ export const insertContentAt: RawCommands['insertContentAt'] =
 
         const fromSelectionAtStart = selection.$from.parentOffset === 0
         const isTextSelection = selection.$from.node().isText || selection.$from.node().isTextblock
+        const hasContent = selection.$from.node().content.size > 0
 
-        if (fromSelectionAtStart && isTextSelection) {
+        if (fromSelectionAtStart && isTextSelection && hasContent) {
           from = Math.max(0, from - 1)
         }
 


### PR DESCRIPTION
… would replace the existing one.

## Changes Overview

This PR fixes an issue that was brought up by a community member.When I add a image, then add a new empty paragraph below and add a new image with the cursor at the first position of the new empty paragraph, the editor replaced the preceding image.

## Implementation Approach

The commit in #5651 did not handle the case where the text content is empty, which could lead to incorrect expansion of the selection. This fix adds a check for empty text content.

## Testing Done

 manual tests

## Verification Steps


## Additional Notes


## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

[<!-- Link any related issues here -->](https://github.com/ueberdosis/tiptap/pull/5651)
https://github.com/ueberdosis/tiptap/issues/6401
