### PR TITLE
Update publishing workflow to use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --strict-peer-dependencies
 
-      - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-
       - name: Create Release PR or publish stable version to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Changes Overview

To publish new versions of Tiptap packages on NPM, trusted publishing is necessary and this pull request changes everything needed:

- Install a pinned version of npm CLI >= 11.5.1
- Remove old usage of secret `NPM_TOKEN`, because classic NPM tokens aren't working since December 9, 2025

## Implementation Approach

Some changes to the GitHub workflow `publish.yml`

## Testing Done

The changes are tested in a fork within a different NPM scope.

## Verification Steps

Run workflow `publish.yml`

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [X] My changes do not break the library.
- [ ] I have added tests where applicable.
- [X] I have followed the project guidelines.
- [X] I have fixed any lint issues.
