### PR TITLE
feature: add new make:demo script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "publish": "pnpm run build && pnpm changeset publish",
     "clean:packages": "rm -rf ./packages/*/dist && rm -rf ./packages/pm/*/dist && rm -rf ./packages-deprecated/*/dist",
     "clean:packs": "rm -rf ./packages/*/*.tgz && rm -rf ./packages-deprecated/*/*.tgz",
+    "make:demo": "sh ./scripts/make-demo.sh",
     "reset": "pnpm run clean:packages && pnpm run clean:packs && rm -rf ./**/.cache && rm -rf ./**/node_modules && rm -rf ./package-lock.json && pnpm install",
     "prepare": "husky install",
     "turbo": "turbo",

--- a/scripts/make-demo.sh
+++ b/scripts/make-demo.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Ask user what the new Demo should be called
+read -p "What is the name of the new Demo? " DEMO_NAME
+
+# remove spaces with underscores
+DEMO_NAME=${DEMO_NAME// /_}
+
+# Ask user what category the new Demo should be in (options: "Dev", "Examples", "Extensions", "Experiments", "Marks", "Nodes")
+read -p "What category should the new Demo be in? (Options: Dev, Examples, Extensions, Experiments, Marks, Nodes) " DEMO_CATEGORY
+
+if [[ ! "$DEMO_CATEGORY" =~ ^(Dev|Examples|Extensions|Experiments|Marks|Nodes)$ ]]; then
+  echo "Invalid category. Please choose from: Dev, Examples, Extensions, Experiments, Marks, Nodes."
+  exit 1
+fi
+
+NEW_DEMO_DIR="demos/src/$DEMO_CATEGORY/$DEMO_NAME"
+
+# Check if the directory already exists
+if [ -d "$NEW_DEMO_DIR" ]; then
+  echo "Directory $NEW_DEMO_DIR already exists. Please choose a different name."
+  exit 1
+fi
+
+# Copy demos/src/Examples/Default to the new directory
+cp -r demos/src/Examples/Default "$NEW_DEMO_DIR"


### PR DESCRIPTION
## Changes Overview

This pull request introduces a new script to streamline the creation of demo projects and adds a corresponding script command to the project configuration. The main changes are focused on developer tooling to make it easier to generate demo scaffolding in the correct location.

## Implementation Approach


**Developer tooling improvements:**

* Added a new script `scripts/make-demo.sh` that interactively prompts the user for a demo name and category, validates input, and copies a default demo template to a new directory for easy demo creation.
* Added a `make:demo` script command to `package.json` to run the new demo creation script via `pnpm run make:demo`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
