### PR TITLE
refactor: remove redundant id attribute from table of contents node m…

### DIFF
--- a/.changeset/chilly-eels-grin.md
+++ b/.changeset/chilly-eels-grin.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table-of-contents': patch
+---
+
+fix(extension-table-of-contents): stop overriding the id attribute on nodes

--- a/packages/extension-table-of-contents/src/plugin.ts
+++ b/packages/extension-table-of-contents/src/plugin.ts
@@ -49,7 +49,6 @@ export const TableOfContentsPlugin = ({
             tr.setNodeMarkup(pos, undefined, {
               ...node.attrs,
               'data-toc-id': id,
-              id,
             })
 
             modified = true

--- a/packages/extension-table-of-contents/src/tableOfContents.ts
+++ b/packages/extension-table-of-contents/src/tableOfContents.ts
@@ -296,7 +296,6 @@ export const TableOfContents = Extension.create<TableOfContentsOptions, TableOfC
         tr.setNodeMarkup(pos, undefined, {
           ...node.attrs,
           'data-toc-id': id,
-          id,
         })
       }
 


### PR DESCRIPTION
…arkup

## Changes Overview

This PR fixes an issue where the TableOfContents extension was incorrectly overriding the id attribute on nodes (headings) whenever a data-toc-id was assigned. This caused conflicts with other extensions (like unique-id) or manual ID management systems.

## Implementation Approach

The `TableOfContents` extension was explicitly setting the id attribute to match the `data-toc-id`during both initial creation (`onCreate`) and document updates (`appendTransaction`).

I have:

- Removed the `id` assignment from the `setNodeMarkup` calls in `packages/extension-table-of-contents/src/plugin.ts`.
- Removed the `id` assignment from the `setNodeMarkup` calls in `packages/extension-table-of-contents/src/tableOfContents.ts`.

By removing these assignments, the extension now only manages the `data-toc-id` attribute, leaving the standard `id` attribute to be managed by other extensions or the user.

## Testing Done

- Verified using the local TOC demo.
- Confirmed that headings no longer receive a redundant id attribute automatically upon editor load or update.
- Verified that the Table of Contents sidebar still functions correctly, as it relies on data-toc-id for state tracking and link generation.
- Confirmed that there are no console errors or regressions in TOC indexing.

## Verification Steps

1. Open the Table of Contents demo page.
2. Inspect any heading in the DOM; verify it has a `data-toc-id` but **no** id attribute (unless provided by another extension).
3. Type in the editor to trigger a transaction; verify that no id is added to the headings.
4. If testing with a unique ID extension, verify that its IDs are now preserved and NOT overwritten by TOC.

## Additional Notes

This makes the TableOfContents extension a "good citizen" by not interfering with global attributes it doesn't strictly need to own.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable. (Manual verification performed).
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7721
