### PR TITLE
Make tabindex configurable

### DIFF
--- a/.changeset/many-houses-occur.md
+++ b/.changeset/many-houses-occur.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": minor
+---
+
+Add configurable tabindex option to allow customizing the tabindex attribute on the editor element via coreExtensionOptions

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -430,7 +430,9 @@ export class Editor extends EventEmitter<EditorEvents> {
           Commands,
           FocusEvents,
           Keymap,
-          Tabindex,
+          Tabindex.configure({
+            value: this.options.coreExtensionOptions?.tabindex?.value,
+          }),
           Drop,
           Paste,
           Delete,

--- a/packages/core/src/extensions/tabindex.ts
+++ b/packages/core/src/extensions/tabindex.ts
@@ -5,12 +5,18 @@ import { Extension } from '../Extension.js'
 export const Tabindex = Extension.create({
   name: 'tabindex',
 
+  addOptions() {
+    return {
+      value: undefined,
+    }
+  },
+
   addProseMirrorPlugins() {
     return [
       new Plugin({
         key: new PluginKey('tabindex'),
         props: {
-          attributes: (): { [name: string]: string } => (this.editor.isEditable ? { tabindex: '0' } : {}),
+          attributes: (): { [name: string]: string } => (this.editor.isEditable ? { tabindex: this.options.value ?? '0' } : {}),
         },
       }),
     ]


### PR DESCRIPTION
## Changes Overview

Makes the tabindex for the Tabindex core extension configurable, in order to accommodate specific requirements wrt focus order when used in forms.

## Implementation Approach

An approach was already outlined in issue https://github.com/ueberdosis/tiptap/issues/4632 using the coreExtensionOptions configuration option for passing a custom value to the extension. So basically when initializing the editor it can be configured like follows:

```
new Editor({
    coreExtensionOptions: {
        tabindex: {
            value: '4',
        },
    },
})
```

## Testing Done

Tested locally, with and without specifying a value through the configuration option. When no configuration is specified the behaviour remains unchanged (the extension will add a `tabindex="0"` to the editor).

## Verification Steps

When specifying a value through the configuration options the tabindex on the editor instance in the DOM will reflect this value.

## Additional Notes

As there is no existing documentation for the Tabindex core extension I have not updated any documentation. This feature probably has a very niche use-case, and I am not sure what the best way is to document this.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/4632
