### PR TITLE
use --strict-peer-dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Install dependencies
         id: install-dependencies
-        run: pnpm install && pnpm exec cypress install
+        run: pnpm install --strict-peer-dependencies && pnpm exec cypress install
 
       - name: Try to build the packages
         id: build-packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Install Dependencies
-        run: pnpm i
+        run: pnpm install --strict-peer-dependencies
 
       - name: Setup npmrc
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc


### PR DESCRIPTION
This PR will make pnpm use the `--strict-peer-dependencies` option to make sure our CI catches faulty peer deps earlier