### PR TITLE
Fix suggestion menu not working with non-react envs

### DIFF
--- a/.changeset/remove-suggestion-document-handler.md
+++ b/.changeset/remove-suggestion-document-handler.md
@@ -1,0 +1,14 @@
+---
+"@tiptap/suggestion": patch
+---
+
+Remove the global document `mousedown` handler that closed suggestion popups when clicking outside.
+
+Previously the suggestion plugin listened for document `mousedown` events and closed suggestion UIs when the user clicked outside the editor or suggestion portal. That behavior has been removed to avoid framework-specific coupling (for example reliance on `.react-renderer`) and related compatibility issues.
+
+Now suggestions are closed via other signals:
+
+- pressing Escape (unchanged)
+- selection/cursor changes
+- renderer.onExit (renderers can call this)
+- programmatic calls to `exitSuggestion(view)`


### PR DESCRIPTION
## Changes Overview

This pull request removes the global document `mousedown` event handler that was previously used to close suggestion popups when clicking outside the editor or suggestion UI. This change is intended to reduce framework-specific coupling and improve compatibility. Suggestions are now closed via keyboard (Escape), selection/cursor changes, renderer exit signals, or programmatic calls.

## Implementation Approach

**Removal of global click-outside handling:**

* Deleted the logic and related code for tracking and installing document-level `mousedown` handlers in `suggestion.ts`, including the `clickHandlerMap` and associated functions (`ensureClickHandler`, `removeClickHandler`). [[1]](diffhunk://#diff-c16484042622aaa7ff275b7931a38149dfd69125ed9737cce7ffa397d3a63005L9-L13) [[2]](diffhunk://#diff-c16484042622aaa7ff275b7931a38149dfd69125ed9737cce7ffa397d3a63005L269-R260)
* Removed the code that triggered suggestion exit on outside clicks, including references to `.react-renderer` and DOM containment checks. [[1]](diffhunk://#diff-c16484042622aaa7ff275b7931a38149dfd69125ed9737cce7ffa397d3a63005L233-L236) [[2]](diffhunk://#diff-c16484042622aaa7ff275b7931a38149dfd69125ed9737cce7ffa397d3a63005L382-L393)

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- fixes #6901 
