### PR TITLE
docs: propose contribution and agent guidance updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.github/instructions/tiptap.instructions.md
+++ b/.github/instructions/tiptap.instructions.md
@@ -29,9 +29,8 @@ Key points for AI assistants:
 │  ├─ extension-*/           # Individual extensions
 │  ├─ pm/                    # ProseMirror related internals and helpers
 │  └─ ...                    # Shared utilities, framework bindings, etc.
-├─ demos/                    # Vite app for live examples
-│  ├─ react/                 # React demos
-│  └─ vue/                   # Vue demos
+├─ demos/                    # Demo app and runnable examples
+│  └─ src/                   # Example categories and demo implementations
 ├─ tests/                    # Cypress e2e tests that run against the demos
 ├─ .changeset/               # Changesets for versioning and changelogs
 └─ .github/                  # Workflows and docs like this file
@@ -51,11 +50,11 @@ Scripts defined at the repo root:
 * `pnpm build` - build all packages via Turborepo
 * `pnpm lint` - run eslint checks
 * `pnpm lint:fix` - run prettier + eslint fix
-* `pnpm test:open` - open Cypress against `tests/`
-* `pnpm test:run` - run Cypress in headless mode
+* `pnpm test:e2e:open` - open Cypress against `tests/`
+* `pnpm test:e2e` - run Cypress in headless mode
 * `pnpm test` - build then run all tests
 * `pnpm serve` - build and serve the demos on port 3000
-* `pnpm publish` - build and publish with Changesets
+* `pnpm publish` - build and publish with Changesets for repository-controlled release workflows
 * `pnpm reset` - remove caches, build artifacts, and reinstall deps
 
 ---
@@ -77,8 +76,8 @@ pnpm lint:fix
 
 ## Demos
 
-* Demos are a Vite app in `demos/`.
-* React and Vue examples live in `demos/react` and `demos/vue`. They are automatically parsed into the app.
+* Demos live in `demos/`.
+* Example implementations live under `demos/src/` in grouped categories such as `Examples`, `Extensions`, `Marks`, and `Nodes`.
 * Start in dev mode:
 
   ```bash
@@ -102,14 +101,14 @@ When adding a demo, keep it small and self-contained, with imports from publishe
 Workflow:
 
 ```bash
-pnpm dev         # terminal A
-pnpm test:open   # terminal B
+pnpm dev              # terminal A
+pnpm test:e2e:open    # terminal B
 ```
 
 or for headless CI runs:
 
 ```bash
