### PR TITLE
fix broken chain types

### DIFF
--- a/.changeset/brave-zoos-cheat.md
+++ b/.changeset/brave-zoos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix: Fix broken types for function chaining when calling extend

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -1,3 +1,4 @@
+import type { Editor } from './Editor.js'
 import { type ExtendableConfig, Extendable } from './Extendable.js'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -31,18 +32,21 @@ export class Extension<Options = any, Storage = any> extends Extendable<
     return super.configure(options) as Extension<Options, Storage>
   }
 
-  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: () => Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>>,
-  ): Extension<ExtendedOptions, ExtendedStorage>
-  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>>,
-  ): Extension<ExtendedOptions, ExtendedStorage>
   extend<
     ExtendedOptions = Options,
     ExtendedStorage = Storage,
     ExtendedConfig = ExtensionConfig<ExtendedOptions, ExtendedStorage>,
   >(
-    extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>),
+    extendedConfig?:
+      | (() => Partial<ExtendedConfig>)
+      | (Partial<ExtendedConfig> &
+          ThisType<{
+            name: string
+            options: ExtendedOptions
+            storage: ExtendedStorage
+            editor: Editor
+            type: null
+          }>),
   ): Extension<ExtendedOptions, ExtendedStorage> {
     // If the extended config is a function, execute it to get the configuration object
     const resolvedConfig = typeof extendedConfig === 'function' ? extendedConfig() : extendedConfig

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -188,18 +188,21 @@ export class Mark<Options = any, Storage = any> extends Extendable<Options, Stor
     return super.configure(options) as Mark<Options, Storage>
   }
 
-  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: () => Partial<MarkConfig<ExtendedOptions, ExtendedStorage>>,
-  ): Mark<ExtendedOptions, ExtendedStorage>
-  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<MarkConfig<ExtendedOptions, ExtendedStorage>>,
-  ): Mark<ExtendedOptions, ExtendedStorage>
   extend<
     ExtendedOptions = Options,
     ExtendedStorage = Storage,
     ExtendedConfig = MarkConfig<ExtendedOptions, ExtendedStorage>,
   >(
-    extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>),
+    extendedConfig?:
+      | (() => Partial<ExtendedConfig>)
+      | (Partial<ExtendedConfig> &
+          ThisType<{
+            name: string
+            options: ExtendedOptions
+            storage: ExtendedStorage
+            editor: Editor
+            type: MarkType
+          }>),
   ): Mark<ExtendedOptions, ExtendedStorage> {
     // If the extended config is a function, execute it to get the configuration object
     const resolvedConfig = typeof extendedConfig === 'function' ? extendedConfig() : extendedConfig

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -354,18 +354,21 @@ export class Node<Options = any, Storage = any> extends Extendable<Options, Stor
     return super.configure(options) as Node<Options, Storage>
   }
 
-  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: () => Partial<NodeConfig<ExtendedOptions, ExtendedStorage>>,
-  ): Node<ExtendedOptions, ExtendedStorage>
-  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>>,
-  ): Node<ExtendedOptions, ExtendedStorage>
   extend<
     ExtendedOptions = Options,
     ExtendedStorage = Storage,
     ExtendedConfig = NodeConfig<ExtendedOptions, ExtendedStorage>,
   >(
-    extendedConfig?: Partial<ExtendedConfig> | (() => Partial<ExtendedConfig>),
+    extendedConfig?:
+      | (() => Partial<ExtendedConfig>)
+      | (Partial<ExtendedConfig> &
+          ThisType<{
+            name: string
+            options: ExtendedOptions
+            storage: ExtendedStorage
+            editor: Editor
+            type: NodeType
+          }>),
   ): Node<ExtendedOptions, ExtendedStorage> {
     // If the extended config is a function, execute it to get the configuration object
     const resolvedConfig = typeof extendedConfig === 'function' ? extendedConfig() : extendedConfig


### PR DESCRIPTION
## Changes Overview

This PR fixes a problem introduced by #6645

## Implementation Approach

Instead of using overloads creating broken union types for the extend return type which in turn broke chaining we use ThisType to get the correct types for this.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

