### PR TITLE
fix: update y-tiptap to stable v3.0.0 to resolve emoji collaboration issues

### DIFF
--- a/.changeset/fix-emoji-collaboration-surrogate-pairs--swift-phoenix.md
+++ b/.changeset/fix-emoji-collaboration-surrogate-pairs--swift-phoenix.md
@@ -4,4 +4,4 @@
 '@tiptap/extension-drag-handle': patch
 ---
 
-Fixed collaborative editing issues with certain emoji combinations by updating `@tiptap/y-tiptap` from beta to stable v3.0.0. Previously, specific emoji pairs (like 🔴🟢, 😎🐈, 🟣🔵) caused `URIError: URI malformed` errors that would break Y.js synchronization. This was due to improper handling of UTF-16 surrogate pairs in the underlying lib0 library. The stable release includes lib0 v0.2.100+ which correctly handles surrogate pairs, preventing them from being split during collaborative text operations.
+Fixed collaborative editing errors with certain emoji combinations (like 🔴🟢, 😎🐈, 🟣🔵) by updating `@tiptap/y-tiptap` to stable v3.0.0.

--- a/.changeset/fix-emoji-collaboration-surrogate-pairs--swift-phoenix.md
+++ b/.changeset/fix-emoji-collaboration-surrogate-pairs--swift-phoenix.md
@@ -1,0 +1,7 @@
+---
+'@tiptap/extension-collaboration': patch
+'@tiptap/extension-collaboration-caret': patch
+'@tiptap/extension-drag-handle': patch
+---
+
+Fixed collaborative editing issues with certain emoji combinations by updating `@tiptap/y-tiptap` from beta to stable v3.0.0. Previously, specific emoji pairs (like 🔴🟢, 😎🐈, 🟣🔵) caused `URIError: URI malformed` errors that would break Y.js synchronization. This was due to improper handling of UTF-16 surrogate pairs in the underlying lib0 library. The stable release includes lib0 v0.2.100+ which correctly handles surrogate pairs, preventing them from being split during collaborative text operations.

--- a/packages/extension-collaboration-caret/package.json
+++ b/packages/extension-collaboration-caret/package.json
@@ -33,12 +33,12 @@
   "devDependencies": {
     "@tiptap/core": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.0-beta.3"
+    "@tiptap/y-tiptap": "^3.0.0"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.0-beta.3"
+    "@tiptap/y-tiptap": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -33,12 +33,12 @@
   "devDependencies": {
     "@tiptap/core": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.0-beta.3"
+    "@tiptap/y-tiptap": "^3.0.0"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.0-beta.3",
+    "@tiptap/y-tiptap": "^3.0.0",
     "yjs": "^13"
   },
   "repository": {

--- a/packages/extension-drag-handle/package.json
+++ b/packages/extension-drag-handle/package.json
@@ -40,7 +40,7 @@
     "@tiptap/core": "workspace:^",
     "@tiptap/extension-collaboration": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.0-beta.3"
+    "@tiptap/y-tiptap": "^3.0.0"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.6.13"
@@ -51,7 +51,7 @@
     "@tiptap/core": "workspace:^",
     "@tiptap/extension-collaboration": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.0-beta.3"
+    "@tiptap/y-tiptap": "^3.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,8 +474,8 @@ importers:
         specifier: workspace:^
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^3.0.0-beta.3
-        version: 3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.0
+        version: 3.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-collaboration-caret:
     devDependencies:
@@ -486,8 +486,8 @@ importers:
         specifier: workspace:^
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^3.0.0-beta.3
-        version: 3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.0
+        version: 3.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-color:
     devDependencies:
@@ -532,8 +532,8 @@ importers:
         specifier: workspace:^
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^3.0.0-beta.3
-        version: 3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.0
+        version: 3.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-drag-handle-react:
     devDependencies:
@@ -3079,16 +3079,6 @@ packages:
 
   '@tiptap/y-tiptap@3.0.0':
     resolution: {integrity: sha512-HIeJZCj+KYJde2x6fONzo4o6kd7gW7eonwhQsv2p2VQnUgwNXMVhN+D6Z3AH/2i541Sq33y1PO4U/1ThCPjqbA==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
-    peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
-      y-protocols: ^1.0.1
-      yjs: ^13.5.38
-
-  '@tiptap/y-tiptap@3.0.0-beta.3':
-    resolution: {integrity: sha512-1U/MTG7mpkc2VEIRzVueXqpHpawflF0DUuqkPwTezmBst6HPZ+NnZuDbJGay8dh//KSXcrS1Vtu1Wqa2Z/1HTw==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
       prosemirror-model: ^1.7.1
@@ -9218,15 +9208,6 @@ snapshots:
       '@tiptap/pm': 2.14.0
 
   '@tiptap/y-tiptap@3.0.0(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
-    dependencies:
-      lib0: 0.2.104
-      prosemirror-model: 1.24.1
-      prosemirror-state: 1.4.3
-      prosemirror-view: 1.38.1
-      y-protocols: 1.0.6(yjs@13.6.23)
-      yjs: 13.6.23
-
-  '@tiptap/y-tiptap@3.0.0-beta.3(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.38.1)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
     dependencies:
       lib0: 0.2.104
       prosemirror-model: 1.24.1


### PR DESCRIPTION
Updated @tiptap/y-tiptap from beta.3 to stable v3.0.0 in collaboration-related packages to fix URIError issues with certain emoji combinations (🔴🟢, 😎🐈, 🟣🔵).

The stable release includes lib0 v0.2.100+ which properly handles UTF-16 surrogate pairs, preventing them from being split during collaborative text operations.

Affected packages:
- @tiptap/extension-collaboration
- @tiptap/extension-collaboration-caret
- @tiptap/extension-drag-handle

Fixes #3020 