### PR TITLE
Show mention indicator when converting document to HTML (cherry-pick)

### DIFF
--- a/.changeset/moody-insects-guess.md
+++ b/.changeset/moody-insects-guess.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-mention': patch
+---
+
+Show mention indicator when converting document to HTML


### PR DESCRIPTION
Cherry-picks #6518

## Changes Overview

Fixes bug in Mention extension causing the rendered HTML to be incorrect

## Implementation Approach

The rendered HTML was incorrect because the extension storage is not initialized when the HTML utility is called. The solution is to not depend on extension storage to render the HTML with the HTML utility. The extension storage has been replaced by utility functions.

## Testing Done

Run the existing tests, they still pass

## Verification Steps

Described in issue #6517

## Additional Notes



## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#6517
