### PR TITLE
fix: more accurate typing for `element` option

### DIFF
--- a/.changeset/hip-windows-retire.md
+++ b/.changeset/hip-windows-retire.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Update the types of the element to create an editor instance from

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -300,7 +300,7 @@ export class Editor extends EventEmitter<EditorEvents> {
           this.editorState = state
         },
         dispatch: (tr: Transaction): ReturnType<EditorView['dispatch']> => {
-          this.editorState = this.state.apply(tr)
+          this.dispatchTransaction(tr)
         },
 
         // Stub some commonly accessed properties to prevent errors
@@ -496,7 +496,7 @@ export class Editor extends EventEmitter<EditorEvents> {
   /**
    * Creates a ProseMirror view.
    */
-  private createView(element: NonNullable<EditorOptions['element']> & {}): void {
+  private createView(element: NonNullable<EditorOptions['element']>): void {
     this.editorView = new EditorView(element, {
       ...this.options.editorProps,
       attributes: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -261,11 +261,13 @@ export type EnableRules = (AnyExtension | string)[] | boolean
 
 export interface EditorOptions {
   /**
-   * The element or selector to bind the editor to
-   * If `null` is passed, the editor will not be mounted automatically
-   * If a function is passed, it will be called with the editor's root element
+   * The element to bind the editor to:
+   * - If an `Element` is passed, the editor will be mounted appended to that element
+   * - If `null` is passed, the editor will not be mounted automatically
+   * - If an object with a `mount` property is passed, the editor will be mounted to that element
+   * - If a function is passed, it will be called with the editor's element, which should place the editor within the document
    */
-  element: Element | null
+  element: Element | { mount: HTMLElement } | ((editor: HTMLElement) => void) | null
   /**
    * The content of the editor (HTML, JSON, or a JSON array)
    */

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -121,7 +121,7 @@ export class PureEditorContent extends React.Component<
 
       const element = this.editorContentRef.current
 
-      element.append(...editor.options.element.childNodes)
+      element.append(editor.view.dom)
 
       editor.setOptions({
         element,
@@ -176,14 +176,14 @@ export class PureEditorContent extends React.Component<
 
     editor.contentComponent = null
 
-    if (!editor.options.element?.firstChild) {
+    if (!editor.view.dom?.firstChild) {
       return
     }
 
     // TODO using the new editor.mount method might allow us to remove this
     const newElement = document.createElement('div')
 
-    newElement.append(...editor.options.element.childNodes)
+    newElement.append(editor.view.dom)
 
     editor.setOptions({
       element: newElement,

--- a/packages/vue-2/src/EditorContent.ts
+++ b/packages/vue-2/src/EditorContent.ts
@@ -25,11 +25,11 @@ export const EditorContent: Component = {
           this.$nextTick(() => {
             const element = this.$el
 
-            if (!element || !editor.options.element?.firstChild) {
+            if (!element || !editor.view.dom?.firstChild) {
               return
             }
 
-            element.append(...editor.options.element.childNodes)
+            element.append(editor.view.dom)
             editor.contentComponent = this
 
             editor.setOptions({
@@ -62,14 +62,14 @@ export const EditorContent: Component = {
 
     editor.contentComponent = null
 
-    if (!editor.options.element?.firstChild) {
+    if (!editor.view.dom?.firstChild) {
       return
     }
 
     // TODO using the new editor.mount method might allow us to remove this
     const newElement = document.createElement('div')
 
-    newElement.append(...editor.options.element.childNodes)
+    newElement.append(editor.view.dom)
 
     editor.setOptions({
       element: newElement,

--- a/packages/vue-3/src/EditorContent.ts
+++ b/packages/vue-3/src/EditorContent.ts
@@ -22,14 +22,14 @@ export const EditorContent = defineComponent({
 
       if (editor && editor.options.element && rootEl.value) {
         nextTick(() => {
-          if (!rootEl.value || !editor.options.element?.firstChild) {
+          if (!rootEl.value || !editor.view.dom?.firstChild) {
             return
           }
 
           // TODO using the new editor.mount method might allow us to remove this
           const element = unref(rootEl.value)
 
-          rootEl.value.append(...editor.options.element.childNodes)
+          rootEl.value.append(editor.view.dom)
 
           // @ts-ignore
           editor.contentComponent = instance.ctx._

--- a/packages/vue-3/src/useEditor.ts
+++ b/packages/vue-3/src/useEditor.ts
@@ -12,7 +12,7 @@ export const useEditor = (options: Partial<EditorOptions> = {}) => {
 
   onBeforeUnmount(() => {
     // Cloning root node (and its children) to avoid content being lost by destroy
-    const nodes = editor.value?.options.element
+    const nodes = editor.value?.view.dom
     const newEl = nodes?.cloneNode(true) as HTMLElement
 
     nodes?.parentNode?.replaceChild(newEl, nodes)


### PR DESCRIPTION
## Changes Overview
This changes the `element` option on the `Editor` to more accurately reflect the different ways that ProseMirror can mount it's view. There are 3 options ([see docs here](https://prosemirror.net/docs/ref/#view.EditorView.constructor)):
 - passing an HTMLElement which appends to the element specified
 - passing a `{mount: HTMLElement}` which mounts to that element (A pretty useful thing to get rid of the wrapper div)
 - passing a function which takes an editor element and you can place it wherever you want in the document
 - passing null to not create an element

This now exposes the options & changes the react & vue bindings to pull the correct element from the `editor.view.dom` instead of relying on the option being a specific shape.
<!-- Briefly describe your changes. -->

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

All existing tests work, which means the mounting is done properly.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
