### PR TITLE
Mark prosemirror-dev-toolkit library as an external module

### DIFF
--- a/.changeset/gorgeous-buses-fly.md
+++ b/.changeset/gorgeous-buses-fly.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Mark prosemirror-dev-toolkit dependency as an external module because otherwise the minified code is not compatible with turbopack

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig([
     clean: true,
     sourcemap: true,
     format: ['esm', 'cjs'],
+    external: ['prosemirror-dev-toolkit'],
   },
   {
     entry: ['src/jsx-runtime.ts'],


### PR DESCRIPTION
## Changes Overview

Mark prosemirror-dev-toolkit dependency as an external module because otherwise the minified code is not compatible with turbopack

## Implementation Approach

Edit tsup config

## Testing Done

Tested that the minified code did not give problems with turbopack anymore.

## Verification Steps

Install in a Next.js project and run it


## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
