### PR TITLE
Allow key handling for suggestions when ESC is pressed

### DIFF
--- a/.changeset/allow-escape-keydown-handling.md
+++ b/.changeset/allow-escape-keydown-handling.md
@@ -1,0 +1,9 @@
+---
+"@tiptap/suggestion": patch
+---
+
+Allow consumers to handle the Escape key via `render().onKeyDown` before the suggestion plugin auto-exits.
+
+Previously the suggestion plugin intercepted Escape internally and immediately called `onExit`, preventing `render().onKeyDown` from receiving the event and stopping propagation. Now `render().onKeyDown` is invoked first for Escape; if it returns `true` the plugin assumes the consumer handled the event (so they can call `event.preventDefault()` / `event.stopPropagation()` and optionally call `exitSuggestion(view)` themselves). If it returns `false` (or is absent), the plugin will continue to call `onExit` and close the suggestion as before.
+
+This change enables scenarios where the editor is inside a modal/drawer and the consumer needs to prevent the outer UI from reacting to Escape while still controlling the suggestion's lifecycle.

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -459,6 +459,16 @@ export function Suggestion<I = any, TSelected = any>({
             cachedNode ??
             (state?.decorationId ? view.dom.querySelector(`[data-decoration-id="${state.decorationId}"]`) : null)
 
+          // Give the consumer a chance to handle Escape via onKeyDown first.
+          // If the consumer returns `true` we assume they handled the event and
+          // we won't call onExit/dispatchExit so they can both prevent
+          // propagation and decide whether to close the suggestion themselves.
+          const handledByKeyDown = renderer?.onKeyDown?.({ view, event, range: state.range }) || false
+
+          if (handledByKeyDown) {
+            return true
+          }
+
           const exitProps: SuggestionProps = {
             editor,
             range: state.range,


### PR DESCRIPTION
## Changes Overview

This pull request improves the flexibility of Escape key handling in the TipTap suggestion plugin, allowing consumers to intercept and manage Escape key events before the plugin auto-exits. This enables better integration with custom UI scenarios, such as editors embedded in modals or drawers.

## Implementation Approach

**Escape key handling improvements:**

* The suggestion plugin now invokes the consumer's `render().onKeyDown` handler for Escape key events before auto-exiting; if the handler returns `true`, the plugin assumes the consumer handled the event and does not auto-exit, letting the consumer control propagation and suggestion lifecycle.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Fixes #6898 
