### PR TITLE
fix: guard unsetMark delete handling at document start

### DIFF
--- a/.changeset/tall-bugs-tap.md
+++ b/.changeset/tall-bugs-tap.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Guard mark delete event handling when `unsetMark` removes a mark from inline content that starts at position `0`, preventing a `RangeError` during the before-node lookup.

--- a/packages/core/__tests__/delete.spec.ts
+++ b/packages/core/__tests__/delete.spec.ts
@@ -1,0 +1,48 @@
+import { Editor } from '@tiptap/core'
+import Bold from '@tiptap/extension-bold'
+import Document from '@tiptap/extension-document'
+import Text from '@tiptap/extension-text'
+import { describe, expect, it, vi } from 'vitest'
+
+const InlineDocument = Document.extend({
+  content: 'inline*',
+})
+
+describe('delete extension', () => {
+  it('should not throw when removing a mark from inline content at position 0', () => {
+    const onDelete = vi.fn()
+    const editor = new Editor({
+      extensions: [InlineDocument, Text, Bold],
+      content: 'hello world',
+      onDelete,
+      coreExtensionOptions: {
+        delete: {
+          async: false,
+        },
+      },
+    })
+
+    editor.commands.selectAll()
+    editor.commands.setMark('bold')
+    editor.commands.selectAll()
+
+    expect(() => editor.commands.unsetMark('bold')).not.toThrow()
+    expect(editor.getJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'text',
+          text: 'hello world',
+        },
+      ],
+    })
+    expect(onDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'mark',
+        partial: false,
+      }),
+    )
+
+    editor.destroy()
+  })
+})

--- a/packages/core/src/extensions/delete.ts
+++ b/packages/core/src/extensions/delete.ts
@@ -55,7 +55,8 @@ export const Delete = Extension.create({
           const oldStart = mapping.invert().map(newStart, -1)
           const oldEnd = mapping.invert().map(newEnd)
 
-          const foundBeforeMark = nextTransaction.doc.nodeAt(newStart - 1)?.marks.some(mark => mark.eq(step.mark))
+          const foundBeforeMark =
+            newStart > 0 ? nextTransaction.doc.nodeAt(newStart - 1)?.marks.some(mark => mark.eq(step.mark)) : false
           const foundAfterMark = nextTransaction.doc.nodeAt(newEnd)?.marks.some(mark => mark.eq(step.mark))
 
           this.editor.emit('delete', {


### PR DESCRIPTION
## Changes Overview

- fix the core delete extension so removing a mark from inline-only content starting at position `0` no longer throws
- add a regression test covering `unsetMark('bold')` on a custom `Document` with `content: 'inline*'`
- add a patch changeset for `@tiptap/core`

## Implementation Approach

- guard the before-node lookup in the `RemoveMarkStep` delete event handler so it only checks `nodeAt(newStart - 1)` when `newStart > 0`
- keep the existing partial-mark detection semantics by treating the missing before-node at the document boundary as `false` rather than clamping to position `0`

## Testing Done

- ran `pnpm exec vitest run packages/core/__tests__/delete.spec.ts packages/core/__tests__/dispatchTransaction.spec.ts packages/core/__tests__/isActive.spec.ts packages/core/__tests__/extendMarkRange.spec.ts`

## Verification Steps

- create an editor with a custom `Document` node using `content: 'inline*'`
- insert text, select all, apply `bold`, then select all again and call `unsetMark('bold')`
- confirm the mark is removed without throwing `RangeError: Position -1 outside of fragment`

## Additional Notes

- Closes #7661
- See #7661

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- #7661