### PR TITLE
feat(inputRule): add undoable option

### DIFF
--- a/packages/core/src/InputRule.ts
+++ b/packages/core/src/InputRule.ts
@@ -33,6 +33,8 @@ export class InputRule {
     can: () => CanCommands
   }) => void | null
 
+  undoable: boolean
+
   constructor(config: {
     find: InputRuleFinder
     handler: (props: {
@@ -43,9 +45,11 @@ export class InputRule {
       chain: () => ChainedCommands
       can: () => CanCommands
     }) => void | null
+    undoable?: boolean
   }) {
     this.find = config.find
     this.handler = config.handler
+    this.undoable = config.undoable ?? true
   }
 }
 
@@ -149,12 +153,14 @@ function run(config: {
 
     // store transform as meta data
     // so we can undo input rules within the `undoInputRules` command
-    tr.setMeta(plugin, {
-      transform: tr,
-      from,
-      to,
-      text,
-    })
+    if (rule.undoable) {
+      tr.setMeta(plugin, {
+        transform: tr,
+        from,
+        to,
+        text,
+      })
+    }
 
     view.dispatch(tr)
     matched = true

--- a/packages/core/src/inputRules/markInputRule.ts
+++ b/packages/core/src/inputRules/markInputRule.ts
@@ -14,6 +14,7 @@ import { callOrReturn } from '../utilities/callOrReturn.js'
 export function markInputRule(config: {
   find: InputRuleFinder
   type: MarkType
+  undoable?: boolean
   getAttributes?: Record<string, any> | ((match: ExtendedRegExpMatchArray) => Record<string, any>) | false | null
 }) {
   return new InputRule({
@@ -62,5 +63,6 @@ export function markInputRule(config: {
         tr.removeStoredMark(config.type)
       }
     },
+    undoable: config.undoable,
   })
 }

--- a/packages/core/src/inputRules/nodeInputRule.ts
+++ b/packages/core/src/inputRules/nodeInputRule.ts
@@ -22,6 +22,12 @@ export function nodeInputRule(config: {
   type: NodeType
 
   /**
+   * Whether the input rule should be undoable
+   * when the user presses backspace.
+   */
+  undoable?: boolean
+
+  /**
    * A function that returns the attributes for the node
    * can also be an object of attributes
    */
@@ -62,5 +68,6 @@ export function nodeInputRule(config: {
 
       tr.scrollIntoView()
     },
+    undoable: config.undoable,
   })
 }

--- a/packages/core/src/inputRules/textInputRule.ts
+++ b/packages/core/src/inputRules/textInputRule.ts
@@ -6,7 +6,7 @@ import { InputRule } from '../InputRule.js'
  * matched text is typed into it.
  * @see https://tiptap.dev/docs/editor/extensions/custom-extensions/extend-existing#input-rules
  */
-export function textInputRule(config: { find: InputRuleFinder; replace: string }) {
+export function textInputRule(config: { find: InputRuleFinder; replace: string; undoable?: boolean }) {
   return new InputRule({
     find: config.find,
     handler: ({ state, range, match }) => {
@@ -30,5 +30,6 @@ export function textInputRule(config: { find: InputRuleFinder; replace: string }
 
       state.tr.insertText(insert, start, end)
     },
+    undoable: config.undoable,
   })
 }

--- a/packages/core/src/inputRules/textblockTypeInputRule.ts
+++ b/packages/core/src/inputRules/textblockTypeInputRule.ts
@@ -15,6 +15,7 @@ import { callOrReturn } from '../utilities/callOrReturn.js'
 export function textblockTypeInputRule(config: {
   find: InputRuleFinder
   type: NodeType
+  undoable?: boolean
   getAttributes?: Record<string, any> | ((match: ExtendedRegExpMatchArray) => Record<string, any>) | false | null
 }) {
   return new InputRule({
@@ -29,5 +30,6 @@ export function textblockTypeInputRule(config: {
 
       state.tr.delete(range.from, range.to).setBlockType(range.from, range.from, config.type, attributes)
     },
+    undoable: config.undoable,
   })
 }

--- a/packages/core/src/inputRules/wrappingInputRule.ts
+++ b/packages/core/src/inputRules/wrappingInputRule.ts
@@ -28,6 +28,7 @@ export function wrappingInputRule(config: {
   keepMarks?: boolean
   keepAttributes?: boolean
   editor?: Editor
+  undoable?: boolean
   getAttributes?: Record<string, any> | ((match: ExtendedRegExpMatchArray) => Record<string, any>) | false | null
   joinPredicate?: (match: ExtendedRegExpMatchArray, node: ProseMirrorNode) => boolean
 }) {
@@ -76,5 +77,6 @@ export function wrappingInputRule(config: {
         tr.join(range.from - 1)
       }
     },
+    undoable: config.undoable,
   })
 }


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->
A new version of ProseMirror's InputRules includes an undoable option for InputRules, which TipTap does not currently support.
So, I implemented the `undoable` option.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

Since Tiptap implements its own InputRule, I referred to [the ProseMirror commit that adds the undoable option](https://github.com/ProseMirror/prosemirror-inputrules/commit/8b6eabc2c2a6d737ac33e5080d5607e0a25b77a5)

Specifically, `setMeta` is only called when `undoable` is set to true.
This prevents the state of the InputPlugin from being updated, and the undoInputRule command is not triggered.

For backward compatibility, the default value of undoable is true when it is not specified.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

I tested it in the demo by changing the undoable option for the extensions that use each rule.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

Please test it in the demo.
- markInputRule -> bold
- nodeInputRule -> horizontal-rule
- textblockTypeInputRule -> heading
- textInputRule -> typography
- wrappingInputRule -> blockquote

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
#4659 