### PR TITLE
Fix: BubbleMenu jumps when text element size changes

### DIFF
--- a/demos/src/Extensions/BubbleMenu/React/styles.scss
+++ b/demos/src/Extensions/BubbleMenu/React/styles.scss
@@ -51,7 +51,7 @@
   h6 {
     font-size: 1rem;
   }
-
+  
   /* Code and preformatted text styles */
   code {
     background-color: var(--purple-light);
@@ -98,6 +98,11 @@
   box-shadow: var(--shadow);
   display: flex;
   padding: 0.2rem;
+  position: fixed;
+  // z-index: 9999;
+  top: -50;
+  left: 50%;
+
 
   button {
     background-color: unset;


### PR DESCRIPTION
## Changes Overview
### What Was Changed
- Applied `position: fixed` to the BubbleMenu container.
- Used `left: 50%` `top:-50 to keep it centered horizontally `.

### Result
The BubbleMenu now remains visually steady and centered regardless of text wrapping or content changes.
<!-- Link any related issues here -->
https://github.com/ueberdosis/tiptap/issues/6716
