### PR TITLE
Fix autolink inside shadow dom

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -5,6 +5,8 @@ import { Plugin, PluginKey } from '@tiptap/pm/state'
 import type { MultiToken } from 'linkifyjs'
 import { tokenize } from 'linkifyjs'
 
+import { UNICODE_WHITESPACE_REGEX, UNICODE_WHITESPACE_REGEX_END } from './whitespace.js'
+
 /**
  * Check if the provided tokens form a valid link structure, which can either be a single link token
  * or a link token surrounded by parentheses or square brackets.
@@ -81,17 +83,17 @@ export function autolink(options: AutolinkOptions): Plugin {
             undefined,
             ' ',
           )
-        } else if (
-          nodesInChangedRanges.length &&
-          // We want to make sure to include the block seperator argument to treat hard breaks like spaces.
-          newState.doc.textBetween(newRange.from, newRange.to, ' ', ' ').endsWith(' ')
-        ) {
+        } else if (nodesInChangedRanges.length) {
+          const endText = newState.doc.textBetween(newRange.from, newRange.to, ' ', ' ')
+          if (!UNICODE_WHITESPACE_REGEX_END.test(endText)) {
+            return
+          }
           textBlock = nodesInChangedRanges[0]
           textBeforeWhitespace = newState.doc.textBetween(textBlock.pos, newRange.to, undefined, ' ')
         }
 
         if (textBlock && textBeforeWhitespace) {
-          const wordsBeforeWhitespace = textBeforeWhitespace.split(' ').filter(s => s !== '')
+          const wordsBeforeWhitespace = textBeforeWhitespace.split(UNICODE_WHITESPACE_REGEX).filter(Boolean)
 
           if (wordsBeforeWhitespace.length <= 0) {
             return false

--- a/packages/extension-link/src/helpers/whitespace.ts
+++ b/packages/extension-link/src/helpers/whitespace.ts
@@ -1,0 +1,7 @@
+// From DOMPurify
+// https://github.com/cure53/DOMPurify/blob/main/src/regexp.ts
+export const UNICODE_WHITESPACE_PATTERN = '[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]'
+
+export const UNICODE_WHITESPACE_REGEX = new RegExp(UNICODE_WHITESPACE_PATTERN)
+export const UNICODE_WHITESPACE_REGEX_END = new RegExp(`${UNICODE_WHITESPACE_PATTERN}$`)
+export const UNICODE_WHITESPACE_REGEX_GLOBAL = new RegExp(UNICODE_WHITESPACE_PATTERN, 'g')

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -6,6 +6,7 @@ import { find, registerCustomProtocol, reset } from 'linkifyjs'
 import { autolink } from './helpers/autolink.js'
 import { clickHandler } from './helpers/clickHandler.js'
 import { pasteHandler } from './helpers/pasteHandler.js'
+import { UNICODE_WHITESPACE_REGEX_GLOBAL } from './helpers/whitespace.js'
 
 export interface LinkProtocolOptions {
   /**
@@ -155,11 +156,6 @@ declare module '@tiptap/core' {
   }
 }
 
-// From DOMPurify
-// https://github.com/cure53/DOMPurify/blob/main/src/regexp.js
-// eslint-disable-next-line no-control-regex
-const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
-
 export function isAllowedUri(uri: string | undefined, protocols?: LinkOptions['protocols']) {
   const allowedProtocols: string[] = ['http', 'https', 'ftp', 'ftps', 'mailto', 'tel', 'callto', 'sms', 'cid', 'xmpp']
 
@@ -175,7 +171,7 @@ export function isAllowedUri(uri: string | undefined, protocols?: LinkOptions['p
 
   return (
     !uri ||
-    uri.replace(ATTR_WHITESPACE, '').match(
+    uri.replace(UNICODE_WHITESPACE_REGEX_GLOBAL, '').match(
       new RegExp(
         // eslint-disable-next-line no-useless-escape
         `^(?:(?:${allowedProtocols.join('|')}):|[^a-z]|[a-z0-9+.\-]+(?:[^a-z+.\-:]|$))`,


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->
Enhanced link detection and sanitization to be more robust and Unicode-compliant, especially within shadow DOM contexts.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

- Improved how whitespace is handled when detecting and processing autolinks, especially to support the shadow DOM case.
- Added a new helper file (whitespace.ts) that defines Unicode whitespace regular expressions, based on [DOMPurify's](https://github.com/cure53/DOMPurify) implementation.
- Updated autolink.ts to use these new Unicode-aware whitespace checks, replacing previous plain space checks and logic.
- Updated link.ts to use the new Unicode whitespace regex for sanitizing URIs, replacing the previous hardcoded regex.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
Manual

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->
Place Editor inside shadow dom

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
