### PR TITLE
fix(react BubbleMenu): BubbleMenu now reacts to prop changes

### DIFF
--- a/.changeset/fix-bubblemenu.md
+++ b/.changeset/fix-bubblemenu.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Fix BubbleMenu so it now reacts to prop changes after initial mount

--- a/.changeset/fix-bubblemenu.md
+++ b/.changeset/fix-bubblemenu.md
@@ -2,4 +2,4 @@
 "@tiptap/react": patch
 ---
 
-Fix BubbleMenu so it now reacts to prop changes after initial mount
+Resolved an issue where the React BubbleMenu did not update when FloatingUI option props changed after initial mount. The BubbleMenu now correctly responds to updated option props.

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -36,7 +36,6 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
 
     useEffect(() => {
       const bubbleMenuElement = menuEl.current
-
       bubbleMenuElement.style.visibility = 'hidden'
       bubbleMenuElement.style.position = 'absolute'
 
@@ -73,8 +72,17 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
           }
         })
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [editor, currentEditor])
+    }, [
+      editor,
+      currentEditor,
+      pluginKey,
+      updateDelay,
+      resizeDelay,
+      appendTo,
+      shouldShow,
+      getReferencedVirtualElement,
+      options,
+    ])
 
     return createPortal(<div {...restProps}>{children}</div>, menuEl.current)
   },


### PR DESCRIPTION
## Changes Overview

Fixed an issue where the React BubbleMenu didn’t pick up prop changes after initial mount. In particular, updates to options according to issue #6963

## Implementation Approach

The effect that registers the BubbleMenu plugin now includes all relevant configuration in its dependency list.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [X] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [X] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
