### PR TITLE
fix: preserve lazy continuation lines in ordered lists (CommonMark)

### DIFF
--- a/.changeset/ordered-list-lazy-continuation.md
+++ b/.changeset/ordered-list-lazy-continuation.md
@@ -7,5 +7,3 @@ Preserve lazy continuation lines in ordered lists per CommonMark §5.3.
 Non-indented continuation lines that appear immediately after a list item marker (and before a blank line)
 are now treated as part of the current list item instead of terminating the list. Adds a focused regression
 test (markdown) that enables `marked`'s `breaks: true` option to ensure inline hard-breaks are preserved.
-
-Fixes: #7677

--- a/.changeset/ordered-list-lazy-continuation.md
+++ b/.changeset/ordered-list-lazy-continuation.md
@@ -1,0 +1,11 @@
+---
+"@tiptap/extension-list": patch
+---
+
+Preserve lazy continuation lines in ordered lists per CommonMark §5.3.
+
+Non-indented continuation lines that appear immediately after a list item marker (and before a blank line)
+are now treated as part of the current list item instead of terminating the list. Adds a focused regression
+test (markdown) that enables `marked`'s `breaks: true` option to ensure inline hard-breaks are preserved.
+
+Fixes: #7677

--- a/.changeset/ordered-list-lazy-continuation.md
+++ b/.changeset/ordered-list-lazy-continuation.md
@@ -2,8 +2,8 @@
 "@tiptap/extension-list": patch
 ---
 
-Preserve lazy continuation lines in ordered lists per CommonMark §5.3.
+Treat non-indented continuation lines following an ordered list marker as part of the same list item.
 
-Non-indented continuation lines that appear immediately after a list item marker (and before a blank line)
-are now treated as part of the current list item instead of terminating the list. Adds a focused regression
-test (markdown) that enables `marked`'s `breaks: true` option to ensure inline hard-breaks are preserved.
+This aligns ordered list parsing with CommonMark behavior: lines immediately after a list item (before a
+blank line) are considered lazy continuation and remain inside the list item rather than ending it.
+

