### PR TITLE
fix(table):resolve self-closing tag issue

### DIFF
--- a/.changeset/shy-wombats-drum.md
+++ b/.changeset/shy-wombats-drum.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-table": patch
+---
+
+Modified col tags to be self-closing

--- a/packages/extension-table/src/table/utilities/createColGroup.ts
+++ b/packages/extension-table/src/table/utilities/createColGroup.ts
@@ -55,7 +55,11 @@ export function createColGroup(
 
       const [property, value] = getColStyleDeclaration(cellMinWidth, hasWidth)
 
-      cols.push(['col', { style: `${property}: ${value}` }])
+      cols.push([
+        'col',
+        { style: `${property}: ${value}` },
+        0,
+      ])
     }
   }
 


### PR DESCRIPTION
## Changes Overview
Replaces closed PR #6229  due to branch deletion.
Fixes #6226 

This PR fixes issue #6226 by ensuring `<col style="min-width: 25px>` tags in the generated output are properly self closing (`<col style="min-width: 25px" />`).


## Implementation Approach
Modified the `createColGroup.ts` file and added the third parameter as 0 in the `cols.push()` function to ensure the tag will be self closing.

## Testing Done
Ran all existing tests; they passed

## Verification Steps
Run `npm test ` to confirm no tests are failing.

## Additional Notes
Cypress tests were failing probably due to windows path issues, but unit tests ran succesfully

## Checklist
- [X] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [ ] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues
Fixes #6226
