### PR TITLE
test(core): add markPasteRule inclusivity regression coverage

### DIFF
--- a/packages/core/__tests__/markPasteRule.spec.ts
+++ b/packages/core/__tests__/markPasteRule.spec.ts
@@ -1,0 +1,88 @@
+import { Editor, Mark, markPasteRule } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const pasteRegex = /==(.*?)==/g
+const editorElClass = 'tiptap-mark-paste-rule-test'
+
+const createEditorEl = () => {
+  const editorEl = document.createElement('div')
+
+  editorEl.classList.add(editorElClass)
+  document.body.appendChild(editorEl)
+
+  return editorEl
+}
+
+const InclusiveMark = Mark.create({
+  name: 'inclusiveMark',
+  inclusive: true,
+  parseHTML() {
+    return [{ tag: 'span[data-inclusive-mark]' }]
+  },
+  renderHTML() {
+    return ['span', { 'data-inclusive-mark': 'true' }, 0]
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: pasteRegex,
+        type: this.type,
+      }),
+    ]
+  },
+})
+
+const ExclusiveMark = Mark.create({
+  name: 'exclusiveMark',
+  inclusive: false,
+  parseHTML() {
+    return [{ tag: 'span[data-exclusive-mark]' }]
+  },
+  renderHTML() {
+    return ['span', { 'data-exclusive-mark': 'true' }, 0]
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: pasteRegex,
+        type: this.type,
+      }),
+    ]
+  },
+})
+
+describe('markPasteRule', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+    document.querySelector(`.${editorElClass}`)?.remove()
+  })
+
+  it('keeps typing inside an inclusive mark when pasted text ends in that mark', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Paragraph, Text, InclusiveMark],
+    })
+
+    editor.view.pasteText('==test==')
+    editor.commands.insertContent('x')
+
+    expect(editor.getHTML()).toBe('<p><span data-inclusive-mark="true">testx</span></p>')
+  })
+
+  it('keeps typing outside a non-inclusive mark when pasted text ends in that mark', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Paragraph, Text, ExclusiveMark],
+    })
+
+    editor.view.pasteText('==test==')
+    editor.commands.insertContent('x')
+
+    expect(editor.getHTML()).toBe('<p><span data-exclusive-mark="true">test</span>x</p>')
+  })
+})


### PR DESCRIPTION
## Changes Overview

- Add a core regression test suite for `markPasteRule` instead of testing this through the bold extension.
- Cover both inclusive and non-inclusive custom marks when pasted text ends in a matched mark.
- Follow up on the original fix from #7692 with direct behavior coverage.

## Implementation Approach

- Added `packages/core/__tests__/markPasteRule.spec.ts` with two minimal custom marks that differ only by `inclusive`.
- Used `editor.view.pasteText()` to exercise the real paste-rule path and then inserted another character to verify the resulting cursor/typing behavior.
- Kept the assertions focused on the behavior fixed in #7692: inclusive marks should keep typing inside the mark, while non-inclusive marks should keep typing outside it.

## Testing Done

- Ran `pnpm vitest run packages/core/__tests__/markPasteRule.spec.ts packages/extension-bold/__tests__/bold.spec.ts`

## Verification Steps

1. Run `pnpm vitest run packages/core/__tests__/markPasteRule.spec.ts`.
2. Confirm the inclusive-mark test produces `<p><span data-inclusive-mark=\"true\">testx</span></p>` after pasting `==test==` and typing `x`.
3. Confirm the non-inclusive-mark test produces `<p><span data-exclusive-mark=\"true\">test</span>x</p>` after the same steps.

## Additional Notes

- This PR adds regression coverage for the behavior fixed in #7692.
- No changeset was added because this only adds tests.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Follow-up coverage for #7692