### PR TITLE
add alt attribute to emoji extension for accessibility

### DIFF
--- a/.changeset/five-rules-pull.md
+++ b/.changeset/five-rules-pull.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-emoji': patch
+---
+
+Added alt tag to emoji extension

--- a/packages/extension-emoji/src/emoji.ts
+++ b/packages/extension-emoji/src/emoji.ts
@@ -218,6 +218,7 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
               draggable: 'false',
               loading: 'lazy',
               align: 'absmiddle',
+              alt: `${emojiItem.name} emoji`,
             },
           ]
         : emojiItem.emoji || `:${emojiItem.shortcodes[0]}:`,


### PR DESCRIPTION
## Changes Overview

This PR adds a alt tag to emoji fallback images ensuring better a11y results.

## AI Summary

This pull request introduces a minor improvement to the `@tiptap/extension-emoji` package by adding an `alt` tag to the emoji extension, enhancing accessibility.

Accessibility improvement:

* [`.changeset/five-rules-pull.md`](diffhunk://#diff-d3faea9a86577007663296de25356e29b715e4fcb4b00cacee1b0f36560808c9R1-R5): Documented the addition of an `alt` tag as a patch change for the `@tiptap/extension-emoji` package.
* [`packages/extension-emoji/src/emoji.ts`](diffhunk://#diff-49e6b314687626255e0569b417deb0efa514ec2b21fb3f6146e4e8d253801df3R221): Updated the `Emoji` node to include an `alt` attribute with the emoji's name (e.g., "smile emoji") to improve accessibility.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [x] I have fixed any lint issues.
