### PR TITLE
Add agent skill for Tiptap integration

### DIFF
--- a/skills/tiptap-integration/SKILL.md
+++ b/skills/tiptap-integration/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: tiptap-integration
+description: Helps coding agents integrate and work with the Tiptap rich text editor. Use when building or modifying a rich text editor with Tiptap, installing Tiptap extensions, or implementing features like collaboration, comments, AI, or document conversion.
+compatibility: Requires git and Node.js
+metadata:
+  author: tiptap
+  version: "1.0"
+---
+
+# Tiptap Integration Skill
+
+Instructions for coding agents integrating the Tiptap rich text editor
+
+## Reference Repositories
+
+Clone the tiptap and tiptap-docs repositories so you can search the source code and documentation.
+- https://github.com/ueberdosis/tiptap
+- https://github.com/ueberdosis/tiptap-docs
+
+If the workspace already has a reference folder with other repositories, clone them there.
+
+Otherwise, clone the repositories in a new `.reference` folder. The reference folder should be git-ignored.
+
+Before you start a task, make sure the repositories are updated to the latest version.
+
+## Best Practices
+
+### General
+
+- Use the latest stable version of **Tiptap 3**.
+- All packages that start with `@tiptap/` must have the **same version number**.
+- When integrating Tiptap for the first time, read the corresponding installation guide in tiptap-docs.
+- When server-side rendering (e.g. Next.js), set the `immediatelyRender: false` option when initializing the editor. Otherwise, the editor will crash. Learn more about this in tiptap-docs.
+
+### React
+
+- Prefer using the React Composable API. See `guides/react-composable-api`
+
+## Implementing Editor Features
+
+When the user asks you to implement one of these features, read the corresponding section in tiptap-docs for guidance.
+
+- **Real-time collaboration** — Multiple users editing a document simultaneously. See `collaboration/` in tiptap-docs.
+- **Comments** — Thread-based inline and document comments. See `comments/` in tiptap-docs.
+- **Tracked changes** — Track, accept, and reject document edits. See `tracked-changes/` in tiptap-docs.
+- **Import/Export** — Convert documents to and from DOCX, PDF, Markdown, and other formats. See `conversion/` in tiptap-docs.
+- **AI content generation** — Generate text content into the document using AI. See `content-ai/capabilities/ai-toolkit/workflows/insert-content` in tiptap-docs.
+- **AI agent document editing** — Give an AI agent the ability to edit Tiptap documents. See `content-ai/capabilities/ai-toolkit/` in tiptap-docs.
+- **AI review and proofreading** — Review, proofread, and suggest style improvements. See `content-ai/capabilities/ai-toolkit/workflows/proofreader` in tiptap-docs.
+- **AI server-side processing** — Run AI workflows that edit rich text documents on the server. See `content-ai/capabilities/server-ai-toolkit/` in tiptap-docs.
+- **Version history** — Save and restore document snapshots. See `collaboration/documents/snapshot` in tiptap-docs.
+- **Snapshot compare** — Highlight differences between document versions. See `collaboration/documents/snapshot-compare` in tiptap-docs.
+- **Pages** — Print-ready page layout with headers, footers, and page breaks. See `pages/` in tiptap-docs.
+
+## Pro Extensions
+
+Some Tiptap extensions are distributed through a private npm registry. To install pro packages, see `guides/pro-extensions` in tiptap-docs for setup instructions.

--- a/skills/tiptap-integration/SKILL.md
+++ b/skills/tiptap-integration/SKILL.md
@@ -34,24 +34,24 @@ Before you start a task, make sure the repositories are updated to the latest ve
 
 ### React
 
-- Prefer using the React Composable API. See `guides/react-composable-api`
+- Prefer using the React Composable API. See `tiptap-docs/guides/react-composable-api`
 
 ## Implementing Editor Features
 
 When the user asks you to implement one of these features, read the corresponding section in tiptap-docs for guidance.
 
