### PR TITLE
fix: avoid extending node range selections on boundary overlap

### DIFF
--- a/.changeset/rare-beds-marry.md
+++ b/.changeset/rare-beds-marry.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-node-range': patch
+---
+
+Add an option to control whether node ranges extend when a selection only touches a node boundary.

--- a/.changeset/twelve-spoons-care.md
+++ b/.changeset/twelve-spoons-care.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': patch
+---
+
+Fix drag selections so crossing a node boundary does not incorrectly include the next node.

--- a/packages/extension-drag-handle/src/helpers/dragHandler.ts
+++ b/packages/extension-drag-handle/src/helpers/dragHandler.ts
@@ -56,7 +56,7 @@ function getDragHandleRanges(
   const $from = doc.resolve(result.pos)
   const $to = doc.resolve(result.pos + result.resultNode.nodeSize + offset)
 
-  return getSelectionRanges($from, $to, 0)
+  return getSelectionRanges($from, $to, 0, { extendOnBoundaryOverlap: false })
 }
 
 export function dragHandler(
@@ -75,7 +75,7 @@ export function dragHandler(
 
   const dragHandleRanges = getDragHandleRanges(event, editor, nestedOptions, dragContext)
 
-  const selectionRanges = getSelectionRanges($from, $to, 0)
+  const selectionRanges = getSelectionRanges($from, $to, 0, { extendOnBoundaryOverlap: false })
   const isDragHandleWithinSelection = selectionRanges.some(range => {
     return dragHandleRanges.find(dragHandleRange => {
       return dragHandleRange.$from === range.$from && dragHandleRange.$to === range.$to

--- a/packages/extension-node-range/__tests__/getSelectionRanges.spec.ts
+++ b/packages/extension-node-range/__tests__/getSelectionRanges.spec.ts
@@ -1,0 +1,110 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { getSelectionRanges } from '../src/helpers/getSelectionRanges.js'
+
+function getNodeContentStart(nodeStart: number): number {
+  return nodeStart + 1
+}
+
+function getNodeContentEnd(nodeStart: number, nodeSize: number): number {
+  return nodeStart + nodeSize - 1
+}
+
+describe('getSelectionRanges', () => {
+  let editor: Editor | null = null
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+  })
+
+  it('extends the trailing range by default when the selection ends at the next node start', () => {
+    editor = new Editor({
+      element: document.body,
+      extensions: [Document, Paragraph, Text],
+      content: '<p>First</p><p>Second</p>',
+    })
+
+    const firstParagraphStart = 0
+    const firstParagraphSize = editor.state.doc.child(0).nodeSize
+    const secondParagraphStart = firstParagraphSize
+    const $from = editor.state.doc.resolve(getNodeContentStart(firstParagraphStart))
+    const $to = editor.state.doc.resolve(getNodeContentStart(secondParagraphStart))
+
+    const ranges = getSelectionRanges($from, $to, 0)
+
+    expect(ranges).toHaveLength(2)
+    expect(ranges[0].$from.pos).toBe(firstParagraphStart)
+    expect(ranges[1].$from.pos).toBe(secondParagraphStart)
+  })
+
+  it('does not extend the trailing range when boundary overlap is disabled', () => {
+    editor = new Editor({
+      element: document.body,
+      extensions: [Document, Paragraph, Text],
+      content: '<p>First</p><p>Second</p>',
+    })
+
+    const firstParagraphStart = 0
+    const firstParagraphSize = editor.state.doc.child(0).nodeSize
+    const secondParagraphStart = firstParagraphSize
+    const $from = editor.state.doc.resolve(getNodeContentStart(firstParagraphStart))
+    const $to = editor.state.doc.resolve(getNodeContentStart(secondParagraphStart))
+
+    const ranges = getSelectionRanges($from, $to, 0, {
+      extendOnBoundaryOverlap: false,
+    })
+
+    expect(ranges).toHaveLength(1)
+    expect(ranges[0].$from.pos).toBe(firstParagraphStart)
+    expect(ranges[0].$to.pos).toBe(secondParagraphStart)
+  })
+
+  it('extends the leading range by default when the selection starts at the previous node end', () => {
+    editor = new Editor({
+      element: document.body,
+      extensions: [Document, Paragraph, Text],
+      content: '<p>First</p><p>Second</p>',
+    })
+
+    const firstParagraphStart = 0
+    const firstParagraphSize = editor.state.doc.child(0).nodeSize
+    const secondParagraphStart = firstParagraphSize
+    const secondParagraphSize = editor.state.doc.child(1).nodeSize
+    const $from = editor.state.doc.resolve(getNodeContentEnd(firstParagraphStart, firstParagraphSize))
+    const $to = editor.state.doc.resolve(getNodeContentEnd(secondParagraphStart, secondParagraphSize))
+
+    const ranges = getSelectionRanges($from, $to, 0)
+
+    expect(ranges).toHaveLength(2)
+    expect(ranges[0].$from.pos).toBe(firstParagraphStart)
+    expect(ranges[1].$from.pos).toBe(secondParagraphStart)
+  })
+
+  it('does not extend the leading range when boundary overlap is disabled', () => {
+    editor = new Editor({
+      element: document.body,
+      extensions: [Document, Paragraph, Text],
+      content: '<p>First</p><p>Second</p>',
+    })
+
+    const firstParagraphStart = 0
+    const firstParagraphSize = editor.state.doc.child(0).nodeSize
+    const secondParagraphStart = firstParagraphSize
+    const secondParagraphSize = editor.state.doc.child(1).nodeSize
+    const $from = editor.state.doc.resolve(getNodeContentEnd(firstParagraphStart, firstParagraphSize))
+    const $to = editor.state.doc.resolve(getNodeContentEnd(secondParagraphStart, secondParagraphSize))
+
+    const ranges = getSelectionRanges($from, $to, 0, {
+      extendOnBoundaryOverlap: false,
+    })
+
+    expect(ranges).toHaveLength(1)
+    expect(ranges[0].$from.pos).toBe(secondParagraphStart)
+    expect(ranges[0].$to.pos).toBe(secondParagraphStart + secondParagraphSize)
+  })
+})

--- a/packages/extension-node-range/src/helpers/getSelectionRanges.ts
+++ b/packages/extension-node-range/src/helpers/getSelectionRanges.ts
@@ -1,9 +1,62 @@
 import { type ResolvedPos, NodeRange } from '@tiptap/pm/model'
 import { SelectionRange } from '@tiptap/pm/state'
 
-export function getSelectionRanges($from: ResolvedPos, $to: ResolvedPos, depth?: number): SelectionRange[] {
+export interface GetSelectionRangesOptions {
+  /**
+   * Whether nodes should be included when the selection only overlaps their
+   * start or end content boundary.
+   * @default true
+   */
+  extendOnBoundaryOverlap?: boolean
+}
+
+function getNodeContentBounds(nodeStart: number, nodeSize: number, node: { isText: boolean; isAtom: boolean }) {
+  const contentOffset = node.isText || node.isAtom ? 0 : 1
+
+  return {
+    start: nodeStart + contentOffset,
+    end: nodeStart + nodeSize - contentOffset,
+  }
+}
+
+/**
+ * Calculates node-aligned selection ranges between two resolved positions.
+ *
+ * The helper derives a suitable depth when none is provided and returns a
+ * `SelectionRange` for each matching child node in the computed `NodeRange`.
+ * Each returned range exposes `$from` as the resolved start position of the
+ * node selection and `$to` as the resolved end position.
+ *
+ * @param $from The resolved anchor position where the selection starts.
+ * @param $to The resolved head position where the selection ends.
+ * @param depth An optional depth to force when creating the ProseMirror `NodeRange`.
+ * When omitted, the depth is inferred from the shared depth of `$from` and `$to`.
+ * @param options Optional behavior flags for how boundary nodes are handled.
+ * @param options.extendOnBoundaryOverlap Whether touching only a node's start
+ * or end content boundary should still include that node in the returned ranges.
+ * @returns An array of `SelectionRange` objects for the nodes covered at the
+ * computed depth.
+ * @example
+ * ```ts
+ * const { $from, $to } = editor.state.selection
+ * const ranges = getSelectionRanges($from, $to, undefined, {
+ *   extendOnBoundaryOverlap: false,
+ * })
+ *
+ * ranges.forEach(range => {
+ *   console.log(range.$from.pos, range.$to.pos)
+ * })
+ * ```
+ */
+export function getSelectionRanges(
+  $from: ResolvedPos,
+  $to: ResolvedPos,
+  depth?: number,
+  options: GetSelectionRangesOptions = {},
+): SelectionRange[] {
   const ranges: SelectionRange[] = []
   const doc = $from.node(0)
+  const { extendOnBoundaryOverlap = true } = options
 
   // Determine the appropriate depth
   if (typeof depth === 'number' && depth >= 0) {
@@ -20,8 +73,16 @@ export function getSelectionRanges($from: ResolvedPos, $to: ResolvedPos, depth?:
   nodeRange.parent.forEach((node, pos) => {
     const from = offset + pos
     const to = from + node.nodeSize
+    const contentBounds = getNodeContentBounds(from, node.nodeSize, node)
+    const overlapsNodeContent = extendOnBoundaryOverlap
+      ? $to.pos >= contentBounds.start && $from.pos <= contentBounds.end
+      : $to.pos > contentBounds.start && $from.pos < contentBounds.end
 
     if (from < nodeRange.start || from >= nodeRange.end) {
+      return
+    }
+
+    if (!overlapsNodeContent) {
       return
     }
 


### PR DESCRIPTION
## Changes Overview

This updates node range selection handling around boundary-only overlaps.

It adds a new `extendOnBoundaryOverlap` option to `getSelectionRanges` in `@tiptap/extension-node-range` so callers can decide whether touching only a node boundary should include that node.

It also updates `@tiptap/extension-drag-handle` to disable that boundary extension when calculating drag selections, which fixes the case where dragging across a boundary could incorrectly include the next node.

## Implementation Approach

The `getSelectionRanges` helper now computes per-node content bounds and checks overlap either inclusively or strictly depending on `extendOnBoundaryOverlap`.

`DragHandle` now calls `getSelectionRanges(..., { extendOnBoundaryOverlap: false })` for drag target and selection matching so boundary-only overlaps do not expand the dragged range.

Focused unit tests were added for both leading and trailing boundary cases.

## Testing Done

Ran:

`pnpm vitest run packages/extension-node-range/__tests__/getSelectionRanges.spec.ts`

Result: 4 tests passed.

## Verification Steps

1. In code, call `getSelectionRanges($from, $to, 0, { extendOnBoundaryOverlap: false })` with a selection that only touches the start or end boundary of an adjacent node and confirm that node is excluded.
2. In the drag handle flow, drag a selection that ends exactly on the next node boundary and confirm the next node is not included in the dragged selection.
3. Repeat the same boundary case without disabling `extendOnBoundaryOverlap` and confirm the default inclusive behavior is preserved.

## Additional Notes

Two separate changesets are included so the node-range API addition and the drag-handle bug fix appear as distinct changelog entries.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- closes https://github.com/ueberdosis/tiptap/issues/7703

