### PR TITLE
fix(drag-handle): align drag ghost previews

### DIFF
--- a/.changeset/drag-handle-ghost-fix.md
+++ b/.changeset/drag-handle-ghost-fix.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': patch
+---
+
+Fix drag handle ghost image alignment when dragging blocks inside offset layouts, and preserve correct ghost image behavior for RTL content.

--- a/demos/src/Extensions/DragHandle/React/index.jsx
+++ b/demos/src/Extensions/DragHandle/React/index.jsx
@@ -5,12 +5,14 @@ import Image from '@tiptap/extension-image'
 import { TableKit } from '@tiptap/extension-table'
 import { EditorContent, useEditor, useEditorState } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
-const NESTED_CONFIG = { edgeDetection: { threshold: -16 } }
+const NESTED_CONFIG_LTR = { edgeDetection: { threshold: -16, direction: 'left' } }
+const NESTED_CONFIG_RTL = { edgeDetection: { threshold: -16, direction: 'right' } }
 
 export default () => {
   const [nested, setNested] = useState(true)
+  const [rtl, setRtl] = useState(false)
 
   const editor = useEditor({
     extensions: [StarterKit, Image.configure({ inline: false }), TableKit],
@@ -18,9 +20,11 @@ export default () => {
       <h1>The Complete Guide to Modern Web Development</h1>
       <p>Web development has evolved significantly over the past decade. What once required multiple tools and complex setups can now be accomplished with modern frameworks and libraries that prioritize developer experience.</p>
 
-      <img src="https://unsplash.it/500/500" alt="Random Image" />
+        <img src="https://unsplash.it/500/500" alt="Random Image" />
 
-      <h2>Getting Started</h2>
+        <p dir="rtl">تجربة سحب هذا النص توضح كيف يجب أن يلتصق شبح السحب بالمؤشر حتى داخل المحتوى من اليمين إلى اليسار.</p>
+
+        <h2>Getting Started</h2>
       <p>Before diving into the technical details, it's important to understand the foundational concepts that make modern web development possible.</p>
 
       <blockquote>
@@ -117,6 +121,30 @@ export default () => {
     setNested(!nested)
   }
 
+  const toggleRtl = () => {
+    setRtl(!rtl)
+  }
+
+  let nestedConfig = false
+
+  if (nested) {
+    nestedConfig = rtl ? NESTED_CONFIG_RTL : NESTED_CONFIG_LTR
+  }
+
+  const computePositionConfig = { placement: rtl ? 'right-start' : 'left-start' }
+
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+
+    if (rtl) {
+      editor.view.dom.setAttribute('dir', 'rtl')
+    } else {
+      editor.view.dom.removeAttribute('dir')
+    }
+  }, [editor, rtl])
+
   return (
     <>
       <div className="control-group">
@@ -127,9 +155,12 @@ export default () => {
           <button className={nested ? 'is-active' : ''} onClick={toggleNested}>
             Toggle nested drag handle
           </button>
+          <button className={rtl ? 'is-active' : ''} onClick={toggleRtl}>
+            Toggle RTL editor
+          </button>
         </div>
       </div>
-      <DragHandle editor={editor} nested={nested ? NESTED_CONFIG : false}>
+      <DragHandle editor={editor} nested={nestedConfig} computePositionConfig={computePositionConfig}>
         <div className="custom-drag-handle" />
       </DragHandle>
       <EditorContent editor={editor} />

--- a/demos/src/Extensions/DragHandle/React/index.jsx
+++ b/demos/src/Extensions/DragHandle/React/index.jsx
@@ -7,8 +7,8 @@ import { EditorContent, useEditor, useEditorState } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useEffect, useState } from 'react'
 
-const NESTED_CONFIG_LTR = { edgeDetection: { threshold: -16, direction: 'left' } }
-const NESTED_CONFIG_RTL = { edgeDetection: { threshold: -16, direction: 'right' } }
+const NESTED_CONFIG_LTR = { edgeDetection: { threshold: -16, edges: ['left'] } }
+const NESTED_CONFIG_RTL = { edgeDetection: { threshold: -16, edges: ['right'] } }
 
 export default () => {
   const [nested, setNested] = useState(true)

--- a/demos/src/Extensions/DragHandle/React/styles.scss
+++ b/demos/src/Extensions/DragHandle/React/styles.scss
@@ -10,7 +10,7 @@
   }
 
   > * {
-    margin-left: 3rem;
+    margin-inline-start: 3rem;
   }
 
   .ProseMirror-widget * {
@@ -19,7 +19,7 @@
 
   ul,
   ol {
-    padding: 0 1rem;
+    padding-inline: 1rem;
   }
 }
 

--- a/demos/src/Extensions/DragHandle/Vue/index.vue
+++ b/demos/src/Extensions/DragHandle/Vue/index.vue
@@ -21,8 +21,8 @@ import { TableKit } from '@tiptap/extension-table'
 import StarterKit from '@tiptap/starter-kit'
 import { Editor, EditorContent } from '@tiptap/vue-3'
 
-const NESTED_CONFIG_LTR = { edgeDetection: { threshold: -16, direction: 'left' } }
-const NESTED_CONFIG_RTL = { edgeDetection: { threshold: -16, direction: 'right' } }
+const NESTED_CONFIG_LTR = { edgeDetection: { threshold: -16, edges: ['left'] } }
+const NESTED_CONFIG_RTL = { edgeDetection: { threshold: -16, edges: ['right'] } }
 
 export default {
   components: {

--- a/demos/src/Extensions/DragHandle/Vue/index.vue
+++ b/demos/src/Extensions/DragHandle/Vue/index.vue
@@ -3,10 +3,11 @@
     <div class="button-group">
       <button :class="{ 'is-active': editable }" @click="editable = !editable">Toggle editable</button>
       <button :class="{ 'is-active': nested }" @click="nested = !nested">Toggle nested drag handle</button>
+      <button :class="{ 'is-active': rtl }" @click="rtl = !rtl">Toggle RTL editor</button>
     </div>
   </div>
 
-  <drag-handle v-if="editor" :editor="editor" :nested="nestedOptions">
+  <drag-handle v-if="editor" :editor="editor" :nested="nestedOptions" :compute-position-config="computePositionConfig">
     <div class="custom-drag-handle" />
   </drag-handle>
   <editor-content :editor="editor" />
@@ -20,7 +21,8 @@ import { TableKit } from '@tiptap/extension-table'
 import StarterKit from '@tiptap/starter-kit'
 import { Editor, EditorContent } from '@tiptap/vue-3'
 
-const NESTED_CONFIG = { edgeDetection: { threshold: -16 } }
+const NESTED_CONFIG_LTR = { edgeDetection: { threshold: -16, direction: 'left' } }
+const NESTED_CONFIG_RTL = { edgeDetection: { threshold: -16, direction: 'right' } }
 
 export default {
   components: {
@@ -32,17 +34,38 @@ export default {
       editor: null,
       editable: true,
       nested: true,
+      rtl: false,
     }
   },
   computed: {
+    computePositionConfig() {
+      return {
+        placement: this.rtl ? 'right-start' : 'left-start',
+      }
+    },
     nestedOptions() {
-      return this.nested ? NESTED_CONFIG : false
+      if (!this.nested) {
+        return false
+      }
+
+      return this.rtl ? NESTED_CONFIG_RTL : NESTED_CONFIG_LTR
     },
   },
   watch: {
     editable(newValue) {
       if (this.editor) {
         this.editor.setEditable(newValue)
+      }
+    },
+    rtl(newValue) {
+      if (!this.editor) {
+        return
+      }
+
+      if (newValue) {
+        this.editor.view.dom.setAttribute('dir', 'rtl')
+      } else {
+        this.editor.view.dom.removeAttribute('dir')
       }
     },
   },
@@ -66,6 +89,8 @@ export default {
         <p>Web development has evolved significantly over the past decade. What once required multiple tools and complex setups can now be accomplished with modern frameworks and libraries that prioritize developer experience.</p>
 
         <img src="https://unsplash.it/500/500" alt="Random Image" />
+
+        <p dir="rtl">تجربة سحب هذا النص توضح كيف يجب أن يلتصق شبح السحب بالمؤشر حتى داخل المحتوى من اليمين إلى اليسار.</p>
 
         <h2>Getting Started</h2>
         <p>Before diving into the technical details, it's important to understand the foundational concepts that make modern web development possible.</p>
@@ -147,6 +172,10 @@ export default {
         <p>By following these guidelines, you'll create applications that are easier to maintain, test, and extend over time.</p>
       `,
     })
+
+    if (this.rtl) {
+      this.editor.view.dom.setAttribute('dir', 'rtl')
+    }
   },
   beforeUnmount() {
     this.editor?.destroy()
@@ -167,7 +196,7 @@ export default {
   }
 
   > * {
-    margin-left: 3rem;
+    margin-inline-start: 3rem;
   }
 
   .ProseMirror-widget * {
@@ -176,7 +205,7 @@ export default {
 
   ul,
   ol {
-    padding: 0 1rem;
+    padding-inline: 1rem;
   }
 }
 

--- a/packages/extension-drag-handle/__tests__/cloneElement.spec.ts
+++ b/packages/extension-drag-handle/__tests__/cloneElement.spec.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { cloneElement } from '../src/helpers/cloneElement.js'
 
 describe('cloneElement', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('copies computed styles to the clone', () => {
     const element = document.createElement('p')
     const child = document.createElement('span')

--- a/packages/extension-drag-handle/__tests__/cloneElement.spec.ts
+++ b/packages/extension-drag-handle/__tests__/cloneElement.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { cloneElement } from '../src/helpers/cloneElement.js'
+
+describe('cloneElement', () => {
+  it('copies computed styles to the clone', () => {
+    const element = document.createElement('p')
+    const child = document.createElement('span')
+
+    element.appendChild(child)
+
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((node: Element) => {
+      const styles = node === element ? ['margin-top', 'color'] : ['font-weight']
+
+      return {
+        length: styles.length,
+        0: styles[0],
+        1: styles[1],
+        getPropertyValue: (property: string) => {
+          if (property === 'margin-top') {
+            return '24px'
+          }
+
+          if (property === 'color') {
+            return 'rgb(1, 2, 3)'
+          }
+
+          if (property === 'font-weight') {
+            return '700'
+          }
+
+          return ''
+        },
+      } as unknown as CSSStyleDeclaration
+    })
+
+    const clone = cloneElement(element)
+
+    expect(clone.style.cssText).toContain('margin-top: 24px;')
+    expect(clone.style.cssText).toContain('color: rgb(1, 2, 3);')
+    expect((clone.firstElementChild as HTMLElement).style.cssText).toContain('font-weight: 700;')
+  })
+})

--- a/packages/extension-drag-handle/__tests__/dragHandler.spec.ts
+++ b/packages/extension-drag-handle/__tests__/dragHandler.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDragImageOffset } from '../src/helpers/dragHandler.js'
+
+describe('getDragImageOffset', () => {
+  it('anchors ltr previews to the left edge', () => {
+    expect(getDragImageOffset('ltr', 180)).toBe(0)
+  })
+
+  it('anchors rtl previews to the right edge', () => {
+    expect(getDragImageOffset('rtl', 180)).toBe(180)
+  })
+})

--- a/packages/extension-drag-handle/__tests__/getDraggedBlockDir.spec.ts
+++ b/packages/extension-drag-handle/__tests__/getDraggedBlockDir.spec.ts
@@ -1,7 +1,7 @@
 import type { EditorView } from '@tiptap/pm/view'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getDraggedBlockDir } from '../src/helpers/getDraggedBlockDir.js'
+import { getDraggedBlockDir, getDraggedBlockElement } from '../src/helpers/getDraggedBlockDir.js'
 
 function createMockView(overrides: Partial<EditorView> = {}): EditorView {
   const editorDom = document.createElement('div')
@@ -31,6 +31,23 @@ function mockDirection(map: Map<Element, string>) {
 describe('getDraggedBlockDir', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+  })
+
+  describe('getDraggedBlockElement', () => {
+    it('should prefer the child at domAtPos when nodeDOM resolves to the editor root', () => {
+      const editorRoot = document.createElement('div')
+      const paragraph = document.createElement('p')
+
+      editorRoot.appendChild(paragraph)
+
+      const view = createMockView({
+        dom: editorRoot,
+        nodeDOM: vi.fn(() => editorRoot),
+        domAtPos: vi.fn(() => ({ node: editorRoot, offset: 0 })),
+      })
+
+      expect(getDraggedBlockElement(view, 0)).toBe(paragraph)
+    })
   })
 
   afterEach(() => {

--- a/packages/extension-drag-handle/src/helpers/dragHandler.ts
+++ b/packages/extension-drag-handle/src/helpers/dragHandler.ts
@@ -6,12 +6,16 @@ import { type SelectionRange, NodeSelection } from '@tiptap/pm/state'
 import type { NormalizedNestedOptions } from '../types/options.js'
 import { cloneElement } from './cloneElement.js'
 import { findElementNextToCoords } from './findNextElementFromCursor.js'
-import { getDraggedBlockDir } from './getDraggedBlockDir.js'
+import { getDraggedBlockDir, getDraggedBlockElement } from './getDraggedBlockDir.js'
 import { removeNode } from './removeNode.js'
 
 export interface DragContext {
   node: Node | null
   pos: number
+}
+
+export function getDragImageOffset(direction: string, wrapperWidth: number): number {
+  return direction === 'rtl' ? wrapperWidth : 0
 }
 
 function getDragHandleRanges(
@@ -93,8 +97,9 @@ export function dragHandler(
 
   const from = ranges[0].$from.pos
   const to = ranges[ranges.length - 1].$to.pos
+  const direction = getDraggedBlockDir(view, from)
 
-  wrapper.setAttribute('dir', getDraggedBlockDir(view, from))
+  wrapper.setAttribute('dir', direction)
 
   // For nested mode, create slice directly to avoid NodeRangeSelection expanding to parent
   const isNestedDrag = nestedOptions?.enabled && dragContext?.node
@@ -115,8 +120,15 @@ export function dragHandler(
   }
 
   ranges.forEach(range => {
-    const element = view.nodeDOM(range.$from.pos) as HTMLElement
+    const element = getDraggedBlockElement(view, range.$from.pos) as HTMLElement | null
+
+    if (!element) {
+      return
+    }
+
     const clonedElement = cloneElement(element)
+
+    clonedElement.style.margin = '0'
 
     wrapper.append(clonedElement)
   })
@@ -127,8 +139,9 @@ export function dragHandler(
 
   event.dataTransfer.clearData()
   const wrapperRect = wrapper.getBoundingClientRect()
-  const dragImageX = event.clientX - wrapperRect.left
-  event.dataTransfer.setDragImage(wrapper, Math.max(0, Math.min(dragImageX, wrapperRect.width)), 0)
+  const dragImageX = getDragImageOffset(direction, wrapperRect.width)
+
+  event.dataTransfer.setDragImage(wrapper, dragImageX, 0)
 
   let cleanedUp = false
 

--- a/packages/extension-drag-handle/src/helpers/getDraggedBlockDir.ts
+++ b/packages/extension-drag-handle/src/helpers/getDraggedBlockDir.ts
@@ -1,6 +1,34 @@
 import type { EditorView } from '@tiptap/pm/view'
 
 /**
+ * Resolves the DOM element that visually represents the dragged block.
+ */
+export function getDraggedBlockElement(view: EditorView, pos: number): Element | null {
+  const nodeDom = view.nodeDOM(pos)
+
+  if (nodeDom instanceof Element && nodeDom !== view.dom) {
+    return nodeDom
+  }
+
+  const { node, offset } = view.domAtPos(pos)
+  const child = node.childNodes[offset]
+
+  if (child instanceof Element) {
+    return child
+  }
+
+  if (node instanceof Element) {
+    return node
+  }
+
+  if (node.nodeType === Node.TEXT_NODE && node.parentElement) {
+    return node.parentElement
+  }
+
+  return null
+}
+
+/**
  * Resolves the text direction (`dir` attribute value) for the block being
  * dragged. Uses `view.nodeDOM` first because it maps a ProseMirror position
  * directly to the block-level DOM element. Falls back to `view.domAtPos` with
@@ -8,23 +36,7 @@ import type { EditorView } from '@tiptap/pm/view'
  * and ultimately to the editor root direction.
  */
 export function getDraggedBlockDir(view: EditorView, pos: number): string {
-  let draggedDom: Element | null = null
-  const nodeDom = view.nodeDOM(pos)
-
-  if (nodeDom instanceof Element) {
-    draggedDom = nodeDom
-  } else {
-    const { node, offset } = view.domAtPos(pos)
-    const child = node.childNodes[offset]
-
-    if (child instanceof Element) {
-      draggedDom = child
-    } else if (node instanceof Element) {
-      draggedDom = node
-    } else if (node.nodeType === Node.TEXT_NODE && node.parentElement) {
-      draggedDom = node.parentElement
-    }
-  }
+  const draggedDom = getDraggedBlockElement(view, pos)
 
   const contentDir = draggedDom ? getComputedStyle(draggedDom).direction : getComputedStyle(view.dom).direction
 


### PR DESCRIPTION
## Changes Overview

- fix drag handle ghost image alignment when dragging blocks inside offset layouts
- preserve correct RTL drag ghost behavior and keep the drag preview anchored to the expected edge
- add React and Vue drag handle demo controls to simulate RTL mode with the handle moved to the inline end
- add a changeset for the patch release

## Implementation Approach

- resolve the dragged block element consistently before deriving the preview direction
- reset the top-level cloned block margin in the drag preview so block margins do not offset the visible ghost image
- keep RTL preview support by setting the preview `dir` from the dragged block and anchoring the drag image based on content direction
- update the demos to toggle editor direction, switch drag handle placement between `left-start` and `right-start`, and flip nested edge detection for RTL

## Testing Done

- ran `pnpm vitest packages/extension-drag-handle/__tests__/cloneElement.spec.ts packages/extension-drag-handle/__tests__/dragHandler.spec.ts packages/extension-drag-handle/__tests__/getDraggedBlockDir.spec.ts packages/extension-drag-handle/__tests__/drag-handle.spec.ts`
- ran `pnpm turbo run build --filter=@tiptap/extension-drag-handle`
- manually verified drag ghost alignment in the demo for both LTR and RTL content

## Verification Steps

- open the DragHandle demo in React or Vue
- drag a heading or paragraph in LTR mode and confirm the ghost image is aligned with the cursor without extra top or left offset
- toggle RTL mode and drag the Arabic paragraph to confirm the ghost image remains aligned and the drag handle appears on the right side
- verify nested drag handle mode still works in both directions

## Additional Notes

- this fixes the regression introduced by the RTL drag ghost work in `3.22.1`
- the changeset included in this PR is:

```md
---
'@tiptap/extension-drag-handle': patch
---

Fix drag handle ghost image alignment when dragging blocks inside offset layouts, and preserve correct ghost image behavior for RTL content.
```

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- reported regression in drag handle ghost image alignment since `3.22.1`
- related RTL drag ghost work: #7629