### PR TITLE
fix broken menus when inline is true

### DIFF
--- a/.changeset/afraid-oranges-smell.md
+++ b/.changeset/afraid-oranges-smell.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-floating-menu': patch
+'@tiptap/extension-bubble-menu': patch
+---
+
+Fix: Fix a problem with the inline option and virtual elements missing getClientRects

--- a/demos/src/Extensions/BubbleMenu/React/index.jsx
+++ b/demos/src/Extensions/BubbleMenu/React/index.jsx
@@ -27,6 +27,7 @@ export default () => {
   return (
     <>
       <button
+        type="button"
         onClick={() => {
           setShowMenu(old => !old)
           editor.commands.focus()
@@ -42,23 +43,26 @@ export default () => {
       </div>
 
       {editor && showMenu && (
-        <BubbleMenu editor={editor} options={{ placement: 'bottom', offset: 8 }}>
+        <BubbleMenu editor={editor} options={{ placement: 'bottom', offset: 8, inline: true }}>
           <div className="bubble-menu">
             <button
               onClick={() => editor.chain().focus().toggleBold().run()}
               className={editor.isActive('bold') ? 'is-active' : ''}
+              type="button"
             >
               Bold
             </button>
             <button
               onClick={() => editor.chain().focus().toggleItalic().run()}
               className={editor.isActive('italic') ? 'is-active' : ''}
+              type="button"
             >
               Italic
             </button>
             <button
               onClick={() => editor.chain().focus().toggleStrike().run()}
               className={editor.isActive('strike') ? 'is-active' : ''}
+              type="button"
             >
               Strike
             </button>

--- a/demos/src/Extensions/BubbleMenu/React/index.jsx
+++ b/demos/src/Extensions/BubbleMenu/React/index.jsx
@@ -43,7 +43,7 @@ export default () => {
       </div>
 
       {editor && showMenu && (
-        <BubbleMenu editor={editor} options={{ placement: 'bottom', offset: 8, inline: true }}>
+        <BubbleMenu editor={editor} options={{ placement: 'bottom', offset: 8 }}>
           <div className="bubble-menu">
             <button
               onClick={() => editor.chain().focus().toggleBold().run()}

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -316,8 +316,10 @@ export class BubbleMenuView implements PluginView {
 
   updatePosition() {
     const { selection } = this.editor.state
+    const domRect = posToDOMRect(this.view, selection.from, selection.to)
     let virtualElement = {
-      getBoundingClientRect: () => posToDOMRect(this.view, selection.from, selection.to),
+      getBoundingClientRect: () => domRect,
+      getClientRects: () => [domRect],
     }
 
     // this is a special case for cell selections

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -346,6 +346,7 @@ export class BubbleMenuView implements PluginView {
 
       virtualElement = {
         getBoundingClientRect: () => clientRect,
+        getClientRects: () => [clientRect],
       }
     }
 

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -288,8 +288,11 @@ export class FloatingMenuView {
   updatePosition() {
     const { selection } = this.editor.state
 
+    const domRect = posToDOMRect(this.view, selection.from, selection.to)
+
     const virtualElement = {
-      getBoundingClientRect: () => posToDOMRect(this.view, selection.from, selection.to),
+      getBoundingClientRect: () => domRect,
+      getClientRects: () => [domRect],
     }
 
     computePosition(virtualElement, this.element, {


### PR DESCRIPTION
## Changes Overview

This PR fixes a bug with the new menus when the `inline` option is enabled.

## AI Summary

This pull request addresses a bug related to virtual elements missing the `getClientRects` method and improves the functionality of the `BubbleMenu` and `FloatingMenu` components. The most important changes include fixing the virtual element issue, updating menu options, and ensuring proper button attributes in the demo.

### Bug Fixes for Virtual Elements:
* [`packages/extension-bubble-menu/src/bubble-menu-plugin.ts`](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953R319-R322): Updated the `BubbleMenuView` class to include `getClientRects` in the virtual element using `domRect`.
* [`packages/extension-floating-menu/src/floating-menu-plugin.ts`](diffhunk://#diff-38847814cfb3e8f7590cb4b22ce7ad8f53915fad16a384d379ddec52a606d8e0R291-R295): Updated the `FloatingMenuView` class to include `getClientRects` in the virtual element using `domRect`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #6633 
