### PR TITLE
Fix: generateHTML on server

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -15,7 +15,11 @@
   "exports": {
     ".": {
       "types": {
-        "import": "./dist/index.d.ts",
+        "import": {
+          "browser": "./dist/index.js",
+          "node": "./dist/server/index.js",
+          "default": "./dist/index.js"
+        },
         "require": "./dist/index.d.cts"
       },
       "import": "./dist/index.js",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -15,14 +15,13 @@
   "exports": {
     ".": {
       "types": {
-        "import": {
-          "browser": "./dist/index.js",
-          "node": "./dist/server/index.js",
-          "default": "./dist/index.js"
-        },
         "require": "./dist/index.d.cts"
       },
-      "import": "./dist/index.js",
+      "import": {
+        "browser": "./dist/index.js",
+        "node": "./dist/server/index.js",
+        "default": "./dist/index.js"
+      },
       "require": "./dist/index.cjs"
     },
     "./server": {

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": {
+        "import": "./dist/index.d.ts",
         "require": "./dist/index.d.cts"
       },
       "import": {


### PR DESCRIPTION
## Changes Overview
This pull request updates the module export configuration in the `packages/html/package.json` file to better support different environments (browser and Node.js). The most important change is the introduction of environment-specific entry points for the ES module import field.

Module resolution improvements:

* Updated the `import` field in `exports` to specify separate entry points for `browser` (`./dist/index.js`), `node` (`./dist/server/index.js`), and a `default` fallback (`./dist/index.js`).

## Implementation Approach

This allows consumers to automatically get the appropriate build depending on their environment.

## Verification Steps

Create a Node.js script to test server-side HTML generation:
```javascript
// test-server.js
import { generateHTML } from '@tiptap/html'
import { Document } from '@tiptap/extension-document'
import { Paragraph } from '@tiptap/extension-paragraph'
import { Text } from '@tiptap/extension-text'

const doc = {
  type: 'doc',
  content: [{
    type: 'paragraph',
    content: [{ type: 'text', text: 'Hello world!' }]
  }]
}

const extensions = [Document, Paragraph, Text]
const html = generateHTML(doc, extensions)
console.log(html) // Should output: <p>Hello world!</p>
```


## Checklist

- [] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#6782 
