### PR TITLE
fix: use named import for Suggestion to resolve Jest/CJS interop issue

### DIFF
--- a/.changeset/6665-mention-import-fix.md
+++ b/.changeset/6665-mention-import-fix.md
@@ -1,0 +1,10 @@
+---
+"@tiptap/extension-mention": patch
+---
+
+Use a named import for Suggestion from `@tiptap/suggestion` to avoid bundler ESM/CJS interop
+wrapping (`__toESM`) that caused Jest/CJS consumers to receive a module object instead of the
+callable plugin factory.
+
+This is a non-breaking internal fix. It keeps runtime module shape stable for CommonJS (Jest)
+and prevents the TypeError thrown when the extension attempted to call a non-function.

--- a/packages/extension-mention/src/mention.ts
+++ b/packages/extension-mention/src/mention.ts
@@ -3,7 +3,7 @@ import { mergeAttributes, Node } from '@tiptap/core'
 import type { DOMOutputSpec } from '@tiptap/pm/model'
 import { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import type { SuggestionOptions } from '@tiptap/suggestion'
-import Suggestion from '@tiptap/suggestion'
+import { Suggestion } from '@tiptap/suggestion'
 
 import { getSuggestionOptions } from './utils/get-default-suggestion-attributes.js'
 


### PR DESCRIPTION
## Changes Overview

This pull request addresses an internal module import issue in the `@tiptap/extension-mention` package to improve compatibility with CommonJS consumers such as Jest. The main change is switching to a named import for `Suggestion` to prevent runtime errors caused by ESM/CJS interop.

## Implementation Approach

Internal module compatibility fix:

* Updated the import of `Suggestion` in `packages/extension-mention/src/mention.ts` to use a named import, preventing Jest/CJS consumers from receiving a module object instead of a callable function.
* Documented the change in `.changeset/6665-mention-import-fix.md`, explaining that this is a non-breaking internal fix to keep runtime module shape stable and prevent TypeErrors in CommonJS environments.

## Testing Done

I ran a local build to check if `__toESM` is still wrapped around the suggestion_import is still applied which was not the case.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Fixes #6665 
- Fixes #6657
