### PR TITLE
Hotfix for Drag Handling in Safari

### DIFF
--- a/.changeset/fix-safari-drag-image.md
+++ b/.changeset/fix-safari-drag-image.md
@@ -1,0 +1,10 @@
+---
+"@tiptap/core": patch
+---
+
+Ensure drag previews for node views work correctly in Safari by attaching
+an offscreen clone of the node to the DOM while calling
+`setDragImage`, and by preserving the original element's pixel
+`width`/`height` so the preview matches the original. This prevents
+Safari from immediately cancelling the drag when a detached element is
+used as the drag image.


### PR DESCRIPTION
## Changes Overview

This pull request addresses a compatibility issue with drag-and-drop previews for node views in Safari browsers. The main improvement ensures that drag previews display correctly by attaching a visually accurate offscreen clone of the node to the DOM during the drag operation, preventing Safari from cancelling the drag unexpectedly. The changes also preserve the original node's size and prevent pointer events on the clone.

## Implementation Approach

Safari drag-and-drop compatibility:

* Updated `NodeView.ts` to preserve the pixel width and height of the original node when creating a drag preview clone, ensuring the preview matches the original element visually.
* Ensured the drag image clone is temporarily attached offscreen to the DOM during the drag operation, which is required by Safari for the drag to work correctly, and removed the clone immediately after.

Documentation:

* Added a changeset describing the Safari drag preview fix and the technical rationale for the approach. (.changeset/fix-safari-drag-image.md)

## Testing Done

Did manually testing locally and ensured that the change doesnt break drag handling in Chrome or Firefox.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