-pnpm test:run
+pnpm test:e2e
 ```
 
 ---
@@ -123,6 +122,12 @@ We focus heavily on **User Experience** and **Developer Experience**. Every publ
 * At least one runnable example
 
 This ensures our automated API docs are complete and examples are usable without extra context.
+
+When adding or changing user-facing behavior:
+
+* Prefer meaningful option names over vague ones.
+* Expose options or explicit APIs instead of hardcoding one workflow when a configurable design is possible.
+* Provide escape hatches where reasonable so users can adapt behavior without patching internals.
 
 Example:
 
@@ -149,7 +154,8 @@ export function toggleBold(editor: Editor): boolean {
 
 * Run `pnpm changeset` to create a new changeset (choose packages + bump type).
 * Run `pnpm version` to update versions and changelogs.
-* Maintainers publish with `pnpm publish`.
+* Publishing is handled by the repository's automated workflow using trusted publishing.
+* Do not manually publish packages from local machines as part of normal contribution flow.
 
 Changelogs must describe **user-facing changes**. Avoid internal noise.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Key locations:
 - `demos/` contains the demo app and example implementations used for development, manual verification, and end-to-end testing.
 - `tests/` contains end-to-end tests that run against the demos.
 - `.changeset/` contains Changesets used for versioning and release notes.
+- `CONTRIBUTING.md` contains the repository contribution policy. Read it before opening issues or pull requests, especially for issue assignment, Changesets, AI usage, and PR requirements.
 
 ## How to think about the codebase
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS
+
+## What this project is
+
+Tiptap is a headless rich text editor toolkit built on top of ProseMirror. It is designed as a composable system of focused packages rather than a single monolithic editor.
+
+This repository is a monorepo.
+
+Key locations:
+
+- `packages/` contains the published packages, core modules, framework bindings, and first-party extensions.
+- `demos/` contains the demo app and example implementations used for development, manual verification, and end-to-end testing.
+- `tests/` contains end-to-end tests that run against the demos.
+- `.changeset/` contains Changesets used for versioning and release notes.
+
+## How to think about the codebase
+
+Treat Tiptap as a collection of small, focused building blocks.
+
+Important principles:
+
+- Keep extensions separated and composable.
+- Avoid hardcoding cross-extension behavior unless it is absolutely necessary.
+- Prefer extension interoperability through editor events, explicit APIs, exposed options, or other extension hooks.
+- If compatibility between extensions is needed, first look for a way to express that through editor events, extension options, or public integration points.
+- Favor predictable, explicit, testable behavior over hidden magic.
+
+Do not assume a single framework. Many packages are framework-agnostic, with separate bindings for React and Vue.
+
+## Developer Experience is a product goal
+
+Tiptap focuses heavily on Developer Experience. Our users, and AI systems using Tiptap, should be able to understand and use the API correctly with minimal friction.
+
+That means:
+
+- Public APIs must be easy to discover and understand.
+- Naming must be clear and meaningful.
+- Options should be explicit and well documented.
+- Escape hatches should exist when reasonable so users can adapt behavior without patching internals.
+- Defaults should be strong, but users should retain control.
+
+## Documentation expectations
+
+Add good and extensive JSDoc for any user-facing API surface, including:
+
+- functions
+- commands
+- options
+- classes
+- types
+- interfaces
+- properties
+- events
+- extension configuration
+
+JSDoc should:
+
+- explain what the API does
+- explain why or when to use it when that is not obvious
+- describe parameters and return values clearly
+- include examples when helpful
+- stay accurate as behavior changes
+
+If a change affects a public API, update the documentation in the same change.
+
+## API design expectations
+
+When adding or changing user-facing behavior:
+
+- Prefer meaningful option names over vague or overly generic names.
+- Provide escape hatches where reasonable.
+- Do not lock users into one hardcoded workflow if a configurable design is possible.
+- Expose control through options or explicit APIs when default behavior will not fit every integration.
+- Keep defaults sensible, but avoid making assumptions that users cannot override.
+
+If something is not supported by default, prefer adding a clear option or extension point instead of forcing users into internal patches or forks.
+
+## Monorepo guidance
+
+When working in this repository:
+
+- Look in `packages/` for the source of published functionality.
+- Look in `demos/` for runnable examples and manual verification targets.
+- Keep changes scoped to the relevant package or extension when possible.
+- Avoid leaking package-specific behavior into unrelated extensions.
+- Prefer small, focused changes over broad cross-package rewrites unless the architecture clearly requires it.
+
+## Changesets and releases
+
+This repository uses Changesets for versioning and changelog generation.
+
+Guidelines:
+
+- Add a Changeset for user-facing changes.
+- Write Changesets for users, not maintainers.
+- Keep changelog text focused on visible outcomes and API changes.
+- Do not add internal-only noise to release notes.
+
+Publishing is handled by the repository's automated workflow using trusted publishing. Do not publish packages manually.
+
+## Validation mindset
+
+Before considering work complete:
+
+- ensure relevant linting, tests, and builds pass
+- add or update tests when behavior changes
+- update demos when they help verify user-visible behavior
+- update JSDoc and public-facing documentation when APIs or behavior change
+
+## Contribution flow awareness
+
+Pull requests are expected to follow the repository contribution policy:
+
+- PRs must be linked to an issue
+- contributors should request assignment or maintainer approval on the issue before opening a PR
+- use the repository pull request template
+- include a Changeset when required
+
+## General implementation style
+
+- Prefer the smallest correct change.
+- Keep code deterministic and explicit.
+- Avoid unnecessary abstractions.
+- Preserve separation between extensions.
+- Build APIs that are understandable by both humans and AI tools.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,15 @@ Key locations:
 - `.changeset/` contains Changesets used for versioning and release notes.
 - `CONTRIBUTING.md` contains the repository contribution policy. Read it before opening issues or pull requests, especially for issue assignment, Changesets, AI usage, and PR requirements.
 
+## Tooling conventions
+
+- Use `pnpm` for package management and workspace scripts.
+- Use ESLint for semantic correctness, code quality, and avoiding logical issues.
+- Use Prettier for code formatting.
+- Use Cypress for end-to-end testing.
+- Use Vitest for unit testing.
+- When GitHub is involved, check whether the `gh` CLI is available and use it for GitHub-related tasks.
+
 ## How to think about the codebase
 
 Treat Tiptap as a collection of small, focused building blocks.
@@ -114,7 +123,7 @@ Pull requests are expected to follow the repository contribution policy:
 
 - PRs must be linked to an issue
 - contributors should request assignment or maintainer approval on the issue before opening a PR
-- use the repository pull request template
+- if an agent creates a PR, always use `.github/pull_request_template.md` as the base and fill it out as completely and accurately as possible
 - include a Changeset when required
 
 ## General implementation style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@ Contributions are **welcome** and will be fully **credited**.
 
 Please read and understand the [contribution guide](https://www.tiptap.dev/overview/contributing/) before creating an issue or pull request.
 
-## Why this process exists
+## General information
+
+### Why this process exists
 
 We want to reduce one-off drive-by pull requests and keep better control over issue ownership.
 
@@ -14,7 +16,7 @@ This helps us:
 - give contributors clear maintainer feedback before work starts
 - spend review time on changes that align with the roadmap and project standards
 
-## Etiquette
+### Etiquette
 
 This project is open source, and as such, the maintainers give their free time to build and maintain the source code held within. They make the code freely available in the hope that it will be of use to other developers. It would be extremely unfair for them to suffer abuse or anger for their hard work.
 
@@ -22,11 +24,54 @@ Please be considerate towards maintainers when raising issues or presenting pull
 
 It's the duty of the maintainer to ensure that all submissions to the project are of sufficient quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
 
-## Viability
+### Viability
 
 When requesting or submitting new features, first consider whether it might be useful to others. Open source projects are used by many developers, who may have entirely different needs to your own. Think about whether or not your feature is likely to be used by other users of the project.
 
-## Required contribution flow
+### Licensing
+
+Please respect open source licenses when contributing to this project.
+
+- Make sure any new dependency, copied code, asset, or external source you introduce is compatible with this repository's license and distribution model.
+- If a dependency does not allow MIT-compatible usage, redistribution, or commercial use, do not add it to the project.
+- If you are unsure whether a license is compatible, ask a maintainer before proceeding.
+- When in doubt, prefer a clearly licensed and compatible alternative.
+
+### AI usage
+
+We use AI in parts of our workflow, but we do not treat AI output as self-approving or self-merging.
+
+Maintainers may use AI for:
+
+- code generation and implementation support
+- code review support
+- automated communication drafts
+
+However, all maintainers remain responsible for the final outcome:
+
+- everything must go through human review
+- we do not send, merge, or publish AI-generated output without manually checking it first
+- maintainers are accountable for the correctness, tone, and quality of what is submitted
+
+Contributor use of AI is allowed, including AI-assisted issues and pull requests, with the following expectations:
+
+- a human must define the problem, intent, and specification
+- do not fully automate contribution work end to end without meaningful human oversight
+- contributors must understand, review, and stand behind the final issue, discussion, or pull request they submit
+
+We do not want maintainers or contributors to fully rely on AI for development or discussion:
+
+- do not turn the repository into fully automated "vibe code" contributions
+- do not let AI agents conduct the entire collaboration loop without human involvement
+- this repository should not become AI bots talking to each other
+
+### Security
+
+If you discover a security vulnerability, please refer to our [Security Policy](SECURITY.md) for reporting instructions.
+
+## Contribution guidelines
+
+### Required contribution flow
 
 Every pull request must be backed by a valid issue and an explicit maintainer assignment or go-ahead.
 
@@ -39,7 +84,7 @@ The expected flow is:
 5. You open a pull request using `.github/pull_request_template.md` and link the issue with an auto-closing keyword such as `Closes #123`.
 6. Once the pull request is merged, GitHub closes the linked issue automatically.
 
