### PR TITLE
Improve Tiptap JSON Type Documentation

### DIFF
--- a/.changeset/eleven-brooms-jog.md
+++ b/.changeset/eleven-brooms-jog.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Add documentation comments to Tiptap JSON types

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -450,6 +450,29 @@ export type HTMLContent = string
  * `doc`. Nodes can have other nodes as children. Nodes can also have marks and
  * attributes. Text nodes (nodes with type `text`) have a `text` property and no
  * children.
+ *
+ * @example
+ * ```ts
+ * const content: JSONContent = {
+ *   type: 'doc',
+ *   content: [
+ *     {
+ *       type: 'paragraph',
+ *       content: [
+ *         {
+ *           type: 'text',
+ *           text: 'Hello ',
+ *         },
+ *         {
+ *           type: 'text',
+ *           text: 'world',
+ *           marks: [{ type: 'bold' }],
+ *         },
+ *       ],
+ *     },
+ *   ],
+ * }
+ * ```
  */
 export type JSONContent = {
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -442,17 +442,48 @@ export interface EditorOptions {
 export type HTMLContent = string
 
 /**
- * Loosely describes a JSON representation of a Prosemirror document or node
+ * A Tiptap JSON node or document. Tiptap JSON is the standard format for
+ * storing and manipulating Tiptap content. It is equivalent to the JSON
+ * representation of a Prosemirror node.
+ *
+ * Tiptap JSON documents are trees of nodes. The root node is usually of type
+ * `doc`. Nodes can have other nodes as children. Nodes can also have marks and
+ * attributes. Text nodes (nodes with type `text`) have a `text` property and no
+ * children.
  */
 export type JSONContent = {
+  /**
+   * The type of the node
+   */
   type?: string
+  /**
+   * The attributes of the node. Attributes can have any JSON-serializable value.
+   */
   attrs?: Record<string, any> | undefined
+  /**
+   * The children of the node. A node can have other nodes as children.
+   */
   content?: JSONContent[]
+  /**
+   * A list of marks of the node. Inline nodes can have marks.
+   */
   marks?: {
+    /**
+     * The type of the mark
+     */
     type: string
+    /**
+     * The attributes of the mark. Attributes can have any JSON-serializable value.
+     */
     attrs?: Record<string, any>
     [key: string]: any
   }[]
+  /**
+   * The text content of the node. This property is only present on text nodes
+   * (i.e. nodes with `type: 'text'`).
+   *
+   * Text nodes cannot have children, but they can have marks.
+   */
   text?: string
   [key: string]: any
 }


### PR DESCRIPTION
## Changes Overview

This PR enhances the documentation for the `JSONContent` type in `packages/core/src/types.ts`. The changes add comprehensive JSDoc comments that explain the structure and usage of Tiptap JSON, making it easier for developers to understand and work with the JSON representation of Tiptap documents.

The improvements include:
- Enhanced main type description explaining what Tiptap JSON is and how it relates to Prosemirror
- Detailed property-level documentation for `type`, `attrs`, `content`, `marks`, and `text`
- Nested documentation for mark properties (`type` and `attrs`)
- Clarification about text nodes and their constraints

## Implementation Approach

The changes were implemented by adding JSDoc comments directly to the `JSONContent` type definition. Each property now has inline documentation that explains:
- What the property represents
- When it's used (e.g., `text` is only on text nodes)
- The structure and constraints (e.g., text nodes cannot have children)

The documentation follows TypeScript JSDoc conventions and provides clear, concise explanations that will appear in IDE tooltips and generated documentation.

## Testing Done

- Verified that the TypeScript types compile without errors
- Confirmed that the JSDoc comments appear correctly in IDE tooltips
- Checked that existing code using `JSONContent` continues to work as expected

## Verification Steps

1. Open `packages/core/src/types.ts` and navigate to the `JSONContent` type (around line 454)
2. Hover over the `JSONContent` type name in your IDE to see the enhanced documentation
3. Hover over individual properties (`type`, `attrs`, `content`, `marks`, `text`) to see their documentation
4. Verify that TypeScript compilation succeeds: `pnpm build` or `pnpm typecheck`

## Additional Notes

These documentation improvements make the Tiptap JSON type system more accessible to developers, especially those new to Tiptap or Prosemirror. The enhanced type information will help with:
- Better IDE autocomplete and IntelliSense
- Clearer understanding of the JSON structure when working with Tiptap content
- Reduced need to reference external documentation for basic type information

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->

