### PR TITLE
Prevent bubble menu plugin from reloading every time the dependencies change

### DIFF
--- a/.changeset/two-moles-learn.md
+++ b/.changeset/two-moles-learn.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Prevent Bubble Menu plugin from re-loading every time the BubbleMenu component re-renders. Reverts a regression introduced in v3.6.3, in PR #7028.

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -39,6 +39,8 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
      */
     const pluginEditor = editor || currentEditor
 
+    // Creating a useMemo would be more computationally expensive than just
+    // re-creating this object on every render.
     const bubbleMenuPluginProps: Omit<BubbleMenuPluginProps, 'editor' | 'element'> = {
       updateDelay,
       resizeDelay,

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -49,8 +49,9 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
       options,
     }
     /**
-     * The props for the bubble menu plugin. They are accessed inside a ref to avoid
-     * re-rendering the plugin when the props change.
+     * The props for the bubble menu plugin. They are accessed inside a ref to
+     * avoid running the useEffect hook and re-registering the plugin when the
+     * props change.
      */
     const bubbleMenuPluginPropsRef = useRef(bubbleMenuPluginProps)
     bubbleMenuPluginPropsRef.current = bubbleMenuPluginProps


### PR DESCRIPTION
## Changes Overview

Hotfix that reverts a regression introduced in PR #7028. That PR was a breaking change and it caused a bug in one of our enterprise customers' code.

It's a breaking change because, if one of these options (appendTo, shouldShow, getReferencedVirtualElement, options) is not memoized, the bubble menu plugin is unregistered and registered again every time the component re-renders. This caused a lot of transactions and a bug where the editor selection was unset.


## Implementation Approach

- Fix: remove the dependencies from the useEffect, that were causing the plugin to re-load every time the component re-rendered.
- Refactor: simplify `useEffect` code so that the useEffect has 1 dependency instead of 2. Remove redundant dependency.
- Refector: inside the `useEffect`, create the html element after the `if` statement instead of doing it before. This avoids it being created redundantly.
- Refactor: use useRef to avoid having the dependency in the dependency array. This way, I don't need to suppress the ESLint rule. This complies with React best practices.

## Testing Done

Tried in the demo, no changes in behaviour were observed.

Tested internally by the customer that was having the bug.

## Additional Notes

To remove dependencies from a useEffect, change the code. Do not suppress the ESLint rule. https://react.dev/learn/removing-effect-dependencies

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#7028
#6963