### PR TITLE
fix: resolve drag handle detection for indented blocks

### DIFF
--- a/.changeset/metal-trees-build.md
+++ b/.changeset/metal-trees-build.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': patch
+---
+
+Updated `findElementNextToCoords` to fall back to `view.posAtCoords` when `elementsFromPoint` returns no matching block, resolving the position to the top-level block node.

--- a/packages/extension-drag-handle/src/helpers/findNextElementFromCursor.ts
+++ b/packages/extension-drag-handle/src/helpers/findNextElementFromCursor.ts
@@ -146,6 +146,29 @@ export const findElementNextToCoords = (
   })
 
   if (!block) {
+    // elementsFromPoint may return nothing if the coordinates land outside an element
+    // (e.g., in margins, overlays, gaps, or indented nodes). posAtCoords uses the
+    // caret API, so it still resolves to the nearest text position.
+    const coords = view.posAtCoords({ left: clampedX, top: clampedY })
+
+    if (coords) {
+      const $pos = state.doc.resolve(coords.pos)
+      // Walk up to the top-level block
+      const depth = Math.min($pos.depth, 1)
+      const blockPos = depth > 0 ? $pos.before(depth) : $pos.pos
+      const blockNode = state.doc.nodeAt(blockPos)
+
+      if (blockNode) {
+        const dom = view.nodeDOM(blockPos)
+
+        return {
+          resultElement: dom instanceof HTMLElement ? dom : null,
+          resultNode: blockNode,
+          pos: blockPos,
+        }
+      }
+    }
+
     return { resultElement: null, resultNode: null, pos: null }
   }
 


### PR DESCRIPTION
## Changes Overview

Adds a `posAtCoords` fallback in `findElementNextToCoords` when `elementsFromPoint` fails to find a block.

## Implementation Approach

By using `posAtCoords` because `elementsFromPoint` can miss when coordinates fall outside any elements border box — e.g. the CSS margin gap of indented blocks.

## Testing Done

Manual testing in the notion-like template

## Verification Steps

Try adding margin left to any block and try dragging the block it will fail.

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
