### PR TITLE
fix: Error when computing DragHandlePosition

### DIFF
--- a/demos/src/Extensions/DragHandleWithNodeViews/React/index.jsx
+++ b/demos/src/Extensions/DragHandleWithNodeViews/React/index.jsx
@@ -11,13 +11,14 @@ export default () => {
   const editor = useEditor({
     extensions: [StarterKit, Recommendation],
     content: `
+      <div class="node-recommendation" data-id="1"></div>
       <h1>
         This is a very unique heading.
       </h1>
       <p>
         This is a unique paragraph. It’s so unique, it even has an ID attached to it.
       </p>
-      <div class="node-recommendation" data-id="123"></div>
+      <div class="node-recommendation" data-id="2"></div>
       <p>
         And this one, too.
       </p>

--- a/packages/extension-drag-handle/src/helpers/findNextElementFromCursor.ts
+++ b/packages/extension-drag-handle/src/helpers/findNextElementFromCursor.ts
@@ -42,7 +42,7 @@ export const findElementNextToCoords = (options: FindElementNextToCoords) => {
 
   const finalCandidate = candidates[0]
   const candidatePos = editor.view.posAtDOM(finalCandidate, 0)
-  if (candidatePos === -1) {
+  if (candidatePos <= 0) {
     return { resultElement: finalCandidate, resultNode: null, pos: null }
   }
 


### PR DESCRIPTION
## Changes Overview

Fix edge case when a matching node is at pos 0

## Implementation Approach

Increase early return check

## Testing Done

Testable on Extensions/DragHandleWithNodeViews [Link from last stable version PR](https://deploy-preview-6912--tiptap-embed.netlify.app/preview/Extensions/DragHandleWithNodeViews)
* In current version, drag the NodeView at 1st pos
* The handle is not displayed anymore

## Verification Steps

* Open Extensions/DragHandleWithNodeViews sample
* The handle is properly displayed on 1st

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [ ] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/6923
https://github.com/ueberdosis/tiptap/issues/6930
