### PR TITLE
fix(markdown): preserve adjacent marks with different attrs

### DIFF
--- a/.changeset/fix-7682-silent-harbor.md
+++ b/.changeset/fix-7682-silent-harbor.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/markdown": patch
+---
+
+Fix markdown output so adjacent links and other inline marks stay separate when they use different attributes.

--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -535,6 +535,42 @@ Final paragraph.`
       expect(markdown).toBe('before **bold** after')
     })
 
+    it('keeps adjacent same-type marks separate when their attrs differ', () => {
+      const doc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'example',
+                marks: [{ type: 'link', attrs: { href: 'https://example.com', target: '_blank' } }],
+              },
+              {
+                type: 'text',
+                text: 'github',
+                marks: [{ type: 'link', attrs: { href: 'https://github.com', target: '_blank' } }],
+              },
+              {
+                type: 'text',
+                text: 'tiptap',
+                marks: [{ type: 'link', attrs: { href: 'https://tiptap.dev', target: '_blank' } }],
+              },
+              {
+                type: 'text',
+                text: '.',
+              },
+            ],
+          },
+        ],
+      }
+
+      expect(markdownManager.serialize(doc)).toBe(
+        '[example](https://example.com)[github](https://github.com)[tiptap](https://tiptap.dev).',
+      )
+    })
+
     it('should handle trailing whitespace in italic marks (Issue #7180)', () => {
       const doc = {
         type: 'doc',

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -16,6 +16,7 @@ import {
   flattenExtensions,
   generateJSON,
   getExtensionField,
+  objectIncludes,
 } from '@tiptap/core'
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
 
@@ -1124,7 +1125,13 @@ export class MarkdownManager {
             ...activeMarksClosingHere, // outer (were active before) — close last
           ]
         } else {
-          marksToCloseAtEnd = findMarksToCloseAtEnd(activeMarks, currentMarks, nextNode, this.markSetsEqual.bind(this))
+          marksToCloseAtEnd = findMarksToCloseAtEnd(
+            activeMarks,
+            currentMarks,
+            nextNode,
+            this.markSetsEqual.bind(this),
+            this.marksEqual.bind(this),
+          )
         }
 
         // Extract trailing whitespace before closing marks to prevent invalid markdown like "**text **"
@@ -1284,6 +1291,24 @@ export class MarkdownManager {
   }
 
   /**
+   * Check if two marks have the same type and attributes.
+   */
+  private marksEqual(mark1: any, mark2: any): boolean {
+    if (mark1?.type !== mark2?.type) {
+      return false
+    }
+
+    const attrs1 = mark1?.attrs ?? {}
+    const attrs2 = mark2?.attrs ?? {}
+
+    return (
+      Object.keys(attrs1).length === Object.keys(attrs2).length &&
+      objectIncludes(attrs1, attrs2) &&
+      objectIncludes(attrs2, attrs1)
+    )
+  }
+
+  /**
    * Check if two mark sets are equal.
    */
   private markSetsEqual(marks1: Map<string, any>, marks2: Map<string, any>): boolean {
@@ -1291,7 +1316,11 @@ export class MarkdownManager {
       return false
     }
 
-    return Array.from(marks1.keys()).every(type => marks2.has(type))
+    return Array.from(marks1.entries()).every(([type, mark]) => {
+      const otherMark = marks2.get(type)
+
+      return !!otherMark && this.marksEqual(mark, otherMark)
+    })
   }
 }
 

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -64,6 +64,7 @@ export function findMarksToCloseAtEnd(
   currentMarks: Map<string, any>,
   nextNode: any,
   markSetsEqual: (a: Map<string, any>, b: Map<string, any>) => boolean,
+  marksEqual: (a: any, b: any) => boolean,
 ): string[] {
   const isLastNode = !nextNode
   const nextNodeHasNoMarks = nextNode && nextNode.type === 'text' && (!nextNode.marks || nextNode.marks.length === 0)
@@ -80,7 +81,10 @@ export function findMarksToCloseAtEnd(
       Array.from(activeMarks.keys())
         .reverse()
         .forEach(markType => {
-          if (!nextMarks.has(markType)) {
+          const activeMark = activeMarks.get(markType)
+          const nextMark = nextMarks.get(markType)
+
+          if (!nextMark || !marksEqual(activeMark, nextMark)) {
             marksToCloseAtEnd.push(markType)
           }
         })


### PR DESCRIPTION
## Changes Overview

Fix markdown serialization so adjacent marks of the same type are only merged when their attributes also match.

## Implementation Approach

Updated markdown mark-boundary handling to compare both mark type and mark attributes when deciding whether a mark continues into the next text node. Added a regression test for adjacent link marks with different `href` values.

## Testing Done

- `pnpm vitest run packages/markdown/__tests__/manager.spec.ts`
- `pnpm vitest run packages/markdown/__tests__`
- `pnpm run test:unit`

## Verification Steps

1. Create a document with adjacent link marks that use different URLs.
2. Call `editor.getMarkdown()`.
3. Confirm the output keeps them as separate markdown links instead of merging them into one link targeting the last URL.

## Additional Notes

A changeset is included for `@tiptap/markdown`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7682