### PR TITLE
fix(drag-handle): fix Vue 3 drag handle disappearing during external state updates

### DIFF
--- a/packages/extension-drag-handle-vue-3/src/DragHandle.ts
+++ b/packages/extension-drag-handle-vue-3/src/DragHandle.ts
@@ -143,7 +143,7 @@ export const DragHandle = defineComponent({
         {
           ref: root,
           class: props.class,
-          style: { visibility: 'hidden', position: 'absolute' },
+          style: { position: 'absolute' },
           'data-dragging': 'false',
         },
         slots.default?.(),

--- a/packages/extension-drag-handle-vue-3/src/DragHandle.ts
+++ b/packages/extension-drag-handle-vue-3/src/DragHandle.ts
@@ -119,6 +119,10 @@ export const DragHandle = defineComponent({
     }
 
     onMounted(async () => {
+      // Hide via DOM (not reactive style) so re-renders don't override plugin's visibility control
+      if (root.value) {
+        root.value.style.visibility = 'hidden'
+      }
       await nextTick()
       initPlugin()
     })


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->
While fixing a related issue in nuxt-ui (nuxt/ui#5960) which uses tiptap, I noticed the Vue 3 DragHandle would disappear when its state is updated and causes external re-renders/changes.

I reproduced the issue in Tiptap and opened #7471 with a minimal example in the demo for vue drag handles. Using DOM breakpoints, I traced the issue to the drag handle’s initial visibility: hidden style being reapplied during reactive state updates.

Removing this initial style allows the DragHandlePlugin to fully control visibility without regressions.

## Implementation Approach

The fix removes the initial visibility: hidden style from the Vue 3 drag handle element.
Visibility is now managed exclusively by the DragHandlePlugin via its existing showHandle() and hideHandle() logic.

This aligns the DOM behavior with the plugin’s intended state management and avoids conflicts with external reactive updates.

## Testing Done

- [x] Verified DragHandle behavior on the regular demo page
- [x] Reproduced the bug in my forked repo - [Bug + Bug Fix in two commits](https://github.com/solidprinciples/tiptap-draghandle-state-update-bug/tree/bug/drag-handle)
- [x] Confirmed the fix resolves the issue without introducing regressions

## Verification Steps

1. Open the DragHandle demo
2. Interact with editor - drag handles appear and hide as expected
3. Test external state updates - my repo is useful for this - not sure a concise example to add to demo.
4. Confirm drag handles no longer disappear unexpectedly.

Bug Branch also works as expect (with example for external state): 
https://github.com/ueberdosis/tiptap/compare/develop...solidprinciples:tiptap-draghandle-state-update-bug:bug/drag-handle

Bug repro + fix branch:
https://github.com/ueberdosis/tiptap/compare/develop...solidprinciples:tiptap-draghandle-state-update-bug:bug/drag-handle

## Additional Notes

This PR fixes a bug in the Vue 3 drag handle implementation where drag handles disappear when state is updated externally from @nodeChange events. The fix removes the initial visibility: 'hidden' style from the drag handle element, allowing the DragHandlePlugin to manage visibility entirely through its showHandle() and hideHandle() functions.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

- #7471 
