### PR TITLE
revert flushSync removal

### DIFF
--- a/.changeset/cyan-starfishes-dream.md
+++ b/.changeset/cyan-starfishes-dream.md
@@ -1,5 +1,0 @@
----
-'@tiptap/react': minor
----
-
-Removed flushSync on NodeView render which caused performance regressions, bugs with unused NodeViews still being reconciled for PMViewDesc checks and more

--- a/.changeset/stale-ties-press.md
+++ b/.changeset/stale-ties-press.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': minor
+---
+
+Reintroduce flushSync to sync rendering of React and ProseMirror

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -8,6 +8,7 @@ import type {
   RefAttributes,
 } from 'react'
 import { version as reactVersion } from 'react'
+import { flushSync } from 'react-dom'
 
 import type { EditorWithContentComponent } from './Editor.js'
 
@@ -176,9 +177,18 @@ export class ReactRenderer<R = unknown, P extends Record<string, any> = object> 
       this.element.classList.add(...className.split(' '))
     }
 
-    queueMicrotask(() => {
-      this.render()
-    })
+    // If the editor is already initialized, we will need to
+    // synchronously render the component to ensure it renders
+    // together with Prosemirror's rendering.
+    if (this.editor.isInitialized) {
+      flushSync(() => {
+        this.render()
+      })
+    } else {
+      queueMicrotask(() => {
+        this.render()
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
## Changes Overview

This PR reverts the change of #6538 because it introduced a lot of problems with async vs sync rendering leading to infinite rendering cycles.