### PR TITLE
Use href attribute from `mark` instead of `node` in renderToMarkdown

### DIFF
--- a/.changeset/large-mugs-like.md
+++ b/.changeset/large-mugs-like.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/static-renderer': patch
+---
+
+fix renderToMarkdown rendering a link href's as undefined

--- a/packages/static-renderer/src/pm/markdown/markdown.ts
+++ b/packages/static-renderer/src/pm/markdown/markdown.ts
@@ -128,8 +128,8 @@ export function renderToMarkdown({
         superscript({ children }) {
           return `<sup>${serializeChildrenToHTMLString(children)}</sup>`
         },
-        link({ node, children }) {
-          return `[${serializeChildrenToHTMLString(children)}](${node.attrs.href})`
+        link({ mark, children }) {
+          return `[${serializeChildrenToHTMLString(children)}](${mark.attrs.href})`
         },
         highlight({ children }) {
           return `==${serializeChildrenToHTMLString(children)}==`


### PR DESCRIPTION
## Changes Overview

in renderToMarkdown, when rendering links the code was erroneously trying to pick the href from the node. This PR changes to pick it out of the mark instead.

## Implementation Approach

Changed node for mark

## Testing Done

I patched tiptap in my project using patch-package with the same change made here and it works.

## Verification Steps

use renderToMarkdown on a doc with links in, and inspect the markdown to ensure the href is rendered as expected

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#6742
