### PR TITLE
Fix bubble menu positionning first render

### DIFF
--- a/.changeset/good-maps-leave.md
+++ b/.changeset/good-maps-leave.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-bubble-menu': patch
+---
+
+Update the position right after showing the bubble menu to ensure shift is applied

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -445,6 +445,9 @@ export class BubbleMenuView implements PluginView {
     // attach to editor's parent element
     this.view.dom.parentElement?.appendChild(this.element)
 
+    // Update position immediately after showing to ensure shift works on first apparition
+    this.updatePosition()
+
     if (this.floatingUIOptions.onShow) {
       this.floatingUIOptions.onShow()
     }

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -136,6 +136,8 @@ export class BubbleMenuView implements PluginView {
 
   private resizeDebounceTimer: number | undefined
 
+  private positionUpdateFrameId: number | undefined
+
   private isVisible = false
 
   private floatingUIOptions: NonNullable<BubbleMenuPluginProps['options']> = {
@@ -446,13 +448,13 @@ export class BubbleMenuView implements PluginView {
     this.view.dom.parentElement?.appendChild(this.element)
 
     // Use requestAnimationFrame to ensure position is calculated after DOM update
-    requestAnimationFrame(() => {
+    this.positionUpdateFrameId = requestAnimationFrame(() => {
       this.updatePosition()
-    })
 
-    if (this.floatingUIOptions.onShow) {
-      this.floatingUIOptions.onShow()
-    }
+      if (this.floatingUIOptions.onShow) {
+        this.floatingUIOptions.onShow()
+      }
+    })
 
     this.isVisible = true
   }
@@ -476,6 +478,11 @@ export class BubbleMenuView implements PluginView {
 
   destroy() {
     this.hide()
+
+    if (this.positionUpdateFrameId) {
+      cancelAnimationFrame(this.positionUpdateFrameId)
+    }
+
     this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.view.dom.removeEventListener('dragstart', this.dragstartHandler)
     window.removeEventListener('resize', this.resizeHandler)

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -445,8 +445,10 @@ export class BubbleMenuView implements PluginView {
     // attach to editor's parent element
     this.view.dom.parentElement?.appendChild(this.element)
 
-    // Update position immediately after showing to ensure shift works on first apparition
-    this.updatePosition()
+    // Use requestAnimationFrame to ensure position is calculated after DOM update
+    requestAnimationFrame(() => {
+      this.updatePosition()
+    })
 
     if (this.floatingUIOptions.onShow) {
       this.floatingUIOptions.onShow()


### PR DESCRIPTION
## Changes Overview

Call the updatePosition when showing the bubble menu to ensure the shift is applied before showing the menu.

## Verification Steps

Copied the package dist (after building it) into my node_modules in my current project to see if the change works.

Before:
![Clipboard-20250708-221029-310](https://github.com/user-attachments/assets/72f16967-3c04-45ae-b878-d2ac1abb6efb)

After:
![Clipboard-20250708-220703-226](https://github.com/user-attachments/assets/97100c96-bc50-40fc-926f-11341593f53a)

## Checklist

- [*] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [*] My changes do not break the library.
- [*] I have added tests where applicable.
- [*] I have followed the project guidelines.
- [*] I have fixed any lint issues.
