### PR TITLE
fix(core): make input and paste rules respect extension priority

### DIFF
--- a/.changeset/input-rules-respect-priority.md
+++ b/.changeset/input-rules-respect-priority.md
@@ -1,0 +1,36 @@
+---
+"@tiptap/core": minor
+---
+
+Make input rules and paste rules respect extension `priority` by registering
+them per-extension instead of aggregating them into a single global plugin.
+
+Why
+---
+Previously all `addInputRules()` and `addPasteRules()` were gathered into one
+global plugin which ran before the other plugins. That caused conflicts where
+some extensions (for example mention/suggestion with `#`) could not preempt the
+built-in heading input rule.
+
+What changed
+---
+- Input and paste rules are now created and registered at the position of the
+  owning extension. This makes their execution order follow the extension
+  sorting/`priority` mechanism.
+- Behavior is more predictable: extensions with higher `priority` can now take
+  precedence over lower priority extensions' input/paste rules.
+
+Migration & compatibility
+---
+- This is a behavioral change. If you relied on the old global ordering (input
+  rules always running before other plugins), you may observe different
+  outcomes. In most cases this is desirable and fixes conflicts (like the
+  `#` mention vs. heading shortcut), but be aware of the change.
+- If you need to force the previous behavior for a specific rule, you can:
+  - Register the rule as a ProseMirror plugin via `addProseMirrorPlugins()` on
+    the extension and place it where you want it to run.
+  - Adjust the extension `priority` value so the extension sits earlier or
+    later in the ordering.
+
+If you have any questions or see regressions after upgrading, please open an
+issue with a small repro and we'll help triage.

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -132,12 +132,14 @@ export class ExtensionManager {
           const rules = addInputRules()
 
           if (rules && rules.length) {
-            plugins.push(
-              inputRulesPlugin({
-                editor,
-                rules,
-              }),
-            )
+            const inputResult = inputRulesPlugin({
+              editor,
+              rules,
+            })
+
+            const inputPlugins = Array.isArray(inputResult) ? inputResult : [inputResult]
+
+            plugins.push(...inputPlugins)
           }
         }
 
@@ -147,7 +149,9 @@ export class ExtensionManager {
           const rules = addPasteRules()
 
           if (rules && rules.length) {
-            plugins.push(...pasteRulesPlugin({ editor, rules }))
+            const pasteRules = pasteRulesPlugin({ editor, rules })
+
+            plugins.push(...pasteRules)
           }
         }
 


### PR DESCRIPTION
## Changes Overview

This pull request updates how input rules and paste rules are registered in the Tiptap core, making their execution order respect extension priorities. Previously, all input and paste rules were aggregated into global plugins, which could cause conflicts between extensions. Now, rules are registered per-extension, allowing extensions with higher priority to take precedence and making behavior more predictable.

## Implementation Approach

**Input & Paste Rule Registration Improvements:**

* Input and paste rules are now created and registered at the position of their owning extension, following the extension sorting and `priority` mechanism. This replaces the previous global aggregation approach. [[1]](diffhunk://#diff-34ea668dac19f1717ece64fd0716f0709a69da5401e5615aa8de1cd801c9f30cL137-R151) [[2]](diffhunk://#diff-34ea668dac19f1717ece64fd0716f0709a69da5401e5615aa8de1cd801c9f30cL162-R170)
* Extensions with higher `priority` can now override lower priority extensions’ input and paste rules, resolving previous conflicts (e.g., mention/suggestion extensions vs. heading shortcuts).

## Testing Done

- I created a local-only test that would simulate a bug described in #2570 where the hash character that is used by the Heading extension as an input rule would cause issues with mentions using hashes as well
  - The test worked as expected and the mention extension would now take over the key handling instead of transforming the node into a heading
- I tested old input and paste rules to check if this change causes any issue with existing rules & couldn't find any issues

## Additional Notes

I marked this as a **minor** change even though that theoretically it could cause issues in existing apps that previously relied on the old system not respecting priorities but this should be an edge case and this change should usually rather fix problems than causing new ones.

> This is a behavioral change. If you relied on the old global ordering (input
  rules always running before other plugins), you may observe different
  outcomes. In most cases this is desirable and fixes conflicts (like the
  `#` mention vs. heading shortcut), but be aware of the change.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Fixes #2570 
