### PR TITLE
dispatchTransaction in extensions

### DIFF
--- a/.changeset/add-dispatch-transaction-hook-joyful-leaping-lynx.md
+++ b/.changeset/add-dispatch-transaction-hook-joyful-leaping-lynx.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": minor
+---
+
+Add a new `dispatchTransaction` hook to extensions, allowing developers to intercept, modify, or block transactions before they are applied to the editor state.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ dist
 .instructions
 .agent
 
+docs
+
 # Log files
 npm-debug.log*
 yarn-debug.log*

--- a/packages/core/__tests__/dispatchTransaction.spec.ts
+++ b/packages/core/__tests__/dispatchTransaction.spec.ts
@@ -1,0 +1,110 @@
+import { Editor, Extension } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('dispatchTransaction', () => {
+  it('should call dispatchTransaction from an extension', () => {
+    const dispatchTransaction = vi.fn(({ transaction, next }) => next(transaction))
+    const CustomExtension = Extension.create({
+      name: 'custom',
+      dispatchTransaction,
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, CustomExtension],
+    })
+
+    editor.commands.insertContent('foo')
+
+    expect(dispatchTransaction).toHaveBeenCalled()
+  })
+
+  it('should call multiple dispatchTransaction hooks in priority order', () => {
+    const order: string[] = []
+    const Extension1 = Extension.create({
+      name: 'extension1',
+      priority: 10,
+      dispatchTransaction({ transaction, next }) {
+        order.push('extension1')
+        next(transaction)
+      },
+    })
+    const Extension2 = Extension.create({
+      name: 'extension2',
+      priority: 20,
+      dispatchTransaction({ transaction, next }) {
+        order.push('extension2')
+        next(transaction)
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, Extension1, Extension2],
+    })
+
+    editor.commands.insertContent('foo')
+
+    expect(order).toEqual(['extension2', 'extension1'])
+  })
+
+  it('should block transaction if next is not called', () => {
+    const Extension1 = Extension.create({
+      name: 'extension1',
+      dispatchTransaction() {
+        // do nothing
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, Extension1],
+    })
+
+    editor.commands.insertContent('foo')
+
+    expect(editor.getText()).toBe('')
+  })
+
+  it('should allow user-provided dispatchTransaction as base', () => {
+    const userDispatch = vi.fn(_tr => {
+      // In a real scenario, the user would update the view state here.
+      // For this test, we just want to see if it's called.
+    })
+
+    const Extension1 = Extension.create({
+      name: 'extension1',
+      dispatchTransaction({ transaction, next }) {
+        next(transaction)
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, Extension1],
+      editorProps: {
+        dispatchTransaction: userDispatch,
+      } as any,
+    })
+
+    editor.commands.insertContent('foo')
+
+    expect(userDispatch).toHaveBeenCalled()
+  })
+
+  it('should bypass extensions if enableExtensionDispatchTransaction is false', () => {
+    const dispatchTransaction = vi.fn(({ transaction, next }) => next(transaction))
+    const CustomExtension = Extension.create({
+      name: 'custom',
+      dispatchTransaction,
+    })
+
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, CustomExtension],
+      enableExtensionDispatchTransaction: false,
+    })
+
+    editor.commands.insertContent('foo')
+
+    expect(dispatchTransaction).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -115,6 +115,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     onPaste: () => null,
     onDrop: () => null,
     onDelete: () => null,
+    enableExtensionDispatchTransaction: true,
   }
 
   constructor(options: Partial<EditorOptions> = {}) {
@@ -518,14 +519,23 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Creates a ProseMirror view.
    */
   private createView(element: NonNullable<EditorOptions['element']>): void {
+    const { editorProps, enableExtensionDispatchTransaction } = this.options
+    // If a user provided a custom `dispatchTransaction` through `editorProps`,
+    // we use that as the base dispatch function.
+    // Otherwise, we use Tiptap's internal `dispatchTransaction` method.
+    const baseDispatch = (editorProps as any).dispatchTransaction || this.dispatchTransaction.bind(this)
+    const dispatch = enableExtensionDispatchTransaction
+      ? this.extensionManager.dispatchTransaction(baseDispatch)
+      : baseDispatch
+
     this.editorView = new EditorView(element, {
-      ...this.options.editorProps,
+      ...editorProps,
       attributes: {
         // add `role="textbox"` to the editor element
         role: 'textbox',
-        ...this.options.editorProps?.attributes,
+        ...editorProps?.attributes,
       },
-      dispatchTransaction: this.dispatchTransaction.bind(this),
+      dispatchTransaction: dispatch,
       state: this.editorState,
       markViews: this.extensionManager.markViews,
       nodeViews: this.extensionManager.nodeViews,

--- a/packages/core/src/Extendable.ts
+++ b/packages/core/src/Extendable.ts
@@ -9,6 +9,7 @@ import type { Node } from './Node.js'
 import type { PasteRule } from './PasteRule.js'
 import type {
   AnyConfig,
+  DispatchTransactionProps,
   EditorEvents,
   Extensions,
   GlobalAttributes,
@@ -445,6 +446,33 @@ export interface ExtendableConfig<
           parent: ParentConfig<Config>['onDestroy']
         },
         event: EditorEvents['destroy'],
+      ) => void)
+    | null
+
+  /**
+   * This hook allows you to intercept and modify transactions before they are dispatched.
+   *
+   * Example
+   * ```ts
+   * dispatchTransaction({ transaction, next }) {
+   *   console.log('Dispatching transaction:', transaction)
+   *   next(transaction)
+   * }
+   * ```
+   *
+   * @param props - The dispatch transaction props
+   */
+  dispatchTransaction?:
+    | ((
+        this: {
+          name: string
+          options: Options
+          storage: Storage
+          editor: Editor
+          type: PMType
+          parent: ParentConfig<Config>['dispatchTransaction']
+        },
+        props: DispatchTransactionProps,
       ) => void)
     | null
 }

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -1,6 +1,6 @@
 import { keymap } from '@tiptap/pm/keymap'
 import type { Schema } from '@tiptap/pm/model'
-import type { Plugin } from '@tiptap/pm/state'
+import type { Plugin, Transaction } from '@tiptap/pm/state'
 import type { MarkViewConstructor, NodeViewConstructor } from '@tiptap/pm/view'
 
 import type { Editor } from './Editor.js'
@@ -241,6 +241,40 @@ export class ExtensionManager {
           return [extension.name, nodeview]
         }),
     )
