### PR TITLE
[collaboration-caret] Add missing clientId arg to render caret methods

### DIFF
--- a/packages/extension-collaboration-caret/src/collaboration-caret.ts
+++ b/packages/extension-collaboration-caret/src/collaboration-caret.ts
@@ -23,6 +23,7 @@ export interface CollaborationCaretOptions {
   /**
    * A function that returns a DOM element for the cursor.
    * @param user The user details object
+   * @param clientId The user client id
    * @example
    * render: user => {
    *  const cursor = document.createElement('span')
@@ -38,11 +39,12 @@ export interface CollaborationCaretOptions {
    *  return cursor
    * }
    */
-  render(user: Record<string, any>): HTMLElement
+  render(user: Record<string, any>, clientId: number): HTMLElement
 
   /**
    * A function that returns a ProseMirror DecorationAttrs object for the selection.
    * @param user The user details object
+   * @param clientId The user client id
    * @example
    * selectionRender: user => {
    * return {
@@ -52,7 +54,7 @@ export interface CollaborationCaretOptions {
    *  'data-user': user.name,
    * }
    */
-  selectionRender(user: Record<string, any>): DecorationAttrs
+  selectionRender(user: Record<string, any>, clientId: number): DecorationAttrs
 
   /**
    * @deprecated The "onUpdate" option is deprecated. Please use `editor.storage.collaborationCaret.users` instead. Read more: https://tiptap.dev/api/extensions/collaboration-caret


### PR DESCRIPTION
## Changes Overview

In a recent commit in y-tiptap, clientId was added as second arg to render methods of collaboration caret.

ref: https://github.com/ueberdosis/y-tiptap/commit/68f39d4bf02f2efc32d7ad2dbdcecec81bb8cf0b

This commit updates the types of the collaboration-caret extension accordingly


## Implementation Approach

Updates the type declaration of the render methods in the collaboration-caret extension

## Testing Done

tsc doesn't complain

## Verification Steps

Since this PR only affects typescript types, I'd assume that running tsc would be enough

## Additional Notes

nope

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

I did not create an issue for thiss