### PR TITLE
fix: trim text from end when character limit exceeded

### DIFF
--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -133,21 +133,17 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
                 } else {
                   const remainingChars = limit - charCount
                   let charIndex = 0
-                  let currentCharCount = 0
 
                   for (let i = 0; i < nodeText.length; i++) {
                     const substring = nodeText.slice(0, i + 1)
                     const substringCharCount = this.options.textCounter(substring)
-                    
                     if (substringCharCount > remainingChars) {
                       break
                     }
-                    
                     charIndex = i + 1
-                    currentCharCount = substringCharCount
                   }
 
-                  limitPosition = pos + 1 + charIndex
+                  limitPosition = pos + charIndex
                   return false
                 }
               }

--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -119,14 +119,44 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
           const initialContentSize = this.storage.characters({ node: newState.doc })
 
           if (initialContentSize > limit) {
-            const over = initialContentSize - limit
-            const from = 0
-            const to = over
+            const doc = newState.doc
+            let charCount = 0
+            let limitPosition = doc.content.size
+
+            doc.nodesBetween(0, doc.content.size, (node, pos) => {
+              if (node.isText) {
+                const nodeText = node.text || ''
+                const nodeCharCount = this.options.textCounter(nodeText)
+
+                if (charCount + nodeCharCount <= limit) {
+                  charCount += nodeCharCount
+                } else {
+                  const remainingChars = limit - charCount
+                  let charIndex = 0
+                  let currentCharCount = 0
+
+                  for (let i = 0; i < nodeText.length; i++) {
+                    const substring = nodeText.slice(0, i + 1)
+                    const substringCharCount = this.options.textCounter(substring)
+                    
+                    if (substringCharCount > remainingChars) {
+                      break
+                    }
+                    
+                    charIndex = i + 1
+                    currentCharCount = substringCharCount
+                  }
+
+                  limitPosition = pos + 1 + charIndex
+                  return false
+                }
+              }
+            })
 
             console.warn(
               `[CharacterCount] Initial content exceeded limit of ${limit} characters. Content was automatically trimmed.`,
             )
-            const tr = newState.tr.deleteRange(from, to)
+            const tr = newState.tr.deleteRange(limitPosition, doc.content.size)
 
             initialEvaluationDone = true
             return tr

--- a/tests/cypress/integration/extensions/character-count.spec.ts
+++ b/tests/cypress/integration/extensions/character-count.spec.ts
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { CharacterCount } from '@tiptap/extensions'
+
+describe('CharacterCount initial trim', () => {
+  const limit = 100
+
+  it('trims from the end when initial content exceeds limit', () => {
+    const longText =
+      "Let's make sure people can't write more than 100 characters. I bet you could build one of the biggest social networks on that idea."
+    const editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        CharacterCount.configure({ limit }),
+      ],
+      content: `<p>${longText}</p>`,
+    })
+
+    const text = editor.getText()
+    const count = editor.storage.characterCount.characters()
+
+    expect(count).to.be.at.most(limit)
+    expect(text.startsWith("Let's make sure people can't write more than 100 characters.")).to.be
+      .true
+    expect(text).not.to.include('one of the biggest social networks on that idea.')
+
+    editor.destroy()
+  })
+
+  it('keeps content under limit unchanged', () => {
+    const shortText = 'Hello world'
+    const editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        CharacterCount.configure({ limit }),
+      ],
+      content: `<p>${shortText}</p>`,
+    })
+
+    expect(editor.getText()).to.eq(shortText)
+    expect(editor.storage.characterCount.characters()).to.eq(shortText.length)
+
+    editor.destroy()
+  })
+
+  it('respects limit exactly when content equals limit', () => {
+    const exactText = 'a'.repeat(limit)
+    const editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        CharacterCount.configure({ limit }),
+      ],
+      content: `<p>${exactText}</p>`,
+    })
+
+    expect(editor.storage.characterCount.characters()).to.eq(limit)
+    expect(editor.getText().length).to.eq(limit)
+
+    editor.destroy()
+  })
+})


### PR DESCRIPTION
fix: #7254 

### Changes Overview

- Fixed character count extension to trim from the end instead of the beginning when initial content exceeds the limit.

### Implementation Approach

- Updated the trimming logic to find the position where the limit is reached and delete from that position to the end, preserving the beginning text.