### PR TITLE
feat: add events for `mount` and `unmount`

### DIFF
--- a/.changeset/new-impalas-notice.md
+++ b/.changeset/new-impalas-notice.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': minor
+---
+
+Add `mount` and `unmount` events to the `Editor` instance for tracking mounts and unmounts

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -154,6 +154,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       )
     }
     this.createView(el)
+    this.emit('mount', { editor: this })
 
     window.setTimeout(() => {
       if (this.isDestroyed) {
@@ -184,6 +185,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.isInitialized = false
     this.css?.remove()
     this.css = null
+    this.emit('unmount', { editor: this })
   }
 
   /**

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -95,6 +95,8 @@ export class Editor extends EventEmitter<EditorEvents> {
     emitContentError: false,
     onBeforeCreate: () => null,
     onCreate: () => null,
+    onMount: () => null,
+    onUnmount: () => null,
     onUpdate: () => null,
     onSelectionUpdate: () => null,
     onTransaction: () => null,
@@ -117,6 +119,8 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.createSchema()
     this.on('beforeCreate', this.options.onBeforeCreate)
     this.emit('beforeCreate', { editor: this })
+    this.on('mount', this.options.onMount)
+    this.on('unmount', this.options.onUnmount)
     this.on('contentError', this.options.onContentError)
     this.on('create', this.options.onCreate)
     this.on('update', this.options.onUpdate)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -384,6 +384,14 @@ export interface EditorOptions {
    */
   onCreate: (props: EditorEvents['create']) => void
   /**
+   * Called when the editor is mounted.
+   */
+  onMount: (props: EditorEvents['mount']) => void
+  /**
+   * Called when the editor is unmounted.
+   */
+  onUnmount: (props: EditorEvents['unmount']) => void
+  /**
    * Called when the editor encounters an error while parsing the content.
    * Only enabled if `enableContentCheck` is `true`.
    */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,18 @@ export type MaybeThisParameterType<T> =
   Exclude<T, Primitive> extends (...args: any) => any ? ThisParameterType<Exclude<T, Primitive>> : any
 
 export interface EditorEvents {
+  mount: {
+    /**
+     * The editor instance
+     */
+    editor: Editor
+  }
+  unmount: {
+    /**
+     * The editor instance
+     */
+    editor: Editor
+  }
   beforeCreate: {
     /**
      * The editor instance


### PR DESCRIPTION
## Changes Overview
This adds both an `mount` and `unmount` event for tracking externally when the editor has been mounted or unmounted
<!-- Briefly describe your changes. -->

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
Trivial
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
