### PR TITLE
feat: Added `showOnMouseUp` option to bubble menu

### DIFF
--- a/.changeset/yummy-queens-rush.md
+++ b/.changeset/yummy-queens-rush.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-bubble-menu': minor
+---
+
+Added `showOnMouseUp` option to bubble menu. This option allows the bubble menu to be displayed when the user releases the mouse button after a text selection, enhancing the user experience during text editing.

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -439,6 +439,9 @@ export class BubbleMenuView implements PluginView {
       const selectionChanged = !oldState?.selection.eq(view.state.selection)
       const docChanged = !oldState?.doc.eq(view.state.doc)
 
+      // Defer the update to the next tick so the browser has fully applied the
+      // mouseup-triggered selection and DOM changes before we read and position
+      // the bubble menu.
       setTimeout(() => {
         this.updateHandler(view, selectionChanged, docChanged, oldState)
       }, 0)

--- a/packages/extension-bubble-menu/src/bubble-menu.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu.ts
@@ -26,6 +26,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
       updateDelay: undefined,
       appendTo: undefined,
       shouldShow: null,
+      showOnMouseUp: false,
     }
   },
 
@@ -44,6 +45,7 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
         appendTo: this.options.appendTo,
         getReferencedVirtualElement: this.options.getReferencedVirtualElement,
         shouldShow: this.options.shouldShow,
+        showOnMouseUp: this.options.showOnMouseUp,
       }),
     ]
   },

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -17,6 +17,7 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
       resizeDelay,
       appendTo,
       shouldShow = null,
+      showOnMouseUp = false,
       getReferencedVirtualElement,
       options,
       children,
@@ -47,6 +48,7 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
       appendTo,
       pluginKey,
       shouldShow,
+      showOnMouseUp,
       getReferencedVirtualElement,
       options,
     }
@@ -135,6 +137,7 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
       updateDelay,
       resizeDelay,
       shouldShow,
+      showOnMouseUp,
       options,
       appendTo,
       getReferencedVirtualElement,

--- a/packages/vue-2/src/menus/BubbleMenu.ts
+++ b/packages/vue-2/src/menus/BubbleMenu.ts
@@ -12,6 +12,7 @@ export interface BubbleMenuInterface {
   resizeDelay: BubbleMenuPluginProps['resizeDelay']
   appendTo: BubbleMenuPluginProps['appendTo']
   shouldShow: BubbleMenuPluginProps['shouldShow']
+  showOnMouseUp: BubbleMenuPluginProps['showOnMouseUp']
   getReferencedVirtualElement: BubbleMenuPluginProps['getReferencedVirtualElement']
   options: BubbleMenuPluginProps['options']
 }
@@ -52,6 +53,11 @@ export const BubbleMenu: Component = {
       type: Function as PropType<Exclude<BubbleMenuPluginProps['shouldShow'], null>>,
       default: null,
     },
+
+    showOnMouseUp: {
+      type: Boolean as PropType<BubbleMenuPluginProps['showOnMouseUp']>,
+      default: false,
+    },
   },
 
   mounted(this: BubbleMenuInterface) {
@@ -79,6 +85,7 @@ export const BubbleMenu: Component = {
           pluginKey: this.pluginKey,
           appendTo: this.appendTo,
           shouldShow: this.shouldShow,
+          showOnMouseUp: this.showOnMouseUp,
           getReferencedVirtualElement: this.getReferencedVirtualElement,
         }),
       )

--- a/packages/vue-3/src/menus/BubbleMenu.ts
+++ b/packages/vue-3/src/menus/BubbleMenu.ts
@@ -44,6 +44,11 @@ export const BubbleMenu = defineComponent({
       default: null,
     },
 
+    showOnMouseUp: {
+      type: Boolean as PropType<BubbleMenuPluginProps['showOnMouseUp']>,
+      default: false,
+    },
+
     getReferencedVirtualElement: {
       type: Function as PropType<Exclude<Required<BubbleMenuPluginProps>['getReferencedVirtualElement'], null>>,
       default: undefined,
@@ -61,6 +66,7 @@ export const BubbleMenu = defineComponent({
         resizeDelay,
         appendTo,
         shouldShow,
+        showOnMouseUp,
         getReferencedVirtualElement,
         updateDelay,
       } = props
@@ -87,6 +93,7 @@ export const BubbleMenu = defineComponent({
             resizeDelay,
             appendTo,
             shouldShow,
+            showOnMouseUp,
             getReferencedVirtualElement,
             updateDelay,
           }),


### PR DESCRIPTION
## Changes Overview

Adds a new `showOnMouseUp` option to the bubble menu that defers showing the menu until the mouse button is released, similar to Notion's text selection behavior.

## Implementation Approach

Added a new optional `showOnMouseUp` prop (default: `false`) to the bubble menu that defers menu display until mouseup occurs. 

Key implementation details:
- Track mouse state via `isMouseDown` flag
- Store pending updates while mouse is down instead of immediately showing the menu
- Process pending updates on mouseup to display the menu

## Testing Done

- Verified menu appears only after mouseup when `showOnMouseUp: true`

## Verification Steps

1. Enable the `showOnMouseUp`: `<BubbleMenu showOnMouseUp={true} />`
2. Click and drag to select text - menu should NOT appear during selection
3. Release mouse button - menu should appear at selection

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
