### PR TITLE
fix(collaboration): correct warning message to reference undo-redo extension

### DIFF
--- a/.changeset/sweet-panthers-decide.md
+++ b/.changeset/sweet-panthers-decide.md
@@ -2,5 +2,4 @@
 '@tiptap/extension-collaboration': patch
 ---
 
-- The code is checking for UndoRedo, but the warning message still talks about History (outdated).
-- The fix is just to update the string so it correctly warns about UndoRedo.
+Fixed outdated warning message to reference `@tiptap/extension-undo-redo` instead of `@tiptap/extension-history`.

--- a/.changeset/sweet-panthers-decide.md
+++ b/.changeset/sweet-panthers-decide.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-collaboration': patch
+---
+
+- The code is checking for UndoRedo, but the warning message still talks about History (outdated).
+- The fix is just to update the string so it correctly warns about UndoRedo.

--- a/packages/extension-collaboration/src/collaboration.ts
+++ b/packages/extension-collaboration/src/collaboration.ts
@@ -105,7 +105,7 @@ export const Collaboration = Extension.create<CollaborationOptions, Collaboratio
   onCreate() {
     if (this.editor.extensionManager.extensions.find(extension => extension.name === 'undoRedo')) {
       console.warn(
-        '[tiptap warn]: "@tiptap/extension-collaboration" comes with its own history support and is not compatible with "@tiptap/extension-history".',
+        '[tiptap warn]: "@tiptap/extension-collaboration" comes with its own history support and is not compatible with "@tiptap/extension-undo-redo".',
       )
     }
   },


### PR DESCRIPTION
## Changes Overview

The current warning in `@tiptap/extension-collaboration` checks for the `undoRedo` extension, 
but the message still references the outdated `@tiptap/extension-history`.

This PR updates the warning to correctly reference `@tiptap/extension-undo-redo`.

- Before: "[tiptap warn]: ... not compatible with @tiptap/extension-history"
- After:  "[tiptap warn]: ... not compatible with @tiptap/extension-undo-redo"


## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#6869 
