### PR TITLE
fix: correct order of closing markdown marks

### DIFF
--- a/.changeset/fix-markdown-mark-closing-order--bright-bear.md
+++ b/.changeset/fix-markdown-mark-closing-order--bright-bear.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/markdown": patch
+---
+
+Fixed a bug where marks were resolved in incorrect orders, breaking markdown rendering for nested marks.

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -26,7 +26,6 @@ export function wrapInMarkdownBlock(prefix: string, content: string) {
 
 /**
  * Identifies marks that need to be closed (active but not in current node).
- * Returns the mark types in reverse order for proper closing sequence.
  */
 export function findMarksToClose(activeMarks: Map<string, any>, currentMarks: Map<string, any>): string[] {
   const marksToClose: string[] = []
@@ -35,7 +34,7 @@ export function findMarksToClose(activeMarks: Map<string, any>, currentMarks: Ma
       marksToClose.push(markType)
     }
   })
-  return marksToClose.reverse()
+  return marksToClose
 }
 
 /**
@@ -88,7 +87,7 @@ export function findMarksToCloseAtEnd(
     }
   }
 
-  return marksToCloseAtEnd.reverse()
+  return marksToCloseAtEnd
 }
 
 /**

--- a/tests/cypress/integration/markdown/manager.spec.ts
+++ b/tests/cypress/integration/markdown/manager.spec.ts
@@ -8,6 +8,7 @@ import { Link } from '@tiptap/extension-link'
 import { BulletList, ListItem, OrderedList, TaskItem, TaskList } from '@tiptap/extension-list'
 import { Mention } from '@tiptap/extension-mention'
 import { Paragraph } from '@tiptap/extension-paragraph'
+import { Strike } from '@tiptap/extension-strike'
 import { Text } from '@tiptap/extension-text'
 import { Youtube } from '@tiptap/extension-youtube'
 import { MarkdownManager } from '@tiptap/markdown'
@@ -61,7 +62,19 @@ describe('MarkdownManager Direct Tests', () => {
 
   beforeEach(() => {
     // Basic extensions for standard markdown
-    basicExtensions = [Document, Paragraph, Text, Heading, Bold, Italic, Link, BulletList, OrderedList, ListItem]
+    basicExtensions = [
+      Document,
+      Paragraph,
+      Text,
+      Heading,
+      Bold,
+      Italic,
+      Strike,
+      Link,
+      BulletList,
+      OrderedList,
+      ListItem,
+    ]
 
     // Extended extensions with custom markdown features
     extendedExtensions = [
@@ -197,6 +210,60 @@ Final paragraph.`
 
       const markdown = markdownManager.renderNodes(doc)
       expect(markdown).to.equal('Hello world')
+    })
+
+    it('should render nested marks with correct tag order', () => {
+      // Test case: bold inside strike should render as ~**text**~
+      const doc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Test: ',
+                marks: [],
+              },
+              {
+                type: 'text',
+                text: 'abcd',
+                marks: [
+                  { type: 'bold' }, // Opens first: **
+                  { type: 'strike' }, // Opens second: ~
+                ],
+              },
+              {
+                type: 'text',
+                text: ' end.',
+                marks: [],
+              },
+            ],
+          },
+        ],
+      }
+
+      const docAtEnd = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'abcd',
+                marks: [
+                  { type: 'bold' }, // Opens first: **
+                  { type: 'strike' }, // Opens second: ~
+                ],
+              },
+            ],
+          },
+        ],
+      }
+
+      expect(markdownManager.renderNodes(doc)).to.equal('Test: ~~**abcd**~~ end.')
+      expect(markdownManager.renderNodes(docAtEnd)).to.equal('~~**abcd**~~')
     })
 
     it('should render headings', () => {

--- a/tests/cypress/integration/markdown/manager.spec.ts
+++ b/tests/cypress/integration/markdown/manager.spec.ts
@@ -213,7 +213,7 @@ Final paragraph.`
     })
 
     it('should render nested marks with correct tag order', () => {
-      // Test case: bold inside strike should render as ~**text**~
+      // Test case: bold inside strike should render as ~~**text**~~
       const doc = {
         type: 'doc',
         content: [


### PR DESCRIPTION
## Changes Overview

Fixed the order of closing markdown marks when rendering nested marks to ensure correct markdown syntax.

## Implementation Approach

Removed `.reverse()` calls in `findMarksToClose` and `findMarksToCloseAtEnd` functions in `packages/markdown/src/utils.ts` to prevent incorrect closing order. Added a test case for nested marks rendering in `tests/cypress/integration/markdown/manager.spec.ts`.

## Testing Done

- Added Cypress test for nested marks (e.g., bold inside strike) to verify correct tag order (`~~**text**~~`).
- Ran existing round-trip tests to ensure no regressions.
- Verified linting and build pass.

## Verification Steps

1. Run `pnpm test:run` to execute Cypress tests.
2. Check that nested marks render correctly in markdown output.
3. Test with Tiptap editor to confirm markdown serialization works for complex mark combinations.

## Additional Notes

This PR makes [PR #7133](https://github.com/ueberdosis/tiptap/pull/7133) obsolete. Thanks to suyao for the initial investigation and approach—suyao is coauthored on this commit.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7117