### PR TITLE
Fix/bump linkifyjs dependency vulnerability

### DIFF
--- a/.changeset/calm-colts-study.md
+++ b/.changeset/calm-colts-study.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-link': patch
+---
+
+Bump linkifyjs version to latest to address the recently discovered prototype pollution vulnerability

--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "dependencies": {
-    "linkifyjs": "^4.2.0"
+    "linkifyjs": "^4.3.2"
   },
   "devDependencies": {
     "@tiptap/core": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,8 +699,8 @@ importers:
   packages/extension-link:
     dependencies:
       linkifyjs:
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: ^4.3.2
+        version: 4.3.2
     devDependencies:
       '@tiptap/core':
         specifier: workspace:^
@@ -5154,6 +5154,9 @@ packages:
 
   linkifyjs@4.2.0:
     resolution: {integrity: sha512-pCj3PrQyATaoTYKHrgWRF3SJwsm61udVh+vuls/Rl6SptiDhgE7ziUIudAedRY9QEfynmM7/RmLEfPUyw1HPCw==}
+
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
   lint-staged@15.4.1:
     resolution: {integrity: sha512-P8yJuVRyLrm5KxCtFx+gjI5Bil+wO7wnTl7C3bXhvtTaAFGirzeB24++D0wGoUwxrUKecNiehemgCob9YL39NA==}
@@ -11350,6 +11353,8 @@ snapshots:
       uc.micro: 2.1.0
 
   linkifyjs@4.2.0: {}
+
+  linkifyjs@4.3.2: {}
 
   lint-staged@15.4.1:
     dependencies:


### PR DESCRIPTION
## Changes Overview

Upgrade linkifyjs dependency for `@tiptap/extension-link`

## Implementation Approach

Upgrade linkifyjs dependency for `@tiptap/extension-link`

## Testing Done

`n/a`

## Verification Steps

`n/a`

## Additional Notes

`n/a`

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/pull/6739
