### PR TITLE
prevent crash during editor mounting/unmounting when not initialized

### DIFF
--- a/.changeset/update-react-unmount.md
+++ b/.changeset/update-react-unmount.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Hotfix: Fix a crash in the React package that could occur during mounting/unmounting when the editor wasn't fully initialized. This prevents a runtime error and improves stability.

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -176,18 +176,24 @@ export class PureEditorContent extends React.Component<
 
     editor.contentComponent = null
 
-    if (!editor.view.dom?.firstChild) {
-      return
+    // try to reset the editor element
+    // may fail if this editor's view.dom was never initialized/mounted yet
+    try {
+      if (!editor.view.dom?.firstChild) {
+        return
+      }
+
+      // TODO using the new editor.mount method might allow us to remove this
+      const newElement = document.createElement('div')
+
+      newElement.append(editor.view.dom)
+
+      editor.setOptions({
+        element: newElement,
+      })
+    } catch {
+      // do nothing, nothing to reset
     }
-
-    // TODO using the new editor.mount method might allow us to remove this
-    const newElement = document.createElement('div')
-
-    newElement.append(editor.view.dom)
-
-    editor.setOptions({
-      element: newElement,
-    })
   }
 
   render() {


### PR DESCRIPTION
## Changes Overview

Fixed a crash in the React package that could occur during mounting/unmounting when the editor wasn't fully initialized. The change prevents a runtime error when the editor's internal view is not yet available. This is a critical hotfix for 3.6.0.

## Implementation Approach

- Added a defensive guard in the React EditorContent integration to avoid referencing the editor view before it exists.
- Minimal, localized change to avoid touching public APIs or other packages.

## Testing Done

- Manual verification in a local React demo:
  - Reproduced previous crash by mounting and immediately unmounting the editor; confirmed the crash no longer appears.
  - Verified normal editor lifecycle (mount → use → unmount) still works and no regressions visible.
- Smoke-checked build for the demos environment to ensure no immediate build/runtime errors during demo load.

## Verification Steps

Reviewers can verify quickly:

1. Run the demos (or a minimal React app using @tiptap/react).
2. Mount the editor and immediately unmount it (for example, toggle rendering with a button that mounts/unmounts quickly).
3. Confirm no runtime errors in the browser console related to `editor.view` or unmount.

## Additional Notes

- This is intentionally small and non-breaking; it only adds a defensive check to avoid a null/dereference error.
- The changeset for this fix was added so the release tooling will pick it up as a patch for the React package.

## Checklist

- [x] I have created a changeset for this PR.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- (none linked) — marked as a critical hotfix for 3.6.0