### PR TITLE
fix(react): use circularDeepEqual in useEditorState to prevent stack overflow

### DIFF
--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -1,5 +1,5 @@
 import type { Editor } from '@tiptap/core'
-import { deepEqual } from 'fast-equals'
+import { circularDeepEqual } from 'fast-equals'
 import { useDebugValue, useEffect, useLayoutEffect, useState } from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector.js'
 
@@ -21,7 +21,7 @@ export type UseEditorStateOptions<TSelectorResult, TEditor extends Editor | null
   selector: (context: EditorStateSnapshot<TEditor>) => TSelectorResult
   /**
    * A custom equality function to determine if the editor should re-render.
-   * @default `deepEqual` from `fast-deep-equal`
+   * @default `circularDeepEqual` from `fast-equals`
    */
   equalityFn?: (a: TSelectorResult, b: TSelectorResult | null) => boolean
 }
@@ -160,7 +160,7 @@ export function useEditorState<TSelectorResult>(
     editorStateManager.getSnapshot,
     editorStateManager.getServerSnapshot,
     options.selector as UseEditorStateOptions<TSelectorResult, Editor | null>['selector'],
-    options.equalityFn ?? deepEqual,
+    options.equalityFn ?? circularDeepEqual,
   )
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
### Changes Overview

- Default equality in useEditorState changed from deepEqual to circularDeepEqual.

### Implementation Approach

- Import and default equalityFn now use circularDeepEqual.
- JSDoc updated for the default equality function.
- No other logic or APIs changed.

### Testing Done

- Build passes.
- Behavior unchanged for non-circular selector results.

### Verification Steps

- Use an app that uses useEditorState with editor state.
- Confirm no "Maximum call stack size exceeded" and re-renders still work.

### Additional Notes

- Fixes regression from switching fast-deep-equal to fast-equals (circular refs).

### Checklist

[ ] Changeset if needed.
[ ] No library breakage.

fix: #7482