### PR TITLE
fix: improve types for rendered components props for ReactRenderer

### DIFF
--- a/.changeset/new-rabbits-hunt.md
+++ b/.changeset/new-rabbits-hunt.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Improve typings for rendered component props in ReactRenderer.

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -98,7 +98,7 @@ function isReact19Plus(): boolean {
   return false
 }
 
-export interface ReactRendererOptions {
+export interface ReactRendererOptions<P extends Record<string, any> = object> {
   /**
    * The editor instance.
    * @type {Editor}
@@ -107,10 +107,10 @@ export interface ReactRendererOptions {
 
   /**
    * The props for the component.
-   * @type {Record<string, any>}
+   * @type {P}
    * @default {}
    */
-  props?: Record<string, any>
+  props?: P
 
   /**
    * The tag name of the element.
@@ -164,12 +164,12 @@ export class ReactRenderer<R = unknown, P extends Record<string, any> = object> 
    */
   constructor(
     component: ComponentType<R, P>,
-    { editor, props = {}, as = 'div', className = '' }: ReactRendererOptions,
+    { editor, props, as = 'div', className = '' }: ReactRendererOptions<Omit<P, 'ref'>>,
   ) {
     this.id = Math.floor(Math.random() * 0xffffffff).toString()
     this.component = component
     this.editor = editor as EditorWithContentComponent
-    this.props = props as P
+    this.props = (props ?? {}) as P
     this.element = document.createElement(as)
     this.element.classList.add('react-renderer')
 
@@ -226,7 +226,7 @@ export class ReactRenderer<R = unknown, P extends Record<string, any> = object> 
   /**
    * Re-renders the React component with new props.
    */
-  updateProps(props: Record<string, any> = {}): void {
+  updateProps(props: Partial<Omit<P, 'ref'>> = {}): void {
     this.props = {
       ...this.props,
       ...props,


### PR DESCRIPTION
## Changes Overview

This PR improves the TypeScript types for the ReactRenderer to provide better type safety and autocompletion for the rendered component props.

Previously, the rendered component props were typed as `Record<string, any>`, which allowed for common errors like typos or incorrect prop value types to go unnoticed by the compiler. This change ensures that any props passed to the `ReactRenderer` are correctly validated against the rendered component's actual prop types, leading to a more robust developer experience.

## Implementation Approach

The implementation introduces a generic type parameter `P` to the `ReactRenderer` class and `ReactRendererOptions` interface.

This generic `P`, representing the rendered component's props, is used to strictly type the props object in the constructor.

The `updateProps` method is now typed to accept `Partial<Omit<P, 'ref'>>`, ensuring type-safe partial updates and preventing the internally-managed `ref` prop from being overwritten.

The constructor logic is updated to handle cases where props might be `undefined`, mostly to avoid type casting in the constructor declaration.

## Testing Done

As this is a type-only change, no runtime behavior is altered. All existing unit and integration tests continue to pass. The primary validation for this change is through TypeScript's static analysis, which now correctly identifies type errors at compile time when using the ReactRenderer. 

## Verification Steps

A verification test was done in a consuming project locally by installing the `@tiptap/react` package via `pnpm add file:<path to clone>/packages/react`. The improved types worked as expected when autocompleting and inspecting them.

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
~- [ ] I have added tests where applicable.~
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
