### PR TITLE
Bdbch/drop devtools

### DIFF
--- a/.changeset/gorgeous-buses-fly.md
+++ b/.changeset/gorgeous-buses-fly.md
@@ -1,5 +1,0 @@
----
-'@tiptap/core': patch
----
-
-Mark prosemirror-dev-toolkit dependency as an external module because otherwise the minified code is not compatible with turbopack

--- a/.changeset/many-trainers-yawn.md
+++ b/.changeset/many-trainers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': minor
+---
+
+Remove enableDevTools option

--- a/.changeset/silly-hats-doubt.md
+++ b/.changeset/silly-hats-doubt.md
@@ -1,5 +1,0 @@
----
-'@tiptap/core': minor
----
-
-Added lazy-loaded ProseMirror Devtools integration which can be enabled via the new editor option `enableDevTools: true`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,8 +52,7 @@
     "jsx-dev-runtime"
   ],
   "devDependencies": {
-    "@tiptap/pm": "workspace:*",
-    "prosemirror-dev-toolkit": "^1.1.8"
+    "@tiptap/pm": "workspace:*"
   },
   "peerDependencies": {
     "@tiptap/pm": "workspace:*"

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -92,7 +92,6 @@ export class Editor extends EventEmitter<EditorEvents> {
     enablePasteRules: true,
     enableCoreExtensions: true,
     enableContentCheck: false,
-    enableDevTools: false,
     emitContentError: false,
     onBeforeCreate: () => null,
     onCreate: () => null,
@@ -185,43 +184,6 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.isInitialized = false
     this.css?.remove()
     this.css = null
-  }
-
-  /**
-   *
-   * @returns
-   */
-  /**
-   * Applies ProseMirror dev tools to the editor instance if enabled and running in a browser environment.
-   *
-   * This method dynamically imports the `prosemirror-dev-toolkit` package and applies it to the current
-   * editor view. If the dev tools are not installed, a warning is logged to the console.
-   *
-   * @private
-   * @remarks
-   * - Dev tools are only applied if `this.options.enableDevTools` is `true` and the code is running in a browser.
-   * - If the editor view is not available, the dev tools are not applied.
-   * - If the `prosemirror-dev-toolkit` package is missing, a warning is shown in the console.
-   *
-   * @returns {void}
-   */
-  private applyDevTools(): void {
-    if (typeof window === 'undefined' || !this.options.enableDevTools) {
-      return
-    }
-
-    import('prosemirror-dev-toolkit')
-      .then(({ applyDevTools }) => {
-        if (!this.editorView) {
-          return
-        }
-
-        applyDevTools(this.editorView)
-      })
-      .catch(() => {
-        console.warn('[Tiptap warning]: Devtools are enabled but `prosemirror-dev-toolkit` is not installed.')
-        console.warn("Install 'prosemirror-dev-toolkit' as a dev dependency to use the dev tools.")
-      })
   }
 
   /**
@@ -526,11 +488,6 @@ export class Editor extends EventEmitter<EditorEvents> {
       dispatchTransaction: this.dispatchTransaction.bind(this),
       state: this.editorState,
     })
-
-    // Apply dev tools if enabled
-    if (this.options.enableDevTools) {
-      this.applyDevTools()
-    }
 
     // `editor.view` is not yet available at this time.
     // Therefore we will add all plugins and node views directly afterwards.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -364,18 +364,6 @@ export interface EditorOptions {
    */
   emitContentError: boolean
   /**
-   * Enable a lazy-loaded Prosemirror DevTools integration.
-   *
-   * Requires having the `prosemirror-dev-toolkit` npm package installed.
-   * @type boolean
-   * @default false
-   * @example
-   * ```js
-   * enableDevTools: true
-   * ```
-   */
-  enableDevTools: boolean
-  /**
    * Called before the editor is constructed.
    */
   onBeforeCreate: (props: EditorEvents['beforeCreate']) => void

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -9,7 +9,6 @@ export default defineConfig([
     clean: true,
     sourcemap: true,
     format: ['esm', 'cjs'],
-    external: ['prosemirror-dev-toolkit'],
   },
   {
     entry: ['src/jsx-runtime.ts'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,9 +408,6 @@ importers:
       '@tiptap/pm':
         specifier: workspace:*
         version: link:../pm
-      prosemirror-dev-toolkit:
-        specifier: ^1.1.8
-        version: 1.1.8(svelte@4.2.19)
 
   packages/extension-blockquote:
     devDependencies:
@@ -3773,10 +3770,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  concat-stream@1.6.2:
-    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
-    engines: {'0': node >= 0.8}
-
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -4886,10 +4879,6 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  html@1.0.0:
-    resolution: {integrity: sha512-lw/7YsdKiP3kk5PnR1INY17iJuzdAtJewxr14ozKJWbbR97znovZ0mh+WEMZ8rjc3lgTK+ID/htTjuyGKB52Kw==}
-    hasBin: true
-
   htmlparser2@7.2.0:
     resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
 
@@ -5159,9 +5148,6 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
-
-  isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -5968,9 +5954,6 @@ packages:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
 
-  process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -5986,9 +5969,6 @@ packages:
 
   prosemirror-commands@1.6.2:
     resolution: {integrity: sha512-0nDHH++qcf/BuPLYvmqZTUUsPJUCPBUXt0J1ErTcDIS369CTp773itzLGIgIXG4LJXOlwYCr44+Mh4ii6MP1QA==}
-
-  prosemirror-dev-toolkit@1.1.8:
-    resolution: {integrity: sha512-Qi549XA+DqU5cCkn/xv+M53gy1sQbyOTjiOfiG7Gjq5gm6ZxLilGN04UITWTAYx9kzLBi7Y9RJmvmWB4xiRauA==}
 
   prosemirror-dropcursor@1.8.1:
     resolution: {integrity: sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==}
@@ -6122,9 +6102,6 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
-
-  readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -6476,9 +6453,6 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
-  string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -6542,11 +6516,6 @@ packages:
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0
-
-  svelte-tree-view@1.4.2:
-    resolution: {integrity: sha512-z3yQq+/4CceyefVj03t9BG9AiZ7syovmRRo96aj8V65d1FsRS/BL2AxzcD4vl5GJg7o9qbz2mWWJzyFWENISCQ==}
-    peerDependencies:
-      svelte: '>=3'
 
   svelte@4.2.19:
     resolution: {integrity: sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==}
@@ -6785,9 +6754,6 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
-
-  typedarray@0.0.6:
-    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -10175,13 +10141,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  concat-stream@1.6.2:
-    dependencies:
-      buffer-from: 1.1.2
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      typedarray: 0.0.6
-
   confbox@0.1.8: {}
 
   confusing-browser-globals@1.0.11: {}
@@ -11500,10 +11459,6 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html@1.0.0:
-    dependencies:
-      concat-stream: 1.6.2
-
   htmlparser2@7.2.0:
     dependencies:
       domelementtype: 2.3.0
@@ -11776,8 +11731,6 @@ snapshots:
       get-intrinsic: 1.2.7
 
   is-windows@1.0.2: {}
-
-  isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
@@ -12559,8 +12512,6 @@ snapshots:
 
   prismjs@1.29.0: {}
 
-  process-nextick-args@2.0.1: {}
-
   process@0.11.10: {}
 
   property-information@6.5.0: {}
@@ -12578,14 +12529,6 @@ snapshots:
       prosemirror-model: 1.24.1
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.2
-
-  prosemirror-dev-toolkit@1.1.8(svelte@4.2.19):
-    dependencies:
-      html: 1.0.0
-      prosemirror-model: 1.24.1
-      svelte-tree-view: 1.4.2(svelte@4.2.19)
-    transitivePeerDependencies:
-      - svelte
 
   prosemirror-dropcursor@1.8.1:
     dependencies:
@@ -12764,16 +12707,6 @@ snapshots:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.2
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -13212,10 +13145,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -13272,10 +13201,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svelte-hmr@0.16.0(svelte@4.2.19):
-    dependencies:
-      svelte: 4.2.19
-
-  svelte-tree-view@1.4.2(svelte@4.2.19):
     dependencies:
       svelte: 4.2.19
 
@@ -13543,8 +13468,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
-
-  typedarray@0.0.6: {}
 
   typescript@5.7.3: {}
 


### PR DESCRIPTION
## Changes Overview

We're dropping the `enableDevTools` integration as it was causing a lot of errors with bundlers trying to statically analyze the package on build-time.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
