### PR TITLE
make shouldShow optional on bubble and floating menu

### DIFF
--- a/.changeset/rude-students-drive.md
+++ b/.changeset/rude-students-drive.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-floating-menu': patch
+'@tiptap/extension-bubble-menu': patch
+---
+
+Refactor: Make shouldShow optional on bubbleMenu and floatingMenu options

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -69,7 +69,7 @@ export interface BubbleMenuPluginProps {
    * A function that determines whether the menu should be shown or not.
    * If this function returns `false`, the menu will be hidden, otherwise it will be shown.
    */
-  shouldShow:
+  shouldShow?:
     | ((props: {
         editor: Editor
         element: HTMLElement

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -40,7 +40,7 @@ export interface FloatingMenuPluginProps {
    * A function that determines whether the menu should be shown or not.
    * If this function returns `false`, the menu will be hidden, otherwise it will be shown.
    */
-  shouldShow:
+  shouldShow?:
     | ((props: {
         editor: Editor
         view: EditorView


### PR DESCRIPTION
## Changes Overview

This PR makes the `shouldShow` option optional so there's no need to pass an explicit `null`.

## AI Summary

This pull request refactors the `shouldShow` property in the `BubbleMenu` and `FloatingMenu` options to make it optional. This change simplifies the API for these extensions and ensures backward compatibility.

### Refactor: Optional `shouldShow` Property
* [`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953L72-R72): Updated the `BubbleMenuPluginProps` interface to make the `shouldShow` property optional.
* [`packages/extension-floating-menu/src/floating-menu-plugin.ts`](diffhunk://#diff-38847814cfb3e8f7590cb4b22ce7ad8f53915fad16a384d379ddec52a606d8e0L43-R43): Updated the `FloatingMenuPluginProps` interface to make the `shouldShow` property optional.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #6634 
