### PR TITLE
fix: resolve YouTube extension blocking subsequent content in SR

### DIFF
--- a/.changeset/fix-youtube-rendering-stops-sunny-ocean-breeze.md
+++ b/.changeset/fix-youtube-rendering-stops-sunny-ocean-breeze.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-youtube': patch
+---
+
+Fix static HTML renderer not rendering content after YouTube embeds.

--- a/packages/extension-youtube/src/youtube.ts
+++ b/packages/extension-youtube/src/youtube.ts
@@ -331,6 +331,7 @@ export const Youtube = Node.create<YoutubeOptions>({
           },
           HTMLAttributes,
         ),
+        0,
       ],
     ]
   },

--- a/tests/cypress/integration/static-renderer/json-string.spec.ts
+++ b/tests/cypress/integration/static-renderer/json-string.spec.ts
@@ -5,6 +5,7 @@ import Bold from '@tiptap/extension-bold'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
+import Youtube from '@tiptap/extension-youtube'
 import { Mark, Node } from '@tiptap/pm/model'
 import { renderJSONContentToString, serializeChildrenToHTMLString } from '@tiptap/static-renderer/json/html-string'
 import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
@@ -292,5 +293,36 @@ describe('static render json to string (with prosemirror)', () => {
     })
 
     expect(html).to.eq('<doc><p><b>Example Text</b></p></doc>')
+  })
+
+  it('renders youtube extension followed by other nodes correctly', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'youtube',
+          attrs: {
+            src: 'https://www.youtube.com/watch?v=3lTUAWOgoHs',
+          },
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'text after youtube',
+            },
+          ],
+        },
+      ],
+    }
+
+    const html = renderToHTMLString({
+      content: json,
+      extensions: [Document, Paragraph, Text, Youtube],
+    })
+
+    expect(html).to.include('data-youtube-video')
+    expect(html).to.include('<p>text after youtube</p>')
   })
 })


### PR DESCRIPTION
## Changes Overview

  Fixed the YouTube extension preventing content after it from being rendered when using the static HTML renderer.

  ## Implementation Approach

  Added a hole marker to the iframe element in the YouTube extension's `renderHTML` method. This ensures the HTML
  serializer correctly processes all subsequent nodes in the document.

  ## Testing Done

  - Added a cypress test in `tests/cypress/integration/static-renderer/json-string.spec.ts` that verifies YouTube embeds
   followed by other content render correctly
  - All 7 tests in the static renderer test suite pass
  - Verified the fix with `renderToHTMLString` including YouTube extension and subsequent paragraph nodes

  ## Verification Steps

  1. Build the project: `pnpm build`
  2. Run the test: `pnpm exec cypress run --spec "tests/cypress/integration/static-renderer/json-string.spec.ts"
  --project tests`
  3. Verify the new test "renders youtube extension followed by other nodes correctly" passes
  4. Or manually test using `renderToHTMLString` with a document containing a YouTube embed followed by other content

  ## Additional Notes

  None.

  ## Checklist

  - [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
  - [x] My changes do not break the library.
  - [x] I have added tests where applicable.
  - [x] I have followed the project guidelines.
  - [x] I have fixed any lint issues.

  ## Related Issues

  Closes #6971