### PR TITLE
Add failing reproduction

### DIFF
--- a/demos/src/Commands/InsertContent/React/index.spec.js
+++ b/demos/src/Commands/InsertContent/React/index.spec.js
@@ -45,6 +45,13 @@ context('/src/Commands/InsertContent/React/', () => {
     })
   })
 
+  it('should keep newlines in pre tag between nodes', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      editor.commands.insertContent('<pre><div>foo</div>\n<code>foo\nbar</code></pre>')
+      cy.get('.tiptap').should('contain.html', '<pre><div>foo</div>\n<code>foo\nbar</code></pre>')
+    })
+  })
+
   it('should keep newlines and tabs', () => {
     cy.get('.tiptap').then(([{ editor }]) => {
       editor.commands.insertContent('<p>Hello\n\tworld\n\t\thow\n\t\t\tnice.\ntest\tOK</p>')


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->
This PR serves as an issue report for #4792. I wanted to discuss implementation strategy before I implement this. Currently, whitespace is trimmed before the document is parsed by ProseMirror. This means that the `whitespace: pre` [option](https://tiptap.dev/docs/editor/extensions/custom-extensions/create-new/node#whitespace) isn't correctly respected.

I noticed this bug while implementing a custom node intended to function like a raw HTML node. The `removeWhitespaces(html)` call inside `elementFromString` prevents access to whitespace.

## Implementation Approach

There are a couple ways to solve this. The "best" way to solve this would be to invert the whitespace stripping process:

- Parse the document with ProseMirror
- Traverse the document tree, removing empty text nodes if `whitespace: pre` isn't set.

The alternative approach is to allow an "escape hatch" for the `useEditor` hook earlier in the process. The full call chain there looks like:

- `useEditor` (calls `EditorInstanceManager`)
- `packages/react/EditorInstanceManager.createEditor()`
- `Editor()`
- `Editor.createDoc`
- `createDocument`
- `createNodeFromContent`
- `elementFromString`

This entire call chain is private, which means that the only way to circumvent this behavior is to reimplement + extend from:

- `useEditor`, `EditorInstanceManager` and `Editor`.

This is a lot of code duplication to do this. Any option to override this in `createNodeFromContent` would make this much easier, such as:

- `CreateNodeFromContentOptions.removeWhitespaceNodes` (passed to `elementFromString` to strip whitespace or not)
- `CreateNodeFromContentOptions.elementFromString` (optional function override)

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

[WIP] Will update
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

[WIP] Will update

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->
N/A

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#4792

Let me know which approach is preferred (if any) and I will add it.
