### PR TITLE
Prevent Vue 2 EditorContent components from destroying in-use Editors

### DIFF
--- a/packages/vue-2/src/EditorContent.ts
+++ b/packages/vue-2/src/EditorContent.ts
@@ -50,7 +50,7 @@ export const EditorContent: Component = {
   beforeDestroy(this: EditorContentInterface) {
     const { editor } = this
 
-    if (!editor) {
+    if (!editor || editor.contentComponent !== this) {
       return
     }
 


### PR DESCRIPTION
## Changes Overview

Without checking if this EditorContent instance is currently assigned to the `contentComponent` property, it's possible for the EditorContent instance to destroy an Editor that is in use by another EditorContent instance.  Before destroying the editor's view, it should make sure that it is the last EditorContent to use the editor.

## Implementation Approach

It's just a single line change in a destruction function.

## Testing Done

I've tested the change myself and it seems to be fine.  In my case, I have a text editor that I want to quickly move from one component to another.  Without this, the first component ends up destroying the text editor after it's already been put to use by the second component.  With this, the second component is allowed to take the Editor from the first component without the second component destroying it on them.

## Verification Steps

- [ ] Do EditorContent component instances still destroy the views for Editor instances that have **not** been initialized by other EditorContent component instances?
- [ ] Do EditorContent component instances not destroy the views of Editor instances that have been initialized by other EditorContent component instances?

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
