### PR TITLE
Refactor/vue3 flatmap

### DIFF
--- a/.changeset/flatmap-vue3.md
+++ b/.changeset/flatmap-vue3.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/vue-3': patch
+---
+
+refactor: replace `map(...).flat()` with `flatMap` for simpler, more efficient array flattening

--- a/packages/vue-2/src/VueNodeViewRenderer.ts
+++ b/packages/vue-2/src/VueNodeViewRenderer.ts
@@ -208,8 +208,7 @@ class VueNodeView extends NodeView<Vue | VueConstructor, Editor, VueNodeViewRend
     return (
       this.decorations
         // @ts-ignore
-        .map(item => item.type.attrs.class)
-        .flat()
+        .flatMap(item => item.type.attrs.class)
         .join(' ')
     )
   }

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -260,8 +260,7 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
     return (
       this.decorations
         // @ts-ignore
-        .map(item => item.type.attrs.class)
-        .flat()
+        .flatMap(item => item.type.attrs.class)
         .join(' ')
     )
   }


### PR DESCRIPTION
## Changes Overview

Replaced `map(...).flat()` with `flatMap` in `@tiptap/vue-3`.
This simplifies array transformations and avoids creating intermediate arrays.

---

## Implementation Approach

* Identified instances of `map(...).flat()` used for single-level flattening.
* Refactored them to use `flatMap`, which performs mapping + flattening in one pass.
* No logic changes, behavior remains the same.

---

## Testing Done

* Verified that existing test suite passes without modifications.
* Manually tested code block rendering to ensure identical results pre/post change.

---

## Verification Steps

1. Pull this branch and build the package.
2. Open a Tiptap editor instance with `code-block-lowlight` enabled.
3. Insert and format code blocks.
4. Confirm rendering, highlighting, and parsing works as expected.

---

## Additional Notes

* `flatMap` only flattens one level, which is exactly what was needed here.
* This refactor is non-breaking and safe for downstream consumers.

---

## Checklist

* [x] I have created a [[changeset](https://github.com/changesets/changesets)](https://github.com/changesets/changesets) for this PR if necessary.
* [x] My changes do not break the library.
* [x] I have added tests where applicable.
* [x] I have followed the project guidelines.
* [x] I have fixed any lint issues.

---

## Related Issues

N/A
