### PR TITLE
🩹 fix: skip processing when emojis are present during IME conversion

### DIFF
--- a/.changeset/many-timers-argue.md
+++ b/.changeset/many-timers-argue.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-emoji": patch
+---
+
+🩹 fix: skip processing when emojis are present during IME conversion

--- a/.changeset/many-timers-argue.md
+++ b/.changeset/many-timers-argue.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-emoji": patch
 ---
 
-🩹 fix: skip processing when emojis are present during IME conversion
+Fixed a problem where the emoji extension would interfer with editor's in composing mode (for example in IME conversion)

--- a/packages/extension-emoji/src/emoji.ts
+++ b/packages/extension-emoji/src/emoji.ts
@@ -389,6 +389,10 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
 
         // replace text emojis with emoji node on any change
         appendTransaction: (transactions, oldState, newState) => {
+          // Skip processing during IME composition
+          if (this.editor.view.composing) {
+            return
+          }
           const docChanges = transactions.some(transaction => transaction.docChanged) && !oldState.doc.eq(newState.doc)
 
           if (!docChanges) {


### PR DESCRIPTION
  ## Changes Overview

  This PR fixes an issue where emoji processing interferes with IME (Input Method Editor) composition, particularly affecting Japanese, Chinese, and Korean input methods.

  ## Implementation Approach

  Added a check to skip emoji processing in the `appendTransaction` hook when the editor is in IME composition mode (`editor.view.composing`). This prevents the emoji
  extension from interfering with the IME's text conversion process.

  ## Testing Done

  - Tested with Japanese IME to ensure emoji characters are not processed during composition
  - Verified that emoji conversion still works correctly after IME composition is complete
  - Confirmed no regression in regular emoji input without IME

  ## Verification Steps

  1. Enable an IME (Japanese, Chinese, or Korean)
  2. Type text that includes emoji characters during composition
  3. Verify that the text is not processed until IME composition is complete
  4. Confirm that emoji conversion works normally after pressing Enter/Space to confirm IME input

  ## Additional Notes

  This fix addresses issue #6758 where IME input was being disrupted by premature emoji processing.

  ## Checklist

  - [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
  - [x] My changes do not break the library.
  - [ ] I have added tests where applicable.
  - [x] I have followed the project guidelines.
  - [x] I have fixed any lint issues.

  ## Related Issues

  Fixes #6758