### PR TITLE
perf(core): provide `markViews` & `nodeViews` on `view` creation

### DIFF
--- a/.changeset/slimy-buttons-remember.md
+++ b/.changeset/slimy-buttons-remember.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+When the editor view is created, it now will also include `nodeViews` and `markViews` properties instead of setting them afterward. This avoids serialization of the editor state to HTML which will be replaced by node views anyway.

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -506,6 +506,8 @@ export class Editor extends EventEmitter<EditorEvents> {
       },
       dispatchTransaction: this.dispatchTransaction.bind(this),
       state: this.editorState,
+      markViews: this.extensionManager.markViews,
+      nodeViews: this.extensionManager.nodeViews,
     })
 
     // `editor.view` is not yet available at this time.
@@ -516,7 +518,6 @@ export class Editor extends EventEmitter<EditorEvents> {
 
     this.view.updateState(newState)
 
-    this.createNodeViews()
     this.prependClass()
     this.injectCSS()
 


### PR DESCRIPTION
## Changes Overview

This change improves the performance of the editor on startup, by not having to re-render the document to the editor.view when `nodeViews` or `markViews` invalidate it.

## Implementation Approach

Here are the order of events:

1. editor.create (not mount)
2. editor.mount
   - editor.createView: creates a new view (notably missing the markViews & markViews properties)
   - the view attempts to render the current document (any nodes or marks with nodeview will instead use their base `renderHTML` method rather than their nodeview or markview)
   - the view is updated with a state which includes any ProseMirror plugins (these have been deferred until the view actually exists)
   - editor.createNodeViews: the view is updated to include `nodeViews` and `markViews`, causing prosemirror to have to re-validate any nodes or marks which have nodeviews or markviews. 

This change makes it so that the `nodeViews` & `markViews` are provided upfront, reducing the work the prosemirror-view has to do by skipping the invalidation step, since we give it a valid configuration from the start.


<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

I validated that this change still works with the React & Vue integrations. This should help their performance, and reduce any DOM flashing of content (since we now will not fallback to renderHTML and then switch it out quickly).
## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
