### PR TITLE
fix(react/BubbleMenu): fix initial display state

### DIFF
--- a/.changeset/loud-doors-flow.md
+++ b/.changeset/loud-doors-flow.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+fix the initial display state issue of the react BubbleMenu component in strict mode

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -100,6 +100,7 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
       return () => {
         setPluginInitialized(false)
         pluginEditor.unregisterPlugin(createdPluginKey)
+        menuEl.current = document.createElement('div')
         window.requestAnimationFrame(() => {
           if (bubbleMenuElement.parentNode) {
             bubbleMenuElement.parentNode.removeChild(bubbleMenuElement)


### PR DESCRIPTION
fix initial display state in react strict mode
close #7473

## Changes Overview

fix #7473 

## Implementation Approach

update the mounting target of the menu popup element in the useEffect cleanup function of the BubbleMenu component

## Testing Done

1. wrap the demo component with \<StrictMode\/> in the demo's root rendering logic
2. reproduce bug with codesandbox codes in issue#7473
3. open the demo page, refresh, and then check the visibility of the initial render

/demos/setup/react.ts#29-31
```ts
        if (root) {
          createRoot(root).render(
            React.createElement(
              React.StrictMode,
              undefined,
              React.createElement(module.default)
            )
          )
        }
```


## Verification Steps

same as section above

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
