### PR TITLE
Pass `attrs` through to Vue 3 menus

### DIFF
--- a/.changeset/strong-mice-allow.md
+++ b/.changeset/strong-mice-allow.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/vue-3': minor
+---
+
+Pass `attrs` through Vue 3 menus

--- a/packages/vue-3/src/menus/BubbleMenu.ts
+++ b/packages/vue-3/src/menus/BubbleMenu.ts
@@ -6,6 +6,8 @@ import { defineComponent, h, onBeforeUnmount, onMounted, ref, Teleport } from 'v
 export const BubbleMenu = defineComponent({
   name: 'BubbleMenu',
 
+  inheritAttrs: false,
+
   props: {
     pluginKey: {
       type: [String, Object] as PropType<BubbleMenuPluginProps['pluginKey']>,
@@ -48,7 +50,7 @@ export const BubbleMenu = defineComponent({
     },
   },
 
-  setup(props, { slots }) {
+  setup(props, { slots, attrs }) {
     const root = ref<HTMLElement | null>(null)
 
     onMounted(() => {
@@ -95,6 +97,6 @@ export const BubbleMenu = defineComponent({
     })
 
     // Teleport only instantiates element + slot subtree; plugin controls final placement
-    return () => h(Teleport, { to: 'body' }, h('div', { ref: root }, slots.default?.()))
+    return () => h(Teleport, { to: 'body' }, h('div', { ...attrs, ref: root }, slots.default?.()))
   },
 })

--- a/packages/vue-3/src/menus/FloatingMenu.ts
+++ b/packages/vue-3/src/menus/FloatingMenu.ts
@@ -6,6 +6,8 @@ import { defineComponent, h, onBeforeUnmount, onMounted, ref, Teleport } from 'v
 export const FloatingMenu = defineComponent({
   name: 'FloatingMenu',
 
+  inheritAttrs: false,
+
   props: {
     pluginKey: {
       // TODO: TypeScript breaks :(
@@ -35,7 +37,7 @@ export const FloatingMenu = defineComponent({
     },
   },
 
-  setup(props, { slots }) {
+  setup(props, { slots, attrs }) {
     const root = ref<HTMLElement | null>(null)
 
     onMounted(() => {
@@ -70,6 +72,6 @@ export const FloatingMenu = defineComponent({
     })
 
     // Teleport only instantiates element + slot subtree; plugin controls final placement
-    return () => h(Teleport, { to: 'body' }, h('div', { ref: root }, slots.default?.()))
+    return () => h(Teleport, { to: 'body' }, h('div', { ...attrs, ref: root }, slots.default?.()))
   },
 })


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

It will now be possible to set `class` and other properties on `<BubbleMenu>` and `<FloatingMenu>` and they will be passed through to the menu element. Right now, it will pass it implicitly to the `Teleport` which cannot handle them.

This is useful to allow setting `z-index` on the menu as a follow up on https://github.com/ueberdosis/tiptap/pull/6841

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

Simply got passed them through explicitly by getting `attrs` from `setup` and passing them to the `root` element.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] ~~I have added tests where applicable.~~
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->

https://github.com/ueberdosis/tiptap/pull/6841