### PR TITLE
Add updateDocument option to disable document updates caused by the unique id extension (v2 release)

### DIFF
--- a/.changeset/nine-eyes-call.md
+++ b/.changeset/nine-eyes-call.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-unique-id': minor
+---
+
+Add `updateDocument` option to disable document updates caused by the Unique ID extension.

--- a/packages/extension-unique-id/src/unique-id.ts
+++ b/packages/extension-unique-id/src/unique-id.ts
@@ -16,6 +16,14 @@ export interface UniqueIDOptions {
   types: string[],
   generateID: () => any,
   filterTransaction: ((transaction: Transaction) => boolean) | null,
+  /**
+   * Whether to update the document by adding unique IDs to the nodes. Set this
+   * property to `false` if the document is in `readonly` mode, is immutable, or
+   * you don't want it to be modified.
+   *
+   * @default true
+   */
+  updateDocument: boolean
 }
 
 export const UniqueID = Extension.create<UniqueIDOptions>({
@@ -31,6 +39,7 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
       types: [],
       generateID: () => uuidv4(),
       filterTransaction: null,
+      updateDocument: true,
     }
   },
 
@@ -59,6 +68,10 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
 
   // check initial content for missing ids
   onCreate() {
+    if (!this.options.updateDocument) {
+      return
+    }
+
     const collab = this.editor.extensionManager.extensions.find(ext => ext.name === 'collaboration')
     const provider = collab?.options ? collab.options.provider : undefined
 
@@ -103,6 +116,10 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
   },
 
   addProseMirrorPlugins() {
+    if (!this.options.updateDocument) {
+      return []
+    }
+
     let dragSourceElement: Element | null = null
     let transformPasted = false
 


### PR DESCRIPTION
## Changes Overview

This PR fixes an issue that one of our Enterprise customers has, where the Unique ID extension causes the document to be updated even if the document is readonly. This causes trouble with the collaboration server, where certain updates are rejected.

It fixes the issue in Tiptap 2 too, because of long-term support for Enterprise customers.

## Implementation Approach

Add `updateDocument` option to disable document updates caused by the Unique ID extension.

## Testing Done

Tested the demo to see that it did not break. If the `updateDocument` option is not set, the behaviour of the Unique ID extension remains the same.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Docs PR: https://github.com/ueberdosis/tiptap-docs/pull/469
Tiptap 3 PR: #7116
