### PR TITLE
fix(drag-handle-react): dont pass default object to tippyOptions

### DIFF
--- a/.changeset/gentle-yaks-invite.md
+++ b/.changeset/gentle-yaks-invite.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-drag-handle-react": patch
+---
+
+Fix a bug that causes rerenders on the react drag handle breaking it's tippy connection

--- a/packages/extension-drag-handle-react/src/DragHandle.tsx
+++ b/packages/extension-drag-handle-react/src/DragHandle.tsx
@@ -16,6 +16,14 @@ export type DragHandleProps = Omit<Optional<DragHandlePluginProps, 'pluginKey'>,
   className?: string;
   onNodeChange?: (data: { node: Node | null; editor: Editor; pos: number }) => void;
   children: ReactNode;
+
+  /**
+   * Tippy.js options for the drag handle tooltip.
+   *
+   * **IMPORTANT**: Make sure to memorize this object - otherwise the object
+   * will cause the drag handle to be re-initialized on every render breaking it.
+   */
+  tippyOptions?: DragHandlePluginProps['tippyOptions'];
 };
 
 export const DragHandle = (props: DragHandleProps) => {
@@ -25,7 +33,7 @@ export const DragHandle = (props: DragHandleProps) => {
     editor,
     pluginKey = dragHandlePluginDefaultKey,
     onNodeChange,
-    tippyOptions = {},
+    tippyOptions,
   } = props
   const [element, setElement] = useState<HTMLDivElement | null>(null)
   const plugin = useRef<Plugin | null>(null)


### PR DESCRIPTION
## Changes

I removed the default value of tippyOptions since it caused a lot of rerenders breaking the DragHandle. This is not a real fix but since we phase out Tippy.js in 3.0.0 I didn't want to spend time fixing this as we had the problem for a longer time now.

With 3.0.0 we use floating UI which handles re-renders way better.

In the end the developer should always pass through **memorized** values anyways to minimize rerenderin.

## AI Summary

This pull request introduces a new `tippyOptions` property to the `DragHandleProps` type and updates the `DragHandle` component to support it. This change allows developers to customize tooltip behavior for the drag handle using Tippy.js options.

Enhancements to tooltip customization:

* [`packages/extension-drag-handle-react/src/DragHandle.tsx`](diffhunk://#diff-54ff4bc203c850851ded7a4843d32a8957e41f336f83975696d1cba4c2f06d76R19-R26): Added a new `tippyOptions` property to the `DragHandleProps` type, with a note emphasizing the importance of memorizing the object to prevent re-initialization issues.
* [`packages/extension-drag-handle-react/src/DragHandle.tsx`](diffhunk://#diff-54ff4bc203c850851ded7a4843d32a8957e41f336f83975696d1cba4c2f06d76L28-R36): Updated the `DragHandle` component to accept the `tippyOptions` property without providing a default value, ensuring flexibility in tooltip configuration.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
