### PR TITLE
feat: add React implementation of drawing example

### DIFF
--- a/demos/src/Examples/Drawing/React/Component.tsx
+++ b/demos/src/Examples/Drawing/React/Component.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewWrapper } from '@tiptap/react'
+import * as d3 from 'd3'
+import { useEffect, useRef, useState } from 'react'
+import { v4 as uuid } from 'uuid'
+
+type Point = [number, number]
+
+type Line = {
+  id: string
+  color: string
+  size: number
+  path: string
+}
+
+const COLORS = ['#A975FF', '#FB5151', '#FD9170', '#FFCB6B', '#68CEF8', '#80CBC4', '#9DEF8F'] as const
+
+const randomItem = <T,>(list: readonly T[]): T => list[Math.floor(Math.random() * list.length)]
+
+export const Component = ({ node, updateAttributes }: NodeViewProps) => {
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const pathRef = useRef<d3.Selection<SVGPathElement, unknown, null, undefined> | null>(null)
+
+  const drawingRef = useRef<boolean>(false)
+  const pointsRef = useRef<Point[]>([])
+  const idRef = useRef<string>(uuid())
+
+  const [color, setColor] = useState<string>(randomItem(COLORS))
+  const [size, setSize] = useState<number>(Math.ceil(Math.random() * 10))
+
+  const clearCanvas = () => {
+    drawingRef.current = false
+    pointsRef.current = []
+
+    if (svgRef.current) {
+      d3.select(svgRef.current).selectAll('path').remove()
+    }
+    idRef.current = uuid()
+  }
+
+  useEffect(() => {
+    if (!svgRef.current) {return}
+
+    const svg = d3.select(svgRef.current)
+
+    const onMove = (event: MouseEvent) => {
+      if (!drawingRef.current) {return}
+      event.preventDefault()
+
+      const point = d3.pointer(event, svgRef.current)
+      pointsRef.current.push(point)
+
+      const path = d3.line<Point>().curve(d3.curveBasis)(pointsRef.current)
+
+      if (pathRef.current && path) {
+        pathRef.current.attr('d', path)
+      }
+    }
+
+    const onStart = () => {
+      drawingRef.current = true
+      pointsRef.current = []
+
+      pathRef.current = svg
+        .append('path')
+        .attr('id', `id-${idRef.current}`)
+        .attr('stroke', color)
+        .attr('stroke-width', size)
+        .attr('fill', 'none')
+        .attr('stroke-linecap', 'round')
+        .attr('stroke-linejoin', 'round')
+
+      svg.on('mousemove', onMove)
+    }
+
+    const onEnd = () => {
+      svg.on('mousemove', null)
+
+      if (!drawingRef.current) {return}
+      drawingRef.current = false
+
+      if (!pointsRef.current.length) {return}
+
+      const path = d3.line<Point>().curve(d3.curveBasis)(pointsRef.current)
+
+      if (!path) {return}
+
+      const lines: Line[] = (node.attrs.lines as Line[]).filter(item => item.id !== idRef.current)
+
+      updateAttributes({
+        lines: [
+          ...lines,
+          {
+            id: idRef.current,
+            color,
+            size,
+            path,
+          },
+        ],
+      })
+
+      idRef.current = uuid()
+    }
+
+    svg.on('mousedown', onStart).on('mouseup', onEnd).on('mouseleave', onEnd)
+
+    return () => {
+      svg.on('mousedown', null)
+      svg.on('mouseup', null)
+      svg.on('mouseleave', null)
+      svg.on('mousemove', null)
+    }
+  }, [color, size, node.attrs.lines, updateAttributes])
+
+  return (
+    <NodeViewWrapper className="draw" contentEditable={false}>
+      <div className="control-group">
+        <div className="button-group">
+          <input type="color" value={color} onChange={e => setColor(e.target.value)} />
+
+          <input type="number" min={1} max={10} value={size} onChange={e => setSize(Number(e.target.value))} />
+
+          <button onClick={clearCanvas}>Clear</button>
+        </div>
+
+        <svg ref={svgRef} viewBox="0 0 500 250" width="100%">
+          {(node.attrs.lines as Line[]).map(item => (
+            <path
+              key={item.id}
+              d={item.path}
+              stroke={item.color}
+              strokeWidth={item.size}
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))}
+        </svg>
+      </div>
+    </NodeViewWrapper>
+  )
+}

