### PR TITLE
fix(commands): Fix RangeException on cut to document start

### DIFF
--- a/.changeset/slow-mails-vanish.md
+++ b/.changeset/slow-mails-vanish.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix RangeException in cut command when targetPos is zero

--- a/packages/core/src/commands/cut.ts
+++ b/packages/core/src/commands/cut.ts
@@ -30,7 +30,7 @@ export const cut: RawCommands['cut'] =
 
     tr.insert(newPos, contentSlice.content)
 
-    tr.setSelection(new TextSelection(tr.doc.resolve(newPos - 1)))
+    tr.setSelection(new TextSelection(tr.doc.resolve(Math.max(newPos - 1, 0))))
 
     return true
   }


### PR DESCRIPTION
## Changes Overview

Fixes a RangeException that is thrown when calling `commands.cut` with `targetPos = 0`, i.e. start of document

## Implementation Approach

Use `Math.max` to ensure that start position of TextSelection is always greater-equal to zero.

## Testing Done

Tested in own project by calling `commands.cut` with `targetPos = 0`

## Verification Steps

Call `commands.cut` with `targetPos = 0` and check for no RangeException to be thrown and content to be inserted at start of document.

## Additional Notes

-

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#6450 