### PR TITLE
Prevent inline math input rule from replacing previous character

### DIFF
--- a/.changeset/fix-inline-mathematics-input-rule.md
+++ b/.changeset/fix-inline-mathematics-input-rule.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-mathematics': patch
+---
+
+Prevent inline math input rule from capturing previous character. Changed input rule to utilize negative lookbehind to prevent matching previous character. Ensures the range's `from` position is correctly at the start of the double `$` signs.

--- a/.changeset/yellow-bags-pump.md
+++ b/.changeset/yellow-bags-pump.md
@@ -1,7 +1,0 @@
----
-'@tiptap/extension-mathematics': minor
----
-
-Prevent inline math input rule from replacing previous character
-
-- Changed input rule to utilize negative lookbehind rather than regular character match to ensure preceding character is not consumed in final match. This ensures the range's `from` position is correctly at the start of the double `$` signs.

--- a/packages/extension-mathematics/__tests__/inlineMath.spec.ts
+++ b/packages/extension-mathematics/__tests__/inlineMath.spec.ts
@@ -1,0 +1,80 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { InlineMath } from '../src/index.js'
+
+describe('InlineMath', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('preserves previous character to input rule match', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, InlineMath],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Hello $$x$' }],
+          },
+        ],
+      },
+    })
+
+    editor.commands.setTextSelection(editor.state.doc.nodeSize)
+
+    editor.view.someProp('handleTextInput', f =>
+      f(editor.view, editor.state.selection.from, editor.state.selection.from, '$'),
+    )
+
+    expect(editor.getJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              // Ensure previous character is preserved (e.g., space)
+              text: 'Hello ',
+            },
+            {
+              type: 'inlineMath',
+              attrs: { latex: 'x' },
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('ensure unmatched triple $ expressions', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, InlineMath],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Hello $$$x$' }],
+          },
+        ],
+      },
+    })
+
+    editor.commands.setTextSelection(editor.state.doc.nodeSize)
+
+    const handled = editor.view.someProp('handleTextInput', f =>
+      f(editor.view, editor.state.selection.from, editor.state.selection.from, '$'),
+    )
+
+    // Expect no input rule to match
+    expect(handled).toBeFalsy()
+  })
+})

--- a/packages/extension-mathematics/src/extensions/InlineMath.ts
+++ b/packages/extension-mathematics/src/extensions/InlineMath.ts
@@ -220,7 +220,7 @@ export const InlineMath = Node.create<InlineMathOptions>({
   addInputRules() {
     return [
       new InputRule({
-        find: /(?<!$)(\$\$([^$\n]+?)\$\$)(?!\$)/,
+        find: /(?<!\$)(\$\$([^$\n]+?)\$\$)(?!\$)/,
         handler: ({ state, range, match }) => {
           const latex = match[2]
           const { tr } = state


### PR DESCRIPTION
## Changes Overview

Changed the InlineMath extension's input rule to prevent it from consuming the preceding character to a `$$latex$$` expression. 

For example, the string `Hello $$\sigma$$` would be transformed into → `Helloσ` (with the space deleted).

## Implementation Approach

We can utilize a fixed-width negative lookbehind that validates the preceding character is not a $-sign. This mimics the negative lookahead that's used at the end of the regular expression.

## Testing Done

Change is small enough to not require tests.

## Verification Steps

Build the editor. Utilize the mathematics extension and verify that `$$somelatex$$` does not replace the preceding character.

## Additional Notes

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary
- [x] My changes do not break the library.
- [x] I have added tests where applicable: `(N/A here)`
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
