### PR TITLE
Hotfix for BubbleMenu Options Passthrough

### DIFF
--- a/.changeset/fresh-spoons-mate.md
+++ b/.changeset/fresh-spoons-mate.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-bubble-menu': patch
+---
+
+Fix: Correctly pass through the bubble menu floating options

--- a/.changeset/sixty-lizards-flow.md
+++ b/.changeset/sixty-lizards-flow.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-floating-menu': patch
+'@tiptap/extension-bubble-menu': patch
+---
+
+Improvement: Added better JSDocs for the options object

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -82,7 +82,10 @@ export interface BubbleMenuPluginProps {
     | null
 
   /**
-   * FloatingUI options.
+   * The options for the bubble menu. Those are passed to Floating UI and include options for the placement, offset, flip, shift, arrow, size, autoPlacement,
+   * hide, and inline middlewares.
+   * @default {}
+   * @see https://floating-ui.com/docs/computePosition#options
    */
   options?: {
     strategy?: 'absolute' | 'fixed'

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -39,6 +39,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
         editor: this.editor,
         element: this.options.element,
         updateDelay: this.options.updateDelay,
+        options: this.options.options,
         shouldShow: this.options.shouldShow,
       }),
     ]

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -52,7 +52,10 @@ export interface FloatingMenuPluginProps {
     | null
 
   /**
-   * FloatingUI options.
+   * The options for the floating menu. Those are passed to Floating UI and include options for the placement, offset, flip, shift, arrow, size, autoPlacement,
+   * hide, and inline middlewares.
+   * @default {}
+   * @see https://floating-ui.com/docs/computePosition#options
    */
   options?: {
     strategy?: 'absolute' | 'fixed'


### PR DESCRIPTION
## Changes Overview

This PR fixes a problem with the new BubbleMenu API where options are not passed through correctly.

## AI Summary

This pull request introduces fixes and improvements to the `@tiptap/extension-bubble-menu` and `@tiptap/extension-floating-menu` packages. The changes ensure better handling of Floating UI options, enhance documentation, and improve the codebase for clarity and functionality.

### Documentation Improvements

* [`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953L85-R88): Enhances the JSDocs for the `options` property, detailing its usage with Floating UI and providing links to relevant documentation.
* [`packages/extension-floating-menu/src/floating-menu-plugin.ts`](diffhunk://#diff-38847814cfb3e8f7590cb4b22ce7ad8f53915fad16a384d379ddec52a606d8e0L55-R58): Improves the JSDocs for the `options` property in the floating menu plugin, similar to the bubble menu updates.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
