### PR TITLE
fix(BubbleMenu & FloatingMenu): Use floating-ui's recommended middleware order

### DIFF
--- a/.changeset/sharp-camels-sort.md
+++ b/.changeset/sharp-camels-sort.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-bubble-menu': patch
+'@tiptap/extension-floating-menu': patch
+---
+
+Reorder floating-ui middleware per https://floating-ui.com/docs/middleware#ordering: offset first, arrow and hide last

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -196,6 +196,12 @@ export class BubbleMenuView implements PluginView {
   get middlewares() {
     const middlewares: Middleware[] = []
 
+    if (this.floatingUIOptions.offset) {
+      middlewares.push(
+        offset(typeof this.floatingUIOptions.offset !== 'boolean' ? this.floatingUIOptions.offset : undefined),
+      )
+    }
+
     if (this.floatingUIOptions.flip) {
       middlewares.push(flip(typeof this.floatingUIOptions.flip !== 'boolean' ? this.floatingUIOptions.flip : undefined))
     }
@@ -204,16 +210,6 @@ export class BubbleMenuView implements PluginView {
       middlewares.push(
         shift(typeof this.floatingUIOptions.shift !== 'boolean' ? this.floatingUIOptions.shift : undefined),
       )
-    }
-
-    if (this.floatingUIOptions.offset) {
-      middlewares.push(
-        offset(typeof this.floatingUIOptions.offset !== 'boolean' ? this.floatingUIOptions.offset : undefined),
-      )
-    }
-
-    if (this.floatingUIOptions.arrow) {
-      middlewares.push(arrow(this.floatingUIOptions.arrow))
     }
 
     if (this.floatingUIOptions.size) {
@@ -228,14 +224,18 @@ export class BubbleMenuView implements PluginView {
       )
     }
 
-    if (this.floatingUIOptions.hide) {
-      middlewares.push(hide(typeof this.floatingUIOptions.hide !== 'boolean' ? this.floatingUIOptions.hide : undefined))
-    }
-
     if (this.floatingUIOptions.inline) {
       middlewares.push(
         inline(typeof this.floatingUIOptions.inline !== 'boolean' ? this.floatingUIOptions.inline : undefined),
       )
+    }
+
+    if (this.floatingUIOptions.arrow) {
+      middlewares.push(arrow(this.floatingUIOptions.arrow))
+    }
+
+    if (this.floatingUIOptions.hide) {
+      middlewares.push(hide(typeof this.floatingUIOptions.hide !== 'boolean' ? this.floatingUIOptions.hide : undefined))
     }
 
     return middlewares

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -145,6 +145,12 @@ export class FloatingMenuView {
   get middlewares() {
     const middlewares: Middleware[] = []
 
+    if (this.floatingUIOptions.offset) {
+      middlewares.push(
+        offset(typeof this.floatingUIOptions.offset !== 'boolean' ? this.floatingUIOptions.offset : undefined),
+      )
+    }
+
     if (this.floatingUIOptions.flip) {
       middlewares.push(flip(typeof this.floatingUIOptions.flip !== 'boolean' ? this.floatingUIOptions.flip : undefined))
     }
@@ -153,16 +159,6 @@ export class FloatingMenuView {
       middlewares.push(
         shift(typeof this.floatingUIOptions.shift !== 'boolean' ? this.floatingUIOptions.shift : undefined),
       )
-    }
-
-    if (this.floatingUIOptions.offset) {
-      middlewares.push(
-        offset(typeof this.floatingUIOptions.offset !== 'boolean' ? this.floatingUIOptions.offset : undefined),
-      )
-    }
-
-    if (this.floatingUIOptions.arrow) {
-      middlewares.push(arrow(this.floatingUIOptions.arrow))
     }
 
     if (this.floatingUIOptions.size) {
@@ -177,14 +173,18 @@ export class FloatingMenuView {
       )
     }
 
-    if (this.floatingUIOptions.hide) {
-      middlewares.push(hide(typeof this.floatingUIOptions.hide !== 'boolean' ? this.floatingUIOptions.hide : undefined))
-    }
-
     if (this.floatingUIOptions.inline) {
       middlewares.push(
         inline(typeof this.floatingUIOptions.inline !== 'boolean' ? this.floatingUIOptions.inline : undefined),
       )
+    }
+
+    if (this.floatingUIOptions.arrow) {
+      middlewares.push(arrow(this.floatingUIOptions.arrow))
+    }
+
+    if (this.floatingUIOptions.hide) {
+      middlewares.push(hide(typeof this.floatingUIOptions.hide !== 'boolean' ? this.floatingUIOptions.hide : undefined))
     }
 
     return middlewares


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

Change the floating-ui middleware order per https://floating-ui.com/docs/middleware#ordering: offset first, arrow and hide last.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

Reorder the middleware explicitly mentioned in the floating-ui docs while leaving the others as-is.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

In the [React BubbleMenu demo](https://github.com/ueberdosis/tiptap/blob/develop/demos/src/Extensions/BubbleMenu/React/index.jsx#L46), change the BubbleMenu's offset settings to `<BubbleMenu editor={editor} options={{ placement: 'bottom', offset: { crossAxis: -50 } }}>`. Then select text at the left edge of the screen.

Before this change: the default shift settings are applied before the offset, so the menu ends up shifted 50px outside of the viewport.
<img width="151" height="52" alt="Screenshot 2025-09-04 at 9 59 13 AM" src="https://github.com/user-attachments/assets/c59648ad-d586-4310-9b2f-73d74f99d4fa" />

After this change: The menu shifts exactly to the edge of the viewport. (When selecting text not too close to the left edge, the menu is offset -50px as desired.)
<img width="151" height="52" alt="Screenshot 2025-09-04 at 10 00 45 AM" src="https://github.com/user-attachments/assets/33e398dd-7e94-4d1b-8f2a-a35780b7ad11" />

I have not tested the arrow and hide changes, but the floating-ui docs explicitly recommend placing them last.


## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
