### PR TITLE
Avoid stale cursor transaction crashes

### DIFF
--- a/.changeset/fix-stale-cursor-meta-transaction.md
+++ b/.changeset/fix-stale-cursor-meta-transaction.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-collaboration-caret': patch
+---
+
+Prevent collaboration carets from crashing the editor when a stale awareness-only cursor transaction is dispatched after the editor state has already changed.

--- a/packages/extension-collaboration-caret/__tests__/collaboration-caret.spec.ts
+++ b/packages/extension-collaboration-caret/__tests__/collaboration-caret.spec.ts
@@ -1,4 +1,4 @@
-import { Editor } from '@tiptap/core'
+import { Editor, Extension } from '@tiptap/core'
 import Collaboration from '@tiptap/extension-collaboration'
 import CollaborationCaret from '@tiptap/extension-collaboration-caret'
 import Document from '@tiptap/extension-document'
@@ -8,7 +8,8 @@ import TableCell from '@tiptap/extension-table-cell'
 import TableHeader from '@tiptap/extension-table-header'
 import TableRow from '@tiptap/extension-table-row'
 import Text from '@tiptap/extension-text'
-import { describe, expect, it } from 'vitest'
+import { yCursorPluginKey } from '@tiptap/y-tiptap'
+import { describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
 
 /**
@@ -17,6 +18,30 @@ import * as Y from 'yjs'
  */
 describe('extension-collaboration-caret', () => {
   const editorElClass = 'tiptap'
+
+  class MockAwareness {
+    public states = new Map()
+
+    private listeners = new Set<() => void>()
+
+    setLocalStateField = () => {}
+
+    on = (_event: string, listener: () => void) => {
+      this.listeners.add(listener)
+    }
+
+    off = (_event: string, listener: () => void) => {
+      this.listeners.delete(listener)
+    }
+
+    getStates = () => this.states
+
+    getLocalState = () => ({})
+
+    emitUpdate = () => {
+      this.listeners.forEach(listener => listener())
+    }
+  }
 
   const createEditorEl = () => {
     const editorEl = document.createElement('div')
@@ -184,5 +209,62 @@ describe('extension-collaboration-caret', () => {
     }).not.toThrow()
 
     getEditorEl()?.remove()
+  })
+
+  it('should ignore stale awareness-only cursor transactions', async () => {
+    vi.useFakeTimers()
+
+    const ydoc = new Y.Doc()
+    const awareness = new MockAwareness()
+    const mockProvider = { awareness }
+    const editorEl = createEditorEl()
+    let insertedContent = false
+    let editor: Editor
+
+    const staleCursorTransactionExtension = Extension.create({
+      name: 'staleCursorTransaction',
+      priority: 1001,
+      dispatchTransaction({ transaction, next }) {
+        const cursorMeta = transaction.getMeta(yCursorPluginKey)
+
+        if (!insertedContent && cursorMeta?.awarenessUpdated) {
+          insertedContent = true
+          editor.view.dispatch(editor.state.tr.insertText('x', 1))
+        }
+
+        next(transaction)
+      },
+    })
+
+    editor = new Editor({
+      element: editorEl,
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        staleCursorTransactionExtension,
+        Collaboration.configure({
+          document: ydoc,
+        }),
+        CollaborationCaret.configure({
+          provider: mockProvider,
+          user: {
+            name: 'Test User',
+            color: '#ff0000',
+          },
+        }),
+      ],
+      content: '<p>Hello world</p>',
+    })
+
+    awareness.emitUpdate()
+    await vi.runAllTimersAsync()
+
+    expect(editor.isDestroyed).toBe(false)
+    expect(editor.getText()).toBe('x')
+
+    editor.destroy()
+    getEditorEl()?.remove()
+    vi.useRealTimers()
   })
 })

--- a/packages/extension-collaboration-caret/src/collaboration-caret.ts
+++ b/packages/extension-collaboration-caret/src/collaboration-caret.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
 import type { DecorationAttrs } from '@tiptap/pm/view'
-import { defaultSelectionBuilder, yCursorPlugin } from '@tiptap/y-tiptap'
+import { defaultSelectionBuilder, yCursorPlugin, yCursorPluginKey } from '@tiptap/y-tiptap'
 
 type CollaborationCaretStorage = {
   users: { clientId: number; [key: string]: any }[]
@@ -143,6 +143,28 @@ export const CollaborationCaret = Extension.create<CollaborationCaretOptions, Co
   addStorage() {
     return {
       users: [],
+    }
+  },
+
+  dispatchTransaction({ transaction, next }) {
+    const cursorMeta = transaction.getMeta(yCursorPluginKey)
+
+    if (!cursorMeta?.awarenessUpdated || transaction.steps.length > 0) {
+      next(transaction)
+      return
+    }
+
+    try {
+      next(transaction)
+    } catch (error) {
+      // y-tiptap batches awareness-only cursor transactions asynchronously.
+      // If editor state changes before they are applied, dropping the stale
+      // decoration refresh is safer than crashing the editor.
+      if (error instanceof RangeError && error.message === 'Applying a mismatched transaction') {
+        return
+      }
+
+      throw error
     }
   },
 


### PR DESCRIPTION
## Summary
- guard collaboration caret cursor-awareness transactions so stale async awarenessUpdated dispatches do not crash the editor
- add a regression test that forces a stale cursor meta transaction before dispatch and verifies the editor stays alive
- include a changeset for the collaboration caret patch release

## Testing
- fnm use 20.19.2 >/dev/null && pnpm test:unit packages/extension-collaboration-caret/__tests__/collaboration-caret.spec.ts
- fnm use 20.19.2 >/dev/null && ./node_modules/.bin/eslint packages/extension-collaboration-caret/src/collaboration-caret.ts packages/extension-collaboration-caret/__tests__/collaboration-caret.spec.ts