### PR TITLE
Cherry-pick: Add `updateDocument` option to disable document updates caused by the Unique ID extension.

### DIFF
--- a/.changeset/nine-eyes-call.md
+++ b/.changeset/nine-eyes-call.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-unique-id': minor
+---
+
+Add `updateDocument` option to disable document updates caused by the Unique ID extension.

--- a/packages/extension-unique-id/src/unique-id.ts
+++ b/packages/extension-unique-id/src/unique-id.ts
@@ -35,6 +35,14 @@ export interface UniqueIDOptions {
    * @default null
    */
   filterTransaction: ((transaction: Transaction) => boolean) | null
+  /**
+   * Whether to update the document by adding unique IDs to the nodes. Set this
+   * property to `false` if the document is in `readonly` mode, is immutable, or
+   * you don't want it to be modified.
+   *
+   * @default true
+   */
+  updateDocument: boolean
 }
 
 export const UniqueID = Extension.create<UniqueIDOptions>({
@@ -50,6 +58,7 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
       types: [],
       generateID: () => uuidv4(),
       filterTransaction: null,
+      updateDocument: true,
     }
   },
 
@@ -78,6 +87,10 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
 
   // check initial content for missing ids
   onCreate() {
+    if (!this.options.updateDocument) {
+      return
+    }
+
     const collaboration = this.editor.extensionManager.extensions.find(ext => ext.name === 'collaboration')
     const collaborationCaret = this.editor.extensionManager.extensions.find(ext => ext.name === 'collaborationCaret')
 
@@ -126,6 +139,10 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
   },
 
   addProseMirrorPlugins() {
+    if (!this.options.updateDocument) {
+      return []
+    }
+
     let dragSourceElement: Element | null = null
     let transformPasted = false
 


### PR DESCRIPTION
Cherry-picks #7116 to `develop`.