### PR TITLE
feat: hide resize handles when editor is not editable

### DIFF
--- a/.changeset/quick-items-bathe.md
+++ b/.changeset/quick-items-bathe.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extension-image': minor
+'@tiptap/core': minor
+---
+
+dd dynamic resize handle visibility based on editor editable state. Resize handles are now automatically hidden when the editor is in read-only mode and shown when editable, improving UX by preventing confusing interactions and providing clear visual feedback.

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -144,18 +144,13 @@ export const Image = Node.create<ImageOptions>({
   },
 
   addNodeView() {
-    if (
-      !this.options.resize ||
-      !this.options.resize.enabled ||
-      typeof document === 'undefined' ||
-      !this.editor.isEditable
-    ) {
+    if (!this.options.resize || !this.options.resize.enabled || typeof document === 'undefined') {
       return null
     }
 
     const { directions, minWidth, minHeight, alwaysPreserveAspectRatio } = this.options.resize
 
-    return ({ node, getPos, HTMLAttributes }) => {
+    return ({ node, getPos, HTMLAttributes, editor }) => {
       const el = document.createElement('img')
 
       Object.entries(HTMLAttributes).forEach(([key, value]) => {
@@ -175,6 +170,7 @@ export const Image = Node.create<ImageOptions>({
 
       const nodeView = new ResizableNodeView({
         element: el,
+        editor,
         node,
         getPos,
         onResize: (width, height) => {


### PR DESCRIPTION
## Changes Overview

Adds dynamic resize handle visibility based on editor editable state. Resize handles are now automatically hidden when the editor is in read-only mode and shown when editable.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#7218 