### PR TITLE
Fix menus in vue2

### DIFF
--- a/.changeset/fair-bananas-smile.md
+++ b/.changeset/fair-bananas-smile.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/vue-2": patch
+---
+
+Fix Vue2 menus visibility bug.

--- a/packages/vue-2/src/BubbleMenu.ts
+++ b/packages/vue-2/src/BubbleMenu.ts
@@ -61,7 +61,7 @@ export const BubbleMenu: Component = {
   },
 
   render(this: BubbleMenuInterface, createElement: CreateElement) {
-    return createElement('div', { style: { visibility: 'hidden' } }, this.$slots.default)
+    return createElement('div', {}, this.$slots.default)
   },
 
   beforeDestroy(this: BubbleMenuInterface) {

--- a/packages/vue-2/src/FloatingMenu.ts
+++ b/packages/vue-2/src/FloatingMenu.ts
@@ -55,7 +55,7 @@ export const FloatingMenu: Component = {
   },
 
   render(this: FloatingMenuInterface, createElement: CreateElement) {
-    return createElement('div', { style: { visibility: 'hidden' } }, this.$slots.default)
+    return createElement('div', {}, this.$slots.default)
   },
 
   beforeDestroy(this: FloatingMenuInterface) {


### PR DESCRIPTION
## Changes Overview

Fix visibility bug in BubbleMenu and FloatingMenu in the vue2 adaptor.

## Implementation Approach

Same approach as was done in vue3 long time ago: https://github.com/ueberdosis/tiptap/commit/177eed65a4467db511c49f56a31a999e3f611c13

## Testing Done

Yes.

## Verification Steps

Tested in the real app. Works perfectly.

## Additional Notes

This bug can be reproduced only when you have vue 2 app (2.7 in my case) and your menu can change dynamically (e.g. buttons are reactively highlighted). In this case the hardcoded `visibility: hidden` just hides the menu.

## Checklist

- [ + ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ + ] My changes do not break the library.
- [ - ] I have added tests where applicable.
- [ + ] I have followed the project guidelines.
- [ + ] I have fixed any lint issues.

## Related Issues

none