### PR TITLE
feat: BubbleMenu appendTo option

### DIFF
--- a/.changeset/polite-beans-juggle.md
+++ b/.changeset/polite-beans-juggle.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-bubble-menu': patch
+---
+
+Add appendTo option

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -82,6 +82,16 @@ export interface BubbleMenuPluginProps {
     | null
 
   /**
+   * The DOM element to append your menu to. Default is the editor's parent element.
+   *
+   * Sometimes the menu needs to be appended to a different DOM context due to accessibility, clipping, or z-index issues.
+   *
+   * @type {HTMLElement}
+   * @default null
+   */
+  appendTo?: HTMLElement
+
+  /**
    * The options for the bubble menu. Those are passed to Floating UI and include options for the placement, offset, flip, shift, arrow, size, autoPlacement,
    * hide, and inline middlewares.
    * @default {}
@@ -134,6 +144,8 @@ export class BubbleMenuView implements PluginView {
   public updateDelay: number
 
   public resizeDelay: number
+
+  public appendTo: HTMLElement | undefined
 
   private updateDebounceTimer: number | undefined
 
@@ -236,6 +248,7 @@ export class BubbleMenuView implements PluginView {
     updateDelay = 250,
     resizeDelay = 60,
     shouldShow,
+    appendTo,
     options,
   }: BubbleMenuViewProps) {
     this.editor = editor
@@ -243,6 +256,7 @@ export class BubbleMenuView implements PluginView {
     this.view = view
     this.updateDelay = updateDelay
     this.resizeDelay = resizeDelay
+    this.appendTo = appendTo
 
     this.floatingUIOptions = {
       ...this.floatingUIOptions,
@@ -448,8 +462,8 @@ export class BubbleMenuView implements PluginView {
 
     this.element.style.visibility = 'visible'
     this.element.style.opacity = '1'
-    // attach to editor's parent element
-    this.view.dom.parentElement?.appendChild(this.element)
+    // attach to appendTo or editor's parent element
+    ;(this.appendTo ?? this.view.dom.parentElement)?.appendChild(this.element)
 
     if (this.floatingUIOptions.onShow) {
       this.floatingUIOptions.onShow()

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -24,6 +24,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
       element: null,
       pluginKey: 'bubbleMenu',
       updateDelay: undefined,
+      appendTo: undefined,
       shouldShow: null,
     }
   },
@@ -40,6 +41,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
         element: this.options.element,
         updateDelay: this.options.updateDelay,
         options: this.options.options,
+        appendTo: this.options.appendTo,
         shouldShow: this.options.shouldShow,
       }),
     ]


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

Add an `appendTo` option to extension-bubble-menu, modeled on [tippy's appendTo option](https://atomiks.github.io/tippyjs/v6/all-props/#appendto).

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

Add the option following the example of other options, and use it in the one relevant line (show's appendChild call).

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

Copied the built code into our app and verified that menu was appended to the given element, similar to the 2.x behavior with tippy's appendTo option. In our app, this fixes some z-index issues by portaling the menu into the page's root stacking context.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