+  }
+
+  /**
+   * Get the composed dispatchTransaction function from all extensions.
+   * @param baseDispatch The base dispatch function (e.g. from the editor or user props)
+   * @returns A composed dispatch function
+   */
+  dispatchTransaction(baseDispatch: (tr: Transaction) => void): (tr: Transaction) => void {
+    const { editor } = this
+    const extensions = sortExtensions([...this.extensions].reverse())
+
+    return extensions.reduceRight((next, extension) => {
+      const context = {
+        name: extension.name,
+        options: extension.options,
+        storage: this.editor.extensionStorage[extension.name as keyof Storage],
+        editor,
+        type: getSchemaTypeByName(extension.name, this.schema),
+      }
+
+      const dispatchTransaction = getExtensionField<AnyConfig['dispatchTransaction']>(
+        extension,
+        'dispatchTransaction',
+        context,
+      )
+
+      if (!dispatchTransaction) {
+        return next
+      }
+
+      return (transaction: Transaction) => {
+        dispatchTransaction.call(context, { transaction, next })
+      }
+    }, baseDispatch)
   }
 
   get markViews(): Record<string, MarkViewConstructor> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -264,6 +264,23 @@ export interface EditorEvents {
   )
 }
 
+/**
+ * Props passed to the `dispatchTransaction` hook in extensions.
+ */
+export type DispatchTransactionProps = {
+  /**
+   * The transaction that is about to be dispatched.
+   */
+  transaction: Transaction
+  /**
+   * A function that should be called to pass the transaction down to the next extension
+   * (or eventually to the editor).
+   *
+   * @param transaction The transaction to dispatch
+   */
+  next: (transaction: Transaction) => void
+}
+
 export type EnableRules = (AnyExtension | string)[] | boolean
 
 export interface EditorOptions {
@@ -450,6 +467,17 @@ export interface EditorOptions {
    * Called when content is deleted from the editor.
    */
   onDelete: (props: EditorEvents['delete']) => void
+  /**
+   * Whether to enable extension-level dispatching of transactions.
+   * If `false`, extensions cannot define their own `dispatchTransaction` hook.
+   *
+   * @default true
+   * @example
+   * new Editor({
+   *   enableExtensionDispatchTransaction: false,
+   * })
+   */
+  enableExtensionDispatchTransaction?: boolean
 }
 
 /**


### PR DESCRIPTION
## Changes Overview

This PR introduces a new dispatchTransaction hook for Tiptap extensions. This hook allows developers to intercept, modify, or block transactions before they are applied to the editor state, using a middleware-style composition pattern.

## Implementation Approach

- **Extension Hook**: Added a dispatchTransaction configuration option to extensions.
- **Extension Manager**: Implemented composition logic that sorts extensions by priority and wraps them into a single middleware chain. Each hook receives a `next` function to pass the transaction along.
- **Editor Integration**: Updated the view creation process to use this composed dispatch function while ensuring user-provided custom dispatchers remain supported at the base of the chain.
- **Escape Hatch**: Added an option to the editor settings to globally disable extension-level dispatching if needed.

## Testing Done

- Added comprehensive unit tests covering the new hook.
- Verified execution order based on extension priority.
- Verified transaction blocking by omitting the `next()` call.
- Verified compatibility with custom user-provided dispatchers.
- Verified the global escape hatch setting.

## Verification Steps

1. Run the core unit tests for the editor.
2. Create a custom extension with a dispatchTransaction hook.
3. Observe that you can log or modify transactions before they update the editor state.
4. Verify that not calling `next()` prevents the transaction from applying.

## Additional Notes

- This feature is particularly useful for advanced extensions that need to perform validation or specific side effects before the state change is finalized.
- Documentation updates have been submitted separately to the documentation repository.

## Checklist

- [x] I have created a changeset for this PR.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

N/A