### PR TITLE
fix(List): Update TaskItem aria-label when node changes

### DIFF
--- a/.changeset/lazy-donkeys-taste.md
+++ b/.changeset/lazy-donkeys-taste.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': patch
+---
+
+Update TaskItem aria-label when node changes

--- a/packages/extension-list/src/task-item/task-item.ts
+++ b/packages/extension-list/src/task-item/task-item.ts
@@ -146,13 +146,13 @@ export const TaskItem = Node.create<TaskItemOptions>({
       const checkbox = document.createElement('input')
       const content = document.createElement('div')
 
-      const updateA11Y = () => {
+      const updateA11Y = (currentNode: ProseMirrorNode) => {
         checkbox.ariaLabel =
-          this.options.a11y?.checkboxLabel?.(node, checkbox.checked) ||
-          `Task item checkbox for ${node.textContent || 'empty task item'}`
+          this.options.a11y?.checkboxLabel?.(currentNode, checkbox.checked) ||
+          `Task item checkbox for ${currentNode.textContent || 'empty task item'}`
       }
 
-      updateA11Y()
+      updateA11Y(node)
 
       checkboxWrapper.contentEditable = 'false'
       checkbox.type = 'checkbox'
@@ -221,7 +221,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
 
           listItem.dataset.checked = updatedNode.attrs.checked
           checkbox.checked = updatedNode.attrs.checked
-          updateA11Y()
+          updateA11Y(updatedNode)
 
           return true
         },


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

Minor fix for https://github.com/ueberdosis/tiptap/pull/6549: In the NodeView's update function, update the aria-label using the *updated* node, not the original node captured in a closure.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

Pass the updatedNode as an argument.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

In the Nodes/TaskItem demo in the repo, inspect element to see the checkbox's aria-label. Currently, the aria-label does not update when you change the task item's text content. With this change, it updates immediately while typing.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
