### PR TITLE
fix: selection option type

### DIFF
--- a/packages/extensions/src/selection/selection.ts
+++ b/packages/extensions/src/selection/selection.ts
@@ -15,7 +15,7 @@ export type SelectionOptions = {
  * This extension allows you to add a class to the selected text.
  * @see https://www.tiptap.dev/api/extensions/selection
  */
-export const Selection = Extension.create({
+export const Selection = Extension.create<SelectionOptions>({
   name: 'selection',
 
   addOptions() {


### PR DESCRIPTION
## Changes Overview

Fixed TypeScript typing for the `Selection` extension by adding the `SelectionOptions` type parameter.

## Implementation Approach

Added the missing generic type parameter `<SelectionOptions>`in the `Selection` extension. This ensures proper type safety and IntelliSense support for the extension's options, specifically the `className` option.

**Before:**
```typescript
export const Selection = Extension.create({
```

**After:**
```typescript
export const Selection = Extension.create<SelectionOptions>({
```

## Testing Done

- Verified that TypeScript compilation passes without errors
- Confirmed that the extension's options are now properly typed
- Tested that the `className` option maintains its expected string type and default value

## Verification Steps

Selection.configure({ }) shows proper autocomplete for `className`

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.