### PR TITLE
fix cjs modules using esm syntax

### DIFF
--- a/.changeset/tiny-tomatoes-hope.md
+++ b/.changeset/tiny-tomatoes-hope.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fixed a bug where jsx-runtime cjs files would break Jest runners because of ESM syntax

--- a/packages/core/jsx-dev-runtime/index.cjs
+++ b/packages/core/jsx-dev-runtime/index.cjs
@@ -1,1 +1,1 @@
-export * from '../dist/jsx-runtime/jsx-runtime.cjs'
+module.exports = require('../dist/jsx-runtime/jsx-runtime.cjs')

--- a/packages/core/jsx-runtime/index.cjs
+++ b/packages/core/jsx-runtime/index.cjs
@@ -1,1 +1,1 @@
-export * from '../dist/jsx-runtime/jsx-runtime.cjs'
+module.exports = require('../dist/jsx-runtime/jsx-runtime.cjs')


### PR DESCRIPTION
## Changes Overview

This PR fixes a problem reported in #6525 where the cjs files of the core runtime helpers will cause errors with Jest.

## AI Summary

This pull request addresses an issue with ESM syntax in `jsx-runtime` CJS files that caused Jest runners to break. The changes ensure compatibility by modifying the export mechanism and documenting the fix.

Bug fix for Jest compatibility:

* [`.changeset/tiny-tomatoes-hope.md`](diffhunk://#diff-1bffc644e58a4138bc9b84fb67ac16e546e43d6a275041704ccec1d8e830ddafR1-R5): Added a changeset documenting the fix for the `jsx-runtime` CJS files to prevent breakage in Jest runners due to ESM syntax.
* [`packages/core/jsx-dev-runtime/index.cjs`](diffhunk://#diff-482cad78933c24354e83ad1f15ce593e3788d3855a78e4120f10283d23511564L1-R1): Changed the export mechanism from `export *` to `module.exports` to ensure compatibility with Jest.
* [`packages/core/jsx-runtime/index.cjs`](diffhunk://#diff-482cad78933c24354e83ad1f15ce593e3788d3855a78e4120f10283d23511564L1-R1): Applied the same export mechanism fix as above for consistency.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #6525 
