### PR TITLE
fix global react overwrites via jsx-runtime

### DIFF
--- a/.changeset/grumpy-seals-shake.md
+++ b/.changeset/grumpy-seals-shake.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix: Avoid the JSX Runtime to globally overwrite React's Element types when `/** @jsxImportSource @tiptap/core */` is not used

--- a/.changeset/two-chefs-lie.md
+++ b/.changeset/two-chefs-lie.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-blockquote': patch
+'@tiptap/extension-bold': patch
+---
+
+Chore: Removed type overwrites for renderHTML

--- a/packages/core/src/jsx-runtime.ts
+++ b/packages/core/src/jsx-runtime.ts
@@ -13,16 +13,17 @@ export type DOMOutputSpecArray =
   | [string, Attributes, DOMOutputSpecArray | 0]
   | [string, DOMOutputSpecArray]
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    // @ts-ignore - conflict with React typings
-    type Element = [string, ...any[]]
-    // @ts-ignore - conflict with React typings
-    interface IntrinsicElements {
-      // @ts-ignore - conflict with React typings
-      [key: string]: any
-    }
+// JSX types for Tiptap's JSX runtime
+// These types only apply when using @jsxImportSource @tiptap/core
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace JSX {
+  export type Element = DOMOutputSpecArray
+  export interface IntrinsicElements {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any
+  }
+  export interface ElementChildrenAttribute {
+    children: unknown
   }
 }
 

--- a/packages/extension-blockquote/src/blockquote.tsx
+++ b/packages/extension-blockquote/src/blockquote.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @tiptap/core */
 import { mergeAttributes, Node, wrappingInputRule } from '@tiptap/core'
-import type { DOMOutputSpecArray } from '@tiptap/core/jsx-runtime'
 
 export interface BlockquoteOptions {
   /**
@@ -63,7 +62,7 @@ export const Blockquote = Node.create<BlockquoteOptions>({
       <blockquote {...mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)}>
         <slot />
       </blockquote>
-    ) as unknown as DOMOutputSpecArray
+    )
   },
 
   addCommands() {

--- a/packages/extension-bold/src/bold.tsx
+++ b/packages/extension-bold/src/bold.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @tiptap/core */
 import { Mark, markInputRule, markPasteRule, mergeAttributes } from '@tiptap/core'
-import type { DOMOutputSpecArray } from '@tiptap/core/jsx-runtime'
 
 export interface BoldOptions {
   /**
@@ -88,7 +87,7 @@ export const Bold = Mark.create<BoldOptions>({
       <strong {...mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)}>
         <slot />
       </strong>
-    ) as unknown as DOMOutputSpecArray
+    )
   },
 
   addCommands() {


### PR DESCRIPTION
## Changes Overview

This PR fixes a bug introduced by 3.0.0's `jsx-runtime` that caused issues with global React types.

## AI Summary

This pull request addresses issues with type conflicts between Tiptap's JSX runtime and React's typings, simplifies type handling in extensions, and improves compatibility when `/** @jsxImportSource @tiptap/core */` is not used. The most important changes include refining JSX type definitions, removing unnecessary type overwrites, and updating extensions to align with the new type system.

### Fixes for JSX type conflicts:
* [`packages/core/src/jsx-runtime.ts`](diffhunk://#diff-9e42edb86426415fbe4c3d7f5e359cdd784e7bd454e022600bbaf91ffb1708adL16-R26): Refined Tiptap's JSX runtime types to avoid conflicts with React's typings. These types now apply only when `/** @jsxImportSource @tiptap/core */` is explicitly used.

### Simplifications in extensions:
* [`packages/extension-blockquote/src/blockquote.tsx`](diffhunk://#diff-51f2df7a575b0fe6fd1d39bec67883fb39f279dbd3fe2432ee48b52db76bc118L66-R65): Removed the explicit use of `DOMOutputSpecArray` in the `Blockquote` node's renderHTML method, simplifying type handling.
* [`packages/extension-bold/src/bold.tsx`](diffhunk://#diff-5f8c5431db8a5074ee89366be031e6ec4c33f305089927b06904741083b7153dL91-R90): Removed the explicit use of `DOMOutputSpecArray` in the `Bold` mark's renderHTML method, aligning with the updated type system.

## Implementation Approach

Instead of overwriting the global JSX namespace, we export the namespace so it can be consumed via `/** @jsxImportSource @tiptap/core */` - that way we don't break typings for JSXs own typings when it's not needed.

## Testing Done

Done tests with the already existing implementions on the blockquote and bold extensions

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #6622 
