### PR TITLE
fix: resolve @tiptap/pm subpath imports in monorepo tsconfig paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "paths": {
       "@tiptap/static-renderer/pm/*": ["packages/static-renderer/src/pm/*"],
       "@tiptap/static-renderer/json/*": ["packages/static-renderer/src/json/*"],
+      "@tiptap/pm/*": ["packages/pm/*/index.ts"],
       "@tiptap/*": ["packages/*/src/index.ts", "packages-deprecated/*/src/index.ts"]
     },
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]


### PR DESCRIPTION
Refs #7680

## Changes Overview

This PR fixes TypeScript path resolution for `@tiptap/pm/*` subpath imports in the monorepo setup.  
It addresses false-positive module resolution errors such as `@tiptap/pm/model` in source files.

## Implementation Approach

Added a dedicated path alias in root `tsconfig.json`:

- `@tiptap/pm/*` -> `packages/pm/*/index.ts`

This ensures `@tiptap/pm` subpaths resolve correctly instead of being mismatched by the generic `@tiptap/*` mapping.

## Testing Done

- Verified the previously failing import location in `packages/vue-3/src/VueNodeViewRenderer.ts`.
- Confirmed linter no longer reports:
  - `Cannot find module '@tiptap/pm/model'`
  - `Cannot find module '@tiptap/pm/view'`
- Ran package-level typecheck and confirmed those specific module-resolution errors are gone.

## Verification Steps

1. Checkout this branch.
2. Open `packages/vue-3/src/VueNodeViewRenderer.ts`.
3. Confirm imports from `@tiptap/pm/model` and `@tiptap/pm/view` resolve correctly.
4. Run:
   - `pnpm --filter @tiptap/vue-3 exec tsc --noEmit`
5. Verify no `@tiptap/pm/model` / `@tiptap/pm/view` resolution errors are reported.

## Additional Notes

- This is a monorepo TypeScript path-mapping fix (developer experience/type resolution).
- No intended runtime behavior or public API changes.

## Checklist

- [x] No changeset needed for this PR (tsconfig/path-resolution fix only, no package release impact).
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7680