### PR TITLE
fix problems with keydown events being blocked by drag handle plugin

### DIFF
--- a/.changeset/tidy-humans-join.md
+++ b/.changeset/tidy-humans-join.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': patch
+---
+
+Fix a bug where new keydown event handling would prevent other events

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -298,7 +298,7 @@ export const DragHandlePlugin = ({
               currentNodePos = -1
               onNodeChange?.({ editor, node: null, pos: -1 })
 
-              return true
+              return false
             }
 
             return false

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -298,6 +298,7 @@ export const DragHandlePlugin = ({
               currentNodePos = -1
               onNodeChange?.({ editor, node: null, pos: -1 })
 
+              // We want to still continue with other keydown events.
               return false
             }
 


### PR DESCRIPTION
## Changes Overview

This PR fixes a bug introduced by #6595 that blocks other key handlers from running

## Implementation Approach

I just always remove false from the keydown handler to allow other events to run through

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
