### PR TITLE
On drop: delete selection in source tiptap only if editable

### DIFF
--- a/.changeset/spicy-horses-smoke.md
+++ b/.changeset/spicy-horses-smoke.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fix: Prevent content deletion from non-editable Tiptap source editors during drag and drop.

--- a/packages/core/src/PasteRule.ts
+++ b/packages/core/src/PasteRule.ts
@@ -267,7 +267,7 @@ export function pasteRulesPlugin(props: { editor: Editor; rules: PasteRule[] }):
             if (!isDroppedFromProseMirror) {
               const dragFromOtherEditor = tiptapDragFromOtherEditor
 
-              if (dragFromOtherEditor) {
+              if (dragFromOtherEditor?.isEditable) {
                 // setTimeout to avoid the wrong content after drop, timeout arg can't be empty or 0
                 setTimeout(() => {
                   const selection = dragFromOtherEditor.state.selection


### PR DESCRIPTION
Currently, if a drag and drop operation is performed between two tiptap editors, the content in the source editor is deleted regardless of it's editable property.
With this PR, the source content is only deleted if the source editor is editable.

https://github.com/user-attachments/assets/225f7517-332b-4d93-aae4-1f96cfd19742

## Changes Overview

I only introduced the editable condition before deleting the source editor's text range.

## Implementation Approach

I reproduced the issue in a sandbox: https://codesandbox.io/p/devbox/compassionate-dhawan-7p3qcy

## Testing Done

I checked out the repo locally, made the change, ran the tests and verified the intended behavior

## Verification Steps

I checked out the repo locally, made the change, ran the tests and verified the intended behavior

## Additional Notes

-

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

-
