### PR TITLE
7632 / Fix Paste Handler Match of Full Text Links

### DIFF
--- a/.changeset/red-lobsters-return.md
+++ b/.changeset/red-lobsters-return.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-link': patch
+---
+
+fix: only match full-text links in paste handler

--- a/packages/extension-link/src/helpers/pasteHandler.ts
+++ b/packages/extension-link/src/helpers/pasteHandler.ts
@@ -33,7 +33,7 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
         })
 
         const link = find(textContent, { defaultProtocol: options.defaultProtocol }).find(
-          item => item.isLink && item.value === textContent,
+          item => item.isLink && item.start === 0 && item.end === textContent.length,
         )
 
         if (!textContent || !link || (shouldAutoLink !== undefined && !shouldAutoLink(link.value))) {


### PR DESCRIPTION
## Changes Overview
Tightens link detection in the paste handler to only treat pasted content as a link when the detected link spans the entire text. Prevents instances of partial matches for links shared in issue #7632.

EDIT: See comment below.

## Implementation Approach
Replaced the equality check (`item.value === textContent`) with a positional check (`item.start === 0 && item.end === textContent.length`) to guarantee the match covers the full pasted string.

## Testing Done
- Pasted a plain URL. Correctly converted to link.
- Pasted text containing a URL. No longer incorrectly treated as a full link.
- Pasted multiple URLs. Unchanged behavior (no regression).
- Verified no impact on existing link parsing logic.

## Verification Steps
1. Paste a pure URL. Should auto-link.
2. Paste text with an embedded URL. Should **not** auto-link the entire text.
3. Paste text with leading/trailing characters around a URL. Should not match as full link.
4. Confirm no regressions in normal link behavior.

## Additional Notes
This is a minimal and targeted fix for incorrect full-text link detection. Does not modify underlying parsing logic or other paste behaviors.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
- #7632