### PR TITLE
fix: respect isRequired attribute in ProseMirror schema generation

### DIFF
--- a/.changeset/fix-required-attributes-schema--wise-owl.md
+++ b/.changeset/fix-required-attributes-schema--wise-owl.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fixed ProseMirror schema generation to properly respect `isRequired` attribute configuration. Previously, attributes marked with `isRequired: true` were incorrectly treated as optional because a `default` property was always included in the schema specification. ProseMirror determines attribute requirements by the absence of the `default` property, so now the `default` is only included when the attribute is not required and a default value is explicitly defined.

--- a/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
+++ b/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
@@ -25,6 +25,29 @@ function cleanUpSchemaItem<T>(data: T) {
 }
 
 /**
+ * Builds an attribute spec tuple for ProseMirror schema from an extension attribute.
+ * @param extensionAttribute The extension attribute to build the spec for
+ * @returns A tuple of [attributeName, spec]
+ */
+function buildAttributeSpec(
+  extensionAttribute: ReturnType<typeof getAttributesFromExtensions>[number],
+): [string, Record<string, any>] {
+  const spec: Record<string, any> = {}
+
+  // Only include 'default' if the attribute is not required and default is defined
+  if (!extensionAttribute?.attribute?.isRequired && extensionAttribute?.attribute?.default !== undefined) {
+    spec.default = extensionAttribute.attribute.default
+  }
+
+  // Only include 'validate' if it's defined
+  if (extensionAttribute?.attribute?.validate !== undefined) {
+    spec.validate = extensionAttribute.attribute.validate
+  }
+
+  return [extensionAttribute.name, spec]
+}
+
+/**
  * Creates a new Prosemirror schema based on the given extensions.
  * @param extensions An array of Tiptap extensions
  * @param editor The editor instance
@@ -70,23 +93,7 @@ export function getSchemaByResolvedExtensions(extensions: Extensions, editor?: E
         ),
         defining: callOrReturn(getExtensionField<NodeConfig['defining']>(extension, 'defining', context)),
         isolating: callOrReturn(getExtensionField<NodeConfig['isolating']>(extension, 'isolating', context)),
-        attrs: Object.fromEntries(
-          extensionAttributes.map(extensionAttribute => {
-            const spec: Record<string, any> = {}
-
-            // Only include 'default' if the attribute is not required and default is defined
-            if (!extensionAttribute?.attribute?.isRequired && extensionAttribute?.attribute?.default !== undefined) {
-              spec.default = extensionAttribute.attribute.default
-            }
-
-            // Only include 'validate' if it's defined
-            if (extensionAttribute?.attribute?.validate !== undefined) {
-              spec.validate = extensionAttribute.attribute.validate
-            }
-
-            return [extensionAttribute.name, spec]
-          }),
-        ),
+        attrs: Object.fromEntries(extensionAttributes.map(buildAttributeSpec)),
       })
 
       const parseHTML = callOrReturn(getExtensionField<NodeConfig['parseHTML']>(extension, 'parseHTML', context))
@@ -143,23 +150,7 @@ export function getSchemaByResolvedExtensions(extensions: Extensions, editor?: E
         group: callOrReturn(getExtensionField<MarkConfig['group']>(extension, 'group', context)),
         spanning: callOrReturn(getExtensionField<MarkConfig['spanning']>(extension, 'spanning', context)),
         code: callOrReturn(getExtensionField<MarkConfig['code']>(extension, 'code', context)),
-        attrs: Object.fromEntries(
-          extensionAttributes.map(extensionAttribute => {
-            const spec: Record<string, any> = {}
-
-            // Only include 'default' if the attribute is not required and default is defined
-            if (!extensionAttribute?.attribute?.isRequired && extensionAttribute?.attribute?.default !== undefined) {
-              spec.default = extensionAttribute.attribute.default
-            }
-
-            // Only include 'validate' if it's defined
-            if (extensionAttribute?.attribute?.validate !== undefined) {
-              spec.validate = extensionAttribute.attribute.validate
-            }
-
-            return [extensionAttribute.name, spec]
-          }),
-        ),
+        attrs: Object.fromEntries(extensionAttributes.map(buildAttributeSpec)),
       })
 
       const parseHTML = callOrReturn(getExtensionField<MarkConfig['parseHTML']>(extension, 'parseHTML', context))

--- a/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
+++ b/packages/core/src/helpers/getSchemaByResolvedExtensions.ts
@@ -72,10 +72,19 @@ export function getSchemaByResolvedExtensions(extensions: Extensions, editor?: E
         isolating: callOrReturn(getExtensionField<NodeConfig['isolating']>(extension, 'isolating', context)),
         attrs: Object.fromEntries(
           extensionAttributes.map(extensionAttribute => {
-            return [
-              extensionAttribute.name,
-              { default: extensionAttribute?.attribute?.default, validate: extensionAttribute?.attribute?.validate },
-            ]
+            const spec: Record<string, any> = {}
+
+            // Only include 'default' if the attribute is not required and default is defined
+            if (!extensionAttribute?.attribute?.isRequired && extensionAttribute?.attribute?.default !== undefined) {
+              spec.default = extensionAttribute.attribute.default
+            }
+
+            // Only include 'validate' if it's defined
+            if (extensionAttribute?.attribute?.validate !== undefined) {
+              spec.validate = extensionAttribute.attribute.validate
+            }
+
+            return [extensionAttribute.name, spec]
           }),
         ),
       })
@@ -136,10 +145,19 @@ export function getSchemaByResolvedExtensions(extensions: Extensions, editor?: E
         code: callOrReturn(getExtensionField<MarkConfig['code']>(extension, 'code', context)),
         attrs: Object.fromEntries(
           extensionAttributes.map(extensionAttribute => {
-            return [
-              extensionAttribute.name,
-              { default: extensionAttribute?.attribute?.default, validate: extensionAttribute?.attribute?.validate },
-            ]
+            const spec: Record<string, any> = {}
+
+            // Only include 'default' if the attribute is not required and default is defined
+            if (!extensionAttribute?.attribute?.isRequired && extensionAttribute?.attribute?.default !== undefined) {
+              spec.default = extensionAttribute.attribute.default
+            }
+
+            // Only include 'validate' if it's defined
+            if (extensionAttribute?.attribute?.validate !== undefined) {
+              spec.validate = extensionAttribute.attribute.validate
+            }
+
+            return [extensionAttribute.name, spec]
           }),
         ),
       })

--- a/tests/cypress/integration/core/requiredAttributes.spec.ts
+++ b/tests/cypress/integration/core/requiredAttributes.spec.ts
@@ -1,0 +1,175 @@
+/// <reference types="cypress" />
+
+import { Editor, Mark, Node } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+
+describe('Required Attributes', () => {
+  it('should mark node attributes as required when isRequired is true and no default is set', () => {
+    const CustomNode = Node.create({
+      name: 'customNode',
+      addAttributes() {
+        return {
+          requiredAttr: {
+            isRequired: true,
+            // No default value specified
+          },
+          optionalAttr: {
+            default: null,
+          },
+        }
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, CustomNode],
+    })
+
+    const schema = editor.schema
+    const nodeType = schema.nodes.customNode
+
+    // Check that the required attribute does not have a default
+    expect(nodeType.spec.attrs?.requiredAttr).to.not.equal(undefined)
+    expect(nodeType.spec.attrs?.requiredAttr).to.not.have.property('default')
+
+    // Check that the optional attribute has a default
+    expect(nodeType.spec.attrs?.optionalAttr).to.not.equal(undefined)
+    expect(nodeType.spec.attrs?.optionalAttr).to.have.property('default')
+
+    editor.destroy()
+  })
+
+  it('should mark mark attributes as required when isRequired is true and no default is set', () => {
+    const CustomMark = Mark.create({
+      name: 'customMark',
+      addAttributes() {
+        return {
+          requiredAttr: {
+            isRequired: true,
+            // No default value specified
+          },
+          optionalAttr: {
+            default: 'test',
+          },
+        }
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, CustomMark],
+    })
+
+    const schema = editor.schema
+    const markType = schema.marks.customMark
+
+    // Check that the required attribute does not have a default
+    expect(markType?.spec.attrs?.requiredAttr).to.not.equal(undefined)
+    expect(markType?.spec.attrs?.requiredAttr).to.not.have.property('default')
+
+    // Check that the optional attribute has a default
+    expect(markType?.spec.attrs?.optionalAttr).to.not.equal(undefined)
+    expect(markType?.spec.attrs?.optionalAttr).to.have.property('default')
+    expect(markType?.spec.attrs?.optionalAttr.default).to.equal('test')
+
+    editor.destroy()
+  })
+
+  it('should not mark attributes as required when they have an explicit default value', () => {
+    const CustomNode = Node.create({
+      name: 'customNode',
+      addAttributes() {
+        return {
+          attrWithNull: {
+            default: null,
+          },
+          attrWithValue: {
+            default: 'defaultValue',
+          },
+          attrWithZero: {
+            default: 0,
+          },
+          attrWithFalse: {
+            default: false,
+          },
+        }
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, CustomNode],
+    })
+
+    const schema = editor.schema
+    const nodeType = schema.nodes.customNode
+
+    // All attributes should have a default property
+    expect(nodeType.spec.attrs?.attrWithNull).to.have.property('default', null)
+    expect(nodeType.spec.attrs?.attrWithValue).to.have.property('default', 'defaultValue')
+    expect(nodeType.spec.attrs?.attrWithZero).to.have.property('default', 0)
+    expect(nodeType.spec.attrs?.attrWithFalse).to.have.property('default', false)
+
+    editor.destroy()
+  })
+
+  it('should only include validate property when it is defined', () => {
+    const CustomNode = Node.create({
+      name: 'customNode',
+      addAttributes() {
+        return {
+          validatedAttr: {
+            default: null,
+            validate: (value: any) => typeof value === 'string',
+          },
+          nonValidatedAttr: {
+            default: null,
+          },
+        }
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, CustomNode],
+    })
+
+    const schema = editor.schema
+    const nodeType = schema.nodes.customNode
+
+    // Check that the validated attribute has a validate property
+    expect(nodeType.spec.attrs?.validatedAttr).to.have.property('validate')
+    expect(nodeType.spec.attrs?.validatedAttr.validate).to.be.a('function')
+
+    // Check that the non-validated attribute does not have a validate property
+    expect(nodeType.spec.attrs?.nonValidatedAttr).to.not.have.property('validate')
+
+    editor.destroy()
+  })
+
+  it('should handle attributes with isRequired and validate together', () => {
+    const CustomNode = Node.create({
+      name: 'customNode',
+      addAttributes() {
+        return {
+          strictAttr: {
+            isRequired: true,
+            validate: (value: any) => value !== null,
+          },
+        }
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, CustomNode],
+    })
+
+    const schema = editor.schema
+    const nodeType = schema.nodes.customNode
+
+    // Check that the attribute is required (no default) but has validation
+    expect(nodeType.spec.attrs?.strictAttr).to.not.equal(undefined)
+    expect(nodeType.spec.attrs?.strictAttr).to.not.have.property('default')
+    expect(nodeType.spec.attrs?.strictAttr).to.have.property('validate')
+
+    editor.destroy()
+  })
+})


### PR DESCRIPTION
Fixes #6952

When building the ProseMirror schema from Tiptap extensions, the code was always including a 'default' property in attribute specs, even when attributes were marked as required (isRequired: true). This caused ProseMirror to treat all attributes as optional, since ProseMirror determines if an attribute is required by checking for the absence of the 'default' property using hasOwnProperty.

Changes:
- Modified getSchemaByResolvedExtensions.ts to only include the 'default' property when the attribute is not marked as required AND a default value is defined
- Applied fix to both Node and Mark attribute processing
- Added comprehensive tests for required attribute functionality