### PR TITLE
refactor: configure build-specific tsconfig for core package to impro…

### DIFF
--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@tiptap/core": ["./src/index.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig([
   {
     entry: ['src/index.ts'],
-    // purposefully not using the build tsconfig, so @tiptap/core's types can be resolved correctly
+    tsconfig: 'tsconfig.build.json',
     outDir: 'dist',
     dts: true,
     clean: true,


### PR DESCRIPTION
…ve type resolution

## Changes Overview

This PR fixes the TypeScript module resolution errors (TS6059 and TS2339) introduced by the new paths configuration in the monorepo setup, specifically affecting @tiptap/core.

## Implementation Approach

The fix involves introducing a localized tsconfig.build.json for @tiptap/core to:

Override paths during build: Disables the repository-wide paths for external workspace packages (@tiptap/pm) to ensure they are resolved via node_modules declarations instead of source files. This resolves the rootDir mismatch (TS6059).
Self-referential path: Adds a self-referential path for @tiptap/core to correctly handle internal module augmentations (e.g., the focus command) during declaration generation (TS2339).
Preserve structure: Maintains the flat dist/ directory structure for @tiptap/core while keeping IDE path resolution active in the root tsconfig.json.

## Testing Done

Successfully ran pnpm --filter @tiptap/core build.
Verified that dist/index.d.ts is generated correctly with a flat structure.
Confirmed that IDE (VSCode) still resolves @tiptap/pm/* imports without red squiggles.

## Verification Steps

Navigate to packages/core.
Run pnpm build.
Check dist/index.d.ts for correct type exports and structure.

## Checklist

- [x] My changes do not break the library.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.


## Related Issues

Refs #7680
