### PR TITLE
Add aria-label support to details toggle button

### DIFF
--- a/.changeset/flat-taxis-promise.md
+++ b/.changeset/flat-taxis-promise.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-details': patch
+---
+
+Add an accessible aria-label to the details toggle button and allow it to be customized.

--- a/packages/extension-details/__tests__/details.spec.ts
+++ b/packages/extension-details/__tests__/details.spec.ts
@@ -1,0 +1,101 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Details, DetailsContent, DetailsSummary } from '../src/index.js'
+
+describe('Details', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('adds a default aria-label to the toggle button', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Details, DetailsSummary, DetailsContent],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'details',
+            content: [
+              {
+                type: 'detailsSummary',
+                content: [{ type: 'text', text: 'Summary' }],
+              },
+              {
+                type: 'detailsContent',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Content' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const toggleButton = editor.view.dom.querySelector('div[data-type="details"] > button')
+
+    expect(toggleButton?.getAttribute('aria-label')).toBe('Expand details content')
+  })
+
+  it('supports a custom aria-label and updates it when the node open state changes', () => {
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Details.configure({
+          persist: true,
+          a11y: {
+            toggleButtonLabel: (node, isOpen) =>
+              `${isOpen ? 'Collapse' : 'Expand'} ${node.textContent || 'details content'}`,
+          },
+        }),
+        DetailsSummary,
+        DetailsContent,
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'details',
+            attrs: {
+              open: false,
+            },
+            content: [
+              {
+                type: 'detailsSummary',
+                content: [{ type: 'text', text: 'Summary' }],
+              },
+              {
+                type: 'detailsContent',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Content' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const getToggleButton = () => editor.view.dom.querySelector('div[data-type="details"] > button')
+
+    expect(getToggleButton()?.getAttribute('aria-label')).toBe('Expand SummaryContent')
+
+    editor.commands.updateAttributes('details', { open: true })
+
+    expect(getToggleButton()?.getAttribute('aria-label')).toBe('Collapse SummaryContent')
+  })
+})

--- a/packages/extension-details/src/details.ts
+++ b/packages/extension-details/src/details.ts
@@ -7,6 +7,7 @@ import {
   mergeAttributes,
   Node,
 } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state'
 import type { ViewMutationRecord } from '@tiptap/pm/view'
 
@@ -28,6 +29,15 @@ export interface DetailsOptions {
    */
   HTMLAttributes: {
     [key: string]: any
+  }
+  /**
+   * Accessibility options for the details node.
+   */
+  a11y?: {
+    /**
+     * Defines the aria-label for the toggle button.
+     */
+    toggleButtonLabel?: (node: ProseMirrorNode, isOpen: boolean) => string
   }
 }
 
@@ -65,6 +75,7 @@ export const Details = Node.create<DetailsOptions>({
       persist: false,
       openClassName: 'is-open',
       HTMLAttributes: {},
+      a11y: undefined,
     }
   },
 
@@ -107,6 +118,7 @@ export const Details = Node.create<DetailsOptions>({
 
   addNodeView() {
     return ({ editor, getPos, node, HTMLAttributes }) => {
+      let currentNode = node
       const dom = document.createElement('div')
       const attributes = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         'data-type': this.name,
@@ -117,6 +129,14 @@ export const Details = Node.create<DetailsOptions>({
       const toggle = document.createElement('button')
 
       toggle.type = 'button'
+
+      const updateA11Y = (nodeToLabel: ProseMirrorNode, isOpen: boolean) => {
+        const toggleButtonLabel =
+          this.options.a11y?.toggleButtonLabel?.(nodeToLabel, isOpen) ||
+          (isOpen ? 'Collapse details content' : 'Expand details content')
+
+        toggle.setAttribute('aria-label', toggleButtonLabel)
+      }
 
       dom.append(toggle)
 
@@ -141,11 +161,17 @@ export const Details = Node.create<DetailsOptions>({
           dom.classList.toggle(this.options.openClassName)
         }
 
+        const isOpen = dom.classList.contains(this.options.openClassName)
+
+        updateA11Y(currentNode, isOpen)
+
         const event = new Event('toggleDetailsContent')
         const detailsContent = content.querySelector(':scope > div[data-type="detailsContent"]')
 
         detailsContent?.dispatchEvent(event)
       }
+
+      updateA11Y(currentNode, Boolean(node.attrs.open))
 
       if (node.attrs.open) {
         setTimeout(() => toggleDetailsContent())
@@ -172,14 +198,14 @@ export const Details = Node.create<DetailsOptions>({
                 return false
               }
 
-              const currentNode = tr.doc.nodeAt(pos)
+              const currentNodeAtPosition = tr.doc.nodeAt(pos)
 
-              if (currentNode?.type !== this.type) {
+              if (currentNodeAtPosition?.type !== this.type) {
                 return false
               }
 
               tr.setNodeMarkup(pos, undefined, {
-                open: !currentNode.attrs.open,
+                open: !currentNodeAtPosition.attrs.open,
               })
 
               return true
@@ -208,9 +234,13 @@ export const Details = Node.create<DetailsOptions>({
             return false
           }
 
+          currentNode = updatedNode
+
           // Only update the open state if set
           if (updatedNode.attrs.open !== undefined) {
             toggleDetailsContent(updatedNode.attrs.open)
+          } else {
+            updateA11Y(currentNode, dom.classList.contains(this.options.openClassName))
           }
 
           return true


### PR DESCRIPTION
## Summary
- add an `a11y.toggleButtonLabel` option to `@tiptap/extension-details`
- apply a default `aria-label` to the generated toggle button and keep it in sync with the open state
- add unit coverage for the default label and a custom override, and include a changeset

## Testing
- `pnpm test:unit -- packages/extension-details/__tests__/details.spec.ts`
- `pnpm lint:fix`