### PR TITLE
fix(emoji): update paste regex to preserve optional prefix

### DIFF
--- a/.changeset/emoji-paste-url-fix.md
+++ b/.changeset/emoji-paste-url-fix.md
@@ -1,0 +1,7 @@
+---
+"@tiptap/extension-emoji": patch
+---
+
+Prevent emoji shortcodes from being converted when they appear inside pasted URLs.
+
+Previously, pasting links such as `https://.../:x:/r/...` could unintentionally convert `:x:` (and similar shortcodes) into emoji nodes and break links. The paste handler now avoids replacing shortcodes that are part of URL-like text.

--- a/packages/extension-emoji/src/emoji.ts
+++ b/packages/extension-emoji/src/emoji.ts
@@ -92,7 +92,7 @@ export const EmojiSuggestionPluginKey = new PluginKey('emojiSuggestion')
 
 export const inputRegex = /:([a-zA-Z0-9_+-]+):$/
 
-export const pasteRegex = /:([a-zA-Z0-9_+-]+):/g
+export const pasteRegex = /(^|\s):([a-zA-Z0-9_+-]+):/g
 
 export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
   name: 'emoji',
@@ -329,15 +329,21 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
       new PasteRule({
         find: pasteRegex,
         handler: ({ range, match, chain }) => {
-          const name = match[1]
+          // match[1] is the optional prefix (start or whitespace), match[2] is the shortcode name
+          const prefix = match[1] || ''
+          const name = match[2]
 
           if (!shortcodeToEmoji(name, this.options.emojis)) {
             return
           }
 
+          // Replace only the shortcode portion (preserve the prefix)
+          const shortcodeFrom = range.from + prefix.length
+          const shortcodeTo = range.to
+
           chain()
             .insertContentAt(
-              range,
+              { from: shortcodeFrom, to: shortcodeTo },
               {
                 type: this.name,
                 attrs: {


### PR DESCRIPTION
## Changes Overview

This pull request refines the emoji paste detection logic in the `packages/extension-emoji/src/emoji.ts` file to more accurately match emoji shortcodes, especially when they appear at the start of a line or after whitespace. The changes ensure that only the shortcode portion is replaced, preserving any prefix such as whitespace.

## Implementation Approach

Improvements to emoji paste handling:

* Updated the `pasteRegex` to include an optional prefix (start of line or whitespace), improving detection of emoji shortcodes in pasted text.
* Modified the paste rule handler to correctly identify and preserve the prefix, replacing only the matched shortcode portion with the corresponding emoji node.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
