### PR TITLE
fix(extension-highlight): improve background color parsing for Safari - #7366

### DIFF
--- a/.changeset/fix-highlight-safari-color.md
+++ b/.changeset/fix-highlight-safari-color.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-highlight": patch
+---
+
+Fix issue with background color switching on mobile/Safari by improving parseHTML and adding priority.

--- a/packages/extension-highlight/src/highlight.spec.ts
+++ b/packages/extension-highlight/src/highlight.spec.ts
@@ -1,0 +1,52 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { describe, expect, it } from 'vitest'
+
+import { Highlight } from './highlight.js'
+
+describe('highlight', () => {
+  it('allows adjacent highlights with different colors', () => {
+    const editor = new Editor({
+      extensions: [Document, Text, Paragraph, Highlight.configure({ multicolor: true })],
+      content: '<p><mark data-color="red">First</mark></p>',
+    })
+
+    editor.chain().focus('end').setHighlight({ color: 'blue' }).insertContent('Second').run()
+
+    const html = editor.getHTML()
+
+    // We expect two distinct mark tags with different colors
+    expect(html).toContain('data-color="red"')
+    expect(html).toContain('data-color="blue"')
+    expect(html).toContain('>First</mark>')
+    expect(html).toContain('>Second</mark>')
+
+    const redMark = '<mark data-color="red" style="background-color: red; color: inherit">First</mark>'
+    const blueMark = '<mark data-color="blue" style="background-color: blue; color: inherit">Second</mark>'
+
+    expect(html).toContain(redMark)
+    expect(html).toContain(blueMark)
+  })
+
+  it('keeps colors distinct when typing after switching', () => {
+    const editor = new Editor({
+      extensions: [Document, Text, Paragraph, Highlight.configure({ multicolor: true })],
+      content: '<p></p>',
+    })
+
+    editor
+      .chain()
+      .focus()
+      .setHighlight({ color: 'red' })
+      .insertContent('A')
+      .setHighlight({ color: 'blue' })
+      .insertContent('B')
+      .run()
+
+    const html = editor.getHTML()
+    expect(html).toContain('data-color="red"')
+    expect(html).toContain('data-color="blue"')
+  })
+})

--- a/packages/extension-highlight/src/highlight.ts
+++ b/packages/extension-highlight/src/highlight.ts
@@ -57,6 +57,8 @@ export const pasteRegex = /(?:^|\s)(==(?!\s+==)((?:[^=]+))==(?!\s+==))/g
 export const Highlight = Mark.create<HighlightOptions>({
   name: 'highlight',
 
+  priority: 51,
+
   addOptions() {
     return {
       multicolor: false,
@@ -72,7 +74,37 @@ export const Highlight = Mark.create<HighlightOptions>({
     return {
       color: {
         default: null,
-        parseHTML: element => element.getAttribute('data-color') || element.style.backgroundColor,
+        parseHTML: element => {
+          const dataColor = element.getAttribute('data-color')
+
+          if (dataColor) {
+            return dataColor
+          }
+
+          const styleAttr = element.getAttribute('style')
+
+          if (styleAttr) {
+            const decls = styleAttr
+              .split(';')
+              .map(s => s.trim())
+              .filter(Boolean)
+
+            for (let i = decls.length - 1; i >= 0; i -= 1) {
+              const parts = decls[i].split(':')
+
+              if (parts.length >= 2) {
+                const prop = parts[0].trim().toLowerCase()
+                const val = parts.slice(1).join(':').trim()
+
+                if (prop === 'background-color') {
+                  return val.replace(/['"]+/g, '')
+                }
+              }
+            }
+          }
+
+          return element.style.backgroundColor
+        },
         renderHTML: attributes => {
           if (!attributes.color) {
             return {}


### PR DESCRIPTION
- Update [parseHTML](cci:1://file:///Users/kumardhananjaya/Desktop/Projects/tiptap/packages/extension-highlight/src/highlight.ts:121:2-127:3) to robustly extract `background-color` from the `style` attribute, addressing issues where Safari drops color during IME composition or selection updates.
- Set extension priority to 51 to ensure proper mark merging behavior.
- Add unit tests for adjacent multicolor highlights.

Changes Overview
This PR addresses a bug where the highlight background color would reset or behave unexpectedly in Safari, particularly when switching colors during text entry or using IME.

- Updated parseHTML in extension-highlight to robustly extract background-color from the style attribute.
- Set extension priority to 51 to ensure correct application order.
- Added a new unit test to verify that adjacent highlights with different colors are preserved correctly.\

Implementation Approach
The core issue was that Safari sometimes normalizes or modifies the DOM in ways that caused the standard 
parseHTML to miss the background color, especially during composition. I updated the  parseHTML method to manually parse the style attribute for the background-color property, similar to how extension-color handles text colors. This ensures we capture the color even if the standard property access fails or if the DOM is in an intermediate state. I also bumped the priority to ensure this mark's rules take precedence where necessary.

Testing Done
- Added a new test file:  packages/extension-highlight/src/highlight.spec.ts
- Verified that the tests pass with pnpm test:unit packages/extension-highlight/src/highlight.spec.ts.
- Confirms that adjacent text with different highlight colors (e.g., Red then Blue) remains distinct and retains the correct attributes.

Verification Steps
Run pnpm install.
Run the specific unit test: pnpm test:unit packages/extension-highlight/src/highlight.spec.ts.
Verify that all tests pass.

Additional Notes
This implementation aligns extension-highlight's parsing logic with extension-color, which has proven to be more robust across different browsers.

Checklist
 I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
 My changes do not break the library.
 I have added tests where applicable.
 I have followed the project guidelines.
 I have fixed any lint issues.

Related Issues
Fixes #7366 
