### PR TITLE
fix(core): only remove injected CSS on unmount if no other editors are attached to DOM

### DIFF
--- a/.changeset/rare-pumpkins-shave.md
+++ b/.changeset/rare-pumpkins-shave.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Only remove injected CSS on unmount if no other editors are in the document (fixes #6836)

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -57,6 +57,8 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   private css: HTMLStyleElement | null = null
 
+  private className = 'tiptap'
+
   public schema!: Schema
 
   private editorView: EditorView | null = null
@@ -193,7 +195,8 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.isInitialized = false
 
     // Safely remove CSS element with fallback for test environments
-    if (this.css) {
+    // Only remove CSS if no other editors exist in the document after unmount
+    if (this.css && !document.querySelectorAll(`.${this.className}`).length) {
       try {
         if (typeof this.css.remove === 'function') {
           this.css.remove()
@@ -556,7 +559,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Prepend class name to element.
    */
   public prependClass(): void {
-    this.view.dom.className = `tiptap ${this.view.dom.className}`
+    this.view.dom.className = `${this.className} ${this.view.dom.className}`
   }
 
   public isCapturingTransaction = false


### PR DESCRIPTION
## Changes Overview

As described in the linked issue below, currently the editor will always remove injected CSS on unmount, even if this instance of the editor did not add it. This can lead to CSS unexpectedly being removed for other editors on the page.

In this PR, when the editor is unmounted, injected CSS will only be removed if there are no other editors attached to the DOM.

<!-- Briefly describe your changes. -->

## Implementation Approach

In the editor's unmount function, I added a check that prevents removing the CSS if there are other elements with the `.tiptap` classname in the document.

This will, of course, only work if the editors are attached to the DOM, but I expect that will be the case almost everywhere, outside of a testing environment.

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

I've added tests for both adding and removing injected CSS.

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

1. Add two editors to a page, but mount the second editor selectively (e.g. when a button is toggled.)
2. Unmount the second editor.
3. The first editor should still have CSS styles applied for the `.ProseMirror` class. Check the document head for a `<style>` tag with the `data-tiptap-style` attribute.

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes ueberdosis/tiptap#6836
