### PR TITLE
fix(markdown): preserve HTML comments as text during markdown parsing

### DIFF
--- a/.changeset/calm-cycles-hear.md
+++ b/.changeset/calm-cycles-hear.md
@@ -1,0 +1,7 @@
+---
+"@tiptap/markdown": patch
+---
+
+Preserve HTML comments in markdown parsing by keeping them as text nodes instead of dropping them.
+
+This improves round-tripping for markdown content that includes hidden metadata comments like `<!-- ... -->`.

--- a/demos/src/Markdown/Parse/React/index.jsx
+++ b/demos/src/Markdown/Parse/React/index.jsx
@@ -47,24 +47,9 @@ ${'```'}
 
 ![Alt text](https://unsplash.it/800/500)
 
-## HTML
-
-<div class="label">test<div>
-
-Inline HTML: hello <em>world</em> and <strong>friends</strong>.
-
-Nested block HTML:
-
-<section class="card">
-  <h4>Card title</h4>
-  <p>Card body with <code>inline code</code>.</p>
-</section>
-
-Self-closing HTML:
-
-<br />
-
 ## Hidden HTML Comments
+
+Test with following hidden comment <!-- i am the comment -->
 
 <!-- This is a hidden comment that should be preserved in the editor document -->
 

--- a/demos/src/Markdown/Parse/React/index.jsx
+++ b/demos/src/Markdown/Parse/React/index.jsx
@@ -47,6 +47,29 @@ ${'```'}
 
 ![Alt text](https://unsplash.it/800/500)
 
+## HTML
+
+<div class="label">test<div>
+
+Inline HTML: hello <em>world</em> and <strong>friends</strong>.
+
+Nested block HTML:
+
+<section class="card">
+  <h4>Card title</h4>
+  <p>Card body with <code>inline code</code>.</p>
+</section>
+
+Self-closing HTML:
+
+<br />
+
+## Hidden HTML Comments
+
+<!-- This is a hidden comment that should be preserved in the editor document -->
+
+<!-- line 1\nline 2 -->
+
 ## Notes
 
 - The demo calls ${'`'}editor.commands.setContent(markdownText, { contentType: 'markdown' })${'`'} to parse Markdown.

--- a/packages/markdown/__tests__/mixed-html.spec.ts
+++ b/packages/markdown/__tests__/mixed-html.spec.ts
@@ -52,6 +52,50 @@ describe('MarkdownManager Mixed Markdown + HTML', () => {
     expect(hasItalic).toBe(true)
   })
 
+  it('preserves standalone block HTML comments as paragraph text', () => {
+    const md = '<!-- This content will not appear in the rendered Markdown -->'
+    const doc = manager.parse(md)
+
+    expect(doc.type).toBe('doc')
+    const para = doc.content![0]
+    expect(para.type).toBe('paragraph')
+    expect(para.content![0].type).toBe('text')
+    expect(para.content![0].text).toBe('<!-- This content will not appear in the rendered Markdown -->')
+  })
+
+  it('preserves inline HTML comments as text content', () => {
+    const md = 'before <!-- hidden --> after'
+    const doc = manager.parse(md)
+
+    expect(doc.type).toBe('doc')
+    const para = doc.content![0]
+    expect(para.type).toBe('paragraph')
+    const texts = para.content!.map((n: any) => n.text || '').join('')
+    expect(texts).toContain('<!-- hidden -->')
+  })
+
+  it('preserves multiline HTML comments as text content', () => {
+    const md = '<!-- line 1\nline 2 -->'
+    const doc = manager.parse(md)
+
+    expect(doc.type).toBe('doc')
+    const para = doc.content![0]
+    expect(para.type).toBe('paragraph')
+    expect(para.content![0].type).toBe('text')
+    expect(para.content![0].text).toBe('<!-- line 1\nline 2 -->')
+  })
+
+  it('preserves surrounding whitespace for standalone HTML comments', () => {
+    const md = '  <!-- hidden -->  '
+    const doc = manager.parse(md)
+
+    expect(doc.type).toBe('doc')
+    const para = doc.content![0]
+    expect(para.type).toBe('paragraph')
+    expect(para.content![0].type).toBe('text')
+    expect(para.content![0].text).toBe('  <!-- hidden -->  ')
+  })
+
   it('parses markdown italic next to HTML italic correctly', () => {
     const md = '*a* <em>b</em> *c*'
     const doc = manager.parse(md)

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -845,9 +845,38 @@ export class MarkdownManager {
    */
   private parseHTMLToken(token: MarkdownToken): JSONContent | JSONContent[] | null {
     const html = token.text || token.raw || ''
+    const normalizedHtml = html.trim()
 
-    if (!html.trim()) {
+    if (!normalizedHtml) {
       return null
+    }
+
+    /**
+     * Detect if the HTML token is actually an HTML comment
+     */
+    const isHtmlComment = /<!--([\s\S]*?)-->/.test(normalizedHtml)
+
+    /**
+     * HTML comments are stripped by the DOM parser, so keep them as plain text
+     * to preserve comment content during markdown parse operations
+     */
+    if (isHtmlComment) {
+      if (token.block) {
+        return {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: html,
+            },
+          ],
+        }
+      }
+
+      return {
+        type: 'text',
+        text: html,
+      }
     }
 
     // Check if we're in a server-side environment (no window object)


### PR DESCRIPTION
## Changes Overview

HTML comments (`<!-- ... -->`) passed through `editor.markdown.parse()` were silently dropped because the browser DOM parser strips comment nodes before `generateJSON` processes them. This fix preserves them as plain text so comment content is not lost.


It should be similar to match [markedJs](https://marked.js.org/demo/?text=Marked%20-%20Markdown%20Parser%0A%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%0A%0A%5BMarked%5D%20lets%20you%20convert%20%5BMarkdown%5D%20into%20HTML.%20%20Markdown%20is%20a%20simple%20text%20format%20whose%20goal%20is%20to%20be%20very%20easy%20to%20read%20and%20write%2C%20even%20when%20not%20converted%20to%20HTML.%20%20This%20demo%20page%20will%20let%20you%20type%20anything%20you%20like%20and%20see%20how%20it%20gets%20converted.%20%20Live.%20%20No%20more%20waiting%20around.%0A%0AHow%20To%20Use%20The%20Demo%0A-------------------%0A%0A1.%20Type%20in%20stuff%20on%20the%20left.%0A2.%20See%20the%20live%20updates%20on%20the%20right.%0A%0AThat%27s%20it.%20%20Pretty%20simple.%20%20There%27s%20also%20a%20drop-down%20option%20above%20to%20switch%20between%20various%20views%3A%0A%0A-%20**Preview%3A**%20%20A%20live%20display%20of%20the%20generated%20HTML%20as%20it%20would%20render%20in%20a%20browser.%0A-%20**HTML%20Source%3A**%20%20The%20generated%20HTML%20before%20your%20browser%20makes%20it%20pretty.%0A-%20**Lexer%20Data%3A**%20%20What%20%5Bmarked%5D%20uses%20internally%2C%20in%20case%20you%20like%20gory%20stuff%20like%20this.%0A-%20**Quick%20Reference%3A**%20%20A%20brief%20run-down%20of%20how%20to%20format%20things%20using%20markdown.%0A%0AWhy%20Markdown%3F%0A-------------%0A%0AIt%27s%20easy.%20%20It%27s%20not%20overly%20bloated%2C%20unlike%20HTML.%20%20Also%2C%20as%20the%20creator%20of%20%5Bmarkdown%5D%20says%2C%0A%0A%3E%20The%20overriding%20design%20goal%20for%20Markdown%27s%0A%3E%20formatting%20syntax%20is%20to%20make%20it%20as%20readable%0A%3E%20as%20possible.%20The%20idea%20is%20that%20a%0A%3E%20Markdown-formatted%20document%20should%20be%0A%3E%20publishable%20as-is%2C%20as%20plain%20text%2C%20without%0A%3E%20looking%20like%20it%27s%20been%20marked%20up%20with%20tags%0A%3E%20or%20formatting%20instructions.%0A%0AReady%20to%20start%20writing%3F%20%20Either%20start%20changing%20stuff%20on%20the%20left%20or%0A%5Bclear%20everything%5D(%2Fdemo%2F%3Ftext%3D)%20with%20a%20simple%20click.%0A%0A%5BMarked%5D%3A%20https%3A%2F%2Fgithub.com%2Fmarkedjs%2Fmarked%2F%0A%5BMarkdown%5D%3A%20http%3A%2F%2Fdaringfireball.net%2Fprojects%2Fmarkdown%2F%0A%0A%3C!--%20This%20is%20a%20hidden%20comment%20that%20should%20be%20preserved%20in%20the%20editor%20document%20--%3E%0A%0A%3C!--%20line%201%5Cnline%202%20--%3E%0A%0A%3Cdiv%20class%3D%22label%22%3ETest%20with%20following%20hidden%20comment%20%3C!--%20i%20am%20the%20comment%20--%3E%3C%2Fdiv%3E&options=%7B%0A%20%22async%22%3A%20false%2C%0A%20%22breaks%22%3A%20false%2C%0A%20%22extensions%22%3A%20null%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22hooks%22%3A%20null%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22tokenizer%22%3A%20null%2C%0A%20%22walkTokens%22%3A%20null%0A%7D&version=18.0.0): 


<img width="1616" height="1043" alt="Screenshot 2026-04-07 at 9 58 03 AM" src="https://github.com/user-attachments/assets/1eb926f3-8395-4417-87f7-0cbf598715ac" />


## Implementation Approach

Added a regex check in `parseHTMLToken` that intercepts comment tokens before they reach the DOM parser, returning them as plain text nodes instead:

```ts
const isHtmlComment = /<!--([\s\S]*?)-->/.test(normalizedHtml)
```

Block comments are wrapped in a paragraph; inline comments are returned as bare text nodes.

## Testing Done

Added 4 unit tests in `mixed-html.spec.ts`:

1. standalone block comment → paragraph text
2. inline comment within surrounding text
3. multiline comment
4. comment with surrounding whitespace

## Verification Steps

pnpm dev → open http://localhost:3000/Markdown/Parse/React
Click Parse Markdown — the Hidden HTML Comments section should render the comment text visibly in the editor
Run `pnpm -w -F @tiptap/markdown test mixed-html`

## Additional Notes

### Before
<img width="1688" height="1133" alt="before" src="https://github.com/user-attachments/assets/dfb90859-a7ef-4390-8375-90c0db7bd88c" />

### After
<img width="660" height="280" alt="Screenshot 2026-04-07 at 3 43 38 PM" src="https://github.com/user-attachments/assets/ea6c2774-e618-459a-8681-3cdbf6339959" />


## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x]  My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7720 
