### PR TITLE
fix: use named import for Suggestion in emoji extension to resolve CJS interop issue

### DIFF
--- a/.changeset/6665-emoji-import-fix.md
+++ b/.changeset/6665-emoji-import-fix.md
@@ -1,0 +1,10 @@
+---
+"@tiptap/extension-emoji": patch
+---
+
+Use a named import for Suggestion from `@tiptap/suggestion` to avoid bundler ESM/CJS interop
+wrapping (`__toESM`) that caused CJS consumers to receive a module object instead of the
+callable plugin factory.
+
+This is a non-breaking internal fix identical to the one applied to `@tiptap/extension-mention`
+in #6994.

--- a/packages/extension-emoji/src/emoji.ts
+++ b/packages/extension-emoji/src/emoji.ts
@@ -12,7 +12,7 @@ import {
 import type { Transaction } from '@tiptap/pm/state'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import type { SuggestionOptions } from '@tiptap/suggestion'
-import Suggestion from '@tiptap/suggestion'
+import { Suggestion } from '@tiptap/suggestion'
 import emojiRegex from 'emoji-regex'
 import { isEmojiSupported } from 'is-emoji-supported'
 


### PR DESCRIPTION
## Changes Overview

Fix CJS interop issue in `@tiptap/extension-emoji` by switching from default import to named import for `Suggestion` — the same fix applied to `@tiptap/extension-mention` in #6994 and also recently for `tiptap/extension-code-block-lowlight` in #7370

## Implementation Approach

In `packages/extension-emoji/src/emoji.ts`, change:

```ts
import Suggestion from '@tiptap/suggestion'
```

to:

```ts
import { Suggestion } from '@tiptap/suggestion'
```

The default import compiles to `__toESM(require("@tiptap/suggestion"), 1)` in the CJS build, where `isNodeMode=1` causes `__toESM` to set `.default` to the entire module object instead of the `Suggestion` function. This makes `(0, import_suggestion.default)({...})` in `addProseMirrorPlugins` throw `TypeError: (0 , u.default) is not a function`.

The named import compiles to `require("@tiptap/suggestion").Suggestion`, which resolves correctly in both ESM and CJS contexts.

## Testing Done

- Reproduced the bug in Node.js by calling `__toESM(require("@tiptap/suggestion"), 1).default` — returns the module object (broken)
- Verified `require("@tiptap/suggestion").Suggestion` returns the function (working)
- Confirmed the identical fix in `extension-mention` (#6994, released in v3.4.5) resolved the same issue for CJS consumers

## Verification Steps

1. Create a CJS package that `require()`s `@tiptap/extension-emoji`
2. Initialize an Editor with the Emoji extension
3. Before fix: crashes with `TypeError: (0 , u.default) is not a function` at `addProseMirrorPlugins`
4. After fix: editor initializes successfully

Alternatively, run Jest tests that use the Emoji extension (Jest runs in CJS).

## Additional Notes

This is the exact same bug that was fixed for `@tiptap/extension-mention` in #6994 / commit f472c5b8. The emoji extension was missed in that fix.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- #6665 — Mention extension crashes in Jest (same root cause, fixed in #6994)
- #5360 — Suggestion is not a function in Jest test (original v2 report)