### PR TITLE
Enhance bubble menu positioning for table cell selections

### DIFF
--- a/.changeset/early-guests-melt.md
+++ b/.changeset/early-guests-melt.md
@@ -1,0 +1,8 @@
+---
+'@tiptap/extension-bubble-menu': patch
+'@tiptap/react': patch
+'@tiptap/vue-2': patch
+'@tiptap/vue-3': patch
+---
+
+Fixed a bug where table cell selections would not position the bubble menu accordingly

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -334,6 +334,10 @@ export class BubbleMenuView implements PluginView {
       const fromDOM = this.view.nodeDOM(from)
       const toDOM = this.view.nodeDOM(to)
 
+      if (!fromDOM || !toDOM) {
+        return
+      }
+
       const clientRect =
         fromDOM === toDOM
           ? (fromDOM as HTMLElement).getBoundingClientRect()

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -12,9 +12,9 @@ import {
 } from '@floating-ui/dom'
 import type { Editor } from '@tiptap/core'
 import { isTextSelection, posToDOMRect } from '@tiptap/core'
-import type { ResolvedPos } from '@tiptap/pm/model'
 import type { EditorState, PluginView } from '@tiptap/pm/state'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { CellSelection } from '@tiptap/pm/tables'
 import type { EditorView } from '@tiptap/pm/view'
 
 function combineDOMRects(rect1: DOMRect, rect2: DOMRect): DOMRect {
@@ -322,12 +322,9 @@ export class BubbleMenuView implements PluginView {
     }
 
     // this is a special case for cell selections
-    const { $anchorCell, $headCell } = selection as unknown as {
-      $anchorCell?: ResolvedPos
-      $headCell?: ResolvedPos
-    }
+    if (selection instanceof CellSelection) {
+      const { $anchorCell, $headCell } = selection
 
-    if ($anchorCell || $headCell) {
       const from = $anchorCell ? $anchorCell.pos : $headCell!.pos
       const to = $headCell ? $headCell.pos : $anchorCell!.pos
 


### PR DESCRIPTION
## Changes Overview

This pull request enhances the `BubbleMenuPlugin` in `packages/extension-bubble-menu` by improving the handling of cell selections in the editor. It introduces a utility function to combine DOM rectangles and updates the logic for positioning the bubble menu when a cell selection is detected.

### Improvements to cell selection handling:

* **Added `combineDOMRects` utility function**: This function calculates a bounding rectangle that encompasses two DOM rectangles, ensuring proper handling of multi-cell selections. (`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`, [packages/extension-bubble-menu/src/bubble-menu-plugin.tsR15-R44](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953R15-R44))

* **Updated `updatePosition` method in `BubbleMenuView`**: Enhanced the logic to detect cell selections and compute the correct bounding rectangle for the bubble menu. This ensures that the menu is positioned correctly for both single-cell and multi-cell selections. (`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`, [packages/extension-bubble-menu/src/bubble-menu-plugin.tsL294-R349](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953L294-R349))

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #6410