-- **Real-time collaboration** — Multiple users editing a document simultaneously. See `collaboration/` in tiptap-docs.
-- **Comments** — Thread-based inline and document comments. See `comments/` in tiptap-docs.
-- **Tracked changes** — Track, accept, and reject document edits. See `tracked-changes/` in tiptap-docs.
-- **Import/Export** — Convert documents to and from DOCX, PDF, Markdown, and other formats. See `conversion/` in tiptap-docs.
-- **AI content generation** — Generate text content into the document using AI. See `content-ai/capabilities/ai-toolkit/workflows/insert-content` in tiptap-docs.
-- **AI agent document editing** — Give an AI agent the ability to edit Tiptap documents. See `content-ai/capabilities/ai-toolkit/` in tiptap-docs.
-- **AI review and proofreading** — Review, proofread, and suggest style improvements. See `content-ai/capabilities/ai-toolkit/workflows/proofreader` in tiptap-docs.
-- **AI server-side processing** — Run AI workflows that edit rich text documents on the server. See `content-ai/capabilities/server-ai-toolkit/` in tiptap-docs.
-- **Version history** — Save and restore document snapshots. See `collaboration/documents/snapshot` in tiptap-docs.
-- **Snapshot compare** — Highlight differences between document versions. See `collaboration/documents/snapshot-compare` in tiptap-docs.
-- **Pages** — Print-ready page layout with headers, footers, and page breaks. See `pages/` in tiptap-docs.
+- **Real-time collaboration** — Multiple users editing a document simultaneously. See `tiptap-docs/collaboration/`.
+- **Comments** — Thread-based inline and document comments. See `tiptap-docs/comments/`.
+- **Tracked changes** — Track, accept, and reject document edits. See `tiptap-docs/tracked-changes/`.
+- **Import/Export** — Convert documents to and from DOCX, PDF, Markdown, and other formats. See `tiptap-docs/conversion/`.
+- **AI content generation** — Generate text content into the document using AI. See `tiptap-docs/content-ai/capabilities/ai-toolkit/workflows/insert-content`.
+- **AI agent document editing** — Give an AI agent the ability to edit Tiptap documents. See `tiptap-docs/content-ai/capabilities/ai-toolkit/`.
+- **AI review and proofreading** — Review, proofread, and suggest style improvements. See `tiptap-docs/content-ai/capabilities/ai-toolkit/workflows/proofreader`.
+- **AI server-side processing** — Run AI workflows that edit rich text documents on the server. See `tiptap-docs/content-ai/capabilities/server-ai-toolkit/`.
+- **Version history** — Save and restore document snapshots. See `tiptap-docs/collaboration/documents/snapshot`.
+- **Snapshot compare** — Highlight differences between document versions. See `tiptap-docs/collaboration/documents/snapshot-compare`.
+- **Pages** — Print-ready page layout with headers, footers, and page breaks. See `tiptap-docs/pages/`.
 
 ## Pro Extensions
 
-Some Tiptap extensions are distributed through a private npm registry. To install pro packages, see `guides/pro-extensions` in tiptap-docs for setup instructions.
+Some Tiptap extensions are distributed through a private npm registry. To install pro packages, see `tiptap-docs/guides/pro-extensions` for setup instructions.

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -34,24 +34,24 @@ Before you start a task, make sure the repositories are updated to the latest ve
 
 ### React
 
-- Prefer using the React Composable API. See `tiptap-docs/guides/react-composable-api`
+- Prefer using the React Composable API. See `tiptap-docs/src/content/guides/react-composable-api.mdx`
 
 ## Implementing Editor Features
 
 When the user asks you to implement one of these features, read the corresponding section in tiptap-docs for guidance.
 
