### PR TITLE
fix: handle hide middleware visibility in bubble-menu and floating-menu

### DIFF
--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -432,11 +432,15 @@ export class BubbleMenuView implements PluginView {
       placement: this.floatingUIOptions.placement,
       strategy: this.floatingUIOptions.strategy,
       middleware: this.middlewares,
-    }).then(({ x, y, strategy }) => {
+    }).then(({ x, y, strategy, middlewareData }) => {
       this.element.style.width = 'max-content'
       this.element.style.position = strategy
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
+
+      if (middlewareData.hide) {
+        this.element.style.visibility = middlewareData.hide.referenceHidden ? 'hidden' : 'visible'
+      }
 
       if (this.isVisible && this.floatingUIOptions.onUpdate) {
         this.floatingUIOptions.onUpdate()

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -396,11 +396,15 @@ export class FloatingMenuView {
       placement: this.floatingUIOptions.placement,
       strategy: this.floatingUIOptions.strategy,
       middleware: this.middlewares,
-    }).then(({ x, y, strategy }) => {
+    }).then(({ x, y, strategy, middlewareData }) => {
       this.element.style.width = 'max-content'
       this.element.style.position = strategy
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
+
+      if (middlewareData.hide) {
+        this.element.style.visibility = middlewareData.hide.referenceHidden ? 'hidden' : 'visible'
+      }
 
       if (this.isVisible && this.floatingUIOptions.onUpdate) {
         this.floatingUIOptions.onUpdate()


### PR DESCRIPTION
### Changes Overview

- fixed bubble-menu and floating-menu not hiding at scroll container boundaries. The hide middleware data was collected but not applied to control visibility.

fix: #7422

### Implementation Approach

- Added handling for `middlewareData.hide.referenceHidden` in the `updatePosition()` method to set visibility based on scroll container boundaries.

### Testing Done

- Tested with hide middleware enabled. Floating elements now hide when reaching scroll container edges, not just viewport edges.

### Verification Steps

1. Enable hide middleware: `options={{ hide: {} }}`
2. Select text and scroll the editor container
3. Verify the floating element hides at container boundaries