### PR TITLE
Bdbch/6446 cleanup bubble menu resize

### DIFF
--- a/.changeset/great-terms-jam.md
+++ b/.changeset/great-terms-jam.md
@@ -1,0 +1,8 @@
+---
+'@tiptap/extension-bubble-menu': patch
+'@tiptap/react': patch
+'@tiptap/vue-2': patch
+'@tiptap/vue-3': patch
+---
+
+Fixed a bug where the global resize handler of the BubbleMenu plugin would not be unregistered on destroy

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -271,6 +271,11 @@ export class BubbleMenuView implements PluginView {
     this.hide()
   }
 
+  /**
+   * Handles the window resize event to update the position of the bubble menu.
+   * It uses a debounce mechanism to prevent excessive updates.
+   * The delay is defined by the `resizeDelay` property.
+   */
   resizeHandler = () => {
     if (this.resizeDebounceTimer) {
       clearTimeout(this.resizeDebounceTimer)

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -254,15 +254,7 @@ export class BubbleMenuView implements PluginView {
     this.view.dom.addEventListener('dragstart', this.dragstartHandler)
     this.editor.on('focus', this.focusHandler)
     this.editor.on('blur', this.blurHandler)
-    window.addEventListener('resize', () => {
-      if (this.resizeDebounceTimer) {
-        clearTimeout(this.resizeDebounceTimer)
-      }
-
-      this.resizeDebounceTimer = window.setTimeout(() => {
-        this.updatePosition()
-      }, this.resizeDelay)
-    })
+    window.addEventListener('resize', this.resizeHandler)
 
     this.update(view, view.state)
 
@@ -277,6 +269,16 @@ export class BubbleMenuView implements PluginView {
 
   dragstartHandler = () => {
     this.hide()
+  }
+
+  resizeHandler = () => {
+    if (this.resizeDebounceTimer) {
+      clearTimeout(this.resizeDebounceTimer)
+    }
+
+    this.resizeDebounceTimer = window.setTimeout(() => {
+      this.updatePosition()
+    }, this.resizeDelay)
   }
 
   focusHandler = () => {
@@ -464,6 +466,7 @@ export class BubbleMenuView implements PluginView {
     this.hide()
     this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.view.dom.removeEventListener('dragstart', this.dragstartHandler)
+    window.removeEventListener('resize', this.resizeHandler)
     this.editor.off('focus', this.focusHandler)
     this.editor.off('blur', this.blurHandler)
 


### PR DESCRIPTION
## Changes Overview

This pull request addresses a bug in the BubbleMenu plugin where the global resize handler was not properly unregistered upon destruction. The changes include refactoring the resize handler to improve maintainability and ensure proper cleanup.

### Bug Fixes:

* [`.changeset/great-terms-jam.md`](diffhunk://#diff-379749d4bd0d25e6b3bcc1e6cf24eafc0308adad0cf4b12f256a8a55ff1785a5R1-R8): Added patch updates for `@tiptap/extension-bubble-menu`, `@tiptap/react`, `@tiptap/vue-2`, and `@tiptap/vue-3` to fix the issue with the BubbleMenu plugin's resize handler not being unregistered on destroy.

### Code Refactoring:

* [`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953R274-R283): Refactored the resize handler by extracting it into a dedicated method (`resizeHandler`) to improve readability and maintainability.
* [`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953R469): Updated the `destroy` method to ensure the resize handler is properly removed from the `window` event listeners.
* [`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953L257-R257): Replaced the inline resize logic in the constructor with the new `resizeHandler` method for consistency.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- fixes #6446 
