### PR TITLE
Update JSONContent to exactly match editor.getJSON()

### DIFF
--- a/.changeset/tame-beans-fly.md
+++ b/.changeset/tame-beans-fly.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Refined the `JSONContent.attrs` definition to exactly mirror the structure returned by `editor.getJSON()`. This ensures strict type safety and consistency between the editor output and the expected type, eliminating errors caused by mismatched attribute signatures.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -444,7 +444,7 @@ export type HTMLContent = string
  */
 export type JSONContent = {
   type?: string
-  attrs?: Record<string, any>
+  attrs?: Record<string, any> | undefined
   content?: JSONContent[]
   marks?: {
     type: string


### PR DESCRIPTION
## Changes Overview

This change is required if the TypeScript option `exactOptionalPropertyTypes` is enabled.

Fixes #6914.

## Implementation Approach

Updated the types.

## Testing Done

Checked that the types match using TypeScript compiler.

## Verification Steps

Ran the TypeScript compiler on a project (see #6914)

## Additional Notes

-

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [X] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues

#6914
