### PR TITLE
feat(react/BubbleMenu): Add menuElStyle prop for BubbleMenu for custom styling

### DIFF
--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -6,14 +6,27 @@ import { createPortal } from 'react-dom'
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 
 export type BubbleMenuProps = Optional<Omit<Optional<BubbleMenuPluginProps, 'pluginKey'>, 'element'>, 'editor'> &
-  React.HTMLAttributes<HTMLDivElement>
+  React.HTMLAttributes<HTMLDivElement> & {
+    menuElStyle?: React.CSSProperties | undefined
+  }
 
 export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
   (
-    { pluginKey = 'bubbleMenu', editor, updateDelay, resizeDelay, shouldShow = null, options, children, ...restProps },
+    {
+      pluginKey = 'bubbleMenu',
+      editor,
+      updateDelay,
+      resizeDelay,
+      shouldShow = null,
+      options,
+      children,
+      menuElStyle,
+      ...restProps
+    },
     ref,
   ) => {
     const menuEl = useRef(document.createElement('div'))
+    Object.assign(menuEl.current.style, menuElStyle)
 
     if (typeof ref === 'function') {
       ref(menuEl.current)


### PR DESCRIPTION
## Changes Overview

Currently, the users are unable to easily add custom styling to BubbleMenu.
This PR introduces a new optional prop:

```ts
menuElStyle?: React.CSSProperties
```

This allows users to provide inline styles for the `menuEl`, enabling customisation.

## Implementation Approach

Adding a typed `menuElStyle` prop to apply styles directly during initialisation

## Testing Done

Tested in Demo

## Verification Steps


## Additional Notes


## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

