### PR TITLE
Fix global attributes not syncing on resizable image updates

### DIFF
--- a/.changeset/friendly-images-sync.md
+++ b/.changeset/friendly-images-sync.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-image": patch
+---
+
+Fix resizable images not synchronizing rendered attributes after updates

--- a/packages/extension-image/__tests__/image.spec.ts
+++ b/packages/extension-image/__tests__/image.spec.ts
@@ -385,6 +385,78 @@ describe('extension-image', () => {
       expect(img?.getAttribute('src')).toBe('https://tiptap.dev/new-image.png')
     })
 
+    it('should clear src on the resizable image when src is set to null', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Image.configure({
+            resize: { enabled: true },
+          }),
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                src: 'https://tiptap.dev/placeholder.png',
+              },
+            },
+          ],
+        },
+      })
+
+      const container = editor.view.dom.querySelector('[data-resize-container]')
+      const img = container?.querySelector('img')
+
+      expect(img?.getAttribute('src')).toBe('https://tiptap.dev/placeholder.png')
+
+      editor.commands.updateAttributes('image', { src: null })
+
+      expect(img?.hasAttribute('src')).toBe(false)
+      expect(img?.getAttribute('src')).toBeNull()
+      expect(img?.src).toBe('')
+    })
+
+    it('should clear src on the resizable image when src is set to an empty string', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Image.configure({
+            resize: { enabled: true },
+          }),
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                src: 'https://tiptap.dev/placeholder.png',
+              },
+            },
+          ],
+        },
+      })
+
+      const container = editor.view.dom.querySelector('[data-resize-container]')
+      const img = container?.querySelector('img')
+
+      expect(img?.getAttribute('src')).toBe('https://tiptap.dev/placeholder.png')
+
+      editor.commands.updateAttributes('image', { src: '' })
+
+      expect(img?.hasAttribute('src')).toBe(false)
+      expect(img?.getAttribute('src')).toBeNull()
+      expect(img?.src).toBe('')
+    })
+
     it('should remove attributes from the resizable image when set to null', () => {
       editor = new Editor({
         element: createEditorEl(),

--- a/packages/extension-image/__tests__/image.spec.ts
+++ b/packages/extension-image/__tests__/image.spec.ts
@@ -1,10 +1,11 @@
-import { Editor } from '@tiptap/core'
+import { Editor, Extension } from '@tiptap/core'
 import Document from '@tiptap/extension-document'
-import Image from '@tiptap/extension-image'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Markdown } from '@tiptap/markdown'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import Image from '../src/index.js'
 
 describe('extension-image', () => {
   const editorElClass = 'tiptap'
@@ -15,11 +16,20 @@ describe('extension-image', () => {
 
     editorEl.classList.add(editorElClass)
     document.body.appendChild(editorEl)
-
     return editorEl
   }
 
   const getEditorEl = () => document.querySelector(`.${editorElClass}`)
+
+  const destroyEditor = () => {
+    editor?.destroy()
+    editor = null
+    getEditorEl()?.remove()
+  }
+
+  afterEach(() => {
+    destroyEditor()
+  })
 
   const imgSrc = 'https://example.com/image.jpg'
 
@@ -48,9 +58,6 @@ describe('extension-image', () => {
     })
 
     expect(editor.getHTML()).toContain('class="my-classname"')
-
-    editor?.destroy()
-    getEditorEl()?.remove()
   })
 
   it('should apply HTMLAttributes in the editor DOM when resize is disabled', () => {
@@ -81,9 +88,6 @@ describe('extension-image', () => {
     expect(img).not.toBeNull()
     // ProseMirror may add additional classes like 'ProseMirror-selectednode'
     expect(img?.getAttribute('class')).toContain('my-classname')
-
-    editor?.destroy()
-    getEditorEl()?.remove()
   })
 
   it('should apply HTMLAttributes via renderHTML when resize is enabled', () => {
@@ -115,9 +119,6 @@ describe('extension-image', () => {
 
     // getHTML() goes through renderHTML which already correctly merges HTMLAttributes
     expect(editor.getHTML()).toContain('class="my-classname"')
-
-    editor?.destroy()
-    getEditorEl()?.remove()
   })
 
   it('should apply HTMLAttributes in the editor DOM when resize is enabled', () => {
@@ -150,14 +151,9 @@ describe('extension-image', () => {
 
     const img = editor.view.dom.querySelector('img')
     expect(img).not.toBeNull()
-    // THIS IS THE BUG: when resize is enabled, addNodeView takes over DOM creation
-    // and does NOT apply this.options.HTMLAttributes - only the node's resolved attrs
     expect(img?.getAttribute('class')).toBe('my-classname')
     expect(img?.getAttribute('data-test')).toBe('value')
     expect(img?.getAttribute('src')).toBe(imgSrc)
-
-    editor?.destroy()
-    getEditorEl()?.remove()
   })
 
   it('should apply HTMLAttributes in the editor DOM when resize is enabled and content is markdown', () => {
@@ -183,12 +179,8 @@ describe('extension-image', () => {
 
     const img = editor.view.dom.querySelector('img')
     expect(img).not.toBeNull()
-    // THIS IS THE BUG: same issue - node view doesn't apply options.HTMLAttributes
     expect(img?.getAttribute('class')).toBe('my-classname')
     expect(img?.getAttribute('src')).toBe('https://example.com/image.jpg')
-
-    editor?.destroy()
-    getEditorEl()?.remove()
   })
 
   it('should apply HTMLAttributes via renderHTML when resize is enabled and content is markdown', () => {
@@ -214,8 +206,225 @@ describe('extension-image', () => {
 
     // getHTML() goes through renderHTML which already correctly merges HTMLAttributes
     expect(editor.getHTML()).toContain('class="my-classname"')
+  })
 
-    editor?.destroy()
-    getEditorEl()?.remove()
+  /**
+   * Minimal extension that adds a global `customId` attribute (rendered as `data-custom-id`)
+   * to specified node types. This simulates what UniqueID does but without the complex
+   * plugin machinery, making it reliable in test environments.
+   */
+  const CustomIdAttribute = Extension.create({
+    name: 'customIdAttribute',
+
+    addGlobalAttributes() {
+      return [
+        {
+          types: ['image'],
+          attributes: {
+            customId: {
+              default: null,
+              parseHTML: (element: HTMLElement) => element.getAttribute('data-custom-id'),
+              renderHTML: (attributes: Record<string, any>) => {
+                if (!attributes.customId) {
+                  return {}
+                }
+
+                return { 'data-custom-id': attributes.customId }
+              },
+            },
+          },
+        },
+      ]
+    },
+  })
+
+  describe('resizable image attribute updates', () => {
+    it('should render global attributes on the resizable image element', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Image.configure({
+            resize: { enabled: true },
+          }),
+          CustomIdAttribute,
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                src: 'https://tiptap.dev/placeholder.png',
+                customId: 'my-id-123',
+              },
+            },
+          ],
+        },
+      })
+
+      const container = editor.view.dom.querySelector('[data-resize-container]')
+
+      expect(container).not.toBeNull()
+
+      const img = container?.querySelector('img')
+
+      expect(img).not.toBeNull()
+      expect(img?.getAttribute('src')).toBe('https://tiptap.dev/placeholder.png')
+      expect(img?.getAttribute('data-custom-id')).toBe('my-id-123')
+    })
+
+    it('should update global attributes on the img element when node attributes change', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Image.configure({
+            resize: { enabled: true },
+          }),
+          CustomIdAttribute,
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                src: 'https://tiptap.dev/placeholder.png',
+                customId: 'original-id',
+              },
+            },
+          ],
+        },
+      })
+
+      const container = editor.view.dom.querySelector('[data-resize-container]')
+      const img = container?.querySelector('img')
+
+      expect(img?.getAttribute('data-custom-id')).toBe('original-id')
+
+      // Update the customId so the img element reflects the new value.
+      editor.commands.updateAttributes('image', { customId: 'updated-id' })
+
+      expect(img?.getAttribute('data-custom-id')).toBe('updated-id')
+    })
+
+    it('should preserve global attributes when other attributes change', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Image.configure({
+            resize: { enabled: true },
+          }),
+          CustomIdAttribute,
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                src: 'https://tiptap.dev/placeholder.png',
+                customId: 'persistent-id',
+              },
+            },
+          ],
+        },
+      })
+
+      const container = editor.view.dom.querySelector('[data-resize-container]')
+      const img = container?.querySelector('img')
+
+      expect(img?.getAttribute('data-custom-id')).toBe('persistent-id')
+
+      // Update alt text while retaining data-custom-id.
+      editor.commands.updateAttributes('image', { alt: 'Updated alt text' })
+
+      expect(img?.getAttribute('alt')).toBe('Updated alt text')
+      expect(img?.getAttribute('data-custom-id')).toBe('persistent-id')
+    })
+
+    it('should update src on the resizable image when src attribute changes', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Image.configure({
+            resize: { enabled: true },
+          }),
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                src: 'https://tiptap.dev/placeholder.png',
+              },
+            },
+          ],
+        },
+      })
+
+      const container = editor.view.dom.querySelector('[data-resize-container]')
+      const img = container?.querySelector('img')
+
+      expect(img?.getAttribute('src')).toBe('https://tiptap.dev/placeholder.png')
+
+      editor.commands.updateAttributes('image', { src: 'https://tiptap.dev/new-image.png' })
+
+      expect(img?.getAttribute('src')).toBe('https://tiptap.dev/new-image.png')
+    })
+
+    it('should remove attributes from the resizable image when set to null', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Image.configure({
+            resize: { enabled: true },
+          }),
+          CustomIdAttribute,
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                src: 'https://tiptap.dev/placeholder.png',
+                alt: 'Some alt text',
+                title: 'Some title',
+                customId: 'to-be-removed',
+              },
+            },
+          ],
+        },
+      })
+
+      const container = editor.view.dom.querySelector('[data-resize-container]')
+      const img = container?.querySelector('img')
+
+      expect(img?.getAttribute('alt')).toBe('Some alt text')
+      expect(img?.getAttribute('title')).toBe('Some title')
+      expect(img?.getAttribute('data-custom-id')).toBe('to-be-removed')
+
+      editor.commands.updateAttributes('image', { alt: null, title: null, customId: null })
+
+      expect(img?.hasAttribute('alt')).toBe(false)
+      expect(img?.hasAttribute('title')).toBe(false)
+      expect(img?.hasAttribute('data-custom-id')).toBe(false)
+    })
   })
 })

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -155,6 +155,7 @@ export const Image = Node.create<ImageOptions>({
     }
 
     const { directions, minWidth, minHeight, alwaysPreserveAspectRatio } = this.options.resize
+    const resizeManagedAttributes = new Set(['src', 'width', 'height'])
 
     return ({ node, getPos, HTMLAttributes, editor }) => {
       const el = document.createElement('img')
@@ -215,22 +216,18 @@ export const Image = Node.create<ImageOptions>({
 
         // Remove attributes that were previously rendered but are no longer present
         Object.keys(previousHTMLAttributes).forEach(key => {
-          if (key !== 'src' && key !== 'width' && key !== 'height' && !(key in newHTMLAttributes)) {
+          if (!resizeManagedAttributes.has(key) && !(key in newHTMLAttributes)) {
             el.removeAttribute(key)
           }
         })
 
         Object.entries(newHTMLAttributes).forEach(([key, value]) => {
+          if (resizeManagedAttributes.has(key)) {
+            return
+          }
+
           if (value != null) {
-            switch (key) {
-              case 'src':
-              case 'width':
-              case 'height':
-                break
-              default:
-                el.setAttribute(key, value)
-                break
-            }
+            el.setAttribute(key, value)
           } else {
             el.removeAttribute(key)
           }

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -1,5 +1,11 @@
-import type { ResizableNodeViewDirection } from '@tiptap/core'
-import { getRenderedAttributes, mergeAttributes, Node, nodeInputRule, ResizableNodeView } from '@tiptap/core'
+import type { ResizableNodeViewDirection, ResizableNodeViewOptions } from '@tiptap/core'
+import {
+  getRenderedAttributes,
+  mergeAttributes,
+  Node,
+  nodeInputRule,
+  ResizableNodeView,
+} from '@tiptap/core'
 
 export interface ImageOptions {
   /**
@@ -173,6 +179,51 @@ export const Image = Node.create<ImageOptions>({
         el.src = mergedAttributes.src
       }
 
+      let previousHTMLAttributes = { ...HTMLAttributes }
+
+      const onUpdate: ResizableNodeViewOptions['onUpdate'] = (
+        updatedNode: Parameters<typeof getRenderedAttributes>[0],
+      ) => {
+        if (updatedNode.type !== node.type) {
+          return false
+        }
+
+        const extensionAttributes = editor.extensionManager.attributes.filter(
+          attribute => attribute.type === updatedNode.type.name,
+        )
+        const newHTMLAttributes = getRenderedAttributes(updatedNode, extensionAttributes)
+
+        // Remove attributes that were previously rendered but are no longer present
+        Object.keys(previousHTMLAttributes).forEach(key => {
+          if (key !== 'width' && key !== 'height' && !(key in newHTMLAttributes)) {
+            el.removeAttribute(key)
+          }
+        })
+
+        Object.entries(newHTMLAttributes).forEach(([key, value]) => {
+          if (value != null) {
+            switch (key) {
+              case 'width':
+              case 'height':
+                break
+              default:
+                el.setAttribute(key, value)
+                break
+            }
+          } else {
+            el.removeAttribute(key)
+          }
+        })
+
+        if (newHTMLAttributes.src !== el.src) {
+          el.src = newHTMLAttributes.src
+        }
+
+        previousHTMLAttributes = newHTMLAttributes
+
+        return true
+      }
+
       const nodeView = new ResizableNodeView({
         element: el,
         editor,
@@ -197,37 +248,7 @@ export const Image = Node.create<ImageOptions>({
             })
             .run()
         },
-        onUpdate: (updatedNode: any) => {
-          if (updatedNode.type !== node.type) {
-            return false
-          }
-
-          const extensionAttributes = editor.extensionManager.attributes.filter(
-            attribute => attribute.type === updatedNode.type.name,
-          )
-          const newHTMLAttributes = getRenderedAttributes(updatedNode, extensionAttributes)
-
-          Object.entries(newHTMLAttributes).forEach(([key, value]) => {
-            if (value != null) {
-              switch (key) {
-                case 'width':
-                case 'height':
-                  break
-                default:
-                  el.setAttribute(key, value)
-                  break
-              }
-            } else {
-              el.removeAttribute(key)
-            }
-          })
-
-          if (newHTMLAttributes.src !== el.src) {
-            el.src = newHTMLAttributes.src
-          }
-
-          return true
-        },
+        onUpdate,
         options: {
           directions,
           min: {

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -165,6 +165,7 @@ export const Image = Node.create<ImageOptions>({
       Object.entries(mergedAttributes).forEach(([key, value]) => {
         if (value != null) {
           switch (key) {
+            case 'src':
             case 'width':
             case 'height':
               break
@@ -180,6 +181,25 @@ export const Image = Node.create<ImageOptions>({
       }
 
       let previousHTMLAttributes = { ...HTMLAttributes }
+      const syncImageSource = (src: unknown) => {
+        if (typeof src === 'string' && src !== '') {
+          if (el.getAttribute('src') !== src) {
+            el.src = src
+          }
+
+          return
+        }
+
+        if (el.hasAttribute('src')) {
+          el.removeAttribute('src')
+        }
+
+        if (el.src !== '') {
+          el.src = ''
+        }
+      }
+
+      syncImageSource(HTMLAttributes.src)
 
       const onUpdate: ResizableNodeViewOptions['onUpdate'] = (
         updatedNode: Parameters<typeof getRenderedAttributes>[0],
@@ -195,7 +215,7 @@ export const Image = Node.create<ImageOptions>({
 
         // Remove attributes that were previously rendered but are no longer present
         Object.keys(previousHTMLAttributes).forEach(key => {
-          if (key !== 'width' && key !== 'height' && !(key in newHTMLAttributes)) {
+          if (key !== 'src' && key !== 'width' && key !== 'height' && !(key in newHTMLAttributes)) {
             el.removeAttribute(key)
           }
         })
@@ -203,6 +223,7 @@ export const Image = Node.create<ImageOptions>({
         Object.entries(newHTMLAttributes).forEach(([key, value]) => {
           if (value != null) {
             switch (key) {
+              case 'src':
               case 'width':
               case 'height':
                 break
@@ -215,9 +236,7 @@ export const Image = Node.create<ImageOptions>({
           }
         })
 
-        if (newHTMLAttributes.src !== el.src) {
-          el.src = newHTMLAttributes.src
-        }
+        syncImageSource(newHTMLAttributes.src)
 
         previousHTMLAttributes = newHTMLAttributes
 

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -1,5 +1,5 @@
 import type { ResizableNodeViewDirection } from '@tiptap/core'
-import { mergeAttributes, Node, nodeInputRule, ResizableNodeView } from '@tiptap/core'
+import { getRenderedAttributes, mergeAttributes, Node, nodeInputRule, ResizableNodeView } from '@tiptap/core'
 
 export interface ImageOptions {
   /**
@@ -197,9 +197,33 @@ export const Image = Node.create<ImageOptions>({
             })
             .run()
         },
-        onUpdate: (updatedNode, _decorations, _innerDecorations) => {
+        onUpdate: (updatedNode: any) => {
           if (updatedNode.type !== node.type) {
             return false
+          }
+
+          const extensionAttributes = editor.extensionManager.attributes.filter(
+            attribute => attribute.type === updatedNode.type.name,
+          )
+          const newHTMLAttributes = getRenderedAttributes(updatedNode, extensionAttributes)
+
+          Object.entries(newHTMLAttributes).forEach(([key, value]) => {
+            if (value != null) {
+              switch (key) {
+                case 'width':
+                case 'height':
+                  break
+                default:
+                  el.setAttribute(key, value)
+                  break
+              }
+            } else {
+              el.removeAttribute(key)
+            }
+          })
+
+          if (newHTMLAttributes.src !== el.src) {
+            el.src = newHTMLAttributes.src
           }
 
           return true


### PR DESCRIPTION
## Fixes

Fixes #7542

## Changes and Review

- Resizable image node views now synchronize rendered global and HTML attributes when image attributes change.
- Added regression coverage for rendering, updating, retaining, and removing resizable image attributes.
- Verify with `pnpm exec vitest run packages/extension-image/__tests__/image.spec.ts`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.