-## What happens if you skip the flow
+### What happens if you skip the flow
 
 - Pull requests without a linked issue will be closed.
 - If you want to fix something that is not an issue yet, create the issue first and wait for maintainer confirmation before opening a pull request.
@@ -47,7 +92,7 @@ The expected flow is:
 - We only accept contributions that are tied to a valid issue and have a contributor assigned or explicitly approved by a maintainer.
 - Pull requests that skip assignment or prior maintainer approval may be closed.
 
-## Before filing an issue
+### Before filing an issue
 
 - Attempt to replicate the problem, to ensure that it wasn't a coincidental incident. Create a CodeSandbox to reproduce the issue. Use one of these templates to get started:
   - [JavaScript template](https://codesandbox.io/s/tiptap-js-fv1lyo)
@@ -58,13 +103,13 @@ The expected flow is:
 - Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
 - Check the pull requests tab to ensure that the feature isn't already in progress.
 
-## Before starting work on an issue
+### Before starting work on an issue
 
 - If possible, comment on the issue early to let maintainers know you are interested in working on it.
 - Before opening a pull request, you must have asked to be assigned and received maintainer approval.
 - If the work is no longer needed, already in progress, or out of scope, respect that decision before starting implementation.
 
-## Before opening a pull request
+### Before opening a pull request
 
 - Make sure the linked issue exists and that you were assigned or explicitly approved to work on it.
 - Check the codebase to ensure that your feature doesn't already exist.
@@ -73,7 +118,7 @@ The expected flow is:
 - Link the original issue with an auto-closing keyword such as `Closes #123`.
 - Follow the one pull request per feature rule.
 
-## Quality standards before submitting
+### Quality standards before submitting
 
 - Run the tests and linter before committing your changes.
 - Add tests where applicable.
@@ -81,7 +126,7 @@ The expected flow is:
 - Make sure your changes do not break the library.
 - Document any change in behaviour in `README.md` and any other relevant documentation.
 
-## Changesets
+### Changesets
 
 [Changesets](https://github.com/changesets/changesets) are how this repository versions packages and generates changelog entries for releases.
 
@@ -116,7 +161,7 @@ Poor examples:
 - `Update tests.`
 - `Clean up extension implementation.`
 
-## Commits and pull request titles
+### Commits and pull request titles
 
 Commits should follow [Conventional Commits](https://www.conventionalcommits.org/) because this repository uses `commitlint` with the conventional config.
 
@@ -133,48 +178,9 @@ Additional rules:
 - Squash intermediate commits before opening your pull request when needed.
 - Name pull requests clearly and consistently. A good default is to use the same style as the final conventional commit summary.
 
-## Licensing
+## Guides
 
-Please respect open source licenses when contributing to this project.
-
-- Make sure any new dependency, copied code, asset, or external source you introduce is compatible with this repository's license and distribution model.
-- If a dependency does not allow MIT-compatible usage, redistribution, or commercial use, do not add it to the project.
-- If you are unsure whether a license is compatible, ask a maintainer before proceeding.
-- When in doubt, prefer a clearly licensed and compatible alternative.
-
-## AI usage
-
-We use AI in parts of our workflow, but we do not treat AI output as self-approving or self-merging.
-
-Maintainers may use AI for:
-
-- code generation and implementation support
-- code review support
-- automated communication drafts
-
-However, all maintainers remain responsible for the final outcome:
-
-- everything must go through human review
-- we do not send, merge, or publish AI-generated output without manually checking it first
-- maintainers are accountable for the correctness, tone, and quality of what is submitted
-
-Contributor use of AI is allowed, including AI-assisted issues and pull requests, with the following expectations:
-
-- a human must define the problem, intent, and specification
-- do not fully automate contribution work end to end without meaningful human oversight
-- contributors must understand, review, and stand behind the final issue, discussion, or pull request they submit
-
-We do not want maintainers or contributors to fully rely on AI for development or discussion:
-
-- do not turn the repository into fully automated "vibe code" contributions
-- do not let AI agents conduct the entire collaboration loop without human involvement
-- this repository should not become AI bots talking to each other
-
-## Security
-
-If you discover a security vulnerability, please refer to our [Security Policy](SECURITY.md) for reporting instructions.
-
-## Create a new demo
+### Create a new demo
 
 To make it easier to add new demos to the demos app we provide a small helper script via `pnpm run make:demo` that scaffolds a new demo directory from our default template.
 
@@ -207,18 +213,32 @@ Then follow the interactive prompts for the demo name and category.
 - If your demo changes package behaviour or exposes user-facing changes, follow the normal rule and add a Changeset and tests as needed.
 - If you don't want your demo to be included in the Git repository, use the `Dev` category. Demos in this category are ignored by git via `.gitignore`.
 
-## Publishing new packages
+### Additional requirements
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](https://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+## For maintainers
+
+### Create a release
 
 Packages are published by the repository's automated release workflow using [Changesets](https://github.com/changesets/changesets) and trusted publishing.
 
 - Do not publish packages manually.
-- When a package should be released, include a correct Changeset in your pull request.
 - The publish workflow is responsible for turning merged Changesets into version bumps, changelog entries, and published packages.
-- Make sure the Changeset clearly describes the user-facing change, because that text is used in the release notes and changelog.
+- Make sure the merged Changesets clearly describe the user-facing change, because that text is used in the release notes and changelog.
 
-## Additional requirements
+When new commits are merged into `main`, `next`, or a `release/*` branch, the Changesets bot opens a pull request for the pending version bumps and changelog updates.
 
-- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
-- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](https://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+The expected release flow is:
+
+1. Review the Changesets pull request closely, especially the proposed version bumps and generated changelog entries.
+2. Merge the Changesets pull request when the release contents look correct.
+3. After that merge, the automated release workflow publishes the packages for the generated versions.
+4. Create the git tag for the released version manually, for example `git tag v3.x.x && git push origin --tags`.
+5. Create the GitHub release manually with the matching tag and title.
+6. Copy the release notes for that version from the global `CHANGELOG.md` into the GitHub release description.
+
+Use `CHANGELOG.md` as the canonical source for the final release notes text.
 
 **Happy coding**!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,31 +4,50 @@ Contributions are **welcome** and will be fully **credited**.
 
 Please read and understand the [contribution guide](https://www.tiptap.dev/overview/contributing/) before creating an issue or pull request.
 
+## Why this process exists
+
+We want to reduce one-off drive-by pull requests and keep better control over issue ownership.
+
+This helps us:
+
+- avoid multiple contributors working on the same issue in parallel
+- give contributors clear maintainer feedback before work starts
+- spend review time on changes that align with the roadmap and project standards
+
 ## Etiquette
 
-This project is open source, and as such, the maintainers give their free time to build and maintain the source code
-held within. They make the code freely available in the hope that it will be of use to other developers. It would be
-extremely unfair for them to suffer abuse or anger for their hard work.
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code held within. They make the code freely available in the hope that it will be of use to other developers. It would be extremely unfair for them to suffer abuse or anger for their hard work.
 
-Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
-world that developers are civilized and selfless people.
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the world that developers are civilized and selfless people.
 
-It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
-quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
-
-## Security
-
-If you discover a security vulnerability, please refer to our [Security Policy](SECURITY.md) for reporting instructions.
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
 
 ## Viability
 
-When requesting or submitting new features, first consider whether it might be useful to others. Open
-source projects are used by many developers, who may have entirely different needs to your own. Think about
-whether or not your feature is likely to be used by other users of the project.
+When requesting or submitting new features, first consider whether it might be useful to others. Open source projects are used by many developers, who may have entirely different needs to your own. Think about whether or not your feature is likely to be used by other users of the project.
 
-## Procedure
+## Required contribution flow
 
-Before filing an issue:
+Every pull request must be backed by a valid issue and an explicit maintainer assignment or go-ahead.
+
+The expected flow is:
+
+1. You want to work on an existing issue, or you create a new issue for the bug or feature first.
+2. You comment on that issue and ask to be assigned.
+3. A maintainer assigns you to the issue, or explicitly tells you to proceed.
+4. You make the changes, add a Changeset if needed, and make sure quality and testing standards are met.
+5. You open a pull request using `.github/pull_request_template.md` and link the issue with an auto-closing keyword such as `Closes #123`.
+6. Once the pull request is merged, GitHub closes the linked issue automatically.
+
+## What happens if you skip the flow
+
+- Pull requests without a linked issue will be closed.
+- If you want to fix something that is not an issue yet, create the issue first and wait for maintainer confirmation before opening a pull request.
+- Before opening a pull request, ask on the issue to be assigned and wait for maintainer approval.
+- We only accept contributions that are tied to a valid issue and have a contributor assigned or explicitly approved by a maintainer.
+- Pull requests that skip assignment or prior maintainer approval may be closed.
+
+## Before filing an issue
 
 - Attempt to replicate the problem, to ensure that it wasn't a coincidental incident. Create a CodeSandbox to reproduce the issue. Use one of these templates to get started:
   - [JavaScript template](https://codesandbox.io/s/tiptap-js-fv1lyo)
@@ -39,15 +58,121 @@ Before filing an issue:
 - Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
 - Check the pull requests tab to ensure that the feature isn't already in progress.
 
-Before submitting a pull request:
+## Before starting work on an issue
 
+- If possible, comment on the issue early to let maintainers know you are interested in working on it.
+- Before opening a pull request, you must have asked to be assigned and received maintainer approval.
+- If the work is no longer needed, already in progress, or out of scope, respect that decision before starting implementation.
+
+## Before opening a pull request
+
+- Make sure the linked issue exists and that you were assigned or explicitly approved to work on it.
 - Check the codebase to ensure that your feature doesn't already exist.
-- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+- Check existing pull requests to ensure that another person hasn't already submitted the feature or fix.
+- Use `.github/pull_request_template.md` when opening the pull request.
+- Link the original issue with an auto-closing keyword such as `Closes #123`.
+- Follow the one pull request per feature rule.
 
-Before committing:
+## Quality standards before submitting
 
-- Make sure to run the tests and linter before committing your changes.
-- If you are making changes to one of the packages, make sure to **always** include a [changeset](https://github.com/changesets/changesets) in your PR describing **what changed** with a **description** of the change. Those are responsible for changelog creation
+- Run the tests and linter before committing your changes.
+- Add tests where applicable.
+- If you are making changes to one of the packages, add a Changeset when the change is user-facing.
+- Make sure your changes do not break the library.
+- Document any change in behaviour in `README.md` and any other relevant documentation.
+
+## Changesets
+
+[Changesets](https://github.com/changesets/changesets) are how this repository versions packages and generates changelog entries for releases.
+
+Create a Changeset with `pnpm changeset` when your pull request includes a user-facing change, for example:
+
+- bug fixes users will notice
+- new features
+- API changes
+- behaviour changes that affect consumers
+
+Usually you do **not** need a Changeset for:
+
+- tests only
+- refactors with no user-facing effect
+- CI or tooling only changes
+- docs only changes
+
+When you write a Changeset:
+
+- write it for users, not maintainers
+- describe the visible outcome, not internal implementation details
+- keep it short and clear
+
+Good examples:
+
+- `Fix pasted content losing paragraph spacing in Markdown output.`
+- `Add support for configuring suggestion item filtering in React integrations.`
+
+Poor examples:
+
+- `Refactor parser internals.`
+- `Update tests.`
+- `Clean up extension implementation.`
+
+## Commits and pull request titles
+
+Commits should follow [Conventional Commits](https://www.conventionalcommits.org/) because this repository uses `commitlint` with the conventional config.
+
+Use commit messages such as:
+
+- `fix: preserve trailing whitespace in markdown serializer`
+- `feat: add support for configurable suggestion filtering`
+- `docs: clarify changeset requirements`
+
+Additional rules:
+
+- Keep commits focused and meaningful.
+- Avoid noisy work-in-progress commit history in submitted pull requests.
+- Squash intermediate commits before opening your pull request when needed.
+- Name pull requests clearly and consistently. A good default is to use the same style as the final conventional commit summary.
+
+## Licensing
+
+Please respect open source licenses when contributing to this project.
+
+- Make sure any new dependency, copied code, asset, or external source you introduce is compatible with this repository's license and distribution model.
+- If a dependency does not allow MIT-compatible usage, redistribution, or commercial use, do not add it to the project.
+- If you are unsure whether a license is compatible, ask a maintainer before proceeding.
+- When in doubt, prefer a clearly licensed and compatible alternative.
+
+## AI usage
+
+We use AI in parts of our workflow, but we do not treat AI output as self-approving or self-merging.
+
+Maintainers may use AI for:
+
+- code generation and implementation support
+- code review support
+- automated communication drafts
+
+However, all maintainers remain responsible for the final outcome:
+
+- everything must go through human review
+- we do not send, merge, or publish AI-generated output without manually checking it first
+- maintainers are accountable for the correctness, tone, and quality of what is submitted
+
+Contributor use of AI is allowed, including AI-assisted issues and pull requests, with the following expectations:
+
+- a human must define the problem, intent, and specification
+- do not fully automate contribution work end to end without meaningful human oversight
+- contributors must understand, review, and stand behind the final issue, discussion, or pull request they submit
+
+We do not want maintainers or contributors to fully rely on AI for development or discussion:
+
+- do not turn the repository into fully automated "vibe code" contributions
+- do not let AI agents conduct the entire collaboration loop without human involvement
+- this repository should not become AI bots talking to each other
+
+## Security
+
+If you discover a security vulnerability, please refer to our [Security Policy](SECURITY.md) for reporting instructions.
 
 ## Create a new demo
 
@@ -61,37 +186,39 @@ To make it easier to add new demos to the demos app we provide a small helper sc
 
 **How to use**
 
-- From the repository root run:
-- If the script is executable:
-- Or with bash directly:
-- Follow the interactive prompts for the demo name and category.
+From the repository root run one of the following:
+
+```bash
+pnpm run make:demo
+```
+
+or:
+
+```bash
+sh ./scripts/make-demo.sh
+```
+
+Then follow the interactive prompts for the demo name and category.
 
 **Notes and follow-up steps**
 
 - The script only copies the template. After the scaffold is created, update the demo's files (title, description, imports) to reflect your example.
 - Make sure to review the generated demo in `demos/` and run the demos app (`pnpm dev`) to verify it appears and works as expected.
-- If your demo changes package behaviour or exposes user-facing changes, follow the normal rule and add a changeset and tests as needed.
+- If your demo changes package behaviour or exposes user-facing changes, follow the normal rule and add a Changeset and tests as needed.
 - If you don't want your demo to be included in the Git repository, use the `Dev` category. Demos in this category are ignored by git via `.gitignore`.
 
-## Publishing New Packages
+## Publishing new packages
 
-When adding a new package to the repository that does not yet exist on NPM, additional setup is required before the automated publish CI can release it:
+Packages are published by the repository's automated release workflow using [Changesets](https://github.com/changesets/changesets) and trusted publishing.
 
-1. **Manual initial publish** - The package must be published manually to NPM for the first time using normal user authentication. This is required because trusted publishing can only be configured for packages that already exist on the registry.
-   - For a single package, run `pnpm run build && pnpm publish` from the package directory (e.g., `packages/extension-audio/`).
-   - Alternatively, run `pnpm run publish` from the root directory to publish all packages.
-2. **Configure trusted publishing** - After the initial publish, set up [NPM trusted publishing](https://docs.npmjs.com/trusted-publishers) (also known as provenance) for the package on NPM. This allows the GitHub Actions workflow to publish subsequent versions automatically.
+- Do not publish packages manually.
+- When a package should be released, include a correct Changeset in your pull request.
+- The publish workflow is responsible for turning merged Changesets into version bumps, changelog entries, and published packages.
+- Make sure the Changeset clearly describes the user-facing change, because that text is used in the release notes and changelog.
 
-Without this setup, the publish CI will fail when attempting to release a new package.
-
-## Requirements
-
-If the project maintainer has any additional requirements, you will find them listed here.
-
-- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+## Additional requirements
 
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
-
 - **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](https://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
 
 **Happy coding**!

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Changes Overview

This proposal updates the contribution guide to clarify issue assignment requirements, Changeset expectations, naming conventions, licensing, and AI usage. It also adds shared agent guidance for AI coding tools via a single `AGENTS.md` source with symlinked variants.

## Implementation Approach

I rewrote `CONTRIBUTING.md` around the actual contributor flow, added explicit policy sections for Changesets, AI usage, licensing, and publishing, and introduced a root `AGENTS.md` for repo-aware AI guidance. The existing internal Tiptap instructions were also updated so they match the current monorepo layout and trusted-publishing workflow.

## Testing Done

Docs-only changes. I verified the resulting markdown content, symlink targets, and git diff locally.

## Verification Steps

1. Review `CONTRIBUTING.md` to confirm the proposed contribution flow, AI policy, licensing guidance, and publishing language match maintainers' intent.
2. Review `AGENTS.md` and the symlinked entrypoints (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`, `.github/copilot-instructions.md`) to confirm the guidance should be shared across tools.
3. Review `.github/instructions/tiptap.instructions.md` to confirm the internal agent guidance matches the current repo structure and trusted publishing flow.

## Additional Notes

This PR is intended as a proposal for now so the wording and structure can be reviewed before finalizing.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

No linked issue yet. This draft PR is opened as a proposal for discussion.