### PR TITLE
fix: prevent infinite loop between UniqueID and TrailingNode extensions

### DIFF
--- a/.changeset/fix-unique-id-trailing-node-infinite-loop.md
+++ b/.changeset/fix-unique-id-trailing-node-infinite-loop.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-unique-id': patch
+'@tiptap/extension-trailing-node': patch
+---
+
+Fixed infinite transaction loop that caused browser tabs to freeze when using UniqueID and TrailingNode extensions together.

--- a/packages/extension-unique-id/src/unique-id.ts
+++ b/packages/extension-unique-id/src/unique-id.ts
@@ -243,8 +243,12 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
           }
 
           // `tr.setNodeMarkup` resets the stored marks
-          // so we’ll restore them if they exist
+          // so we'll restore them if they exist
           tr.setStoredMarks(newState.tr.storedMarks)
+
+          // Mark this transaction as coming from UniqueID
+          // to prevent infinite loops with other extensions (e.g., TrailingNode)
+          tr.setMeta('__uniqueIDTransaction', true)
 
           return tr
         },

--- a/packages/extensions/src/trailing-node/trailing-node.ts
+++ b/packages/extensions/src/trailing-node/trailing-node.ts
@@ -76,6 +76,12 @@ export const TrailingNode = Extension.create<TrailingNodeOptions>({
               return value
             }
 
+            // Ignore transactions from UniqueID extension to prevent infinite loops
+            // when UniqueID adds IDs to newly inserted trailing nodes
+            if (tr.getMeta('__uniqueIDTransaction')) {
+              return value
+            }
+
             const lastNode = tr.doc.lastChild
 
             return !nodeEqualsType({ node: lastNode, types: disabledNodes })


### PR DESCRIPTION
This resolves an issue where using UniqueID and TrailingNode extensions together caused an infinite transaction loop, freezing browser tabs.

The problem occurred because:
1. TrailingNode would insert a trailing node
2. UniqueID would add an ID to that node via setNodeMarkup
3. TrailingNode would see the document change and re-evaluate
4. This triggered another insertion, creating an infinite loop

The fix introduces a transaction metadata flag (__uniqueIDTransaction) that UniqueID sets on its transactions. TrailingNode now checks for this flag and skips re-evaluation for UniqueID transactions, breaking the loop while preserving correct behavior for both extensions.

Fixes #6870