### PR TITLE
fix react static renderer to parse inline styles as string

### DIFF
--- a/.changeset/dry-monkeys-learn.md
+++ b/.changeset/dry-monkeys-learn.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/static-renderer': patch
+---
+
+Fixed a bug causing inline-styles to be parsed as strings for React

--- a/packages/static-renderer/src/pm/react/react.ts
+++ b/packages/static-renderer/src/pm/react/react.ts
@@ -13,7 +13,7 @@ import { renderToElement } from '../extensionRenderer.js'
  * @param key The key to use for the React element
  * @returns The mapped HTML attributes as an object
  */
-function mapAttrsToHTMLAttributes(attrs?: Record<string, any>, key?: string): Record<string, any> {
+export function mapAttrsToHTMLAttributes(attrs?: Record<string, any>, key?: string): Record<string, any> {
   if (!attrs) {
     return { key }
   }
@@ -22,6 +22,23 @@ function mapAttrsToHTMLAttributes(attrs?: Record<string, any>, key?: string): Re
       if (name === 'class') {
         return Object.assign(acc, { className: value })
       }
+
+      // React expects styles to be a object
+      // so we need to convert it from string to object
+      if (name === 'style' && typeof value === 'string') {
+        const styleObject: Record<string, string> = {}
+        value.split(';').forEach(style => {
+          const [styleKey, val] = style.split(':')
+          if (styleKey && val) {
+            // we need to turn the key into camelCase
+            const camelCaseKey = styleKey.trim().replace(/-([a-z])/g, g => g[1].toUpperCase())
+            styleObject[camelCaseKey] = val.trim()
+          }
+        })
+
+        return Object.assign(acc, { style: styleObject })
+      }
+
       return Object.assign(acc, { [name]: value })
     },
     { key },

--- a/tests/cypress/integration/static-renderer/react-string.spec.ts
+++ b/tests/cypress/integration/static-renderer/react-string.spec.ts
@@ -6,8 +6,27 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Mark, Node } from '@tiptap/pm/model'
-import { renderToReactElement } from '@tiptap/static-renderer/pm/react'
+import { mapAttrsToHTMLAttributes,renderToReactElement } from '@tiptap/static-renderer/pm/react'
 import React from 'react'
+
+describe('static renderer: react', () => {
+  it('mapAttrsToHTMLAttributes maps attributes to React attributes', () => {
+    const attrs = {
+      class: 'my-class',
+      style: 'color: red; font-size: 16px; transform: translateX(15px) translateY(10px);',
+      id: 'my-id',
+    }
+
+    const result = mapAttrsToHTMLAttributes(attrs, 'test-key')
+
+    expect(result).to.deep.equal({
+      className: 'my-class',
+      style: { color: 'red', fontSize: '16px', transform: 'translateX(15px) translateY(10px)' },
+      id: 'my-id',
+      key: 'test-key',
+    })
+  })
+})
 
 describe('static render json to react elements (with prosemirror)', () => {
   it('generates a React element from JSON without an editor instance', () => {


### PR DESCRIPTION
## Changes Overview

This pull request addresses a bug in the `@tiptap/static-renderer` package and introduces improvements to attribute mapping for React compatibility. The changes include fixing how inline styles are handled, exporting a utility function for broader usage, and adding a test to ensure the correct functionality of the updated logic.

### Bug Fix and Feature Enhancements:

* **Bug Fix in Inline Styles**: Resolved an issue where inline styles were being parsed as strings instead of objects in React. The `mapAttrsToHTMLAttributes` function now converts style strings into camelCase style objects as expected by React. [[1]](diffhunk://#diff-792896248ab7ccc276c059e2fbadfde637503087c9541b2ad7acf74c80dfd2e8R1-R5) [[2]](diffhunk://#diff-b80b2d335cad7085abdc2238fbeb3205dd0909b6305f9486a472e55afe94a003R25-R41)

* **Exporting Utility Function**: The `mapAttrsToHTMLAttributes` function was updated to be exported, allowing it to be reused in other parts of the codebase.

### Testing Improvements:

* **New Unit Test**: Added a Cypress test to verify that `mapAttrsToHTMLAttributes` correctly maps attributes, including converting inline styles to React-compatible objects. This ensures the reliability of the new functionality.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #6332 
