### PR TITLE
update codemods for history

### DIFF
--- a/codemods/tiptap-2-migrate-imports/package.json
+++ b/codemods/tiptap-2-migrate-imports/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tiptap-2-migrate-imports",
-  "version": "1.0.1-beta.2",
+  "name": "@tiptap/v2-migrate-imports",
+  "version": "1.0.1-beta.1",
   "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
@@ -19,5 +19,6 @@
     ".codemodrc.json",
     "/dist/index.cjs"
   ],
-  "type": "module"
+  "type": "module",
+  "author": "bdbch"
 }

--- a/codemods/tiptap-2-migrate-imports/src/index.ts
+++ b/codemods/tiptap-2-migrate-imports/src/index.ts
@@ -27,7 +27,7 @@ export default function transform(file: any, api: any) {
     "@tiptap/extension-dropcursor": "Dropcursor",
     "@tiptap/extension-gapcursor": "Gapcursor",
     "@tiptap/extension-focus": "Focus",
-    "@tiptap/extension-history": "History",
+    "@tiptap/extension-history": "UndoRedo",
     "@tiptap/extension-placeholder": "Placeholder",
   };
 


### PR DESCRIPTION
## Changes Overview

The history extension was renamed to UndoRedo which caused issues with the codemod package's tests. This PR fixes this.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.