### PR TITLE
Fix horizontal rule `can()` check always returning true

### DIFF
--- a/.changeset/modern-kangaroos-teach.md
+++ b/.changeset/modern-kangaroos-teach.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-horizontal-rule': patch
+---
+
+Fixed a bug that caused the horizontal rule's `setHorizontalRule` command to always return true when checked via `can()`

--- a/.changeset/silver-roses-joke.md
+++ b/.changeset/silver-roses-joke.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Added new `canInsertNode` utility that checks if a node can be inserted into a specific position

--- a/packages/core/src/utilities/canInsertNode.ts
+++ b/packages/core/src/utilities/canInsertNode.ts
@@ -1,0 +1,30 @@
+import type { NodeType } from '@tiptap/pm/model'
+import { type EditorState, NodeSelection } from '@tiptap/pm/state'
+
+export function canInsertNode(state: EditorState, nodeType: NodeType): boolean {
+  const { selection } = state
+  const { $from } = selection
+
+  // Special handling for NodeSelection
+  if (selection instanceof NodeSelection) {
+    const index = $from.index()
+    const parent = $from.parent
+
+    // Can we replace the selected node with the horizontal rule?
+    return parent.canReplaceWith(index, index + 1, nodeType)
+  }
+
+  // Default: check if we can insert at the current position
+  let depth = $from.depth
+
+  while (depth >= 0) {
+    const index = $from.index(depth)
+    const parent = $from.node(depth)
+    const match = parent.contentMatchAt(index)
+    if (match.matchType && match.matchType(nodeType)) {
+      return true
+    }
+    depth -= 1
+  }
+  return false
+}