-- **Real-time collaboration** — Multiple users editing a document simultaneously. See `tiptap-docs/collaboration/`.
-- **Comments** — Thread-based inline and document comments. See `tiptap-docs/comments/`.
-- **Tracked changes** — Track, accept, and reject document edits. See `tiptap-docs/tracked-changes/`.
-- **Import/Export** — Convert documents to and from DOCX, PDF, Markdown, and other formats. See `tiptap-docs/conversion/`.
-- **AI content generation** — Generate text content into the document using AI. See `tiptap-docs/content-ai/capabilities/ai-toolkit/workflows/insert-content`.
-- **AI agent document editing** — Give an AI agent the ability to edit Tiptap documents. See `tiptap-docs/content-ai/capabilities/ai-toolkit/`.
-- **AI review and proofreading** — Review, proofread, and suggest style improvements. See `tiptap-docs/content-ai/capabilities/ai-toolkit/workflows/proofreader`.
-- **AI server-side processing** — Run AI workflows that edit rich text documents on the server. See `tiptap-docs/content-ai/capabilities/server-ai-toolkit/`.
-- **Version history** — Save and restore document snapshots. See `tiptap-docs/collaboration/documents/snapshot`.
-- **Snapshot compare** — Highlight differences between document versions. See `tiptap-docs/collaboration/documents/snapshot-compare`.
-- **Pages** — Print-ready page layout with headers, footers, and page breaks. See `tiptap-docs/pages/`.
+- **Real-time collaboration** — Multiple users editing a document simultaneously. See `tiptap-docs/src/content/collaboration/`.
+- **Comments** — Thread-based inline and document comments. See `tiptap-docs/src/content/comments/`.
+- **Tracked changes** — Track, accept, and reject document edits. See `tiptap-docs/src/content/tracked-changes/`.
+- **Import/Export** — Convert documents to and from DOCX, PDF, Markdown, and other formats. See `tiptap-docs/src/content/conversion/`.
+- **AI content generation** — Generate text content into the document using AI. See `tiptap-docs/src/content/content-ai/capabilities/ai-toolkit/workflows/insert-content.mdx`.
+- **AI agent document editing** — Give an AI agent the ability to edit Tiptap documents. See `tiptap-docs/src/content/content-ai/capabilities/ai-toolkit/`.
+- **AI review and proofreading** — Review, proofread, and suggest style improvements. See `tiptap-docs/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx`.
+- **AI server-side processing** — Run AI workflows that edit rich text documents on the server. See `tiptap-docs/src/content/content-ai/capabilities/server-ai-toolkit/`.
+- **Version history** — Save and restore document snapshots. See `tiptap-docs/src/content/collaboration/documents/snapshot.mdx`.
+- **Snapshot compare** — Highlight differences between document versions. See `tiptap-docs/src/content/collaboration/documents/snapshot-compare.mdx`.
+- **Pages** — Print-ready page layout with headers, footers, and page breaks. See `tiptap-docs/src/content/pages/`.
 
 ## Pro Extensions
 
-Some Tiptap extensions are distributed through a private npm registry. To install pro packages, see `tiptap-docs/guides/pro-extensions` for setup instructions.
+Some Tiptap extensions are distributed through a private npm registry. To install pro packages, see `tiptap-docs/src/content/guides/pro-extensions.mdx` for setup instructions.

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tiptap-integration
+name: tiptap
 description: Helps coding agents integrate and work with the Tiptap rich text editor. Use when building or modifying a rich text editor with Tiptap, installing Tiptap extensions, or implementing features like collaboration, comments, AI, or document conversion.
 compatibility: Requires git and Node.js
 metadata:

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tiptap
 description: Helps coding agents integrate and work with the Tiptap rich text editor. Use when building or modifying a rich text editor with Tiptap, installing Tiptap extensions, or implementing features like collaboration, comments, AI, or document conversion.
-compatibility: Requires git and Node.js
+compatibility: Requires git
 metadata:
   author: tiptap
   version: "1.0"


### PR DESCRIPTION
## Summary

- Adds a `skills/tiptap-integration/SKILL.md` following the [Agent Skills open standard](https://agentskills.io)
- Makes the Tiptap skill installable via `npx skills add ueberdosis/tiptap`
- This allows the skill to appear on [skills.sh](https://skills.sh) for discovery by developers using AI coding agents

## Details

The skill file provides AI coding agents with structured guidance on how to integrate Tiptap into web projects, covering installation, editor setup, extension configuration, and best practices for both React and vanilla JS usage.

## Test plan

- [x] Verify `skills/tiptap-integration/SKILL.md` has valid frontmatter with required fields (`name`, `description`, `version`, `author`)
- [x] Confirm the skill is installable via `npx skills add ueberdosis/tiptap`
- [x] Review the skill content for accuracy against current Tiptap APIs