### PR TITLE
Expose `onDragStart` and `onDragEnd` callbacks for better UI control during node drag

### DIFF
--- a/.changeset/sour-boats-fix.md
+++ b/.changeset/sour-boats-fix.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-drag-handle-react': minor
+'@tiptap/extension-drag-handle': minor
+---
+
+Expose `onDragStart` and `onDragEnd` callbacks to improve custom drag behavior. This allows better UI control compared to relying on `editor.view.dragging`, especially when using absolute-positioned drag handles.

--- a/packages/extension-drag-handle-react/src/DragHandle.tsx
+++ b/packages/extension-drag-handle-react/src/DragHandle.tsx
@@ -24,6 +24,8 @@ export const DragHandle = (props: DragHandleProps) => {
     editor,
     pluginKey = dragHandlePluginDefaultKey,
     onNodeChange,
+    onElementDragStart,
+    onElementDragEnd,
     computePositionConfig = defaultComputePositionConfig,
   } = props
   const [element, setElement] = useState<HTMLDivElement | null>(null)
@@ -52,7 +54,12 @@ export const DragHandle = (props: DragHandleProps) => {
         editor,
         element,
         pluginKey,
-        computePositionConfig: { ...defaultComputePositionConfig, ...computePositionConfig },
+        computePositionConfig: {
+          ...defaultComputePositionConfig,
+          ...computePositionConfig,
+        },
+        onElementDragStart,
+        onElementDragEnd,
         onNodeChange,
       })
       plugin.current = initPlugin.plugin
@@ -68,7 +75,7 @@ export const DragHandle = (props: DragHandleProps) => {
         initPlugin = null
       }
     }
-  }, [element, editor, onNodeChange, pluginKey, computePositionConfig])
+  }, [element, editor, onNodeChange, pluginKey, computePositionConfig, onElementDragStart, onElementDragEnd])
 
   return (
     <div className={className} style={{ visibility: 'hidden', position: 'absolute' }} ref={setElement}>

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -60,6 +60,8 @@ export interface DragHandlePluginProps {
   editor: Editor
   element: HTMLElement
   onNodeChange?: (data: { editor: Editor; node: Node | null; pos: number }) => void
+  onElementDragStart?: (e: DragEvent) => void
+  onElementDragEnd?: (e: DragEvent) => void
   computePositionConfig?: ComputePositionConfig
 }
 
@@ -71,6 +73,8 @@ export const DragHandlePlugin = ({
   editor,
   computePositionConfig,
   onNodeChange,
+  onElementDragStart,
+  onElementDragEnd,
 }: DragHandlePluginProps) => {
   const wrapper = document.createElement('div')
   let locked = false
@@ -117,6 +121,7 @@ export const DragHandlePlugin = ({
   }
 
   function onDragStart(e: DragEvent) {
+    onElementDragStart?.(e)
     // Push this to the end of the event cue
     // Fixes bug where incorrect drag pos is returned if drag handle has position: absolute
     // @ts-ignore
@@ -129,7 +134,8 @@ export const DragHandlePlugin = ({
     }, 0)
   }
 
-  function onDragEnd() {
+  function onDragEnd(e: DragEvent) {
+    onElementDragEnd?.(e)
     hideHandle()
     if (element) {
       element.style.pointerEvents = 'auto'


### PR DESCRIPTION
## Changes Overview

This PR adds support for onDragStart and onDragEnd event callbacks to provide more reliable control over drag-related UI behavior.

Using `editor.view.dragging` in Tiptap is not always reliable for UI updates

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
