### PR TITLE
fix incorrectly added ref props

### DIFF
--- a/.changeset/good-trainers-train.md
+++ b/.changeset/good-trainers-train.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Fixed a bug that incorrectly added ref props when a component can't accept them (for example when React 19 is not used)

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -27,7 +27,55 @@ function isClassComponent(Component: any) {
  * @returns {boolean}
  */
 function isForwardRefComponent(Component: any) {
-  return !!(typeof Component === 'object' && Component.$$typeof?.toString() === 'Symbol(react.forward_ref)')
+  return !!(
+    typeof Component === 'object' &&
+    Component.$$typeof &&
+    (Component.$$typeof.toString() === 'Symbol(react.forward_ref)' ||
+      Component.$$typeof.description === 'react.forward_ref')
+  )
+}
+
+/**
+ * Check if a component is a memoized component.
+ * @param Component
+ * @returns {boolean}
+ */
+function isMemoComponent(Component: any) {
+  return !!(
+    typeof Component === 'object' &&
+    Component.$$typeof &&
+    (Component.$$typeof.toString() === 'Symbol(react.memo)' || Component.$$typeof.description === 'react.memo')
+  )
+}
+
+/**
+ * Check if a component can safely receive a ref prop.
+ * This includes class components, forwardRef components, and memoized components
+ * that wrap forwardRef or class components.
+ * @param Component
+ * @returns {boolean}
+ */
+function canReceiveRef(Component: any) {
+  // Check if it's a class component
+  if (isClassComponent(Component)) {
+    return true
+  }
+
+  // Check if it's a forwardRef component
+  if (isForwardRefComponent(Component)) {
+    return true
+  }
+
+  // Check if it's a memoized component
+  if (isMemoComponent(Component)) {
+    // For memoized components, check the wrapped component
+    const wrappedComponent = Component.type
+    if (wrappedComponent) {
+      return isClassComponent(wrappedComponent) || isForwardRefComponent(wrappedComponent)
+    }
+  }
+
+  return false
 }
 
 /**
@@ -150,27 +198,28 @@ export class ReactRenderer<R = unknown, P extends Record<string, any> = object> 
 
     // Handle ref forwarding with React 18/19 compatibility
     const isReact19 = isReact19Plus()
-    const isClassComp = isClassComponent(Component)
-    const isForwardRefComp = isForwardRefComponent(Component)
+    const componentCanReceiveRef = canReceiveRef(Component)
 
     const elementProps = { ...props }
 
-    if (!elementProps.ref) {
-      if (isReact19) {
-        // React 19: ref is a standard prop for all components
-        // @ts-ignore - Setting ref prop for React 19 compatibility
-        elementProps.ref = (ref: R) => {
-          this.ref = ref
-        }
-      } else if (isClassComp || isForwardRefComp) {
-        // React 18 and prior: only set ref for class components and forwardRef components
-        // @ts-ignore - Setting ref prop for React 18 class/forwardRef components
+    // Handle ref prop based on React version and component type
+    if (elementProps.ref) {
+      // If there's already a ref but the component can't receive it, remove it
+      if (!isReact19 && !componentCanReceiveRef) {
+        delete elementProps.ref
+      }
+    } else {
+      // Only assign ref if:
+      // 1. React 19+ (all components support ref)
+      // 2. React 18 and the component can safely receive a ref
+      const shouldAssignRef = isReact19 || componentCanReceiveRef
+
+      if (shouldAssignRef) {
+        // @ts-ignore - Setting ref prop for compatible components
         elementProps.ref = (ref: R) => {
           this.ref = ref
         }
       }
-      // For function components in React 18, we can't use ref - the component won't receive it
-      // This is a limitation we have to accept for React 18 function components without forwardRef
     }
 
     this.reactElement = <Component {...elementProps} />


### PR DESCRIPTION
## Changes Overview

This pull request addresses a bug related to `ref` props in React components and introduces improvements to component type checks for better compatibility with React 18 and 19. The most important changes include fixing the bug, adding utility functions to check component types, and updating the logic for handling `ref` props.

### Component Type Checking Enhancements:
* [`packages/react/src/ReactRenderer.tsx`](diffhunk://#diff-5400690d6e1e2a99f31d83216b79a9e77e1f6eb0f0362b6f6c71ddd3e42a043aL30-R78): Added new utility functions `isMemoComponent` and `canReceiveRef` to determine if a component is memoized or can safely receive a `ref` prop. These functions improve the handling of various component types, including class components, `forwardRef` components, and memoized components.

### Ref Prop Handling Updates:
* [`packages/react/src/ReactRenderer.tsx`](diffhunk://#diff-5400690d6e1e2a99f31d83216b79a9e77e1f6eb0f0362b6f6c71ddd3e42a043aL153-L173): Refactored the logic for assigning `ref` props to components. The new implementation ensures compatibility with React 18 and 19 by checking if a component can safely receive a `ref` before assigning it. This prevents potential runtime issues.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

There's a comment on my old PR here #6405 that discussed this problem.
Created an issue here: #6457

- fixes #6457
