### PR TITLE
feat(drag-handle): add data-dragging attribute to track drag state

### DIFF
--- a/.changeset/add-data-dragging-attribute--swift-fox.md
+++ b/.changeset/add-data-dragging-attribute--swift-fox.md
@@ -1,0 +1,8 @@
+---
+"@tiptap/extension-drag-handle": patch
+"@tiptap/extension-drag-handle-react": patch
+"@tiptap/extension-drag-handle-vue-2": patch
+"@tiptap/extension-drag-handle-vue-3": patch
+---
+
+Added `data-dragging` attribute to drag handle elements to track drag state.

--- a/packages/extension-drag-handle-react/src/DragHandle.tsx
+++ b/packages/extension-drag-handle-react/src/DragHandle.tsx
@@ -78,7 +78,12 @@ export const DragHandle = (props: DragHandleProps) => {
   }, [element, editor, onNodeChange, pluginKey, computePositionConfig, onElementDragStart, onElementDragEnd])
 
   return (
-    <div className={className} style={{ visibility: 'hidden', position: 'absolute' }} ref={setElement}>
+    <div
+      className={className}
+      style={{ visibility: 'hidden', position: 'absolute' }}
+      data-dragging="false"
+      ref={setElement}
+    >
       {children}
     </div>
   )

--- a/packages/extension-drag-handle-vue-2/src/DragHandle.ts
+++ b/packages/extension-drag-handle-vue-2/src/DragHandle.ts
@@ -84,6 +84,9 @@ export const DragHandle = Vue.extend({
       'div',
       {
         class: this.class,
+        attrs: {
+          'data-dragging': 'false',
+        },
       },
       this.$slots.default,
     )

--- a/packages/extension-drag-handle-vue-3/src/DragHandle.ts
+++ b/packages/extension-drag-handle-vue-3/src/DragHandle.ts
@@ -107,6 +107,7 @@ export const DragHandle = defineComponent({
           ref: root,
           class: props.class,
           style: { visibility: 'hidden', position: 'absolute' },
+          'data-dragging': 'false',
         },
         slots.default?.(),
       )

--- a/packages/extension-drag-handle/__tests__/drag-handle.spec.ts
+++ b/packages/extension-drag-handle/__tests__/drag-handle.spec.ts
@@ -1,0 +1,106 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { DragHandle } from '../src/drag-handle.js'
+
+describe('DragHandle', () => {
+  let editor: Editor
+  let dragHandleElement: HTMLElement
+
+  beforeEach(() => {
+    dragHandleElement = document.createElement('div')
+    dragHandleElement.classList.add('drag-handle')
+
+    editor = new Editor({
+      element: document.body,
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        DragHandle.configure({
+          render: () => dragHandleElement,
+        }),
+      ],
+      content: '<p>Hello World</p>',
+    })
+  })
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  describe('data-dragging attribute', () => {
+    it('should initialize data-dragging attribute to false', () => {
+      expect(dragHandleElement.dataset.dragging).toBe('false')
+    })
+
+    it('should set data-dragging to true on dragstart', () => {
+      const dragStartEvent = new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      })
+
+      dragHandleElement.dispatchEvent(dragStartEvent)
+
+      expect(dragHandleElement.dataset.dragging).toBe('true')
+    })
+
+    it('should set data-dragging to false on dragend', () => {
+      const dragStartEvent = new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      })
+
+      dragHandleElement.dispatchEvent(dragStartEvent)
+
+      expect(dragHandleElement.dataset.dragging).toBe('true')
+
+      const dragEndEvent = new DragEvent('dragend', {
+        bubbles: true,
+        cancelable: true,
+      })
+
+      dragHandleElement.dispatchEvent(dragEndEvent)
+
+      expect(dragHandleElement.dataset.dragging).toBe('false')
+    })
+
+    it('should maintain data-dragging state through multiple drag cycles', () => {
+      const dataTransfer = new DataTransfer()
+
+      for (let i = 0; i < 3; i += 1) {
+        const dragStartEvent = new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        })
+
+        dragHandleElement.dispatchEvent(dragStartEvent)
+        expect(dragHandleElement.dataset.dragging).toBe('true')
+
+        const dragEndEvent = new DragEvent('dragend', {
+          bubbles: true,
+          cancelable: true,
+        })
+
+        dragHandleElement.dispatchEvent(dragEndEvent)
+        expect(dragHandleElement.dataset.dragging).toBe('false')
+      }
+    })
+  })
+
+  describe('element properties', () => {
+    it('should have draggable set to true', () => {
+      expect(dragHandleElement.draggable).toBe(true)
+    })
+
+    it('should have pointer events set to auto initially', () => {
+      expect(dragHandleElement.style.pointerEvents).toBe('auto')
+    })
+  })
+})

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -131,6 +131,10 @@ export const DragHandlePlugin = ({
     // @ts-ignore
     dragHandler(e, editor)
 
+    if (element) {
+      element.dataset.dragging = 'true'
+    }
+
     setTimeout(() => {
       if (element) {
         element.style.pointerEvents = 'none'
@@ -143,6 +147,7 @@ export const DragHandlePlugin = ({
     hideHandle()
     if (element) {
       element.style.pointerEvents = 'auto'
+      element.dataset.dragging = 'false'
     }
   }
 
@@ -228,6 +233,7 @@ export const DragHandlePlugin = ({
       view: view => {
         element.draggable = true
         element.style.pointerEvents = 'auto'
+        element.dataset.dragging = 'false'
 
         editor.view.dom.parentElement?.appendChild(wrapper)
 


### PR DESCRIPTION
## Changes Overview

Added a `data-dragging` attribute to drag handle elements across React, Vue 2, and Vue 3 components to track the drag state. The attribute is set to `"true"` during drag operations and `"false"` otherwise, enabling CSS styling and JavaScript interactions based on drag state.

## Implementation Approach

- Updated the drag handle plugin to manage the `data-dragging` attribute on `dragstart` and `dragend` events.
- Initialized the attribute to `"false"` in the view setup and component renders.
- Ensured consistency across framework bindings (React, Vue 2, Vue 3) by adding the attribute to the root elements.

## Testing Done

Added unit tests in `packages/extension-drag-handle/__tests__/drag-handle.spec.ts` covering:
- Initial attribute value.
- State changes on dragstart and dragend.
- Multiple drag cycles.
- Element properties (draggable, pointer events).

## Verification Steps

1. Install the updated packages and create an editor with a drag handle.
2. Inspect the drag handle element in the DOM; it should have `data-dragging="false"` initially.
3. Start a drag operation; the attribute should change to `"true"`.
4. End the drag; it should revert to `"false"`.
5. Verify CSS selectors like `[data-dragging="true"]` work for styling during drags.

## Additional Notes

This feature allows users to style drag handles differently during drag operations (e.g., visual feedback) without additional JavaScript hooks.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.