--- a/packages/core/src/utilities/canInsertNode.ts
+++ b/packages/core/src/utilities/canInsertNode.ts
@@ -21,7 +21,7 @@ export function canInsertNode(state: EditorState, nodeType: NodeType): boolean {
     const index = $from.index(depth)
     const parent = $from.node(depth)
     const match = parent.contentMatchAt(index)
-    if (match.matchType && match.matchType(nodeType)) {
+    if (match.matchType(nodeType)) {
       return true
     }
     depth -= 1

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -1,4 +1,5 @@
 export * from './callOrReturn.js'
+export * from './canInsertNode.js'
 export * from './createStyleTag.js'
 export * from './deleteProps.js'
 export * from './elementFromString.js'

--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -1,6 +1,6 @@
 import { isNodeSelection, mergeAttributes, Node, nodeInputRule } from '@tiptap/core'
+import { canInsertNode } from '@tiptap/core/src/utilities/canInsertNode'
 import { NodeSelection, TextSelection } from '@tiptap/pm/state'
-import { canInsertNode } from 'packages/core/src/utilities/canInsertNode'
 
 export interface HorizontalRuleOptions {
   /**

--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -1,5 +1,6 @@
 import { isNodeSelection, mergeAttributes, Node, nodeInputRule } from '@tiptap/core'
-import { NodeSelection, TextSelection } from '@tiptap/pm/state'
+import type { NodeType } from '@tiptap/pm/model'
+import { type EditorState,NodeSelection, TextSelection } from '@tiptap/pm/state'
 
 export interface HorizontalRuleOptions {
   /**
@@ -46,10 +47,43 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
   },
 
   addCommands() {
+    function canInsertNode(state: EditorState, nodeType: NodeType): boolean {
+      const { selection } = state
+      const { $from } = selection
+
+      // Special handling for NodeSelection
+      if (selection instanceof NodeSelection) {
+        const index = $from.index()
+        const parent = $from.parent
+
+        // Can we replace the selected node with the horizontal rule?
+        return parent.canReplaceWith(index, index + 1, nodeType)
+      }
+
+      // Default: check if we can insert at the current position
+      let depth = $from.depth
+
+      while (depth >= 0) {
+        const index = $from.index(depth)
+        const parent = $from.node(depth)
+        const match = parent.contentMatchAt(index)
+        if (match.matchType && match.matchType(nodeType)) {
+          return true
+        }
+        depth -= 1
+      }
+      return false
+    }
+
     return {
       setHorizontalRule:
         () =>
         ({ chain, state }) => {
+          // Check if we can insert the node at the current selection
+          if (!canInsertNode(state, state.schema.nodes[this.name])) {
+            return false
+          }
+
           const { selection } = state
           const { $to: $originTo } = selection
 

--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -1,5 +1,4 @@
-import { isNodeSelection, mergeAttributes, Node, nodeInputRule } from '@tiptap/core'
-import { canInsertNode } from '@tiptap/core/src/utilities/canInsertNode'
+import { canInsertNode, isNodeSelection, mergeAttributes, Node, nodeInputRule } from '@tiptap/core'
 import { NodeSelection, TextSelection } from '@tiptap/pm/state'
 
 export interface HorizontalRuleOptions {

--- a/packages/extension-horizontal-rule/src/horizontal-rule.ts
+++ b/packages/extension-horizontal-rule/src/horizontal-rule.ts
@@ -1,6 +1,6 @@
 import { isNodeSelection, mergeAttributes, Node, nodeInputRule } from '@tiptap/core'
-import type { NodeType } from '@tiptap/pm/model'
-import { type EditorState,NodeSelection, TextSelection } from '@tiptap/pm/state'
+import { NodeSelection, TextSelection } from '@tiptap/pm/state'
+import { canInsertNode } from 'packages/core/src/utilities/canInsertNode'
 
 export interface HorizontalRuleOptions {
   /**
@@ -47,34 +47,6 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
   },
 
   addCommands() {
-    function canInsertNode(state: EditorState, nodeType: NodeType): boolean {
-      const { selection } = state
-      const { $from } = selection
-
-      // Special handling for NodeSelection
-      if (selection instanceof NodeSelection) {
-        const index = $from.index()
-        const parent = $from.parent
-
-        // Can we replace the selected node with the horizontal rule?
-        return parent.canReplaceWith(index, index + 1, nodeType)
-      }
-
-      // Default: check if we can insert at the current position
-      let depth = $from.depth
-
-      while (depth >= 0) {
-        const index = $from.index(depth)
-        const parent = $from.node(depth)
-        const match = parent.contentMatchAt(index)
-        if (match.matchType && match.matchType(nodeType)) {
-          return true
-        }
-        depth -= 1
-      }
-      return false
-    }
-
     return {
       setHorizontalRule:
         () =>


### PR DESCRIPTION
## Changes Overview

This pull request introduces a bug fix for the horizontal rule extension and adds a new utility function to the core package for checking node insertion feasibility. The most notable changes include implementing the `canInsertNode` utility function, integrating it into the horizontal rule extension, and ensuring the `setHorizontalRule` command respects insertion constraints.

### Bug Fix for Horizontal Rule Extension:

* [`.changeset/modern-kangaroos-teach.md`](diffhunk://#diff-120e7c73ab740c536484396991612d508c2362596d5be92a1cf1e86f5e1b7a36R1-R5): Fixed a bug causing the `setHorizontalRule` command to always return `true` when checked via `can()`.
* [`packages/extension-horizontal-rule/src/horizontal-rule.ts`](diffhunk://#diff-4dbed6cc257234c3325bd2f2d58f624d41e50881c51bf5acb92a9736546a2c81R54-R58): Updated the `setHorizontalRule` command to use the new `canInsertNode` utility, ensuring it checks if the node can be inserted at the current selection.

### New Utility for Node Insertion:

* [`.changeset/silver-roses-joke.md`](diffhunk://#diff-78537be840051456efd211be2f35d93401c1588194ad8b28873173ffe3f0cc82R1-R5): Added a new `canInsertNode` utility to the core package for checking if a node can be inserted into a specific position.
* [`packages/core/src/utilities/canInsertNode.ts`](diffhunk://#diff-ef70f04cc728a5be448e9f411210f3f4255deb986a69d81caee320f1ec5c8f62R1-R30): Implemented the `canInsertNode` function, which handles both `NodeSelection` and default insertion checks by traversing the selection depth.
* [`packages/extension-horizontal-rule/src/horizontal-rule.ts`](diffhunk://#diff-4dbed6cc257234c3325bd2f2d58f624d41e50881c51bf5acb92a9736546a2c81R3): Imported the `canInsertNode` utility into the horizontal rule extension for use in the `setHorizontalRule` command.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Fixes #6306
