### PR TITLE
fix: add bounds check for nodeAt in RemoveMarkStep handler

### DIFF
--- a/.changeset/fix-remove-mark-position.md
+++ b/.changeset/fix-remove-mark-position.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix RangeError when removing a mark at document position 0

--- a/packages/core/__tests__/delete.spec.ts
+++ b/packages/core/__tests__/delete.spec.ts
@@ -1,0 +1,97 @@
+import { Editor } from '@tiptap/core'
+import Bold from '@tiptap/extension-bold'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('delete event', () => {
+  describe('mark deletion', () => {
+    it('should not throw when removing a mark at position 0 with inline content', () => {
+      const TitleDocument = Document.extend({ content: 'inline*' })
+
+      const onDelete = vi.fn()
+
+      const editor = new Editor({
+        extensions: [TitleDocument, Text, Bold],
+        content: 'Hello world',
+        coreExtensionOptions: {
+          delete: {
+            async: false,
+          },
+        },
+        onDelete,
+      })
+
+      editor.chain().focus().selectAll().setBold().run()
+
+      expect(() => {
+        editor.chain().focus().selectAll().unsetMark('bold').run()
+      }).not.toThrow()
+
+      expect(onDelete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'mark',
+        }),
+      )
+
+      editor.destroy()
+    })
+
+    it('should emit delete event with partial false when removing a mark spanning entire content at position 0', () => {
+      const TitleDocument = Document.extend({ content: 'inline*' })
+
+      const onDelete = vi.fn()
+
+      const editor = new Editor({
+        extensions: [TitleDocument, Text, Bold],
+        content: 'Hello world',
+        coreExtensionOptions: {
+          delete: {
+            async: false,
+          },
+        },
+        onDelete,
+      })
+
+      editor.chain().focus().selectAll().setBold().run()
+      editor.chain().focus().selectAll().unsetMark('bold').run()
+
+      expect(onDelete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'mark',
+          partial: false,
+        }),
+      )
+
+      editor.destroy()
+    })
+
+    it('should emit delete event with partial true when mark remains on adjacent content', () => {
+      const onDelete = vi.fn()
+
+      const editor = new Editor({
+        extensions: [Document, Paragraph, Text, Bold],
+        content: '<p><strong>Hello world</strong></p>',
+        coreExtensionOptions: {
+          delete: {
+            async: false,
+          },
+        },
+        onDelete,
+      })
+
+      // Select only part of the bold text and remove the mark
+      editor.chain().focus().setTextSelection({ from: 2, to: 7 }).unsetMark('bold').run()
+
+      expect(onDelete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'mark',
+          partial: true,
+        }),
+      )
+
+      editor.destroy()
+    })
+  })
+})

--- a/packages/core/src/extensions/delete.ts
+++ b/packages/core/src/extensions/delete.ts
@@ -55,7 +55,8 @@ export const Delete = Extension.create({
           const oldStart = mapping.invert().map(newStart, -1)
           const oldEnd = mapping.invert().map(newEnd)
 
-          const foundBeforeMark = nextTransaction.doc.nodeAt(newStart - 1)?.marks.some(mark => mark.eq(step.mark))
+          const foundBeforeMark =
+            newStart > 0 ? nextTransaction.doc.nodeAt(newStart - 1)?.marks.some(mark => mark.eq(step.mark)) : false
           const foundAfterMark = nextTransaction.doc.nodeAt(newEnd)?.marks.some(mark => mark.eq(step.mark))
 
           this.editor.emit('delete', {


### PR DESCRIPTION
## Summary
- Add a `newStart > 0` bounds check before calling `nodeAt(newStart - 1)` in the `RemoveMarkStep` handler within the delete extension
- Add tests for the delete event on mark removal

## What this fixes
When removing a mark that starts at document position 0 (e.g. in a single-line editor using `content: 'inline*'`), `newStart` maps to `0` and `nodeAt(0 - 1)` throws `RangeError: Position -1 outside of fragment`.

This affects any editor where inline content starts at position 0 — including editors using the built-in `paragraph` and `heading` extensions which both define `content: 'inline*'`.

Fixes #7661

## Testing
- `pnpm vitest run packages/core/__tests__/delete.spec.ts`
- `pnpm vitest run packages/core/__tests__/`