### PR TITLE
fix(drag-handle-vue-2): fix vue2 warnign about objects as default

### DIFF
--- a/.changeset/moody-trees-rescue.md
+++ b/.changeset/moody-trees-rescue.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle-vue-2': patch
+---
+
+Use factory function for object default value as required by vue 2.

--- a/.changeset/serious-tools-hear.md
+++ b/.changeset/serious-tools-hear.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-drag-handle-vue-2": patch
+---
+
+Fixed a bug that would cause Vue 2 to throw errors in console because Vue 2 expects factory functions for prop defaults

--- a/packages/extension-drag-handle-vue-2/src/DragHandle.ts
+++ b/packages/extension-drag-handle-vue-2/src/DragHandle.ts
@@ -20,7 +20,7 @@ export const DragHandle = Vue.extend({
   props: {
     pluginKey: {
       type: [String, Object] as PropType<DragHandleProps['pluginKey']>,
-      default: dragHandlePluginDefaultKey,
+      default: () => dragHandlePluginDefaultKey,
     },
 
     editor: {


### PR DESCRIPTION
## Changes Overview

* Vue2 requires factory functions for defaults for objects and arrays.
* `class` may not be used as prop.

## Implementation Approach

Use a factory function.

## Testing Done

Checked that it prevents the warning by building text with it:

> Invalid default value for prop "PluginKey": Props with type Object/Array must use a factory function to return the default value.

## Verification Steps

Actually testing is cumbersome. Vue 3 seems to have dropped the warning. [I'm still checking](https://github.com/vuejs/docs/pull/3282) if that actually also means it's not an issue anymore.
Checking the code and checking [the docs]( https://v2.vuejs.org/v2/guide/components-props#Prop-Validation) is probably best (search for 'factory function')

## Additional Notes

<img width="949" height="458" alt="grafik" src="https://github.com/user-attachments/assets/2d265e96-3fc0-435e-bbc1-4a7a100524d2" />

I'm still looking into fixing the class reserved name warning.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable (not applicable).
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues (lint is happy).

## Related Issues

Initially came up in https://github.com/nextcloud/text/pull/7537#issuecomment-3197240037
