### PR TITLE
fix(react): prevent useEditorState selectors from running on stale editor

### DIFF
--- a/packages/react/src/__tests__/useEditorState.test.ts
+++ b/packages/react/src/__tests__/useEditorState.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from '@testing-library/react'
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useEditorState } from '../useEditorState.js'
+
+function createEditor() {
+  return new Editor({
+    extensions: [Document, Paragraph, Text],
+  })
+}
+
+describe('useEditorState', () => {
+  it('should return selector result for the current editor', () => {
+    const editor = createEditor()
+
+    const { result } = renderHook(() =>
+      useEditorState({
+        editor,
+        selector: ({ editor: e }) => e?.isDestroyed ?? null,
+      }),
+    )
+
+    expect(result.current).toBe(false)
+    editor.destroy()
+  })
+
+  it('should not run selector against a destroyed editor when editor instance changes', () => {
+    const editorA = createEditor()
+    const editorB = createEditor()
+    let currentEditor: Editor | null = editorA
+
+    const selectorCalls: boolean[] = []
+    const selector = vi.fn(({ editor: e }: { editor: Editor | null; transactionNumber: number }) => {
+      const isDestroyed = e?.isDestroyed ?? null
+      selectorCalls.push(isDestroyed === true)
+      // In the bug scenario, the selector would receive the destroyed editorA
+      // and accessing editorA.view would throw
+      return isDestroyed
+    })
+
+    const { result, rerender } = renderHook(() =>
+      useEditorState({
+        editor: currentEditor,
+        selector,
+        // Use reference equality to avoid deepEqual on complex objects
+        equalityFn: (a, b) => a === b,
+      }),
+    )
+
+    expect(result.current).toBe(false)
+
+    // Simulate what happens when useEditor recreates the editor:
+    // old editor is destroyed, new editor is provided
+    editorA.destroy()
+    currentEditor = editorB
+
+    // This rerender should NOT cause the selector to run on the destroyed editorA
+    rerender()
+
+    expect(result.current).toBe(false)
+    // Verify the selector was never called with a destroyed editor
+    expect(selectorCalls.every(wasDestroyed => wasDestroyed === false)).toBe(true)
+
+    editorB.destroy()
+  })
+
+  it('should handle editor changing to null', () => {
+    const editor = createEditor()
+    let currentEditor: Editor | null = editor
+
+    const { result, rerender } = renderHook(() =>
+      useEditorState({
+        editor: currentEditor,
+        selector: ({ editor: e }) => e?.isDestroyed ?? null,
+        equalityFn: (a, b) => a === b,
+      }),
+    )
+
+    expect(result.current).toBe(false)
+
+    editor.destroy()
+    currentEditor = null
+    rerender()
+
+    expect(result.current).toBeNull()
+  })
+
+  it('should handle editor changing from null to an instance', () => {
+    let currentEditor: Editor | null = null
+
+    const { result, rerender } = renderHook(() =>
+      useEditorState({
+        editor: currentEditor,
+        selector: ({ editor: e }) => e?.isDestroyed ?? null,
+        equalityFn: (a, b) => a === b,
+      }),
+    )
+
+    expect(result.current).toBeNull()
+
+    currentEditor = createEditor()
+    rerender()
+
+    expect(result.current).toBe(false)
+
+    currentEditor.destroy()
+  })
+})

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -84,6 +84,19 @@ class EditorStateManager<TEditor extends Editor | null = Editor | null> {
   }
 
   /**
+   * Eagerly update the editor reference during render.
+   * This prevents selectors from running against a stale/destroyed editor
+   * when the editor instance is recreated (e.g., when useEditor deps change).
+   */
+  setEditorInstance(editor: TEditor) {
+    if (this.editor !== editor) {
+      this.editor = editor
+      // Bump transaction number so getSnapshot returns a fresh snapshot
+      this.transactionNumber += 1
+    }
+  }
+
+  /**
    * Watch the editor instance for changes.
    */
   watch(nextEditor: Editor | null): undefined | (() => void) {
@@ -158,6 +171,12 @@ export function useEditorState<TSelectorResult>(
     | UseEditorStateOptions<TSelectorResult, Editor | null>,
 ): TSelectorResult | null {
   const [editorStateManager] = useState(() => new EditorStateManager(options.editor))
+
+  // Eagerly sync the editor reference during render to prevent selectors from
+  // running against a stale/destroyed editor when the editor instance changes.
+  // Without this, the layout effect (watch) hasn't fired yet, so getSnapshot
+  // would return a snapshot with the old editor.
+  editorStateManager.setEditorInstance(options.editor)
 
   // Using the `useSyncExternalStore` hook to sync the editor instance with the component state
   const selectedState = useSyncExternalStoreWithSelector(


### PR DESCRIPTION
## Summary

Fixes #7346

When `useEditor` deps change, the old editor is destroyed and a new one is created. `EditorStateManager` in `useEditorState` only updated its editor reference via a layout effect (`watch`), which fires **after** render. This caused `useSyncExternalStoreWithSelector` to call selectors with a snapshot containing the **old, destroyed** editor — leading to:

```
[tiptap error]: The editor view is not available. Cannot access view['hasFocus'].
```

## Root Cause

The lifecycle ordering when deps change:

1. `useEditor` effect runs → `refreshEditorInstance` destroys old editor, creates new one
2. `setEditor` notifies `useSyncExternalStore` → React re-renders
3. During re-render, `useEditorState`'s `useSyncExternalStoreWithSelector` calls `getSnapshot()`
4. **Bug**: `EditorStateManager` still holds the old (destroyed) editor — `watch` hasn't fired yet (layout effect)
5. Selector runs against destroyed editor → error

## Fix

Added `setEditorInstance()` to `EditorStateManager` that eagerly syncs the editor reference **during render**, before `useSyncExternalStoreWithSelector` reads the snapshot. The layout effect (`watch`) still handles transaction listener setup/teardown as before.

The change is 2 additions:
- A `setEditorInstance` method on `EditorStateManager` (7 lines)
- One call to it in `useEditorState` before the store selector runs (1 line + comments)

## Testing

- 4 new unit tests in `packages/react/src/__tests__/useEditorState.test.ts`
  - Selector returns correct result for current editor
  - **Selector never runs against a destroyed editor when editor instance changes** (the bug scenario)
  - Editor changing to null
  - Editor changing from null to an instance
- Tests **fail without the fix** (3/4 fail), confirming they capture the bug
- All 657 existing tests pass (zero regressions)
- Build passes (72/72 packages)
- Lint + prettier clean