### PR TITLE
Remove stuck DOM elements after suggestions are removed

### DIFF
--- a/demos/src/Nodes/Mention/React/suggestion.js
+++ b/demos/src/Nodes/Mention/React/suggestion.js
@@ -95,8 +95,8 @@ export default {
       },
 
       onExit() {
-        component.destroy()
         component.element.remove()
+        component.destroy()
       },
     }
   },

--- a/demos/src/Nodes/Mention/React/suggestion.js
+++ b/demos/src/Nodes/Mention/React/suggestion.js
@@ -96,6 +96,7 @@ export default {
 
       onExit() {
         component.destroy()
+        component.element.remove()
       },
     }
   },

--- a/demos/src/Nodes/Mention/Vue/suggestion.js
+++ b/demos/src/Nodes/Mention/Vue/suggestion.js
@@ -100,6 +100,7 @@ export default {
 
       onExit() {
         component.destroy()
+        component.element.remove()
       },
     }
   },

--- a/demos/src/Nodes/Mention/Vue/suggestion.js
+++ b/demos/src/Nodes/Mention/Vue/suggestion.js
@@ -99,8 +99,8 @@ export default {
       },
 
       onExit() {
-        component.destroy()
         component.element.remove()
+        component.destroy()
       },
     }
   },


### PR DESCRIPTION
## Changes Overview

This pull request includes a small but important change to the `onExit` method in two files. The change ensures that the `component.element` is removed from the DOM after the component is destroyed.

* [`demos/src/Nodes/Mention/React/suggestion.js`](diffhunk://#diff-02fe02afccce59e6842070e581311650487b18f84d73f5308c27cc9dce47cdfaR99): Added `component.element.remove()` to the `onExit` method to clean up the DOM.
* [`demos/src/Nodes/Mention/Vue/suggestion.js`](diffhunk://#diff-d8fcfd24bf92a72b66d700da0f205b055ae1bba35efc5b3864a0b84394a8d4e5R103): Added `component.element.remove()` to the `onExit` method to clean up the DOM.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

fixes #6350 
