### PR TITLE
Fix bug where updatePositon event raises an error

### DIFF
--- a/.changeset/perfect-hornets-remain.md
+++ b/.changeset/perfect-hornets-remain.md
@@ -1,0 +1,7 @@
+---
+'@tiptap/extension-bubble-menu': patch
+---
+
+Remove recently added `updateBubbleMenuPosition` method because it would not work in the React and Vue versions of the BubbleMenu, only in the vanilla extension. And that would confuse developers.
+
+Write the `transactionHandler` method as an arrow function because arrow functions have no `this`, so the `this` remains the instance of the `BubbleMenuView` class.

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -547,7 +547,7 @@ export class BubbleMenuView implements PluginView {
     this.isVisible = false
   }
 
-  transactionHandler({ transaction: tr }: { transaction: Transaction }) {
+  transactionHandler = ({ transaction: tr }: { transaction: Transaction }) => {
     const meta = tr.getMeta('bubbleMenu')
     if (meta === 'updatePosition') {
       this.updatePosition()

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -12,19 +12,6 @@ export type BubbleMenuOptions = Omit<BubbleMenuPluginProps, 'editor' | 'element'
   element: HTMLElement | null
 }
 
-declare module '@tiptap/core' {
-  interface Commands<ReturnType> {
-    bubbleMenu: {
-      /**
-       * Update the position of the bubble menu. This command is useful to force
-       * the bubble menu to update its position in response to certain events
-       * (for example, when the bubble menu is resized).
-       */
-      updateBubbleMenuPosition: () => ReturnType
-    }
-  }
-}
-
 /**
  * This extension allows you to create a bubble menu.
  * @see https://tiptap.dev/api/extensions/bubble-menu
@@ -59,15 +46,5 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
         shouldShow: this.options.shouldShow,
       }),
     ]
-  },
-
-  addCommands() {
-    return {
-      updateBubbleMenuPosition:
-        () =>
-        ({ commands }) => {
-          return commands.setMeta('bubbleMenu', 'updatePosition')
-        },
-    }
   },
 })


### PR DESCRIPTION
## Changes Overview

This PR fixes a couple of bugs in the BubbleMenu component that were introduced by a recent PR: #6990. 

The bugs were: the `updateBubbleMenuPosition` command was not available in all setups of the `BubbleMenu` (only in the vanilla extension but not in the React and Vue components) and that the `updatePosition` event raised an error.

## Implementation Approach

Remove recently added `updateBubbleMenuPosition` method because it would not work in the React and Vue versions of the BubbleMenu, only in the vanilla extension. And that would confuse developers.

Write the `transactionHandler` method as an arrow function because arrow functions have no `this`, so the `this` remains the instance of the `BubbleMenuView` class.

## Testing Done

In my local environment, I modified version of the BubbleMenu demo where I added this button that updates the position of the bubble menu

```jsx
      <button
        type="button"
        onClick={() => {
          editor.commands.setMeta('bubbleMenu', 'updatePosition')
        }}
      >
        Update menu position
      </button>
```

Then I checked that the `updatePosition` method got called and that no error was raised.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

In the documentation, I'll mention that developers must call `editor.commands.setMeta('bubbleMenu', 'updatePosition')` to force update the position of the bubble menu.

This is a customer support PR.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#6990
