### PR TITLE
fix: append all children of editors parent node to element

### DIFF
--- a/.changeset/funky-geese-hammer.md
+++ b/.changeset/funky-geese-hammer.md
@@ -1,0 +1,9 @@
+---
+'@tiptap/react': patch
+'@tiptap/vue-2': patch
+'@tiptap/vue-3': patch
+---
+
+Append all children of editors parent node to element
+
+Fixes a regression introduced by #6972, that resulted in elements that got appended to the editors parent node staying detached. E.g. the drag handle plugin is affected by this regression.

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -114,14 +114,14 @@ export class PureEditorContent extends React.Component<
   init() {
     const editor = this.props.editor as EditorWithContentComponent | null
 
-    if (editor && !editor.isDestroyed && editor.options.element) {
+    if (editor && !editor.isDestroyed && editor.view.dom?.parentNode) {
       if (editor.contentComponent) {
         return
       }
 
       const element = this.editorContentRef.current
 
-      element.append(editor.view.dom)
+      element.append(...editor.view.dom.parentNode.childNodes)
 
       editor.setOptions({
         element,
@@ -179,14 +179,14 @@ export class PureEditorContent extends React.Component<
     // try to reset the editor element
     // may fail if this editor's view.dom was never initialized/mounted yet
     try {
-      if (!editor.view.dom?.firstChild) {
+      if (!editor.view.dom?.parentNode) {
         return
       }
 
       // TODO using the new editor.mount method might allow us to remove this
       const newElement = document.createElement('div')
 
-      newElement.append(editor.view.dom)
+      newElement.append(...editor.view.dom.parentNode.childNodes)
 
       editor.setOptions({
         element: newElement,

--- a/packages/vue-2/src/EditorContent.ts
+++ b/packages/vue-2/src/EditorContent.ts
@@ -25,11 +25,11 @@ export const EditorContent: Component = {
           this.$nextTick(() => {
             const element = this.$el
 
-            if (!element || !editor.view.dom?.firstChild) {
+            if (!element || !editor.view.dom?.parentNode) {
               return
             }
 
-            element.append(editor.view.dom)
+            element.append(...editor.view.dom.parentNode.childNodes)
             editor.contentComponent = this
 
             editor.setOptions({
@@ -62,14 +62,14 @@ export const EditorContent: Component = {
 
     editor.contentComponent = null
 
-    if (!editor.view.dom?.firstChild) {
+    if (!editor.view.dom?.parentNode) {
       return
     }
 
     // TODO using the new editor.mount method might allow us to remove this
     const newElement = document.createElement('div')
 
-    newElement.append(editor.view.dom)
+    newElement.append(...editor.view.dom.parentNode.childNodes)
 
     editor.setOptions({
       element: newElement,

--- a/packages/vue-3/src/EditorContent.ts
+++ b/packages/vue-3/src/EditorContent.ts
@@ -22,14 +22,14 @@ export const EditorContent = defineComponent({
 
       if (editor && editor.options.element && rootEl.value) {
         nextTick(() => {
-          if (!rootEl.value || !editor.view.dom?.firstChild) {
+          if (!rootEl.value || !editor.view.dom?.parentNode) {
             return
           }
 
           // TODO using the new editor.mount method might allow us to remove this
           const element = unref(rootEl.value)
 
-          rootEl.value.append(editor.view.dom)
+          rootEl.value.append(...editor.view.dom.parentNode.childNodes)
 
           // @ts-ignore
           editor.contentComponent = instance.ctx._

--- a/packages/vue-3/src/useEditor.ts
+++ b/packages/vue-3/src/useEditor.ts
@@ -12,7 +12,7 @@ export const useEditor = (options: Partial<EditorOptions> = {}) => {
 
   onBeforeUnmount(() => {
     // Cloning root node (and its children) to avoid content being lost by destroy
-    const nodes = editor.value?.view.dom
+    const nodes = editor.value?.view.dom?.parentNode
     const newEl = nodes?.cloneNode(true) as HTMLElement
 
     nodes?.parentNode?.replaceChild(newEl, nodes)


### PR DESCRIPTION
## Changes Overview

Fixes a regression introduced by #6972, that resulted in elements that got appended to the editors parent node staying detached. E.g. the drag handle plugin is affected by this regression.

## Implementation Approach

## Testing Done

All tests pass.

## Verification Steps

I verified manually that the regression was fixed with my reproducer at https://github.com/mejo-/tiptap-drag-handle-vue2-bug.

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes: #7282
