### PR TITLE
fix(placeholder): use isTextblock to skip wrapper node placeholders

### DIFF
--- a/.changeset/cool-elephants-wave.md
+++ b/.changeset/cool-elephants-wave.md
@@ -1,5 +1,0 @@
----
-'@tiptap/extensions': patch
----
-
-Add `excludedNodeTypes` option to Placeholder extension to prevent duplicate placeholders on wrapper nodes like lists when using `includeChildren: true`.

--- a/.changeset/late-seahorses-guess.md
+++ b/.changeset/late-seahorses-guess.md
@@ -1,5 +1,0 @@
----
-"@tiptap/extension-placeholder": patch
----
-
-feat(placeholder): add excludedNodeTypes option to exclude wrapper nodes

--- a/.changeset/slim-waves-happen.md
+++ b/.changeset/slim-waves-happen.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-placeholder': patch
+---
+
+Skip placeholder decorations on non-textblock nodes when `includeChildren` is enabled to prevent duplicate placeholders on wrapper nodes like lists.


### PR DESCRIPTION
## Changes Overview

Add `excludedNodeTypes` option to the Placeholder extension to fix duplicate placeholders appearing on wrapper nodes when using `includeChildren: true`.

## Problem

When using `includeChildren: true` with nested structures like lists, placeholders are shown on all empty descendant nodes, including wrapper nodes (`bulletList`, `listItem`) and content nodes (`paragraph`). This results in visually overlapping placeholders:

```
┌─────────────────────────────────┐
│ • Type something...             │  ← bulletList placeholder
│   ┌─────────────────────────┐   │
│   │ Type something...       │   │  ← listItem placeholder
│   │ ┌─────────────────────┐ │   │
│   │ │ Type something...   │ │   │  ← paragraph placeholder
│   │ └─────────────────────┘ │   │
│   └─────────────────────────┘   │
└─────────────────────────────────┘
```

This is visually confusing and not the intended behavior.

## Solution

Add `excludedNodeTypes` option to allow excluding specific node types from showing placeholders:

```typescript
Placeholder.configure({
  placeholder: 'Type something...',
  includeChildren: true,
  excludedNodeTypes: ['bulletList', 'orderedList', 'listItem'],
})
```

Now only the actual content nodes show placeholders:

```
┌─────────────────────────────────┐
│ •                               │  ← no placeholder (excluded)
│   ┌─────────────────────────┐   │
│   │                         │   │  ← no placeholder (excluded)
│   │ ┌─────────────────────┐ │   │
│   │ │ Type something...   │ │   │  ← placeholder shown
│   │ └─────────────────────┘ │   │
│   └─────────────────────────┘   │
└─────────────────────────────────┘
```

## Implementation Approach

- Added `excludedNodeTypes: string[]` option to `PlaceholderOptions` interface with a default value of empty array `[]`
- In the `doc.descendants()` callback, check if the current node type is in `excludedNodeTypes`
- If excluded, skip placeholder decoration and continue traversing children based on `includeChildren` setting

## Testing Done

Added 4 new test cases in `packages/extensions/__tests__/placeholder.spec.ts`:

- Placeholder not shown on excluded node types
- Placeholder shown on non-excluded nodes (paragraph)
- Multiple node types can be excluded
- `includeChildren: false` stops child traversal when node is excluded

## Verification Steps

1. Create an editor with nested list structure: `<ul><li><p></p></li></ul>`
2. Configure Placeholder with `includeChildren: true` and `excludedNodeTypes: ['bulletList', 'listItem']`
3. Verify that `bulletList` and `listItem` do not have `data-placeholder` attribute
4. Verify that `paragraph` has `data-placeholder` attribute

## Additional Notes

This fix maintains backward compatibility - the default behavior remains unchanged when `excludedNodeTypes` is not specified.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

https://github.com/steven-tey/novel/issues/510
