### PR TITLE
add tab indentation support to code blocks

### DIFF
--- a/.changeset/little-cups-play.md
+++ b/.changeset/little-cups-play.md
@@ -3,4 +3,8 @@
 '@tiptap/extension-code-block-lowlight': patch
 ---
 
-Added new tab indentation option for code blocks.
+Added indentation support for code blocks via `Tab`. Is deactivated by default.
+
+**New Extension Options**:
+- `enableTabIndentation: boolean` - controls if tab completion should be enabled
+- `tabSize: number` - controls how many spaces are inserted for a tab

--- a/.changeset/little-cups-play.md
+++ b/.changeset/little-cups-play.md
@@ -1,5 +1,5 @@
 ---
-'@tiptap/extension-code-block': minor
+'@tiptap/extension-code-block': patch
 '@tiptap/extension-code-block-lowlight': patch
 ---
 

--- a/.changeset/little-cups-play.md
+++ b/.changeset/little-cups-play.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-code-block': minor
+'@tiptap/extension-code-block-lowlight': minor
+---
+
+Added new tab indentation option for code blocks.

--- a/.changeset/little-cups-play.md
+++ b/.changeset/little-cups-play.md
@@ -1,6 +1,6 @@
 ---
 '@tiptap/extension-code-block': minor
-'@tiptap/extension-code-block-lowlight': minor
+'@tiptap/extension-code-block-lowlight': patch
 ---
 
 Added new tab indentation option for code blocks.

--- a/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
+++ b/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
@@ -23,6 +23,8 @@ export const CodeBlockLowlight = CodeBlock.extend<CodeBlockLowlightOptions>({
       exitOnTripleEnter: true,
       exitOnArrowDown: true,
       defaultLanguage: null,
+      enableTabIndentation: false,
+      tabSize: 4,
       HTMLAttributes: {},
     }
   },


### PR DESCRIPTION
## Changes Overview
- Introduced options for enabling tab key indentation and setting tab size in CodeBlock.
- Implemented handling for tab and shift+tab key events to manage indentation and reverse indentation.
- Updated CodeBlockLowlight to inherit new options for consistency.

## Implementation Approach

**New Options Added:**
- `enableTabIndentation: boolean` (default: `false`) - Controls whether tab key indentation is enabled
- `tabSize: number` (default: `4`) - Defines the number of spaces to use for each indentation level

**Tab Key Functionality:**
- **Tab**: Adds indentation by inserting spaces (count determined by `tabSize`)
  - For single cursor: Inserts indentation at current position
  - For text selection: Indents all selected lines
- **Shift+Tab**: Removes indentation by removing up to `tabSize` spaces from the beginning of lines
  - For single cursor: Removes indentation from current line only
  - For text selection: Removes indentation from all selected lines

**Inheritance Pattern:**
- CodeBlockLowlight extension automatically inherits the new tab indentation options
- Maintains backward compatibility by keeping `enableTabIndentation` disabled by default

## Testing Done

- Verified tab indentation works correctly with single cursor position
- Tested multi-line selection indentation and reverse indentation
- Confirmed that tab functionality only activates when `enableTabIndentation` is enabled
- Validated that different `tabSize` values work as expected
- Ensured CodeBlockLowlight inherits options correctly
- Tested that existing functionality (triple enter exit, arrow navigation) remains unaffected

## Verification Steps

1. Create a code block in the editor
2. Enable tab indentation by setting `enableTabIndentation: true` in CodeBlock options
3. Test tab indentation:
   - Place cursor in code block and press Tab - should add 4 spaces (or custom `tabSize`)
   - Select multiple lines and press Tab - should indent all selected lines
4. Test reverse indentation:
   - Press Shift+Tab on indented line - should remove indentation
   - Select multiple indented lines and press Shift+Tab - should remove indentation from all lines
5. Verify the feature is disabled by default when `enableTabIndentation: false`

## Additional Notes

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/ueberdosis/tiptap/issues/6755
<!-- Link any related issues here -->