### PR TITLE
added aria-label support for task items

### DIFF
--- a/.changeset/twelve-peas-smile.md
+++ b/.changeset/twelve-peas-smile.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': patch
+---
+
+Added a new `a11y` option to task list items to set the checkbox aria-label

--- a/packages/extension-task-item/src/task-item.ts
+++ b/packages/extension-task-item/src/task-item.ts
@@ -32,6 +32,19 @@ export interface TaskItemOptions {
    * @example 'myCustomTaskList'
    */
   taskListTypeName: string
+
+  /**
+   * Accessibility options for the task item.
+   * @default {}
+   * @example
+   * ```js
+   * {
+   *   checkboxLabel: (node) => `Task item: ${node.textContent || 'empty task item'}`
+   * }
+   */
+  a11y?: {
+    checkboxLabel?: (node: ProseMirrorNode, checked: boolean) => string
+  }
 }
 
 /**
@@ -51,6 +64,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
       nested: false,
       HTMLAttributes: {},
       taskListTypeName: 'taskList',
+      a11y: undefined,
     }
   },
 
@@ -135,6 +149,13 @@ export const TaskItem = Node.create<TaskItemOptions>({
       const checkbox = document.createElement('input')
       const content = document.createElement('div')
 
+      const updateA11Y = () => {
+        checkbox.ariaLabel = this.options.a11y?.checkboxLabel?.(node, checkbox.checked)
+          || `Task item checkbox for ${node.textContent || 'empty task item'}`
+      }
+
+      updateA11Y()
+
       checkboxWrapper.contentEditable = 'false'
       checkbox.type = 'checkbox'
       checkbox.addEventListener('mousedown', event => event.preventDefault())
@@ -202,6 +223,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
 
           listItem.dataset.checked = updatedNode.attrs.checked
           checkbox.checked = updatedNode.attrs.checked
+          updateA11Y()
 
           return true
         },


### PR DESCRIPTION
## Changes Overview

This PR adds a11y support for task-items (see #6549) for the main branch.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
