### PR TITLE
fix(extension-suggestion): trigger suggestion popup for @ in Chinese input method

### DIFF
--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -210,13 +210,27 @@ export function Suggestion<I = any, TSelected = any>({
   let props: SuggestionProps<I, TSelected> | undefined
   const renderer = render?.()
 
+  // Gets the DOM rectangle corresponding to the current editor cursor anchor position
+  // Calculates screen coordinates based on Tiptap's cursor position and converts to a DOMRect object
+  const getAnchorClientRect = () => {
+    const pos = editor.state.selection.$anchor.pos
+    const coords = editor.view.coordsAtPos(pos)
+    const { top, right, bottom, left } = coords
+
+    try {
+      return new DOMRect(left, top, right - left, bottom - top)
+    } catch {
+      return null
+    }
+  }
+
   // Helper to create a clientRect callback for a given decoration node.
   // Returns null when no decoration node is present. Uses the pluginKey's
   // state to resolve the current decoration node on demand, avoiding a
   // duplicated implementation in multiple places.
   const clientRectFor = (view: EditorView, decorationNode: Element | null) => {
     if (!decorationNode) {
-      return null
+      return getAnchorClientRect
     }
 
     return () => {


### PR DESCRIPTION
## Changes Overview
Previously, clientRect was only obtained through decorationNode. If decorationNode could not be obtained, the value of clientRect was assigned to null. This commit adds a new method to obtain clientRect.

## Implementation Approach
If decorationNode cannot be obtained, the coordinates are obtained according to the editor's cursor position, and the cursor position is used to generate a DOMRect.

## Testing Done
In scenarios where Chinese IME is used, the value of clientRect is almost always null, which causes the "suggestion" to not render. This commit fixes this issue.

## Verification Steps
Just type @ when using the Chinese input method and the result will be verified.


## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->
![before](https://github.com/user-attachments/assets/e8af538d-f8dd-4306-98db-ff89815eda37)

![after](https://github.com/user-attachments/assets/d1271605-6b51-4cc9-ae37-cfb0d58c72a9)

## Checklist
- [x] I have created a changeset for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
