### PR TITLE
fix(core): preserve text selection when toggling off list with AllSelection

### DIFF
--- a/.changeset/fix-togglelist-allselection-selection.md
+++ b/.changeset/fix-togglelist-allselection-selection.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix text selection collapsing after toggling off a list with AllSelection

--- a/packages/core/src/commands/toggleList.ts
+++ b/packages/core/src/commands/toggleList.ts
@@ -89,10 +89,13 @@ function createInnerSelectionForWholeDocList(tr: Transaction) {
 
   // Place the selection inside the list node so that ProseMirror's
   // liftListItem command can operate. AllSelection sits at the doc root.
-  const from = 1
-  const to = list.nodeSize - 1
+  // Use TextSelection.between to resolve positions into valid inline
+  // content positions, so the selection survives position mapping after
+  // liftListItem removes list/item wrappers.
+  const $start = doc.resolve(1)
+  const $end = doc.resolve(list.nodeSize - 1)
 
-  return TextSelection.create(doc, from, to)
+  return TextSelection.between($start, $end)
 }
 export const toggleList: RawCommands['toggleList'] =
   (listTypeOrName, itemTypeOrName, keepMarks, attributes = {}) =>

--- a/packages/extension-list/__tests__/taskItem.spec.ts
+++ b/packages/extension-list/__tests__/taskItem.spec.ts
@@ -546,4 +546,112 @@ describe('TaskItem', () => {
 
     expect(editor.can().toggleBulletList()).toBe(true)
   })
+
+  it('preserves text selection after toggling off an ordered list with AllSelection', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, OrderedList, BulletList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'orderedList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Test item' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.selectAll()
+    editor.commands.toggleOrderedList()
+
+    const { from, to } = editor.state.selection
+
+    expect(from).toBe(1)
+    expect(to).toBe(10)
+  })
+
+  it('preserves text selection after toggling off a bullet list with AllSelection', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, OrderedList, BulletList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Test item' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.selectAll()
+    editor.commands.toggleBulletList()
+
+    const { from, to } = editor.state.selection
+
+    expect(from).toBe(1)
+    expect(to).toBe(10)
+  })
+
+  it('preserves text selection after toggling off a multi-item ordered list with AllSelection', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, OrderedList, BulletList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'orderedList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'First' }],
+                  },
+                ],
+              },
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Second' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.selectAll()
+    editor.commands.toggleOrderedList()
+
+    const { from, to } = editor.state.selection
+
+    expect(from).toBe(1)
+    expect(to).toBe(14)
+  })
 })

--- a/packages/extension-list/__tests__/taskItem.spec.ts
+++ b/packages/extension-list/__tests__/taskItem.spec.ts
@@ -572,6 +572,9 @@ describe('TaskItem', () => {
     })
 
     editor.commands.selectAll()
+    expect(editor.state.selection.from).toBe(0)
+    expect(editor.state.selection.to).toBe(editor.state.doc.content.size)
+
     editor.commands.toggleOrderedList()
 
     const { from, to } = editor.state.selection
@@ -605,6 +608,9 @@ describe('TaskItem', () => {
     })
 
     editor.commands.selectAll()
+    expect(editor.state.selection.from).toBe(0)
+    expect(editor.state.selection.to).toBe(editor.state.doc.content.size)
+
     editor.commands.toggleBulletList()
 
     const { from, to } = editor.state.selection
@@ -647,6 +653,9 @@ describe('TaskItem', () => {
     })
 
     editor.commands.selectAll()
+    expect(editor.state.selection.from).toBe(0)
+    expect(editor.state.selection.to).toBe(editor.state.doc.content.size)
+
     editor.commands.toggleOrderedList()
 
     const { from, to } = editor.state.selection


### PR DESCRIPTION
## Changes Overview

Fix a regression introduced in #7683 where toggling off a list with AllSelection (Ctrl/Cmd+A) causes the text selection to collapse. After the list is lifted, the selection becomes empty (`from === to`), causing the user to lose their selection and BubbleMenu to disappear.

## Implementation Approach

`createInnerSelectionForWholeDocList()` used structural boundary positions (`from = 1`, `to = list.nodeSize - 1`) to create a `TextSelection`. These positions sit outside inline content, so after `liftListItem` removes the list/item wrappers, `TextSelection.map()` falls back to `Selection.near()` and collapses the selection.

Replace `TextSelection.create()` with `TextSelection.between()`, which resolves non-text positions to the nearest valid cursor positions. This ensures the selection maps correctly through the lift operation and remains non-empty afterward.

**Position trace** (single list item containing "abc"):

```
Before lift:                    After lift:
pos 0: <ol>                     pos 0: <p>
pos 1: ├─ <li>   <-- from=1     pos 1: │ a
pos 2: │  ├─ <p>                pos 2: │ b
pos 3: │  │  a                  pos 3: │ c
pos 4: │  │  b                  pos 4: </p>
pos 5: │  │  c
pos 6: │  ├─ </p>
pos 7: ├─ </li>  <-- to=7
pos 8: </ol>
```

With `TextSelection.create`: `from=1 → 0`, `to=7 → 4` — both at doc level, selection collapses.
With `TextSelection.between`: `from=3 → 1`, `to=6 → 4` — both inside paragraph, selection preserved.

## Testing Done

Added 3 regression tests verifying that text selection is preserved after toggling off a list with AllSelection:

- Single-item ordered list
- Single-item bullet list
- Multi-item ordered list

Each test asserts exact `from` and `to` positions after the toggle operation.

## Verification Steps

1. Open the official example: https://tiptap.dev/docs/editor/extensions/nodes/bullet-list
2. Clear editor content and type some text
3. Select all with Ctrl/Cmd+A
4. Click Bullet List to apply a list
5. Click the same button again to toggle the list off
6. Verify that the text selection is preserved (not collapsed to a cursor)

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Regression from #7683 (fix for #7562)
