### PR TITLE
Fix typescript loosing context to "this" when non-function options are set in extended extensions

### DIFF
--- a/.changeset/two-geese-work.md
+++ b/.changeset/two-geese-work.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix: Add correct overload for extension extend types"

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -31,11 +31,19 @@ export class Extension<Options = any, Storage = any> extends Extendable<
     return super.configure(options) as Extension<Options, Storage>
   }
 
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: () => Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>>,
+  ): Extension<ExtendedOptions, ExtendedStorage>
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>>,
+  ): Extension<ExtendedOptions, ExtendedStorage>
   extend<
     ExtendedOptions = Options,
     ExtendedStorage = Storage,
     ExtendedConfig = ExtensionConfig<ExtendedOptions, ExtendedStorage>,
-  >(extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>)) {
+  >(
+    extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>),
+  ): Extension<ExtendedOptions, ExtendedStorage> {
     // If the extended config is a function, execute it to get the configuration object
     const resolvedConfig = typeof extendedConfig === 'function' ? extendedConfig() : extendedConfig
     return super.extend(resolvedConfig) as Extension<ExtendedOptions, ExtendedStorage>

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -188,11 +188,19 @@ export class Mark<Options = any, Storage = any> extends Extendable<Options, Stor
     return super.configure(options) as Mark<Options, Storage>
   }
 
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: () => Partial<MarkConfig<ExtendedOptions, ExtendedStorage>>,
+  ): Mark<ExtendedOptions, ExtendedStorage>
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: Partial<MarkConfig<ExtendedOptions, ExtendedStorage>>,
+  ): Mark<ExtendedOptions, ExtendedStorage>
   extend<
     ExtendedOptions = Options,
     ExtendedStorage = Storage,
     ExtendedConfig = MarkConfig<ExtendedOptions, ExtendedStorage>,
-  >(extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>)) {
+  >(
+    extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>),
+  ): Mark<ExtendedOptions, ExtendedStorage> {
     // If the extended config is a function, execute it to get the configuration object
     const resolvedConfig = typeof extendedConfig === 'function' ? extendedConfig() : extendedConfig
     return super.extend(resolvedConfig) as Mark<ExtendedOptions, ExtendedStorage>

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -354,11 +354,19 @@ export class Node<Options = any, Storage = any> extends Extendable<Options, Stor
     return super.configure(options) as Node<Options, Storage>
   }
 
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: () => Partial<NodeConfig<ExtendedOptions, ExtendedStorage>>,
+  ): Node<ExtendedOptions, ExtendedStorage>
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>>,
+  ): Node<ExtendedOptions, ExtendedStorage>
   extend<
     ExtendedOptions = Options,
     ExtendedStorage = Storage,
     ExtendedConfig = NodeConfig<ExtendedOptions, ExtendedStorage>,
-  >(extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>)) {
+  >(
+    extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>),
+  ): Node<ExtendedOptions, ExtendedStorage> {
     // If the extended config is a function, execute it to get the configuration object
     const resolvedConfig = typeof extendedConfig === 'function' ? extendedConfig() : extendedConfig
     return super.extend(resolvedConfig) as Node<ExtendedOptions, ExtendedStorage>


### PR DESCRIPTION
## Changes Overview

This PR fixes a Typescript bug where extended configs would lose context to `this` inside functions when any non-function option like `priority` was set.

## AI Summary

This pull request introduces improvements to the type definitions for the `extend` method in the `Extension`, `Mark`, and `Node` classes within the `@tiptap/core` package. These changes ensure better overload handling and type safety when extending configurations. Additionally, a changeset file documents the patch version update for this fix.

### Type Definition Improvements:

* **`Extension` class (`packages/core/src/Extension.ts`)**: Added overloads for the `extend` method to support configurations passed as either a function or an object, improving type clarity and flexibility.
* **`Mark` class (`packages/core/src/Mark.ts`)**: Updated the `extend` method with similar overloads to handle both function-based and object-based configurations.
* **`Node` class (`packages/core/src/Node.ts`)**: Enhanced the `extend` method with overloads for consistent handling of configuration types.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #6275 
