### PR TITLE
add full import paths for external storage shim

### DIFF
--- a/.changeset/angry-ladybugs-bow.md
+++ b/.changeset/angry-ladybugs-bow.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Added full import path for external storage sync shim

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -2,7 +2,7 @@ import type { Editor } from '@tiptap/core'
 import type { ForwardedRef, HTMLProps, LegacyRef, MutableRefObject } from 'react'
 import React, { forwardRef } from 'react'
 import ReactDOM from 'react-dom'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import type { ContentComponent, EditorWithContentComponent } from './Editor.js'
 import type { ReactRenderer } from './ReactRenderer.js'

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,7 +1,7 @@
 import { type EditorOptions, Editor } from '@tiptap/core'
 import type { DependencyList, MutableRefObject } from 'react'
 import { useDebugValue, useEffect, useRef, useState } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import { useEditorState } from './useEditorState.js'
 

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -1,7 +1,7 @@
 import type { Editor } from '@tiptap/core'
 import deepEqual from 'fast-deep-equal/es6/react.js'
 import { useDebugValue, useEffect, useLayoutEffect, useState } from 'react'
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector.js'
 
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 


### PR DESCRIPTION
## Changes Overview

This PR adds full import path for the use-external-storage shim package to comply with import standards in esm mode.

## AI Summary

This pull request primarily addresses import path adjustments for compatibility and consistency in the `@tiptap/react` package. The changes ensure that full import paths are specified for external dependencies, which can help avoid module resolution issues in certain environments.

### Import Path Adjustments:

* [`.changeset/angry-ladybugs-bow.md`](diffhunk://#diff-414a237811150dfb3c899cad0d597c30e7f560db9b3f618bd456c2bd069cb77aR1-R5): Added a changeset entry describing the update to use full import paths for the external storage sync shim.
* [`packages/react/src/EditorContent.tsx`](diffhunk://#diff-c1d83c0fa32f3b18f2d8e5b3eb81f9d951c0d6de903191d495d169d248188ceeL5-R5): Updated the import for `useSyncExternalStore` to include the full path (`shim/index.js`).
* [`packages/react/src/useEditor.ts`](diffhunk://#diff-13acb5e551812e195c1140c10ba5ac298a0005996d07756cfd77c2d4194cb350L4-R4): Updated the import for `useSyncExternalStore` to include the full path (`shim/index.js`).
* [`packages/react/src/useEditorState.ts`](diffhunk://#diff-338f818d4bf4a2b3c2467a0092b46387c05cd0398ffc2f1838a7b2caac4a4f38L4-R4): Updated the import for `useSyncExternalStoreWithSelector` to include the full path (`shim/with-selector.js`).

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #6447 