--- a/demos/src/Examples/Drawing/React/Paper.ts
+++ b/demos/src/Examples/Drawing/React/Paper.ts
@@ -1,0 +1,33 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+
+import { Component } from './Component.tsx'
+
+const Paper = Node.create({
+  name: 'paper',
+
+  group: 'block',
+  atom: true,
+
+  addAttributes() {
+    return {
+      lines: {
+        default: [],
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="paper"]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'paper' })]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(Component)
+  },
+})
+
+export default Paper

--- a/demos/src/Examples/Drawing/React/index.spec.js
+++ b/demos/src/Examples/Drawing/React/index.spec.js
@@ -1,0 +1,38 @@
+context('/src/Examples/Drawing/React/', () => {
+  beforeEach(() => {
+    cy.visit('/src/Examples/Drawing/React/')
+  })
+
+  it('should have a working tiptap instance', () => {
+    cy.get('.tiptap').then(([{ editor }]) => {
+      // eslint-disable-next-line
+      expect(editor).to.not.be.null
+    })
+  })
+
+  it('should have a svg canvas', () => {
+    cy.get('.tiptap svg').should('exist')
+  })
+
+  it('should draw on the svg canvas', () => {
+    cy.get('.tiptap svg').should('exist')
+
+    cy.wait(500)
+
+    cy.get('input').then(inputs => {
+      const color = inputs[0].value
+      const size = inputs[1].value
+
+      cy.get('.tiptap svg')
+        .click()
+        .trigger('mousedown', { pageX: 100, pageY: 100, which: 1 })
+        .trigger('mousemove', { pageX: 200, pageY: 200, which: 1 })
+        .trigger('mouseup')
+
+      cy.get('.tiptap svg path')
+        .should('exist')
+        .should('have.attr', 'stroke-width', size)
+        .should('have.attr', 'stroke', color.toUpperCase())
+    })
+  })
+})

--- a/demos/src/Examples/Drawing/React/index.tsx
+++ b/demos/src/Examples/Drawing/React/index.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import './styles.scss'
+
+import Document from '@tiptap/extension-document'
+import Text from '@tiptap/extension-text'
+import { EditorContent, useEditor } from '@tiptap/react'
+
+import Paper from './Paper.js'
+
+export default () => {
+  const editor = useEditor({
+    extensions: [Document.extend({ content: 'paper' }), Text, Paper],
+    content: {
+      type: 'doc',
+      content: [{ type: 'paper' }],
+    },
+  })
+
+  return <EditorContent editor={editor} />
+}

--- a/demos/src/Examples/Drawing/React/styles.scss
+++ b/demos/src/Examples/Drawing/React/styles.scss
@@ -1,0 +1,12 @@
+.draw {
+  svg {
+    background: #f1f3f5;
+    cursor: crosshair;
+  }
+
+  path {
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+}


### PR DESCRIPTION
## Changes Overview

This PR adds a React implementation of the drawing example that previously existed only for Vue.  
The Vue example is unchanged.

## Implementation Approach

The drawing example was ported from the existing Vue implementation to React using `@tiptap/react`.

- Implemented a `paper` node using `ReactNodeViewRenderer`
- Recreated the drawing NodeView with SVG + D3
- Persisted drawing data via node attributes (`lines`)
- Kept the document schema and behavior aligned with the Vue version

## Testing Done

- Verified drawing works visually in the React example
- Ensured drawing data is persisted correctly in editor state
- Manually verified the example runs without build or runtime errors

## Verification Steps

1. Open the React drawing example.
2. Draw on the canvas using the mouse.
3. Confirm strokes appear and persist.
4. Use the color and size controls to change drawing style.
5. Click “Clear” and confirm the canvas resets.

## Additional Notes

This change improves feature parity between Vue and React examples and provides a reference implementation for React users.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Demo

https://github.com/user-attachments/assets/d824fe42-5268-4dbc-8065-e0194d0f1cc3

