### PR TITLE
fix: clean up drag previews after invalid drops

### DIFF
--- a/.changeset/khaki-candles-tan.md
+++ b/.changeset/khaki-candles-tan.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': patch
+---
+
+Fix drag preview cleanup so cloned drag images are also removed when dragging ends without a valid drop.

--- a/packages/extension-drag-handle/src/helpers/dragHandler.ts
+++ b/packages/extension-drag-handle/src/helpers/dragHandler.ts
@@ -124,6 +124,19 @@ export function dragHandler(
   event.dataTransfer.clearData()
   event.dataTransfer.setDragImage(wrapper, 0, 0)
 
+  let cleanedUp = false
+
+  const cleanupDragPreview = () => {
+    if (cleanedUp) {
+      return
+    }
+
+    cleanedUp = true
+    removeNode(wrapper)
+    document.removeEventListener('drop', cleanupDragPreview)
+    document.removeEventListener('dragend', cleanupDragPreview)
+  }
+
   // Tell ProseMirror the dragged content.
   // Pass the NodeSelection as `node` so ProseMirror's drop handler can use it
   // to precisely delete the original node via `node.replace(tr)`. Without this,
@@ -140,6 +153,7 @@ export function dragHandler(
 
   view.dispatch(tr)
 
-  // clean up
-  document.addEventListener('drop', () => removeNode(wrapper), { once: true })
+  // Clean up the drag preview whether the drag results in a valid drop or not.
+  document.addEventListener('drop', cleanupDragPreview)
+  document.addEventListener('dragend', cleanupDragPreview)
 }


### PR DESCRIPTION
## Changes Overview

Fix the drag-handle preview cleanup so cloned drag images are removed even when a drag ends without a valid drop.

## Implementation Approach

Replaced the one-off `drop` cleanup in the drag handler with a shared, idempotent cleanup callback that listens to both `drop` and `dragend`. This preserves the existing valid-drop behavior while also covering invalid drop targets.

## Testing Done

Ran `pnpm vitest run packages/extension-drag-handle/__tests__/drag-handle.spec.ts`.

## Verification Steps

1. Open the drag-handle playground.
2. Start dragging a block so the custom drag preview appears.
3. Drop it in an invalid area outside a valid drop target.
4. Confirm the cloned drag preview is removed when the drag ends.
5. Repeat with a valid drop and confirm the preview still cleans up normally.

## Additional Notes

A patch changeset was added for `@tiptap/extension-drag-handle`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

Fixes the reported drag-handle invalid-drop preview cleanup bug.