### PR TITLE
fix(hard-break): parse markdown hard breaks from double space newlines

### DIFF
--- a/.changeset/fix-hard-break-markdown-br.md
+++ b/.changeset/fix-hard-break-markdown-br.md
@@ -1,0 +1,9 @@
+---
+'@tiptap/extension-hard-break': patch
+---
+
+Ensure that markdown hard breaks (two spaces followed by a newline) are parsed so they render as line breaks (`<br>`) in the editor when using `contentType: 'markdown'`.
+
+Fixes #7107
+
+

--- a/packages/extension-hard-break/src/hard-break.ts
+++ b/packages/extension-hard-break/src/hard-break.ts
@@ -35,6 +35,8 @@ declare module '@tiptap/core' {
 export const HardBreak = Node.create<HardBreakOptions>({
   name: 'hardBreak',
 
+  markdownTokenName: 'br',
+
   addOptions() {
     return {
       keepMarks: true,
@@ -63,6 +65,12 @@ export const HardBreak = Node.create<HardBreakOptions>({
   },
 
   renderMarkdown: (_node, h) => h.indent(`\n`),
+
+  parseMarkdown: () => {
+    return {
+      type: 'hardBreak',
+    }
+  },
 
   addCommands() {
     return {


### PR DESCRIPTION
## Changes Overview
As described in the linked issue below, currently the editor won't render a `<br>` tag, when `contentType: 'markdown'` is set and the markdown content contains a hard break (a line ending with two spaces followed by a newline).

This PR ensures that double space newlines in markdown content are correctly rendered as `<br>` elements.

## Implementation Approach

Extend `HardBreak` to recognize marked's `br` token and return a `hardBreak` node when parsing `contentType: 'markdown'`.

## Testing Done

- Installed locally built tarball into an app.
- Verified that content with two spaces + newline (e.g., `Line 1  \nLine 2`) renders a `<br>` between lines.
- Verified with `StarterKit` + `Markdown` and `contentType: 'markdown'`.

## Verification Steps

1. In an app, include `StarterKit` and `Markdown` with `contentType: 'markdown'`.
2. Set editor content to `First line  \nSecond line`.
3. Confirm the rendered HTML includes a `<br>` between lines.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#7107 
