### PR TITLE
Fix unmounting vue-3 editor in test environments

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -182,7 +182,9 @@ export class Editor extends EventEmitter<EditorEvents> {
     }
     this.editorView = null
     this.isInitialized = false
-    this.css?.remove()
+    if (this.css && typeof this.css.remove === 'function') {
+      this.css.remove()
+    }
     this.css = null
   }
 


### PR DESCRIPTION
## Changes Overview

This adds a safe accessor to ensure that the `css` variable has a `remove` method before trying to invoke it

This is because of this error when unmounting the tiptap editor in vue-test-utils + vitest

```
TypeError: _a.remove is not a function
 ❯ Editor.unmount ../../node_modules/@tiptap/core/src/Editor.ts:185:15
```

I'm not sure of the exact cause, is `css` being set to an object by something that's not the right
type.. or is it lacking the right polyfills in vitest with `happy-dom` and `jsdom`. All I know is I'm
getting the above error.

So it's being set to something, that does not have the remove method. So updating this line to make
sure it actually exists before calling it.

## Implementation Approach

n/a, small safety accessor

## Testing Done

None, change only adds another accessor safety check

## Verification Steps

tests passing

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/6777
