### PR TITLE
Preserve color formats for the background-color and color extension

### DIFF
--- a/.changeset/preserve-inline-color-format.md
+++ b/.changeset/preserve-inline-color-format.md
@@ -1,0 +1,28 @@
+---
+"@tiptap/extension-text-style": patch
+---
+
+Prefer the raw inline `style` attribute when parsing `color` and
+`background-color` so the original format (hex, rgba/hsla, etc.) is
+preserved instead of falling back to the computed `element.style.*`
+value (which often resolves to `rgb(...)`).
+
+This fixes mismatches where consumers (for example, demo toolbars and
+color pickers) expected the original hex values when initializing the
+editor from HTML.
+
+- The `color` and `background-color` parsers now look for a `style`
+  attribute first and extract the declared value. If no raw style is
+  present, they still fall back to `element.style.color` /
+  `element.style.backgroundColor`.
+
+MIGRATION NOTES
+- This is a patch-level change. It corrects parsing behavior and is the
+  least-disruptive fix for the issue.
+- If your code relied on the parser returning computed `rgb(...)`
+  strings, you may see different string values (for example `#958DF1`
+  instead of `rgb(149, 141, 241)`) when HTML contained hex values.
+- If you need a stable, normalized format for comparisons, normalize the
+  attribute (for example with a color utility like `tinycolor2`) before
+  comparing or use the editor APIs in a way that doesn't depend on the
+  exact string representation.

--- a/demos/src/Extensions/BackgroundColor/React/index.tsx
+++ b/demos/src/Extensions/BackgroundColor/React/index.tsx
@@ -12,6 +12,7 @@ export default () => {
     extensions: [Document, Paragraph, Text, TextStyle, BackgroundColor],
     content: `
         <p><span style="background-color: #958DF1">Oh, for some reason that’s purple.</span></p>
+        <p><span style="background-color: rgba(149, 141, 241, 0.5)">Oh, for some reason that’s purple but with rgba.</span></p>
       `,
   })
 

--- a/demos/src/Extensions/BackgroundColor/Vue/index.vue
+++ b/demos/src/Extensions/BackgroundColor/Vue/index.vue
@@ -88,7 +88,8 @@ export default {
     this.editor = new Editor({
       extensions: [Document, Paragraph, Text, TextStyle, BackgroundColor],
       content: `
-        <p><span style="background-color: #958DF1">Oh, for some reason that's purple.</span></p>
+        <p><span style="background-color: #958DF1">Oh, for some reason that’s purple.</span></p>
+        <p><span style="background-color: rgba(149, 141, 241, 0.5)">Oh, for some reason that’s purple but with rgba.</span></p>
       `,
     })
   },

