### PR TITLE
Fix unhandled error in test suite

### DIFF
--- a/packages/core/__tests__/dispatchTransaction.spec.ts
+++ b/packages/core/__tests__/dispatchTransaction.spec.ts
@@ -19,6 +19,8 @@ describe('dispatchTransaction', () => {
     editor.commands.insertContent('foo')
 
     expect(dispatchTransaction).toHaveBeenCalled()
+
+    editor.destroy()
   })
 
   it('should call multiple dispatchTransaction hooks in priority order', () => {
@@ -47,6 +49,8 @@ describe('dispatchTransaction', () => {
     editor.commands.insertContent('foo')
 
     expect(order).toEqual(['extension2', 'extension1'])
+
+    editor.destroy()
   })
 
   it('should block transaction if next is not called', () => {
@@ -64,6 +68,8 @@ describe('dispatchTransaction', () => {
     editor.commands.insertContent('foo')
 
     expect(editor.getText()).toBe('')
+
+    editor.destroy()
   })
 
   it('should allow user-provided dispatchTransaction as base', () => {
@@ -89,6 +95,8 @@ describe('dispatchTransaction', () => {
     editor.commands.insertContent('foo')
 
     expect(userDispatch).toHaveBeenCalled()
+
+    editor.destroy()
   })
 
   it('should bypass extensions if enableExtensionDispatchTransaction is false', () => {
@@ -106,5 +114,7 @@ describe('dispatchTransaction', () => {
     editor.commands.insertContent('foo')
 
     expect(dispatchTransaction).not.toHaveBeenCalled()
+
+    editor.destroy()
   })
 })


### PR DESCRIPTION
## Changes Overview

Destroy editor instances in `dispatchTransaction.spec.ts` to prevent unhandled errors during test runs.

## Implementation Approach

Added `editor.destroy()` at the end of all 5 tests in `packages/core/__tests__/dispatchTransaction.spec.ts`. This follows the same pattern used in PR #7387 for `can.spec.ts`.

When an Editor is created, ProseMirror sets up a DOMObserver with a timeout-based flush mechanism. If the test ends before the observer flushes, it tries to access `document` which no longer exists in the test environment, causing:

```
ReferenceError: document is not defined
 ❯ EditorView.get root [as root] node_modules/.pnpm/prosemirror-view@1.38.1/node_modules/prosemirror-view/dist/index.js:5562:26
 ❯ DOMObserver.flush ...
```

## Testing Done

Ran the test suite for the affected file:

```
pnpm run test:unit "packages/core/__tests__/dispatchTransaction.spec.ts"

 ✓ packages/core/__tests__/dispatchTransaction.spec.ts (5 tests) 44ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Verification Steps

1. Run `pnpm run test:unit "packages/core/__tests__/dispatchTransaction.spec.ts"`
2. Verify all 5 tests pass without unhandled errors
3. Run the full test suite multiple times to confirm the flaky error no longer occurs

## Additional Notes

This was a flaky test failure that occurred intermittently in CI due to race conditions between test cleanup and ProseMirror's async DOM observer flush.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Related to #7387 (same fix pattern applied to `can.spec.ts`)
