### PR TITLE
fix(core): preserve non-empty multiline text in isNodeEmpty

### DIFF
--- a/.changeset/fair-lions-smile.md
+++ b/.changeset/fair-lions-smile.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fixed `isNodeEmpty()` so multi-line text with non-whitespace content is no longer treated as empty when `ignoreWhitespace` is enabled.

--- a/packages/core/__tests__/isNodeEmpty.spec.ts
+++ b/packages/core/__tests__/isNodeEmpty.spec.ts
@@ -24,6 +24,12 @@ describe('isNodeEmpty', () => {
       expect(isNodeEmpty(node, { ignoreWhitespace: true })).toBe(true)
     })
 
+    it('should return false when multi-line text contains non-whitespace content', () => {
+      const node = schema.nodeFromJSON({ type: 'text', text: 'Hello\n\nWorld' })
+
+      expect(isNodeEmpty(node, { ignoreWhitespace: true })).toBe(false)
+    })
+
     it('should return true when a paragraph has only whitespace', () => {
       const node = schema.nodeFromJSON({
         type: 'paragraph',

--- a/packages/core/src/helpers/isNodeEmpty.ts
+++ b/packages/core/src/helpers/isNodeEmpty.ts
@@ -25,7 +25,7 @@ export function isNodeEmpty(
       return true
     }
     if (node.isText) {
-      return /^\s*$/m.test(node.text ?? '')
+      return !/\S/.test(node.text ?? '')
     }
   }
 


### PR DESCRIPTION
## Changes Overview

Fixes `isNodeEmpty()` so multi-line text nodes that contain non-whitespace characters are no longer treated as empty when `ignoreWhitespace` is enabled.

## Implementation Approach

I added a regression test for a multi-line text node containing content separated by blank lines, confirmed it failed, and then replaced the multiline whitespace regex with a direct non-whitespace check in the text-node branch of `isNodeEmpty()`.

## Testing Done

Ran `pnpm test:unit packages/core/__tests__/isNodeEmpty.spec.ts`.
Confirmed the new regression test failed before the fix and the full spec passed after the fix.

## Verification Steps

1. Check out this branch.
2. Run `pnpm test:unit packages/core/__tests__/isNodeEmpty.spec.ts`.
3. Verify the new case for `Hello\n\nWorld` passes with `ignoreWhitespace: true` and returns `false` from `isNodeEmpty()`.

## Additional Notes

A patch changeset for `@tiptap/core` is included.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #6436