### PR TITLE
fix/6725: mount injected css

### DIFF
--- a/.changeset/6725-mount-injected-css.md
+++ b/.changeset/6725-mount-injected-css.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fix an issue where injected CSS was not mounted correctly when the editor instance was mounted. The fix ensures CSS injected by the editor is attached to the document when the editor mounts, preventing missing styles in some mount/unmount scenarios.

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -160,6 +160,10 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.createView(el)
     this.emit('mount', { editor: this })
 
+    if (this.css) {
+      document.head.appendChild(this.css)
+    }
+
     window.setTimeout(() => {
       if (this.isDestroyed) {
         return

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -160,7 +160,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.createView(el)
     this.emit('mount', { editor: this })
 
-    if (this.css) {
+    if (this.css && !document.head.contains(this.css)) {
       document.head.appendChild(this.css)
     }
 


### PR DESCRIPTION
## Changes Overview

This pull request addresses an issue with CSS injection in the editor component to ensure that styles are reliably applied when the editor is mounted. The main focus is to fix cases where styles could be missing due to improper mounting and unmounting of the editor.

## Implementation Approach

CSS injection and mounting:

* Ensured that any CSS injected by the editor (`this.css`) is appended to the document head when the editor is mounted, preventing missing styles in certain mount/unmount scenarios (`Editor.ts`).
* Documented the fix in a changeset, describing the patch and its impact on style mounting. (.changeset/6725-mount-injected-css.md)

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- fixes #6725 
