### PR TITLE
update VueNodeViewRenderer

### DIFF
--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -123,9 +123,6 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
       __file: this.component.__file,
     })
 
-    this.handleSelectionUpdate = this.handleSelectionUpdate.bind(this)
-    this.editor.on('selectionUpdate', this.handleSelectionUpdate)
-
     this.renderer = new VueRenderer(extendedComponent, {
       editor: this.editor,
       props,
@@ -154,33 +151,6 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
     }
 
     return this.dom.querySelector('[data-node-view-content]') as HTMLElement | null
-  }
-
-  /**
-   * On editor selection update, check if the node is selected.
-   * If it is, call `selectNode`, otherwise call `deselectNode`.
-   */
-  handleSelectionUpdate() {
-    const { from, to } = this.editor.state.selection
-    const pos = this.getPos()
-
-    if (typeof pos !== 'number') {
-      return
-    }
-
-    if (from <= pos && to >= pos + this.node.nodeSize) {
-      if (this.renderer.props.selected) {
-        return
-      }
-
-      this.selectNode()
-    } else {
-      if (!this.renderer.props.selected) {
-        return
-      }
-
-      this.deselectNode()
-    }
   }
 
   /**
@@ -268,7 +238,6 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
 
   destroy() {
     this.renderer.destroy()
-    this.editor.off('selectionUpdate', this.handleSelectionUpdate)
   }
 }
 


### PR DESCRIPTION
## Changes Overview

Removed handleSelectionUpdate as it did nothing useful but constantly calculated the position

## Implementation Approach

-

## Testing Done

Yes, I did various tests to make sure nothing would break.

For testing, you can run the repository's development mode and ensure that the ProseMirror-selectednode class and the selected property are set to bypass the remote method.

## Verification Steps

-

## Additional Notes

The selectNode and deselectNode methods are called independently of the handleSelectionUpdate method. Furthermore, previously the handleSelectionUpdate method performed position calculations every time, but never called selectNode and deselectNode because the conditions for calling them were not met.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [+] My changes do not break the library.
- [ ] I have added tests where applicable.
- [+] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/6440
