### PR TITLE
fix(BubbleMenu): prevent error when editor is destroyed during cleanup

### DIFF
--- a/.changeset/fix-bubble-menu-destroyed-editor.md
+++ b/.changeset/fix-bubble-menu-destroyed-editor.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/extension-bubble-menu": patch
+---
+
+Fix a bug where the bubble menu could throw an error if the editor was destroyed
+while the plugin was cleaning up.

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -398,6 +398,11 @@ export class BubbleMenuView implements PluginView {
   }
 
   blurHandler = ({ event }: { event: FocusEvent }) => {
+    if (this.editor.isDestroyed) {
+      this.destroy()
+      return
+    }
+
     if (this.preventHide) {
       this.preventHide = false
 


### PR DESCRIPTION
## Changes Overview

This pull request addresses a bug in the `@tiptap/extension-bubble-menu` package that could cause an error when the editor is destroyed while the bubble menu plugin is cleaning up. The fix ensures that the plugin checks if the editor is destroyed before proceeding with certain operations.

## Implementation Approach

Bug fix:

* Added a check in the `blurHandler` method of `bubble-menu-plugin.ts` to verify if the editor has been destroyed, and if so, immediately destroys the plugin to prevent errors during cleanup.

Changelog update:

* Added a changeset entry documenting the bug fix for the bubble menu error when the editor is destroyed.

## Testing Done

Did a local test with a demo that would destroy the editor which caused the bubble menu to throw an error because `editor.view.dom` would now be non-accessible anymore because the reference from the view's proxy would be unset.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
