### PR TITLE
feat: allow multiple plugins to be registered at once

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -355,13 +355,13 @@ export class Editor extends EventEmitter<EditorEvents> {
    * @param handlePlugins Control how to merge the plugin into the existing plugins.
    * @returns The new editor state
    */
-  public registerPlugin(
-    plugin: Plugin,
-    handlePlugins?: (newPlugin: Plugin, plugins: Plugin[]) => Plugin[],
+  public registerPlugin<T extends Plugin | Plugin[]>(
+    plugin: T,
+    handlePlugins?: (newPlugin: T, plugins: Plugin[]) => Plugin[],
   ): EditorState {
     const plugins = isFunction(handlePlugins)
       ? handlePlugins(plugin, [...this.state.plugins])
-      : [...this.state.plugins, plugin]
+      : [...this.state.plugins, ...(Array.isArray(plugin) ? plugin : [plugin])]
 
     const state = this.state.reconfigure({ plugins })
 


### PR DESCRIPTION
## Changes Overview
This allows for `editor.registerPlugin` to take either a single plugin (original behavior) or an array of plugins as it's argument.

<!-- Briefly describe your changes. -->

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
