### PR TITLE
Fix `exitSuggestions()` acting as trigger for other suggestions

### DIFF
--- a/.changeset/violet-crabs-crash.md
+++ b/.changeset/violet-crabs-crash.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/suggestion': patch
+---
+
+Fix exitSuggestion for one pluginKey can activate another suggestion pluginKey

--- a/packages/suggestion/src/__tests__/suggestion.test.ts
+++ b/packages/suggestion/src/__tests__/suggestion.test.ts
@@ -1,8 +1,9 @@
 import { Editor, Extension } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
 import StarterKit from '@tiptap/starter-kit'
 import { describe, expect, it, vi } from 'vitest'
 
-import { Suggestion } from '../suggestion.js'
+import { exitSuggestion, Suggestion } from '../suggestion.js'
 
 describe('suggestion integration', () => {
   it('should respect shouldShow returning false', async () => {
@@ -121,6 +122,68 @@ describe('suggestion integration', () => {
     expect(capturedProps.text).toBe('@')
     // Check that we receive the correct editor instance
     expect(capturedProps.editor).toBe(editor)
+
+    editor.destroy()
+  })
+
+  it('should not activate another suggestion when exitSuggestion is called', async () => {
+    const pluginKeyA = new PluginKey('suggestionA')
+    const pluginKeyB = new PluginKey('suggestionB')
+
+    const onStartB = vi.fn()
+
+    const SuggestionA = Extension.create({
+      name: 'suggestion-a',
+      addProseMirrorPlugins() {
+        return [
+          Suggestion({
+            editor: this.editor,
+            pluginKey: pluginKeyA,
+            char: '@',
+          }),
+        ]
+      },
+    })
+
+    const SuggestionB = Extension.create({
+      name: 'suggestion-b',
+      addProseMirrorPlugins() {
+        return [
+          Suggestion({
+            editor: this.editor,
+            pluginKey: pluginKeyB,
+            char: '#',
+            render: () => ({
+              onStart: onStartB,
+            }),
+          }),
+        ]
+      },
+    })
+
+    const editor = new Editor({
+      extensions: [StarterKit, SuggestionA, SuggestionB],
+      content: '<p>#tag</p>',
+    })
+
+    // Place cursor at end of "#tag" — this activates suggestion B
+    editor.commands.setTextSelection(5)
+    await Promise.resolve()
+    expect(pluginKeyB.getState(editor.state).active).toBe(true)
+
+    // Exit suggestion B programmatically
+    exitSuggestion(editor.view, pluginKeyB)
+    await Promise.resolve()
+    expect(pluginKeyB.getState(editor.state).active).toBe(false)
+
+    onStartB.mockClear()
+
+    // Now exit suggestion A (not active) — this should NOT re-activate B
+    exitSuggestion(editor.view, pluginKeyA)
+    await Promise.resolve()
+
+    expect(pluginKeyB.getState(editor.state).active).toBe(false)
+    expect(onStartB).not.toHaveBeenCalled()
 
     editor.destroy()
   })

--- a/packages/suggestion/src/suggestion.ts
+++ b/packages/suggestion/src/suggestion.ts
@@ -201,6 +201,14 @@ export interface SuggestionKeyDownProps {
 export const SuggestionPluginKey = new PluginKey('suggestion')
 
 /**
+ * Shared meta key used by all Suggestion plugin instances to signal that
+ * the current transaction is an exit. Other instances skip match logic
+ * when this meta is present so exiting one suggestion cannot accidentally
+ * activate another.
+ */
+const SUGGESTION_EXIT_META = 'suggestionExit'
+
+/**
  * This utility allows you to create suggestions.
  * @see https://tiptap.dev/api/utilities/suggestion
  */
@@ -284,7 +292,7 @@ export function Suggestion<I = any, TSelected = any>({
       // ignore errors from consumer renderers
     }
 
-    const tr = view.state.tr.setMeta(pluginKeyRef, { exit: true })
+    const tr = view.state.tr.setMeta(pluginKeyRef, { exit: true }).setMeta(SUGGESTION_EXIT_META, true)
     // Dispatch a metadata-only transaction to signal the plugin to exit
     view.dispatch(tr)
   }
@@ -416,6 +424,12 @@ export function Suggestion<I = any, TSelected = any>({
           next.text = null
 
           return next
+        }
+
+        // Another suggestion plugin is exiting — keep our current state
+        // unchanged so we don't accidentally activate from the exit transaction.
+        if (transaction.getMeta(SUGGESTION_EXIT_META)) {
+          return prev
         }
 
         next.composing = composing
@@ -580,6 +594,6 @@ export function Suggestion<I = any, TSelected = any>({
  * decorations without touching the document or causing mapping errors.
  */
 export function exitSuggestion(view: EditorView, pluginKeyRef: PluginKey = SuggestionPluginKey) {
-  const tr = view.state.tr.setMeta(pluginKeyRef, { exit: true })
+  const tr = view.state.tr.setMeta(pluginKeyRef, { exit: true }).setMeta(SUGGESTION_EXIT_META, true)
   view.dispatch(tr)
 }


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

Modifies so that suggestion trigger code never runs for a suggestion exit event, even if it's for another suggestion.

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->

I wanted to look at how to fix this, added test to verify the issue, then added another global meta to be able to track it. If the global meta is present, skip running trigger check code.

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

Test verifies that triggering exit on one suggestion-instance does not activate another instance. Tested demos that suggestions still work.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

Verify that exiting suggestions programatically works as expected.

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

I wanted to look at if this would be solvable in a nice way, but looking at it, we can't know it's an exit event without knowing about other suggestions, so using a global meta like this was the way I could see. It's not super pretty, understand if we want to say "it's not really a problem" and just close.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->

This would close #7585 