### PR TITLE
fix(drag-handle-react): prevent plugin re-registration

### DIFF
--- a/.changeset/tame-carrots-add.md
+++ b/.changeset/tame-carrots-add.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-drag-handle-react": minor
+---
+
+Prevent plugin re-registration

--- a/packages/extension-drag-handle-react/src/DragHandle.tsx
+++ b/packages/extension-drag-handle-react/src/DragHandle.tsx
@@ -1,22 +1,28 @@
+import type { DragHandlePluginProps } from '@tiptap/extension-drag-handle'
 import {
   DragHandlePlugin,
   dragHandlePluginDefaultKey,
-  DragHandlePluginProps,
 } from '@tiptap/extension-drag-handle'
-import { Node } from '@tiptap/pm/model'
-import { Plugin } from '@tiptap/pm/state'
-import { Editor } from '@tiptap/react'
-import React, {
-  ReactNode, useEffect, useRef, useState,
-} from 'react'
+import type { Node } from '@tiptap/pm/model'
+import type { Plugin } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/react'
+import type { ReactNode } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
-type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 
-export type DragHandleProps = Omit<Optional<DragHandlePluginProps, 'pluginKey'>, 'element'> & {
-  className?: string;
-  onNodeChange?: (data: { node: Node | null; editor: Editor; pos: number }) => void;
-  children: ReactNode;
-};
+export type DragHandleProps = Omit<
+  Optional<DragHandlePluginProps, 'pluginKey'>,
+  'element'
+> & {
+  className?: string
+  onNodeChange?: (data: {
+    node: Node | null
+    editor: Editor
+    pos: number
+  }) => void
+  children: ReactNode
+}
 
 export const DragHandle = (props: DragHandleProps) => {
   const {
@@ -30,17 +36,20 @@ export const DragHandle = (props: DragHandleProps) => {
   const [element, setElement] = useState<HTMLDivElement | null>(null)
   const plugin = useRef<Plugin | null>(null)
 
-  useEffect(() => {
-    if (!element) {
-      return () => {
-        plugin.current = null
-      }
-    }
+  const onNodeChangeRef = useRef(onNodeChange)
+  const tippyOptionsRef = useRef(tippyOptions)
 
-    if (editor.isDestroyed) {
-      return () => {
-        plugin.current = null
-      }
+  useEffect(() => {
+    onNodeChangeRef.current = onNodeChange
+  }, [onNodeChange])
+
+  useEffect(() => {
+    tippyOptionsRef.current = tippyOptions
+  }, [tippyOptions])
+
+  useEffect(() => {
+    if (!element || editor.isDestroyed) {
+      return
     }
 
     if (!plugin.current) {
@@ -48,18 +57,20 @@ export const DragHandle = (props: DragHandleProps) => {
         editor,
         element,
         pluginKey,
-        tippyOptions,
-        onNodeChange,
+        tippyOptions: tippyOptionsRef.current,
+        onNodeChange: onNodeChangeRef.current,
       })
 
       editor.registerPlugin(plugin.current)
     }
 
     return () => {
-      editor.unregisterPlugin(pluginKey)
-      plugin.current = null
+      if (plugin.current) {
+        editor.unregisterPlugin(pluginKey)
+        plugin.current = null
+      }
     }
-  }, [element, editor, onNodeChange, pluginKey, tippyOptions])
+  }, [editor, element, pluginKey])
 
   return (
     <div className={className} ref={setElement}>


### PR DESCRIPTION
- Use refs to store unstable props (`onNodeChange`, `tippyOptions`)
- Remove unstable dependencies from plugin registration useEffect