### PR TITLE
Add lazy-loaded ProseMirror Devtool integration to Core

### DIFF
--- a/.changeset/silly-hats-doubt.md
+++ b/.changeset/silly-hats-doubt.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': minor
+---
+
+Added lazy-loaded ProseMirror Devtools integration which can be enabled via the new editor option `enableDevTools: true`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,9 @@
     "jsx-dev-runtime"
   ],
   "devDependencies": {
-    "@tiptap/pm": "workspace:*"
+    "@tiptap/pm": "workspace:*",
+    "@types/prosemirror-dev-tools": "^3.0.6",
+    "prosemirror-dev-tools": "^4.2.0"
   },
   "peerDependencies": {
     "@tiptap/pm": "workspace:*"

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -92,6 +92,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     enablePasteRules: true,
     enableCoreExtensions: true,
     enableContentCheck: false,
+    enableDevTools: false,
     emitContentError: false,
     onBeforeCreate: () => null,
     onCreate: () => null,
@@ -184,6 +185,21 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.isInitialized = false
     this.css?.remove()
     this.css = null
+  }
+
+  private applyDevTools(): void {
+    import('prosemirror-dev-tools')
+      .then(({ default: apply }) => {
+        if (!this.editorView) {
+          return
+        }
+
+        apply(this.editorView)
+      })
+      .catch(() => {
+        console.warn('[Tiptap warning]: Devtools are enabled but `prosemirror-dev-tools` is not installed.')
+        console.warn("Install 'prosemirror-dev-tools' as a dev dependency to use the dev tools.")
+      })
   }
 
   /**
@@ -488,6 +504,11 @@ export class Editor extends EventEmitter<EditorEvents> {
       dispatchTransaction: this.dispatchTransaction.bind(this),
       state: this.editorState,
     })
+
+    // Apply dev tools if enabled
+    if (this.options.enableDevTools) {
+      this.applyDevTools()
+    }
 
     // `editor.view` is not yet available at this time.
     // Therefore we will add all plugins and node views directly afterwards.

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -187,7 +187,29 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.css = null
   }
 
+  /**
+   *
+   * @returns
+   */
+  /**
+   * Applies ProseMirror dev tools to the editor instance if enabled and running in a browser environment.
+   *
+   * This method dynamically imports the `prosemirror-dev-tools` package and applies it to the current
+   * editor view. If the dev tools are not installed, a warning is logged to the console.
+   *
+   * @private
+   * @remarks
+   * - Dev tools are only applied if `this.options.enableDevTools` is `true` and the code is running in a browser.
+   * - If the editor view is not available, the dev tools are not applied.
+   * - If the `prosemirror-dev-tools` package is missing, a warning is shown in the console.
+   *
+   * @returns {void}
+   */
   private applyDevTools(): void {
+    if (typeof window === 'undefined' || !this.options.enableDevTools) {
+      return
+    }
+
     import('prosemirror-dev-tools')
       .then(({ default: apply }) => {
         if (!this.editorView) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -365,7 +365,10 @@ export interface EditorOptions {
   emitContentError: boolean
   /**
    * Enable a lazy-loaded Prosemirror DevTools integration.
+   * 
+   * Requires having the `prosemirror-dev-tools` npm package installed.
    * @type boolean
+   * @default false
    * @example
    * ```js
    * enableDevTools: true

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -365,7 +365,7 @@ export interface EditorOptions {
   emitContentError: boolean
   /**
    * Enable a lazy-loaded Prosemirror DevTools integration.
-   * @type {boolean | ((props: { editor: Editor }) => void)}
+   * @type boolean
    * @example
    * ```js
    * enableDevTools: true

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -365,7 +365,7 @@ export interface EditorOptions {
   emitContentError: boolean
   /**
    * Enable a lazy-loaded Prosemirror DevTools integration.
-   * 
+   *
    * Requires having the `prosemirror-dev-tools` npm package installed.
    * @type boolean
    * @default false

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -364,6 +364,15 @@ export interface EditorOptions {
    */
   emitContentError: boolean
   /**
+   * Enable a lazy-loaded Prosemirror DevTools integration.
+   * @type {boolean | ((props: { editor: Editor }) => void)}
+   * @example
+   * ```js
+   * enableDevTools: true
+   * ```
+   */
+  enableDevTools: boolean
+  /**
    * Called before the editor is constructed.
    */
   onBeforeCreate: (props: EditorEvents['beforeCreate']) => void

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,12 @@ importers:
       '@tiptap/pm':
         specifier: workspace:*
         version: link:../pm
+      '@types/prosemirror-dev-tools':
+        specifier: ^3.0.6
+        version: 3.0.6
+      prosemirror-dev-tools:
+        specifier: ^4.2.0
+        version: 4.2.0(@babel/core@7.26.0)(@babel/template@7.25.9)(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/extension-blockquote:
     devDependencies:
@@ -1897,6 +1903,11 @@ packages:
     resolution: {integrity: sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==}
     engines: {node: '>=v18'}
 
+  '@compiled/react@0.11.4':
+    resolution: {integrity: sha512-mtnEUFM7w/5xABWWWj3wW0vjS/cHSg0PAttJC+hOpQ5z5qGZCwk43Gy8Hfjruxvll73igJ5DSMzcAyek6DMKjw==}
+    peerDependencies:
+      react: '>= 16.12.0'
+
   '@cypress/request@3.0.7':
     resolution: {integrity: sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==}
     engines: {node: '>= 6'}
@@ -3014,6 +3025,9 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/base16@1.0.5':
+    resolution: {integrity: sha512-OzOWrTluG9cwqidEzC/Q6FAmIPcnZfm8BFRlIx0+UIUqnuAmi5OS88O0RpT3Yz6qdmqObvUhasrbNsCofE4W9A==}
+
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
@@ -3044,6 +3058,9 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
+  '@types/lodash@4.17.19':
+    resolution: {integrity: sha512-NYqRyg/hIQrYPT9lbOeYc3kIRabJDn/k4qQHIXUpx88CBDww2fD15Sg5kbXlW86zm2XEW4g0QxkTI3/Kfkc7xQ==}
+
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
 
@@ -3064,6 +3081,9 @@ packages:
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
+
+  '@types/prosemirror-dev-tools@3.0.6':
+    resolution: {integrity: sha512-zARROV118nwc+sX7W+0ea4cffqUeRNOSac0jttSpJ921aS6w++Be+RakAgGiTqoRpPV+J+wKomMR/RuKBAlEMg==}
 
   '@types/react-dom@18.3.5':
     resolution: {integrity: sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==}
@@ -3489,6 +3509,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base16@1.0.0:
+    resolution: {integrity: sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3714,6 +3737,12 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@3.2.1:
+    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -3767,6 +3796,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concat-stream@1.6.2:
+    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
+    engines: {'0': node >= 0.8}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -4080,6 +4113,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -4877,6 +4913,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  html@1.0.0:
+    resolution: {integrity: sha512-lw/7YsdKiP3kk5PnR1INY17iJuzdAtJewxr14ozKJWbbR97znovZ0mh+WEMZ8rjc3lgTK+ID/htTjuyGKB52Kw==}
+    hasBin: true
+
   htmlparser2@7.2.0:
     resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
 
@@ -4982,6 +5022,9 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-arrayish@0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
 
   is-async-function@2.1.0:
     resolution: {integrity: sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==}
@@ -5147,6 +5190,9 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -5181,6 +5227,46 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  jotai@1.13.1:
+    resolution: {integrity: sha512-RUmH1S4vLsG3V6fbGlKzGJnLrDcC/HNb5gH2AeA9DzuJknoVxSGvvg8OBB7lke+gDc4oXmdVsaKn/xDUhWZ0vw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      '@babel/template': '*'
+      jotai-devtools: '*'
+      jotai-immer: '*'
+      jotai-optics: '*'
+      jotai-redux: '*'
+      jotai-tanstack-query: '*'
+      jotai-urql: '*'
+      jotai-valtio: '*'
+      jotai-xstate: '*'
+      jotai-zustand: '*'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      jotai-devtools:
+        optional: true
+      jotai-immer:
+        optional: true
+      jotai-optics:
+        optional: true
+      jotai-redux:
+        optional: true
+      jotai-tanstack-query:
+        optional: true
+      jotai-urql:
+        optional: true
+      jotai-valtio:
+        optional: true
+      jotai-xstate:
+        optional: true
+      jotai-zustand:
+        optional: true
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -5259,6 +5345,11 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  jsondiffpatch@0.4.1:
+    resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
+    engines: {node: '>=8.17.0'}
     hasBin: true
 
   jsonfile@4.0.0:
@@ -5375,6 +5466,9 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.curry@4.1.1:
+    resolution: {integrity: sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -5952,9 +6046,15 @@ packages:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
@@ -5967,6 +6067,13 @@ packages:
 
   prosemirror-commands@1.6.2:
     resolution: {integrity: sha512-0nDHH++qcf/BuPLYvmqZTUUsPJUCPBUXt0J1ErTcDIS369CTp773itzLGIgIXG4LJXOlwYCr44+Mh4ii6MP1QA==}
+
+  prosemirror-dev-tools@4.2.0:
+    resolution: {integrity: sha512-Hm1HRgK0Fxhb+Dy507R1uHgP3Ixuwbh7ZHD6NUZGEAl26BKW95L70nwdA1P4odPfxPsx0lBZm1KMpulsOJMwpQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   prosemirror-dropcursor@1.8.1:
     resolution: {integrity: sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==}
@@ -6060,6 +6167,15 @@ packages:
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
+  react-base16-styling@0.9.1:
+    resolution: {integrity: sha512-1s0CY1zRBOQ5M3T61wetEpvQmsYSNtWEcdYzyZNxKa8t7oDvaOn9d21xrGezGAHFWLM7SHcktPuPTrvoqxSfKw==}
+
+  react-dock@0.6.0:
+    resolution: {integrity: sha512-jEOhv1s+pqRQ4JxgUw4XUotnprOehZ23mqchf3whxYXnvNgTQOXCxh6bpcqW8P6OybIk2bYO18r3qimZ3ypCbg==}
+    peerDependencies:
+      '@types/react': ^16.3.0 || ^17.0.0 || ^18.0.0
+      react: ^16.3.0 || ^17.0.0 || ^18.0.0
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -6076,11 +6192,20 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-json-tree@0.17.0:
+    resolution: {integrity: sha512-hcWjibI/fAvsKnfYk+lka5OrE1Lvb1jH5pSnFhIU5T8cCCxB85r6h/NOzDPggSSgErjmx4rl3+2EkeclIKBOhg==}
+    peerDependencies:
+      '@types/react': ^16.3.0 || ^17.0.0 || ^18.0.0
+      react: ^16.3.0 || ^17.0.0 || ^18.0.0
 
   react-refresh@0.13.0:
     resolution: {integrity: sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==}
@@ -6100,6 +6225,9 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -6360,6 +6488,9 @@ packages:
   simple-peer@9.11.1:
     resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
 
+  simple-swizzle@0.2.2:
+    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -6450,6 +6581,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -6756,6 +6890,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -8307,6 +8444,11 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.4.1
 
+  '@compiled/react@0.11.4(react@19.1.0)':
+    dependencies:
+      csstype: 3.1.3
+      react: 19.1.0
+
   '@cypress/request@3.0.7':
     dependencies:
       aws-sign2: 0.7.0
@@ -9277,6 +9419,8 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/base16@1.0.5': {}
+
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 22.10.3
@@ -9310,6 +9454,8 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
+  '@types/lodash@4.17.19': {}
+
   '@types/markdown-it@14.1.2':
     dependencies:
       '@types/linkify-it': 5.0.0
@@ -9332,6 +9478,10 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/prop-types@15.7.14': {}
+
+  '@types/prosemirror-dev-tools@3.0.6':
+    dependencies:
+      prosemirror-view: 1.38.1
 
   '@types/react-dom@18.3.5(@types/react@18.3.18)':
     dependencies:
@@ -9869,6 +10019,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base16@1.0.0: {}
+
   base64-js@1.5.1: {}
 
   basic-auth@2.0.1:
@@ -10096,6 +10248,16 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+
+  color@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+      color-string: 1.9.1
+
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -10148,6 +10310,13 @@ snapshots:
       dot-prop: 5.3.0
 
   concat-map@0.0.1: {}
+
+  concat-stream@1.6.2:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      typedarray: 0.0.6
 
   confbox@0.1.8: {}
 
@@ -10515,6 +10684,8 @@ snapshots:
       dequal: 2.0.3
 
   didyoumean@1.2.2: {}
+
+  diff-match-patch@1.0.5: {}
 
   diff-sequences@29.6.3: {}
 
@@ -11468,6 +11639,10 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  html@1.0.0:
+    dependencies:
+      concat-stream: 1.6.2
+
   htmlparser2@7.2.0:
     dependencies:
       domelementtype: 2.3.0
@@ -11589,6 +11764,8 @@ snapshots:
       get-intrinsic: 1.2.7
 
   is-arrayish@0.2.1: {}
+
+  is-arrayish@0.3.2: {}
 
   is-async-function@2.1.0:
     dependencies:
@@ -11741,6 +11918,8 @@ snapshots:
 
   is-windows@1.0.2: {}
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isbinaryfile@5.0.4: {}
@@ -11768,6 +11947,13 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.4.2: {}
+
+  jotai@1.13.1(@babel/core@7.26.0)(@babel/template@7.25.9)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@babel/core': 7.26.0
+      '@babel/template': 7.25.9
 
   joycon@3.1.1: {}
 
@@ -11862,6 +12048,11 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsondiffpatch@0.4.1:
+    dependencies:
+      chalk: 2.4.2
+      diff-match-patch: 1.0.5
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -11987,6 +12178,8 @@ snapshots:
       p-locate: 6.0.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.curry@4.1.1: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -12521,7 +12714,15 @@ snapshots:
 
   prismjs@1.29.0: {}
 
+  process-nextick-args@2.0.1: {}
+
   process@0.11.10: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   property-information@6.5.0: {}
 
@@ -12538,6 +12739,34 @@ snapshots:
       prosemirror-model: 1.24.1
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.2
+
+  prosemirror-dev-tools@4.2.0(@babel/core@7.26.0)(@babel/template@7.25.9)(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@compiled/react': 0.11.4(react@19.1.0)
+      html: 1.0.0
+      jotai: 1.13.1(@babel/core@7.26.0)(@babel/template@7.25.9)(react@19.1.0)
+      jsondiffpatch: 0.4.1
+      nanoid: 3.3.8
+      prosemirror-model: 1.24.1
+      prosemirror-state: 1.4.3
+      react: 19.1.0
+      react-dock: 0.6.0(@types/react@19.1.6)(react@19.1.0)
+      react-dom: 19.1.0(react@19.1.0)
+      react-json-tree: 0.17.0(@types/react@19.1.6)(react@19.1.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
 
   prosemirror-dropcursor@1.8.1:
     dependencies:
@@ -12678,6 +12907,26 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  react-base16-styling@0.9.1:
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@types/base16': 1.0.5
+      '@types/lodash': 4.17.19
+      base16: 1.0.0
+      color: 3.2.1
+      csstype: 3.1.3
+      lodash.curry: 4.1.1
+
+  react-dock@0.6.0(@types/react@19.1.6)(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@types/lodash': 4.17.19
+      '@types/prop-types': 15.7.14
+      '@types/react': 19.1.6
+      lodash.debounce: 4.0.8
+      prop-types: 15.8.1
+      react: 19.1.0
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -12694,9 +12943,21 @@ snapshots:
       '@babel/runtime': 7.26.0
       react: 19.1.0
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-json-tree@0.17.0(@types/react@19.1.6)(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@types/lodash': 4.17.19
+      '@types/prop-types': 15.7.14
+      '@types/react': 19.1.6
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-base16-styling: 0.9.1
 
   react-refresh@0.13.0: {}
 
@@ -12716,6 +12977,16 @@ snapshots:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.2
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -13045,6 +13316,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-swizzle@0.2.2:
+    dependencies:
+      is-arrayish: 0.3.2
+
   slash@3.0.0: {}
 
   slice-ansi@3.0.0:
@@ -13153,6 +13428,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -13481,6 +13760,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
+
+  typedarray@0.0.6: {}
 
   typescript@5.7.3: {}
 


### PR DESCRIPTION
## Changes Overview

This PR adds [ProseMirror Devtools](https://github.com/d4rkr00t/prosemirror-dev-tools) as an integration right into the core. I thought about how to build it to make sure this doesn't pollute our users code if it is not needed as we don't want to bundle dev tools with Tiptap.

My conclusion was to lazy-load the dependency and **don't deliver it with Tiptap**. How it's integrated now only installs the devtools as a dev dependency which means users will need to install the prosemirror-dev-tools package manually. There are also no peer or optional dependencies for this.

I'm not the pro when it comes to how build tools bundle and tree-shake code but this should be pretty bulletproof when it comes to the bundle as when the dev tools are not loaded, they will not be imported.

The devtools also should not load when the editorView is not accessible, for example on servers.

### Code example (Basic Node):

```
const editor = new Editor({
  // ...
  // by enabling this the prosemirror-dev-tools package will lazy-loaded
  enableDevTools: process.env.NODE_ENV === "development",
})
```

### Code example (Vite):

```
const editor = new Editor({
  // ...
  // by enabling this the prosemirror-dev-tools package will lazy-loaded
  enableDevTools: import.meta.env.DEV,
})
```

## AI Summary

This pull request introduces a minor feature enhancement to the `@tiptap/core` package by adding optional ProseMirror DevTools integration. Additionally, it updates dependencies and configuration files to support this integration. Below is a detailed summary of the most important changes grouped by theme:

### Feature Addition: ProseMirror DevTools Integration
* Added a new editor option, `enableDevTools: true`, to enable lazy-loaded ProseMirror DevTools integration. This allows developers to debug ProseMirror states directly within the editor. (`.changeset/silly-hats-doubt.md`, [.changeset/silly-hats-doubt.mdR1-R5](diffhunk://#diff-173b84e0c986b26c82f9b7809873193d0f843d4a810524eedd32056ecdf36a1fR1-R5))
* Updated the `Editor` class to include the `applyDevTools` method for dynamically importing and applying DevTools when enabled. (`packages/core/src/Editor.ts`, [packages/core/src/Editor.tsR190-R204](diffhunk://#diff-9b7c004a70a95a9e7b2b49f3761403a4abfe14fae1490e32c86306794017e27dR190-R204))
* Integrated the `applyDevTools` method into the editor initialization process to activate DevTools if the `enableDevTools` option is set. (`packages/core/src/Editor.ts`, [packages/core/src/Editor.tsR508-R512](diffhunk://#diff-9b7c004a70a95a9e7b2b49f3761403a4abfe14fae1490e32c86306794017e27dR508-R512))
* Extended the `EditorOptions` interface to include the `enableDevTools` property with documentation and usage examples. (`packages/core/src/types.ts`, [packages/core/src/types.tsR366-R374](diffhunk://#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479R366-R374))

### Dependency Updates
* Added `prosemirror-dev-tools` and `@types/prosemirror-dev-tools` as development dependencies to support the new feature. (`packages/core/package.json`, [packages/core/package.jsonL55-R57](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L55-R57))
* Updated `pnpm-lock.yaml` to include resolutions for `prosemirror-dev-tools` and its dependencies. (`pnpm-lock.yaml`, [pnpm-lock.yamlR6071-R6077](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6071-R6077))

These changes collectively enhance the debugging capabilities of the Tiptap editor while maintaining backward compatibility.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

