### PR TITLE
fix: package.json license field not MIT

### DIFF
--- a/packages/extension-table-of-contents/package.json
+++ b/packages/extension-table-of-contents/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/ueberdosis/tiptap/issues"
   },
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",


### PR DESCRIPTION
## Changes Overview
In the package @tiptap/extension-table-of-contents there was a licence.md refrenced that not exist. In readme.md is MIT defined as the licence so updated the package.json

I found this when I run a licence / dependency check tool on a project.

<!-- Briefly describe your changes. -->

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [X] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
