### PR TITLE
Add more Floating UI options to Drag Handle plugin

### DIFF
--- a/.changeset/cuddly-carpets-think.md
+++ b/.changeset/cuddly-carpets-think.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-drag-handle': minor
 ---
 
-Add `getReferencedVirtualElement` option to drag handle extension to customize the position of the drag handle.
+Add `getReferencedVirtualElement` option to the drag handle extension to customize the position of the drag handle.

--- a/.changeset/cuddly-carpets-think.md
+++ b/.changeset/cuddly-carpets-think.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': minor
+---
+
+Add `getReferencedVirtualElement` option to drag handle extension to customize the position of the drag handle.

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -1,4 +1,4 @@
-import { type ComputePositionConfig, computePosition } from '@floating-ui/dom'
+import { type ComputePositionConfig, type VirtualElement, computePosition } from '@floating-ui/dom'
 import type { Editor } from '@tiptap/core'
 import { isChangeOrigin } from '@tiptap/extension-collaboration'
 import type { Node } from '@tiptap/pm/model'
@@ -63,6 +63,7 @@ export interface DragHandlePluginProps {
   onElementDragStart?: (e: DragEvent) => void
   onElementDragEnd?: (e: DragEvent) => void
   computePositionConfig?: ComputePositionConfig
+  getReferencedVirtualElement?: () => VirtualElement | null
 }
 
 export const dragHandlePluginDefaultKey = new PluginKey('dragHandle')
@@ -72,6 +73,7 @@ export const DragHandlePlugin = ({
   element,
   editor,
   computePositionConfig,
+  getReferencedVirtualElement,
   onNodeChange,
   onElementDragStart,
   onElementDragEnd,
@@ -109,7 +111,7 @@ export const DragHandlePlugin = ({
   }
 
   function repositionDragHandle(dom: Element) {
-    const virtualElement = {
+    const virtualElement = getReferencedVirtualElement?.() || {
       getBoundingClientRect: () => dom.getBoundingClientRect(),
     }
 

--- a/packages/extension-drag-handle/src/drag-handle.ts
+++ b/packages/extension-drag-handle/src/drag-handle.ts
@@ -1,4 +1,4 @@
-import type { ComputePositionConfig } from '@floating-ui/dom'
+import type { ComputePositionConfig, VirtualElement } from '@floating-ui/dom'
 import { type Editor, Extension } from '@tiptap/core'
 import type { Node } from '@tiptap/pm/model'
 
@@ -19,6 +19,11 @@ export interface DragHandleOptions {
    * using the floating-ui/dom package
    */
   computePositionConfig?: ComputePositionConfig
+  /**
+   * A function that returns the virtual element for the drag handle.
+   * This is useful when the menu needs to be positioned relative to a specific DOM element.
+   */
+  getReferencedVirtualElement?: () => VirtualElement | null
   /**
    * Locks the draghandle in place and visibility
    */
@@ -97,6 +102,7 @@ export const DragHandle = Extension.create<DragHandleOptions>({
     return [
       DragHandlePlugin({
         computePositionConfig: { ...defaultComputePositionConfig, ...this.options.computePositionConfig },
+        getReferencedVirtualElement: this.options.getReferencedVirtualElement,
         element,
         editor: this.editor,
         onNodeChange: this.options.onNodeChange,


### PR DESCRIPTION
## Changes Overview

Add `getReferencedVirtualElement` option to the drag handle extension to customize the position of the drag handle.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
