### PR TITLE
Fix flaky Vue images e2e test

### DIFF
--- a/demos/src/Examples/Images/Vue/index.spec.js
+++ b/demos/src/Examples/Images/Vue/index.spec.js
@@ -11,7 +11,12 @@ context('/src/Examples/Images/Vue/', () => {
   it('allows removing images', () => {
     cy.get('.tiptap').should('be.visible')
     cy.get('.tiptap img').should('have.length', 2).and('be.visible')
-    cy.get('.tiptap img').first().click()
+    cy.get('.tiptap img')
+      .first()
+      .should($img => {
+        expect($img[0].naturalWidth).to.be.greaterThan(0)
+      })
+      .click()
     cy.get('.tiptap img.ProseMirror-selectednode').should('exist')
     cy.get('.tiptap').type('{backspace}')
     cy.get('.tiptap img').should('have.length', 1)


### PR DESCRIPTION
## Summary

The `allows removing images` e2e test in `demos/src/Examples/Images/Vue/index.spec.js` was flaky on CI.

## Bug

The test clicks an `<img>` element and expects ProseMirror to add the `ProseMirror-selectednode` class. However, the existing `be.visible` assertion only checks DOM visibility — not that the image has actually loaded from the network. In CI, the `placehold.co` images can load slowly, so the click fires on a zero-dimension broken image placeholder, and ProseMirror never creates a NodeSelection.

## Fix

Added a `.should()` assertion that waits for `naturalWidth > 0` before clicking, ensuring the image is fully loaded from the network. Cypress automatically retries this assertion until the image loads or the default timeout is reached.