### PR TITLE
feat: add GitHub Actions workflow to notify Discord on release

### DIFF
--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -1,0 +1,24 @@
+name: Notify Discord on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  discord_notify:
+    name: Send release to Discord
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Post release to Discord (tsickert/discord-webhook)
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_RELEASES_STABLE_WEBHOOK }}
+          embed-title: ${{ github.event.release.name || github.event.release.tag_name }}
+          embed-description: ${{ github.event.release.body }}
+          embed-url: ${{ github.event.release.html_url }}
+          wait: true


### PR DESCRIPTION
## Changes Overview

Added a new GitHub Actions workflow that notifies Discord when a GitHub Release is published. The workflow uses the maintained action `tsickert/discord-webhook@v7.0.0` and reads the webhook URL from the repository secret `DISCORD_RELEASES_STABLE_WEBHOOK`. The release title becomes the embed title and the release body becomes the embed description.

## Implementation Approach

- Use the community action `tsickert/discord-webhook` instead of a custom curl/python step to avoid YAML quoting/escaping issues and to leverage built-in embed handling and safeguards.
- Wire the release event payload to the action inputs:
  - `embed-title` ← release name (or tag)
  - `embed-description` ← release body
  - `embed-url` ← release HTML URL
  - `webhook-url` ← repository secret `DISCORD_RELEASES_STABLE_WEBHOOK`
- Keep the workflow focused and minimal; no repo code changes or public API changes required.

Files changed
- release-to-discord.yml — new workflow that triggers on `release: published` and posts to Discord via `tsickert/discord-webhook@v7.0.0`.

## Testing Done

- Validated and fixed YAML structure and indentation in the workflow file (removed duplicate/invalid sections and stray code fences).
- Reviewed `tsickert/discord-webhook` README and source to ensure correct input mapping and behavior (description truncation, `raw-data` and embed inputs).
- Performed a static inspection of the workflow to ensure inputs map to the correct GitHub event properties.

Note: I did not execute the workflow in CI (no publish-run performed against an actual Discord webhook during this change). The action is well-tested upstream (tsickert/discord-webhook).

## Verification Steps

1. Add the webhook secret to the repo:
   - GitHub UI: Settings → Secrets and variables → Actions → New repository secret
     - Name: `DISCORD_RELEASES_STABLE_WEBHOOK`
     - Value: your Discord webhook URL
   - OR with the GitHub CLI:
     ```bash
     gh secret set DISCORD_RELEASES_STABLE_WEBHOOK--body 'https://discord.com/api/webhooks/…'
     ```
2. Create and publish a Release for this repository (the workflow triggers on `published` releases).
   - From the Releases page create a release and click Publish.
3. Open Actions → select the workflow run and check logs for the `Post release to Discord (tsickert/discord-webhook)` step.
4. Confirm the message appears in the configured Discord channel as an embed with:
   - Title = release title (or tag)
   - Description = release body
   - Footer contains the tag/author info handled by the action (if present)
5. If the message does not appear:
   - Inspect the action logs (payload printed by the action).
   - Copy the printed payload and try posting with curl/postman to the webhook to debug.

## Additional Notes

- The action supports many extra inputs (raw JSON, file uploads, thread ID, flags). If you want file attachments (e.g., release artifacts) or a raw JSON payload, I can extend the workflow to use `raw-data`/`filename`.
- If you want a manual test trigger in Actions, I can add `workflow_dispatch` to the `on` section so you can run the workflow from the UI.
- The workflow is intentionally minimal to reduce surface area and avoid accidental leaks of the webhook URL (it must live as a secret).

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library (change is CI-only: workflow file).
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines (small, single-purpose change; documented behavior).
- [x] I have fixed any lint issues (workflow YAML validated/cleaned).

## Related Issues

- None linked. (If you have an issue tracking Discord notifications, add it here.)