### PR TITLE
Fix bug in insertContentAt to prevent content from being deleted

### DIFF
--- a/.changeset/unlucky-taxis-decide.md
+++ b/.changeset/unlucky-taxis-decide.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix bug in `insertContentAt` command where extra content would get deleted when the selection was at the beginning of the document and a node was inserted

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -74,7 +74,6 @@ export const insertContentAt: RawCommands['insertContentAt'] =
       }
 
       let content: Fragment | ProseMirrorNode
-      const { selection } = editor.state
 
       const emitContentError = (error: Error) => {
         editor.emit('contentError', {
@@ -180,9 +179,10 @@ export const insertContentAt: RawCommands['insertContentAt'] =
       } else {
         newContent = content
 
-        const fromSelectionAtStart = selection.$from.parentOffset === 0
-        const isTextSelection = selection.$from.node().isText || selection.$from.node().isTextblock
-        const hasContent = selection.$from.node().content.size > 0
+        const $from = tr.doc.resolve(from)
+        const fromSelectionAtStart = $from.parentOffset === 0
+        const isTextSelection = $from.node().isText || $from.node().isTextblock
+        const hasContent = $from.node().content.size > 0
 
         if (fromSelectionAtStart && isTextSelection && hasContent) {
           from = Math.max(0, from - 1)

--- a/packages/core/src/commands/insertContentAt.ts
+++ b/packages/core/src/commands/insertContentAt.ts
@@ -74,7 +74,6 @@ export const insertContentAt: RawCommands['insertContentAt'] =
       }
 
       let content: Fragment | ProseMirrorNode
-      const { selection } = editor.state
 
       const emitContentError = (error: Error) => {
         editor.emit('contentError', {
@@ -180,9 +179,11 @@ export const insertContentAt: RawCommands['insertContentAt'] =
       } else {
         newContent = content
 
-        const fromSelectionAtStart = selection.$from.parentOffset === 0
-        const isTextSelection = selection.$from.node().isText || selection.$from.node().isTextblock
-        const hasContent = selection.$from.node().content.size > 0
+        const fromPos = editor.state.doc.resolve(from)
+        const fromPosNode = fromPos.node()
+        const fromSelectionAtStart = fromPos.parentOffset === 0
+        const isTextSelection = fromPosNode.isText || fromPosNode.isTextblock
+        const hasContent = fromPosNode.content.size > 0
 
         if (fromSelectionAtStart && isTextSelection && hasContent) {
           from = Math.max(0, from - 1)


### PR DESCRIPTION
## Changes Overview

Fixes a bug in the `insertContentAt` command where, if the `position` (first argument) was a range that was different to the editor selection, and the selection started at the beginning of the document, then the `from` position would be set to `from - 1`, and extra content would be deleted before the position.

## Implementation Approach

Upon examining the code, I found that, before inserting the new content at the `position`, a check was performed to see if the selection was at the beginning of the document. This raised the suspicion: why is it checking for the selection, if the content is not inserted in the selection? It appears to be that the code only worked when `position` was the selection, and not in other cases. So, to make it more general, I replaced the `selection` position with the `position` argument. This made the command work as expected.

I'm not entirely sure if this fix is correct or if it will have side effects. The reason is, the developers left no comment of why this check was made so I feel like I'm walking on eggshells. Maybe it could be worth adding a comment to explain why this check is made or remove the check altogether.

## Testing Done

I created a demo with a minimal reproducible example and I tested before/after applying the fix.

## Verification Steps

Try with this demo: https://codesandbox.io/p/sandbox/3ldrn7

In this demo, the error is present because the fix still hasn't been applied yet, but if you modify the code like in this PR, then the error does not happen anymore

## Additional Notes


## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#6920
#6919