### PR TITLE
fix(drag-handle): Change drag event listener registration timing to prevent removal

### DIFF
--- a/.changeset/fuzzy-cups-collect.md
+++ b/.changeset/fuzzy-cups-collect.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': patch
+---
+
+Fix Drag event listener is removed when a plugin is registered after the DragHandle plugin.

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -171,10 +171,6 @@ export const DragHandlePlugin = ({
     }
   }
 
-  element.addEventListener('dragstart', onDragStart)
-  element.addEventListener('dragend', onDragEnd)
-  document.addEventListener('drop', onDrop)
-
   wrapper.appendChild(element)
 
   return {
@@ -263,6 +259,10 @@ export const DragHandlePlugin = ({
         wrapper.style.position = 'absolute'
         wrapper.style.top = '0'
         wrapper.style.left = '0'
+
+        element.addEventListener('dragstart', onDragStart)
+        element.addEventListener('dragend', onDragEnd)
+        document.addEventListener('drop', onDrop)
 
         return {
           update(_, oldState) {


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

Fix node dragging does not work when other prose-mirror plugins are registered after the `DragHandle` plugin

fix #7537

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

Change drag event listener registartion timing to inside of view spec

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

add
` editor.registerPlugin({ spec: {}, props: {}, getState: () => {} }); `
to `drag-handle.spec.ts` and demo.

I didn't add new spec cause I think this is an edge scenario

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

1. Create editor with DragHandle extension
2. Add any prose-mirror plugin with `editor.registerPlugin()` . ex. with empty spec as `editor.registerPlugin({ spec: {}, props: {}, getState: () => {} });`
3. Verify node-dragging feature works well

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
#7537
