### PR TITLE
Add command to update the position of the bubble menu

### DIFF
--- a/.changeset/fluffy-carrots-hide.md
+++ b/.changeset/fluffy-carrots-hide.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-bubble-menu': minor
+---
+
+Add `updateBubbleMenuPosition` command to update position of bubble menu. This command lets developers programmatically update the position of the bubble menu in response to certain events (for example, when the bubble menu is resized).

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -13,8 +13,8 @@ import {
 } from '@floating-ui/dom'
 import type { Editor } from '@tiptap/core'
 import { isTextSelection, posToDOMRect } from '@tiptap/core'
-import type { EditorState, PluginKey, PluginView, Transaction } from '@tiptap/pm/state'
-import { NodeSelection, Plugin } from '@tiptap/pm/state'
+import type { EditorState, PluginView, Transaction } from '@tiptap/pm/state'
+import { NodeSelection, Plugin, PluginKey } from '@tiptap/pm/state'
 import { CellSelection } from '@tiptap/pm/tables'
 import type { EditorView } from '@tiptap/pm/view'
 
@@ -33,8 +33,10 @@ function combineDOMRects(rect1: DOMRect, rect2: DOMRect): DOMRect {
 export interface BubbleMenuPluginProps {
   /**
    * The plugin key.
+   * @type {PluginKey | string}
+   * @default 'bubbleMenu'
    */
-  pluginKey: PluginKey
+  pluginKey: PluginKey | string
 
   /**
    * The editor instance.
@@ -188,8 +190,6 @@ export class BubbleMenuView implements PluginView {
     onDestroy: undefined,
   }
 
-  public pluginKey: PluginKey
-
   public shouldShow: Exclude<BubbleMenuPluginProps['shouldShow'], null> = ({ view, state, from, to }) => {
     const { doc, selection } = state
     const { empty } = selection
@@ -333,7 +333,6 @@ export class BubbleMenuView implements PluginView {
     appendTo,
     getReferencedVirtualElement,
     options,
-    pluginKey,
   }: BubbleMenuViewProps) {
     this.editor = editor
     this.element = element
@@ -342,7 +341,6 @@ export class BubbleMenuView implements PluginView {
     this.resizeDelay = resizeDelay
     this.appendTo = appendTo
     this.scrollTarget = options?.scrollTarget ?? window
-    this.pluginKey = pluginKey
     this.getReferencedVirtualElement = getReferencedVirtualElement
 
     this.floatingUIOptions = {
@@ -550,7 +548,7 @@ export class BubbleMenuView implements PluginView {
   }
 
   transactionHandler({ transaction: tr }: { transaction: Transaction }) {
-    const meta = tr.getMeta(this.pluginKey)
+    const meta = tr.getMeta('bubbleMenu')
     if (meta === 'updatePosition') {
       this.updatePosition()
     }
@@ -574,7 +572,7 @@ export class BubbleMenuView implements PluginView {
 
 export const BubbleMenuPlugin = (options: BubbleMenuPluginProps) => {
   return new Plugin({
-    key: options.pluginKey,
+    key: typeof options.pluginKey === 'string' ? new PluginKey(options.pluginKey) : options.pluginKey,
     view: view => new BubbleMenuView({ view, ...options }),
   })
 }

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -1,35 +1,18 @@
 import { Extension } from '@tiptap/core'
-import { PluginKey } from '@tiptap/pm/state'
 
 import type { BubbleMenuPluginProps } from './bubble-menu-plugin.js'
 import { BubbleMenuPlugin } from './bubble-menu-plugin.js'
 
-export type BubbleMenuOptions = Omit<BubbleMenuPluginProps, 'editor' | 'element' | 'pluginKey'> & {
+export type BubbleMenuOptions = Omit<BubbleMenuPluginProps, 'editor' | 'element'> & {
   /**
    * The DOM element that contains your menu.
    * @type {HTMLElement}
    * @default null
    */
   element: HTMLElement | null
-  /**
-   * The plugin key or plugin key string.
-   * @default 'bubbleMenu'
-   */
-  pluginKey: PluginKey | string
-}
-
-export interface BubbleMenuStorage {
-  /**
-   * The plugin key.
-   */
-  pluginKey: PluginKey
 }
 
 declare module '@tiptap/core' {
-  interface Storage {
-    bubbleMenu: BubbleMenuStorage
-  }
-
   interface Commands<ReturnType> {
     bubbleMenu: {
       /**
@@ -46,7 +29,7 @@ declare module '@tiptap/core' {
  * This extension allows you to create a bubble menu.
  * @see https://tiptap.dev/api/extensions/bubble-menu
  */
-export const BubbleMenu = Extension.create<BubbleMenuOptions, BubbleMenuStorage>({
+export const BubbleMenu = Extension.create<BubbleMenuOptions>({
   name: 'bubbleMenu',
 
   addOptions() {
@@ -59,13 +42,6 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions, BubbleMenuStorage>
     }
   },
 
-  addStorage() {
-    return {
-      pluginKey:
-        typeof this.options.pluginKey === 'string' ? new PluginKey(this.options.pluginKey) : this.options.pluginKey,
-    }
-  },
-
   addProseMirrorPlugins() {
     if (!this.options.element) {
       return []
@@ -73,7 +49,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions, BubbleMenuStorage>
 
     return [
       BubbleMenuPlugin({
-        pluginKey: this.storage.pluginKey,
+        pluginKey: this.options.pluginKey,
         editor: this.editor,
         element: this.options.element,
         updateDelay: this.options.updateDelay,
@@ -90,7 +66,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions, BubbleMenuStorage>
       updateBubbleMenuPosition:
         () =>
         ({ commands }) => {
-          return commands.setMeta(this.storage.pluginKey, 'updatePosition')
+          return commands.setMeta('bubbleMenu', 'updatePosition')
         },
     }
   },

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -1,5 +1,5 @@
 import { Extension } from '@tiptap/core'
-import { PluginKey } from 'packages/pm/state'
+import { PluginKey } from '@tiptap/pm/state'
 
 import type { BubbleMenuPluginProps } from './bubble-menu-plugin.js'
 import { BubbleMenuPlugin } from './bubble-menu-plugin.js'

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -1,5 +1,4 @@
 import { type BubbleMenuPluginProps, BubbleMenuPlugin } from '@tiptap/extension-bubble-menu'
-import { PluginKey } from '@tiptap/pm/state'
 import { useCurrentEditor } from '@tiptap/react'
 import React, { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
@@ -56,7 +55,7 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
         resizeDelay,
         editor: attachToEditor,
         element: bubbleMenuElement,
-        pluginKey: typeof pluginKey === 'string' ? new PluginKey(pluginKey) : pluginKey,
+        pluginKey,
         shouldShow,
         getReferencedVirtualElement,
         options,

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -1,6 +1,6 @@
 import { type BubbleMenuPluginProps, BubbleMenuPlugin } from '@tiptap/extension-bubble-menu'
+import { PluginKey } from '@tiptap/pm/state'
 import { useCurrentEditor } from '@tiptap/react'
-import { PluginKey } from 'packages/pm/state'
 import React, { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -1,5 +1,6 @@
 import { type BubbleMenuPluginProps, BubbleMenuPlugin } from '@tiptap/extension-bubble-menu'
 import { useCurrentEditor } from '@tiptap/react'
+import { PluginKey } from 'packages/pm/state'
 import React, { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
@@ -55,7 +56,7 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
         resizeDelay,
         editor: attachToEditor,
         element: bubbleMenuElement,
-        pluginKey,
+        pluginKey: typeof pluginKey === 'string' ? new PluginKey(pluginKey) : pluginKey,
         shouldShow,
         getReferencedVirtualElement,
         options,


### PR DESCRIPTION
## Changes Overview


Add `updateBubbleMenuPosition` command to update position of bubble menu. This command lets developers programmatically update the position of the bubble menu in response to certain events (for example, when the bubble menu is resized).

## Implementation Approach

The command emits an event. Then, the event is captured in the prosemirror plugin to trigger the position to recompute.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
