### PR TITLE
Remove unnecessary Teleport in menus and fix attribute forwarding

### DIFF
--- a/.changeset/bubble-floating-menu-attrs.md
+++ b/.changeset/bubble-floating-menu-attrs.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/vue-3": patch
+---
+
+Fix attribute forwarding for BubbleMenu and FloatingMenu Vue 3 components to allow setting z-index and other HTML attributes

--- a/packages/vue-3/src/menus/BubbleMenu.ts
+++ b/packages/vue-3/src/menus/BubbleMenu.ts
@@ -1,7 +1,7 @@
 import type { BubbleMenuPluginProps } from '@tiptap/extension-bubble-menu'
 import { BubbleMenuPlugin } from '@tiptap/extension-bubble-menu'
 import type { PropType } from 'vue'
-import { defineComponent, h, nextTick, onBeforeUnmount, onMounted, Teleport } from 'vue'
+import { defineComponent, h, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 
 export const BubbleMenu = defineComponent({
   name: 'BubbleMenu',
@@ -51,7 +51,7 @@ export const BubbleMenu = defineComponent({
   },
 
   setup(props, { slots, attrs }) {
-    const el = document.createElement('div')
+    const root = ref<HTMLElement | null>(null)
 
     onMounted(() => {
       const {
@@ -64,6 +64,12 @@ export const BubbleMenu = defineComponent({
         getReferencedVirtualElement,
         updateDelay,
       } = props
+
+      const el = root.value
+
+      if (!el) {
+        return
+      }
 
       el.style.visibility = 'hidden'
       el.style.position = 'absolute'
@@ -94,7 +100,8 @@ export const BubbleMenu = defineComponent({
       editor.unregisterPlugin(pluginKey)
     })
 
-    // Teleport only instantiates element + slot subtree; plugin controls final placement
-    return () => h(Teleport, { to: el }, h('div', { ...attrs, ref: 'root' }, slots.default?.()))
+    // Vue owns this element; attrs are applied reactively by Vue
+    // Plugin re-parents it when showing the menu
+    return () => h('div', { ref: root, ...attrs }, slots.default?.())
   },
 })

--- a/packages/vue-3/src/menus/FloatingMenu.ts
+++ b/packages/vue-3/src/menus/FloatingMenu.ts
@@ -1,7 +1,7 @@
 import type { FloatingMenuPluginProps } from '@tiptap/extension-floating-menu'
 import { FloatingMenuPlugin } from '@tiptap/extension-floating-menu'
 import type { PropType } from 'vue'
-import { defineComponent, h, onBeforeUnmount, onMounted, ref, Teleport } from 'vue'
+import { defineComponent, h, onBeforeUnmount, onMounted, ref } from 'vue'
 
 export const FloatingMenu = defineComponent({
   name: 'FloatingMenu',
@@ -38,13 +38,14 @@ export const FloatingMenu = defineComponent({
   },
 
   setup(props, { slots, attrs }) {
-    const el = document.createElement('div')
     const root = ref<HTMLElement | null>(null)
 
     onMounted(() => {
       const { pluginKey, editor, options, appendTo, shouldShow } = props
 
-      if (!root.value) {
+      const el = root.value
+
+      if (!el) {
         return
       }
 
@@ -72,7 +73,8 @@ export const FloatingMenu = defineComponent({
       editor.unregisterPlugin(pluginKey)
     })
 
-    // Teleport only instantiates element + slot subtree; plugin controls final placement
-    return () => h(Teleport, { to: el }, h('div', { ...attrs, ref: root }, slots.default?.()))
+    // Vue owns this element; attrs are applied reactively by Vue
+    // Plugin re-parents it when showing the menu
+    return () => h('div', { ref: root, ...attrs }, slots.default?.())
   },
 })


### PR DESCRIPTION
## Changes Overview

A recent PR broke attribute forwarding for Vue 3 BubbleMenu and FloatingMenu components (see https://github.com/ueberdosis/tiptap/pull/7060#issuecomment-3422590191). Users can no longer set `class`, `style`, or other HTML attributes to control z-index and positioning. This PR fixes attribute forwarding by simplifying the implementation. Vue now owns the element directly via a `ref` again instead of using `Teleport` with a raw DOM element.

## Implementation Approach

- Removed the detached `document.createElement('div')` + `Teleport` approach
- Let Vue manage the element via `ref` and spread `attrs` on the root element
- Vue handles attribute reactivity automatically; the plugin still re-parents the element when showing

## Testing Done

- Manually tested in a local Bun + Vue 3 app with linked packages
- Verified `class` and `style` attributes are applied to the menu element
- Tested `appendTo` works correctly for fixing clipping issues
- Confirmed menus appear with correct z-index when set via `:style="{ zIndex: 9999 }"`
- No console errors on mount/unmount

## Verification Steps

1. Use BubbleMenu or FloatingMenu with attributes:
   ```vue
   <BubbleMenu :editor="editor" :append-to="document.body" :style="{ zIndex: 9999 }">
     <button>Bold</button>
   </BubbleMenu>
   ```
2. Wrap editor in a parent with `overflow: hidden`
3. Select text (BubbleMenu) or place cursor in empty paragraph (FloatingMenu)
4. Verify menu appears with the correct class and z-index applied
5. Check browser DevTools to confirm attributes are on the menu element

## Additional Notes

- No breaking changes; internal implementation detail only
- Simpler and more "Vue-ish" than the previous approach
- Attributes are now reactive if they change

## Checklist

- [x] I have created a changeset for this PR.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable (manual testing done).
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes https://github.com/ueberdosis/tiptap/pull/7060#issuecomment-3422590191