### PR TITLE
fix: Select collaboration extension with provider instead of first registered

### DIFF
--- a/.changeset/big-cases-retire.md
+++ b/.changeset/big-cases-retire.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-unique-id': patch
+---
+
+Fix collaboration extension selection to use the extension with a provider instead of the first registered extension

--- a/packages/extension-unique-id/src/unique-id.ts
+++ b/packages/extension-unique-id/src/unique-id.ts
@@ -57,8 +57,10 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
   onCreate() {
     const collaboration = this.editor.extensionManager.extensions.find(ext => ext.name === 'collaboration')
     const collaborationCaret = this.editor.extensionManager.extensions.find(ext => ext.name === 'collaborationCaret')
-    const collab = collaboration || collaborationCaret
-    const provider = collab?.options ? collab.options.provider : undefined
+
+    const collabExtensions = [collaboration, collaborationCaret].filter(Boolean)
+    const collab = collabExtensions.find(ext => ext?.options?.provider)
+    const provider = collab?.options?.provider
 
     const createIds = () => {
       const { view, state } = this.editor


### PR DESCRIPTION
## Changes Overview

The `onCreate` method was incorrectly selecting collaboration extensions by using `collaboration || collaborationCaret`, which would always pick the first extension that exists. However, both extensions are always registered - the difference is that only one actually has a `provider` in its options.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
