### PR TITLE
Node class extend method generic for ExtendedConfig extends NodeConfig

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -357,7 +357,7 @@ export class Node<Options = any, Storage = any> extends Extendable<Options, Stor
   extend<
     ExtendedOptions = Options,
     ExtendedStorage = Storage,
-    ExtendedConfig = NodeConfig<ExtendedOptions, ExtendedStorage>,
+    ExtendedConfig extends NodeConfig<ExtendedOptions, ExtendedStorage> = NodeConfig<ExtendedOptions, ExtendedStorage>,
   >(
     extendedConfig?:
       | (() => Partial<ExtendedConfig>)


### PR DESCRIPTION
## Changes Overview

Upon migrating to v3, I started to run into type errors when using `Node.extend` to extend prebuilt/custom extensions. Here is an example:

<img width="851" height="379" alt="image" src="https://github.com/user-attachments/assets/92fc8e52-d14f-41a5-aacf-0c876aeb6375" />

By having the generic `ExtendedConfig` extend `NodeConfig<ExtendedOptions, ExtendedStorage>`, we can ensure that the parent node types are passed down to the new node we are creating with the extension.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
