### PR TITLE
fix(react): avoid stale getPos in deferred node view selection

### DIFF
--- a/.changeset/fix-react-nodeview-stale-getpos.md
+++ b/.changeset/fix-react-nodeview-stale-getpos.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Prevent React node views from crashing during deferred selection updates when ProseMirror has already detached the node view position lookup.

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -270,7 +270,8 @@ export class ReactNodeView<
     this.selectionRafId = requestAnimationFrame(() => {
       this.selectionRafId = null
       const { from, to } = this.editor.state.selection
-      const pos = this.getPos()
+      // Avoid resolving getPos() after ProseMirror has detached this node view.
+      const pos = this.currentPos
       if (typeof pos !== 'number') {
         return
       }


### PR DESCRIPTION
## Changes Overview

Fix a React-only node view crash during deferred selection updates by avoiding a fresh `getPos()` lookup after ProseMirror has already detached the node view.

## Implementation Approach

The React node view selection handler still defers selection syncing with `requestAnimationFrame`, but it now reads the cached `currentPos` instead of calling `getPos()` inside the deferred callback. This preserves the React timing workaround while avoiding stale ProseMirror `ViewDesc` position resolution.

## Testing Done

The commit passed the repository's `lint-staged` hooks (`prettier` and `eslint --fix --quiet`).

## Verification Steps

1. Run `pnpm --dir demos start`.
2. Open `http://localhost:3000/preview/Extensions/DragHandleWithNodeViews` and switch to the React tab.
3. Drag recommendation blocks repeatedly and click in and out around them after reordering.
4. Confirm the editor no longer crashes and the `pos:` display continues updating correctly.

## Additional Notes

A changeset is included for `@tiptap/react`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

N/A