### PR TITLE
fix: the editor could be destroyed during the resizeDelay interval in BubbleMenu

### DIFF
--- a/.changeset/kind-jobs-search.md
+++ b/.changeset/kind-jobs-search.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-bubble-menu': patch
+---
+
+Fix a bug where the editor could be destroyed during the resizeDelay interval.

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -389,6 +389,11 @@ export class BubbleMenuView implements PluginView {
     }
 
     this.resizeDebounceTimer = window.setTimeout(() => {
+      // The editor might be destroyed during the `resizeDelay` interval.
+      if (this.editor.isDestroyed) {
+        return
+      }
+
       this.updatePosition()
     }, this.resizeDelay)
   }


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

In Storybook and Vitest, the BubbleMenu resizeHandler was firing after the editor had been destroyed, which caused an error. The cause was a setTimeout that triggered the handler 60ms later, so I changed it to ensure it won’t fire after destruction.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

The flow was: resizeHandler (setTimeout) → plugin destroy → updatePosition (error). So I added a guard condition in the setTimeout callback to prevent it from running after destruction.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

Manual testing

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

For debugging, please replace the resizeHandler in `bubble-menu-plugin.ts` with the code below and try it in the demo.

```ts
  resizeHandler = () => {
    if (this.resizeDebounceTimer) {
      clearTimeout(this.resizeDebounceTimer)
    }

    this.resizeDebounceTimer = window.setTimeout(() => {
      // The editor might be destroyed during the `resizeDelay` interval.
      if (this.editor.isDestroyed) {
        console.log('destroyed')
        return
      }

      console.log('update position called')
      this.updatePosition()
    }, 1000)

    this.editor.destroy()
  }
```

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
