### PR TITLE
feat(extension-bubble-menu): add optional scrollTarget for BubbleMenu

### DIFF
--- a/.changeset/bubble-menu-scroll-target.md
+++ b/.changeset/bubble-menu-scroll-target.md
@@ -1,0 +1,13 @@
+---
+"@tiptap/extension-bubble-menu": patch
+---
+
+Listen to a custom scroll target when positioning the BubbleMenu and
+ensure the scroll listener is cleaned up on destroy.
+
+The BubbleMenu now accepts an optional `scrollTarget` option which will be
+used instead of `window` when listening for scroll events that affect the
+menu positioning. The plugin also removes the scroll listener during
+cleanup.
+
+No user-facing API changes other than the new optional `scrollTarget` setting.

--- a/demos/src/Extensions/BubbleMenu/React/index.jsx
+++ b/demos/src/Extensions/BubbleMenu/React/index.jsx
@@ -43,7 +43,7 @@ export default () => {
       </div>
 
       {editor && showMenu && (
-        <BubbleMenu editor={editor} options={{ placement: 'bottom', offset: 8 }}>
+        <BubbleMenu editor={editor} options={{ placement: 'bottom', offset: 8, flip: true }}>
           <div className="bubble-menu">
             <button
               onClick={() => editor.chain().focus().toggleBold().run()}

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -125,6 +125,13 @@ export interface BubbleMenuPluginProps {
     onHide?: () => void
     onUpdate?: () => void
     onDestroy?: () => void
+
+    /**
+     * The scrollable element that should be listened to when updating the position of the bubble menu.
+     * If not provided, the window will be used.
+     * @type {HTMLElement | null}
+     */
+    scrollTarget?: HTMLElement | null
   }
 }
 
@@ -152,6 +159,8 @@ export class BubbleMenuView implements PluginView {
   private resizeDebounceTimer: number | undefined
 
   private isVisible = false
+
+  private scrollTarget: HTMLElement | null = null
 
   private floatingUIOptions: NonNullable<BubbleMenuPluginProps['options']> = {
     strategy: 'absolute',
@@ -257,6 +266,7 @@ export class BubbleMenuView implements PluginView {
     this.updateDelay = updateDelay
     this.resizeDelay = resizeDelay
     this.appendTo = appendTo
+    this.scrollTarget = options?.scrollTarget ?? null
 
     this.floatingUIOptions = {
       ...this.floatingUIOptions,
@@ -274,6 +284,7 @@ export class BubbleMenuView implements PluginView {
     this.editor.on('focus', this.focusHandler)
     this.editor.on('blur', this.blurHandler)
     window.addEventListener('resize', this.resizeHandler)
+    ;(this.scrollTarget ?? window).addEventListener('scroll', this.resizeHandler)
 
     this.update(view, view.state)
 
@@ -511,6 +522,7 @@ export class BubbleMenuView implements PluginView {
     this.element.removeEventListener('mousedown', this.mousedownHandler, { capture: true })
     this.view.dom.removeEventListener('dragstart', this.dragstartHandler)
     window.removeEventListener('resize', this.resizeHandler)
+    ;(this.scrollTarget ?? window).removeEventListener('scroll', this.resizeHandler)
     this.editor.off('focus', this.focusHandler)
     this.editor.off('blur', this.blurHandler)
 


### PR DESCRIPTION
## Changes Overview

This pull request enhances the `@tiptap/extension-bubble-menu` package by allowing the BubbleMenu to listen to scroll events on a custom target element, improving menu positioning in scrollable containers. It also ensures proper cleanup of event listeners to prevent memory leaks. Additionally, a demo update showcases the new option.

## Implementation Approach

**BubbleMenu scroll handling improvements:**

* Added an optional `scrollTarget` property to `BubbleMenuPluginProps`, allowing the BubbleMenu to listen for scroll events on a specified element instead of the default `window`. This enables more accurate positioning when the editor is inside a scrollable container.
* The `BubbleMenuView` class now stores the `scrollTarget` and attaches the scroll event listener to either the provided element or `window` during initialization. [[1]](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953R163-R164) [[2]](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953R269) [[3]](diffhunk://#diff-30fdbcf134f53a22876c93ec1e76674f6afef97f9b6162c7eb39b00bb7eef953R287)
* On plugin destroy, the scroll event listener is properly removed from the `scrollTarget` or `window` to ensure cleanup.


## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Fixes #6735 
