### PR TITLE
use changeset publish instead of manually publishing via pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
         uses: changesets/action@v1
         with:
           createGithubReleases: false
-          publish: pnpm run publish --tag ${{ github.ref_name == 'next' && 'next'  || 'latest' }}
+          publish: pnpm run publish
           version: pnpm run version
           title: ${{ github.ref_name == 'main' && 'Publish a new stable version'  || 'Publish a new pre-release version' }}
           commit: >-

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:demos": "pnpm  --prefix demos run build:demos",
     "serve": "pnpm run build:demos && http-server ./demos/dist -s -p 3000",
     "build:ci": "turbo run build",
-    "publish": "pnpm run build && pnpm publish -r --no-git-checks",
+    "publish": "pnpm run build && pnpm changeset publish",
     "clean:packages": "rm -rf ./packages/*/dist && rm -rf ./packages/pm/*/dist && rm -rf ./packages-deprecated/*/dist",
     "clean:packs": "rm -rf ./packages/*/*.tgz && rm -rf ./packages-deprecated/*/*.tgz",
     "reset": "pnpm run clean:packages && pnpm run clean:packs && rm -rf ./**/.cache && rm -rf ./**/node_modules && rm -rf ./package-lock.json && pnpm install",


### PR DESCRIPTION
## Description

This PR replaces the publish script so it uses `changeset publish`. This only publishes packages that actually were version bumped (or were not published yet) - this helps us to only publish packages that need to be re-published & avoid CI failures.

**Important Note**: `changeset publish` will always use the `pre` tag defined for changesets so after this PR is merged, changes that were previously deployed on `@next` will now be deployed as `@beta` (which objectively will be better **BUT** will require Tiptap users to adjust their dependencies).

## AI Summary

### Changes Overview

This pull request updates the publishing workflow and the `publish` script in `package.json` to improve consistency and streamline the release process. The most important changes involve replacing custom logic for determining the publish tag with simpler and more standardized commands.

#### Workflow updates:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L71-R71): Simplified the `publish` command in the `changesets/action` step by removing conditional logic for determining the tag (`next` or `latest`). The command now uses `pnpm run publish` directly.

#### Script updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R26): Updated the `publish` script to use `pnpm changeset publish` instead of `pnpm publish -r --no-git-checks`, aligning it with the changesets workflow.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
