### PR TITLE
fix: allow nullable types for configuration options

### DIFF
--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -6,17 +6,17 @@ export interface CodeBlockOptions {
    * Adds a prefix to language classes that are applied to code tags.
    * @default 'language-'
    */
-  languageClassPrefix: string
+  languageClassPrefix: string | null | undefined
   /**
    * Define whether the node should be exited on triple enter.
    * @default true
    */
-  exitOnTripleEnter: boolean
+  exitOnTripleEnter: boolean | null | undefined
   /**
    * Define whether the node should be exited on arrow down if there is no node after it.
    * @default true
    */
-  exitOnArrowDown: boolean
+  exitOnArrowDown: boolean  | null | undefined
   /**
    * The default language.
    * @default null
@@ -27,12 +27,12 @@ export interface CodeBlockOptions {
    * Enable tab key for indentation in code blocks.
    * @default false
    */
-  enableTabIndentation: boolean
+  enableTabIndentation: boolean | null | undefined
   /**
    * The number of spaces to use for tab indentation.
    * @default 4
    */
-  tabSize: number
+  tabSize: number | null | undefined
   /**
    * Custom HTML attributes that should be added to the rendered HTML tag.
    * @default {}


### PR DESCRIPTION
## Changes Overview

- Updated `CodeBlockOptions` interface to allow **nullable and undefined types** for configuration options.  
- This ensures flexibility when extending a `CodeBlock`, since default values exist and strict typing is not always necessary.  

## Implementation Approach

- Changed option types from strict primitives (`string`, `boolean`, `number`) to union types (`string | null | undefined`, etc.).  
- Preserved default values in comments to clarify intended behavior.  
- Ensured type safety while supporting optional overrides.  

## Testing Done

- Type-checked the updated interface in multiple scenarios:
  - With full config provided.  
  - With missing or `null` values.  
  - With only partial overrides.  
- Verified that defaults still apply when `null` or `undefined` are used.  

## Verification Steps

1. Extend `CodeBlockOptions` with partial or missing fields.  
2. Ensure code compiles without type errors.  
3. Confirm runtime defaults are applied correctly when fields are `null` or `undefined`.  

## Additional Notes

- This change improves **developer experience** by making the config more forgiving.  
- No breaking changes introduced.  

## Checklist

- [x] Nullable type support added for config options.  
- [x] Defaults preserved and documented.  
- [x] Verified no breaking changes.  
- [ ] Added tests (if necessary for config fallback logic).  
- [ ] Fixed any lint issues.  

## Related Issues

- Fix: allow nullable types for configuration options in `CodeBlockOptions`.  