--- a/packages/extension-list/src/ordered-list/utils.ts
+++ b/packages/extension-list/src/ordered-list/utils.ts
@@ -20,7 +20,56 @@ export interface OrderedListItem {
   indent: number
   number: number
   content: string
+  contentLines: string[]
   raw: string
+}
+
+function isBlockContentLine(line: string): boolean {
+  const trimmedLine = line.trimStart()
+
+  return (
+    /^[-+*]\s+/.test(trimmedLine) ||
+    /^[-+*]\s+\[[ xX]\]\s+/.test(trimmedLine) ||
+    /^\d+\.\s+/.test(trimmedLine) ||
+    /^>\s?/.test(trimmedLine) ||
+    /^```/.test(trimmedLine) ||
+    /^~~~/.test(trimmedLine)
+  )
+}
+
+function splitItemContent(contentLines: string[]): {
+  paragraphLines: string[]
+  blockLines: string[]
+} {
+  const paragraphLines: string[] = []
+  const blockLines: string[] = []
+  let reachedBlockBoundary = false
+
+  contentLines.forEach(line => {
+    if (reachedBlockBoundary) {
+      blockLines.push(line)
+      return
+    }
+
+    if (line.trim() === '') {
+      reachedBlockBoundary = true
+      blockLines.push(line)
+      return
+    }
+
+    if (paragraphLines.length > 0 && isBlockContentLine(line)) {
+      reachedBlockBoundary = true
+      blockLines.push(line)
+      return
+    }
+
+    paragraphLines.push(line)
+  })
+
+  return {
+    paragraphLines,
+    blockLines,
+  }
 }
 
 /**
@@ -46,9 +95,10 @@ export function collectOrderedListItems(lines: string[]): [OrderedListItem[], nu
 
     const [, indent, number, content] = match
     const indentLevel = indent.length
-    let itemContent = content
+    const itemContentLines = [content]
     let nextLineIndex = currentLineIndex + 1
     const itemLines = [line]
+    let sawBlankLine = false
 
     // Collect continuation lines for this item (but NOT nested list items)
     while (nextLineIndex < lines.length) {
@@ -64,23 +114,30 @@ export function collectOrderedListItems(lines: string[]): [OrderedListItem[], nu
       if (nextLine.trim() === '') {
         // Empty line
         itemLines.push(nextLine)
-        itemContent += '\n'
+        itemContentLines.push('')
+        sawBlankLine = true
         nextLineIndex += 1
       } else if (nextLine.match(INDENTED_LINE_REGEX)) {
         // Indented content - part of this item (but not a list item)
         itemLines.push(nextLine)
-        itemContent += `\n${nextLine.slice(indentLevel + 2)}` // Remove list marker indent
+        itemContentLines.push(nextLine.slice(indentLevel + 2))
         nextLineIndex += 1
       } else {
-        // Non-indented line means end of list
-        break
+        if (sawBlankLine) {
+          break
+        }
+
+        itemLines.push(nextLine)
+        itemContentLines.push(nextLine)
+        nextLineIndex += 1
       }
     }
 
     listItems.push({
       indent: indentLevel,
       number: parseInt(number, 10),
-      content: itemContent.trim(),
+      content: itemContentLines.join('\n').trim(),
+      contentLines: itemContentLines,
       raw: itemLines.join('\n'),
     })
 
@@ -114,8 +171,8 @@ export function buildNestedStructure(
 
     if (item.indent === baseIndent) {
       // This item belongs at the current level
-      const contentLines = item.content.split('\n')
-      const mainText = contentLines[0]?.trim() || ''
+      const { paragraphLines, blockLines } = splitItemContent(item.contentLines)
+      const mainText = paragraphLines.join('\n').trim()
 
       const tokens = []
 
@@ -128,10 +185,8 @@ export function buildNestedStructure(
         })
       }
 
-      // Handle additional content after the main text
-      const additionalContent = contentLines.slice(1).join('\n').trim()
+      const additionalContent = blockLines.join('\n').trim()
       if (additionalContent) {
-        // Parse as block tokens (handles mixed unordered lists, etc.)
         const blockTokens = lexer.blockTokens(additionalContent)
         tokens.push(...blockTokens)
       }

--- a/packages/extension-list/src/ordered-list/utils.ts
+++ b/packages/extension-list/src/ordered-list/utils.ts
@@ -29,7 +29,6 @@ function isBlockContentLine(line: string): boolean {
 
   return (
     /^[-+*]\s+/.test(trimmedLine) ||
-    /^[-+*]\s+\[[ xX]\]\s+/.test(trimmedLine) ||
     /^\d+\.\s+/.test(trimmedLine) ||
     /^>\s?/.test(trimmedLine) ||
     /^```/.test(trimmedLine) ||

--- a/packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts
+++ b/packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts
@@ -1,0 +1,159 @@
+import { Document } from '@tiptap/extension-document'
+import { HardBreak } from '@tiptap/extension-hard-break'
+import { BulletList, ListItem, OrderedList } from '@tiptap/extension-list'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { describe, expect, it } from 'vitest'
+
+import { MarkdownManager } from '../src/MarkdownManager.js'
+
+describe('Ordered list lazy continuation parsing', () => {
+  const extensions = [Document, Paragraph, Text, HardBreak, BulletList, OrderedList, ListItem]
+
+  it('keeps non-indented lazy continuation lines inside the current list item when breaks are enabled', () => {
+    const markdownManager = new MarkdownManager({
+      extensions,
+      markedOptions: {
+        breaks: true,
+      },
+    })
+
+    const markdown = [
+      '1. First item',
+      'Continuation for the first item.',
+      '',
+      '2. Second item',
+      'Continuation for the second item.',
+    ].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'First item' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: 'Continuation for the first item.' },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'Second item' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: 'Continuation for the second item.' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps nested bullet lists as block content inside ordered list items', () => {
+    const markdownManager = new MarkdownManager({
+      extensions,
+      markedOptions: {
+        breaks: true,
+      },
+    })
+
+    const markdown = ['1. one', '  - inner', '2. two'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'one' }],
+                },
+                {
+                  type: 'bulletList',
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [
+                        {
+                          type: 'paragraph',
+                          content: [{ type: 'text', text: 'inner' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'two' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('stops lazy continuation after a blank line', () => {
+    const markdownManager = new MarkdownManager({
+      extensions,
+      markedOptions: {
+        breaks: true,
+      },
+    })
+
+    const markdown = ['1. one', 'lazy continuation', '', 'Outside paragraph'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'one' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: 'lazy continuation' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Outside paragraph' }],
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Changes Overview

Fix ordered-list markdown parsing so non-indented lazy continuation lines are kept as part of the current list item (CommonMark §5.3). This prevents continuation text from being dropped when `marked` is configured with `breaks: true` and preserves nested list behavior.

## Implementation Approach

- Updated `collectOrderedListItems` in `packages/extension-list/src/ordered-list/utils.ts` to track whether a blank line has been seen and treat non-indented, non-list lines before a blank line as "lazy continuation" belonging to the current list item.
- Added `contentLines` on `OrderedListItem`, `splitItemContent()`, and `isBlockContentLine()` helpers to separate paragraph (inline) lines from block-level lines.
- Updated `buildNestedStructure()` to create the first paragraph using `lexer.inlineTokens()` for the joined paragraph lines (so `breaks: true` produces `hardBreak` tokens), and to parse later block content through `lexer.blockTokens()` so nested lists / block nodes remain intact.
- Added a focused regression test `packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts` that runs with `markedOptions: { breaks: true }` and verifies lazy continuation, nested bullet preservation, and blank-line termination.
- Added a changeset: `.changeset/ordered-list-lazy-continuation.md`.

## Testing Done

- Ran the new focused spec: `pnpm vitest run packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts` — all tests passed.
- Ran the markdown conversion suite: `pnpm vitest run packages/markdown/__tests__/conversion.spec.ts` — all tests passed.
- Verified the repository commit includes the changeset and tests.

## Verification Steps

- Checkout branch: `git fetch && git checkout fix/ordered-list-lazy-continuation`
- Run the focused spec:

```bash
pnpm vitest run packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts
```

- Run the markdown conversion suite to ensure no regressions:

```bash
pnpm vitest run packages/markdown/__tests__/conversion.spec.ts
```

## Additional Notes

- The change keeps blank-line semantics intact: a non-indented continuation line before a blank line is part of the previous list item; a non-indented line after a blank line terminates the list.
- The fix is intentionally conservative: paragraph (inline) lines are tokenized with `inlineTokens()` to preserve `hardBreak` nodes when `breaks: true`, while later block content is parsed via `blockTokens()` to retain nested lists and block nodes.

## Checklist

- [x] I have created a changeset for this PR.
- [x] My changes do not break the library (local markdown tests passed).
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes: #7677

