### PR TITLE
Bdbch/fix nodeview render target

### DIFF
--- a/.changeset/silver-adults-fold.md
+++ b/.changeset/silver-adults-fold.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+attach the contentDOM to the correct position inside a react node view

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -85,7 +85,13 @@ export class ReactNodeView<
       // See: https://github.com/ueberdosis/tiptap/issues/1197
       this.contentDOMElement.style.whiteSpace = 'inherit'
 
-      this.dom.appendChild(this.contentDOMElement)
+      const contentTarget = this.dom.querySelector('[data-node-view-content]')
+
+      if (!contentTarget) {
+        return
+      }
+
+      contentTarget.appendChild(this.contentDOMElement)
     }
   }
 


### PR DESCRIPTION
## Changes Overview

This PR fixes a bug with the react renderer causing it to attach the contentDOM node to the wrong position

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
