### PR TITLE
fix(markdown): prevent crossing marks when serializing overlapping marks

### DIFF
--- a/packages/markdown/__tests__/markdown-overlapping-marks.test.ts
+++ b/packages/markdown/__tests__/markdown-overlapping-marks.test.ts
@@ -1,0 +1,45 @@
+import { Editor } from '@tiptap/core'
+import { Markdown } from '@tiptap/markdown'
+import StarterKit from '@tiptap/starter-kit'
+
+describe('Markdown serialization – overlapping marks', () => {
+  it('serializes overlapping bold and italic without crossing marks', () => {
+    const editor = new Editor({
+      extensions: [StarterKit, Markdown],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: '123',
+                marks: [{ type: 'bold' }],
+              },
+              {
+                type: 'text',
+                text: '456',
+                marks: [{ type: 'bold' }, { type: 'italic' }],
+              },
+              {
+                type: 'text',
+                text: '789',
+                marks: [{ type: 'italic' }],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const markdown = editor.storage.markdown.getMarkdown()
+
+    expect(markdown).toContain('123')
+    expect(markdown).toContain('456')
+    expect(markdown).toContain('789')
+
+    // Ensure marks are not crossing
+    expect(markdown).not.toBe('**123*456**789*')
+  })
+})

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -928,17 +928,20 @@ export class MarkdownManager {
           }
         }
         // Close marks that are ending here
-        marksToClose.forEach(markType => {
-          const mark = currentMarks.get(markType)
-          const closeMarkdown = this.getMarkClosing(markType, mark)
-          if (closeMarkdown) {
-            textContent += closeMarkdown
-          }
-          // deleting closed marks from active marks
-          if (activeMarks.has(markType)) {
-            activeMarks.delete(markType)
-          }
-        })
+        marksToClose
+          .slice()
+          .reverse()
+          .forEach(markType => {
+            const mark = currentMarks.get(markType)
+            const closeMarkdown = this.getMarkClosing(markType, mark)
+            if (closeMarkdown) {
+              textContent += closeMarkdown
+            }
+            // deleting closed marks from active marks
+            if (activeMarks.has(markType)) {
+              activeMarks.delete(markType)
+            }
+          })
 
         // Open new marks (should be at the beginning)
         // Extract leading whitespace before opening marks to prevent invalid markdown like "** text**"
@@ -982,14 +985,17 @@ export class MarkdownManager {
           }
         }
 
-        marksToCloseAtEnd.forEach(markType => {
-          const mark = activeMarks.get(markType)
-          const closeMarkdown = this.getMarkClosing(markType, mark)
-          if (closeMarkdown) {
-            textContent += closeMarkdown
-          }
-          activeMarks.delete(markType)
-        })
+        marksToCloseAtEnd
+          .slice()
+          .reverse()
+          .forEach(markType => {
+            const mark = activeMarks.get(markType)
+            const closeMarkdown = this.getMarkClosing(markType, mark)
+            if (closeMarkdown) {
+              textContent += closeMarkdown
+            }
+            activeMarks.delete(markType)
+          })
 
         // Add trailing whitespace after the mark closing
         textContent += trailingWhitespace


### PR DESCRIPTION
Fixes #7590

When bold and italic marks overlap, the markdown serializer could produce
crossing marks such as:

**123*456**789*

which results in invalid HTML nesting:

<b>123<i>456</b>789</i>

This change ensures marks are closed in reverse order so they are properly nested.

Example output after fix:

**123*456***789*

which corresponds to:

<b>123<i>456</i></b><i>789</i>

A test was added to cover overlapping mark serialization.