--- a/demos/src/Extensions/Color/React/index.tsx
+++ b/demos/src/Extensions/Color/React/index.tsx
@@ -11,7 +11,7 @@ export default () => {
   const editor = useEditor({
     extensions: [Document, Paragraph, Text, TextStyle, Color],
     content: `
-        <p><span style="color: #958DF1">Oh, for some reason that’s purple.</span></p>
+        <p><span style="color: #958DF1">Oh, for some reason that’s purple.</span> This text is using <span style="color: rgba(255, 0, 0, 0.5)">transparent, red rgba colors.</span></p>
       `,
   })
 

--- a/demos/src/Extensions/Color/Vue/index.vue
+++ b/demos/src/Extensions/Color/Vue/index.vue
@@ -78,7 +78,7 @@ export default {
     this.editor = new Editor({
       extensions: [Document, Paragraph, Text, TextStyle, Color],
       content: `
-        <p><span style="color: #958DF1">Oh, for some reason that’s purple.</span></p>
+        <p><span style="color: #958DF1">Oh, for some reason that’s purple.</span> This text is using <span style="color: rgba(255, 0, 0, 0.5)">transparent, red rgba colors.</span></p>
       `,
     })
   },

--- a/packages/extension-text-style/src/background-color/background-color.ts
+++ b/packages/extension-text-style/src/background-color/background-color.ts
@@ -57,7 +57,20 @@ export const BackgroundColor = Extension.create<BackgroundColorOptions>({
         attributes: {
           backgroundColor: {
             default: null,
-            parseHTML: element => element.style.backgroundColor?.replace(/['"]+/g, ''),
+            parseHTML: element => {
+              // Prefer the raw inline `style` attribute so we preserve
+              // the original format (e.g. `#rrggbb`) instead of the
+              // computed `rgb(...)` value returned by `element.style.backgroundColor`.
+              const styleAttr = element.getAttribute && element.getAttribute('style')
+              if (styleAttr) {
+                const match = styleAttr.match(/background-color\s*:\s*([^;]+)/i)
+                if (match && match[1]) {
+                  return match[1].trim().replace(/['"]+/g, '')
+                }
+              }
+
+              return element.style.backgroundColor?.replace(/['"]+/g, '')
+            },
             renderHTML: attributes => {
               if (!attributes.backgroundColor) {
                 return {}

--- a/packages/extension-text-style/src/color/color.ts
+++ b/packages/extension-text-style/src/color/color.ts
@@ -57,7 +57,20 @@ export const Color = Extension.create<ColorOptions>({
         attributes: {
           color: {
             default: null,
-            parseHTML: element => element.style.color?.replace(/['"]+/g, ''),
+            parseHTML: element => {
+              // Prefer the raw inline `style` attribute so we preserve
+              // the original format (e.g. `#rrggbb`) instead of the
+              // computed `rgb(...)` value returned by `element.style.color`.
+              const styleAttr = element.getAttribute && element.getAttribute('style')
+              if (styleAttr) {
+                const match = styleAttr.match(/color\s*:\s*([^;]+)/i)
+                if (match && match[1]) {
+                  return match[1].trim().replace(/['"]+/g, '')
+                }
+              }
+
+              return element.style.color?.replace(/['"]+/g, '')
+            },
             renderHTML: attributes => {
               if (!attributes.color) {
                 return {}

--- a/tests/cypress/integration/extensions/background-color.spec.ts
+++ b/tests/cypress/integration/extensions/background-color.spec.ts
@@ -1,0 +1,36 @@
+/// <reference types="cypress" />
+
+import { BackgroundColor } from '@tiptap/extension-text-style'
+
+const ext: any = (BackgroundColor as any).configure()
+const globalAttrs = ext.config.addGlobalAttributes && ext.config.addGlobalAttributes.call(ext)[0]
+const { parseHTML } = globalAttrs.attributes.backgroundColor
+
+describe('background-color parseHTML', () => {
+  it('parses rgb(...) inline style', () => {
+    const el = document.createElement('span')
+    el.setAttribute('style', 'background-color: rgb(0, 255, 0)')
+
+    const parsed = parseHTML(el)
+
+    expect(parsed).to.equal('rgb(0, 255, 0)')
+  })
+
+  it('parses hex inline style', () => {
+    const el = document.createElement('span')
+    el.setAttribute('style', 'background-color: #00ff00')
+
+    const parsed = parseHTML(el)
+
+    expect(parsed).to.equal('#00ff00')
+  })
+
+  it('parses hsla inline style', () => {
+    const el = document.createElement('span')
+    el.setAttribute('style', 'background-color: hsla(120, 100%, 50%, 0.3)')
+
+    const parsed = parseHTML(el)
+
+    expect(parsed).to.equal('hsla(120, 100%, 50%, 0.3)')
+  })
+})

--- a/tests/cypress/integration/extensions/color.spec.ts
+++ b/tests/cypress/integration/extensions/color.spec.ts
@@ -1,0 +1,36 @@
+/// <reference types="cypress" />
+
+import { Color } from '@tiptap/extension-text-style'
+
+const ext: any = (Color as any).configure()
+const globalAttrs = ext.config.addGlobalAttributes && ext.config.addGlobalAttributes.call(ext)[0]
+const { parseHTML } = globalAttrs.attributes.color
+
+describe('color parseHTML', () => {
+  it('parses rgb(...) inline style', () => {
+    const el = document.createElement('span')
+    el.setAttribute('style', 'color: rgb(149, 141, 241)')
+
+    const parsed = parseHTML(el)
+
+    expect(parsed).to.equal('rgb(149, 141, 241)')
+  })
+
+  it('parses hex inline style', () => {
+    const el = document.createElement('span')
+    el.setAttribute('style', 'color: #958DF1')
+
+    const parsed = parseHTML(el)
+
+    expect(parsed).to.equal('#958DF1')
+  })
+
+  it('parses hsla inline style', () => {
+    const el = document.createElement('span')
+    el.setAttribute('style', 'color: hsla(252, 100%, 80%, 0.5)')
+
+    const parsed = parseHTML(el)
+
+    expect(parsed).to.equal('hsla(252, 100%, 80%, 0.5)')
+  })
+})


### PR DESCRIPTION
## Changes Overview

This pull request improves how color and background-color styles are parsed from HTML in the `@tiptap/extension-text-style` package. The main change is to prefer the raw inline `style` attribute when extracting `color` and `background-color` values, so the original format (such as hex, rgba, hsla) is preserved instead of converting to computed RGB values. This ensures that editors and color pickers work consistently when initializing from HTML. The demos have been updated to showcase this behavior, and new tests have been added to verify the parsing logic.

## Implementation Approach

**Parsing improvements:**

* Updated the `parseHTML` methods in `packages/extension-text-style/src/color/color.ts` and `packages/extension-text-style/src/background-color/background-color.ts` to extract the original color value from the raw inline `style` attribute, falling back to computed styles only if necessary. This preserves formats like hex, rgba, and hsla instead of always converting to `rgb(...)`. [[1]](diffhunk://#diff-1741f29372f3065592ecfd3b496158ba0686960ccbd2a7798ec13502299a4fc3L60-R73) [[2]](diffhunk://#diff-addf85dae44676964b5de1a66727846b2bde7766714f0ff2b4849e7987bb9c53L60-R73)

**Demo updates:**

* Modified demo content in both React and Vue examples for Color and BackgroundColor extensions to include spans with hex and rgba color formats, demonstrating the improved parsing. [[1]](diffhunk://#diff-13781687a1b4a0b65dfd825db2cdfec13270203bf4fd09b442aa08d0c92555c1L14-R14) [[2]](diffhunk://#diff-535d7ad4eb85e1d4dc82eb20a37208ee6296cbaf5afba9e7b8d9a68a86270f2dL81-R81) [[3]](diffhunk://#diff-b1eb7ab46257d480ab3553cb3fc86349486b82e852ede6732ad68e02f33b06f2R15) [[4]](diffhunk://#diff-866c3903d8482ae2ab0d030279cfd48b2bfe47fc18b76008b5be4ff84484e1f8L91-R92)

**Testing:**

* Added new Cypress tests in `tests/cypress/integration/extensions/color.spec.ts` and `tests/cypress/integration/extensions/background-color.spec.ts` to verify that the parser correctly extracts hex, rgb, and hsla color values from inline styles. [[1]](diffhunk://#diff-176ee3b998234e6a8d63a3f31922a713055e235be988457f2477d8a4d1e98216R1-R36) [[2]](diffhunk://#diff-5dc12b77a83baa8088e6bc0d7871525f02cdebe301482724af5690f1030c4299R1-R36)

## Testing Done

- I added integration tests verifying the output of the background-color and color parseHTML functions.

## Verification Steps

- Run the tests locally
- Check the updated demos

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #1818 
