### PR TITLE
add pnpm-patch to fix unwanted peerDependency major release bumping

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,5 +85,10 @@
       "prettier --write",
       "eslint --fix --quiet --no-error-on-unmatched-pattern"
     ]
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@changesets/assemble-release-plan": "patches/@changesets__assemble-release-plan.patch"
+    }
   }
 }

--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index e32a5e5d39c3bd920201b5694632d2b44c92d486..a829860f5e001ce610d7f93daf3da015528e6405 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -344,6 +344,10 @@ function shouldBumpMajor({
+   preInfo,
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
++  if (depType === "peerDependencies") {
++    return false;
++  }
++
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@changesets/assemble-release-plan':
+    hash: k7lv6yvbsp2zaevp6zj5au6glm
+    path: patches/@changesets__assemble-release-plan.patch
+
 importers:
 
   .:
@@ -7654,7 +7659,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.6.3
 
-  '@changesets/assemble-release-plan@6.0.5':
+  '@changesets/assemble-release-plan@6.0.5(patch_hash=k7lv6yvbsp2zaevp6zj5au6glm)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.2
@@ -7670,7 +7675,7 @@ snapshots:
   '@changesets/cli@2.27.11':
     dependencies:
       '@changesets/apply-release-plan': 7.0.7
-      '@changesets/assemble-release-plan': 6.0.5
+      '@changesets/assemble-release-plan': 6.0.5(patch_hash=k7lv6yvbsp2zaevp6zj5au6glm)
       '@changesets/changelog-git': 0.2.0
       '@changesets/config': 3.0.5
       '@changesets/errors': 0.2.0
@@ -7721,7 +7726,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.6':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.5
+      '@changesets/assemble-release-plan': 6.0.5(patch_hash=k7lv6yvbsp2zaevp6zj5au6glm)
       '@changesets/config': 3.0.5
       '@changesets/pre': 2.0.1
       '@changesets/read': 0.6.2


### PR DESCRIPTION
## Changes Overview

This PR includes a PNPM patch that should fix an issue where our changeset versioning would bump to a major unexpectedly because of PNPM workspace peer dependencies.

## AI Summary

This pull request introduces a patch to the `@changesets/assemble-release-plan` dependency to adjust how major version bumps are determined for peer dependencies. The patch ensures that packages listed as `peerDependencies` will no longer trigger a major version bump, addressing an issue with release planning. The changes also update the project configuration files to apply and track this patch via `pnpm`.

Dependency patching and configuration updates:

* Added a patch file (`patches/@changesets__assemble-release-plan.patch`) that modifies the logic in `shouldBumpMajor` to prevent major version bumps for `peerDependencies`.
* Updated `package.json` to specify the patched dependency under the `pnpm.patchedDependencies` field.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
