### PR TITLE
Cherry-pick: Prevent bubble menu plugin from reloading every time the dependencies change

### DIFF
--- a/.changeset/two-moles-learn.md
+++ b/.changeset/two-moles-learn.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Prevent Bubble Menu plugin from re-loading every time the BubbleMenu component re-renders. Reverts a regression introduced in v3.6.3, in PR #7028.


### PR DESCRIPTION
Cherry-picks #7115 to `develop`