### PR TITLE
only run deployments on main & release/* branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ on:
     branches:
       - main
       - develop
-      - next
       - release/*
     tags:
       - '*'
@@ -23,7 +22,6 @@ on:
     branches:
       - main
       - develop
-      - next
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,7 @@ on:
   push:
     branches:
       - main
-      - develop
-      - next
+      - release/*
   # manual trigger for other branches
   workflow_dispatch:
 


### PR DESCRIPTION
This PR updates our workflows to only run on main, develop and the publish workflows should only run on main (stable) and release/* for specific release branches like `release/beta` if needed in the future.