### PR TITLE
fix(table): preserve hardBreak nodes during markdown cell serialization

### DIFF
--- a/packages/extension-table/__tests__/tableMarkdown.spec.ts
+++ b/packages/extension-table/__tests__/tableMarkdown.spec.ts
@@ -3,11 +3,12 @@ import Paragraph from '@tiptap/extension-paragraph'
 import { TableKit } from '@tiptap/extension-table'
 import Text from '@tiptap/extension-text'
 import { MarkdownManager } from '@tiptap/markdown'
+import HardBreak from '@tiptap/extension-hard-break'
 import { describe, expect, it } from 'vitest'
 
 describe('table markdown alignment', () => {
   const markdownManager = new MarkdownManager({
-    extensions: [Document, Paragraph, Text, TableKit],
+    extensions: [Document, Paragraph, Text, TableKit, HardBreak],
   })
 
   it('should parse and serialize left/right/center table alignment', () => {
@@ -30,5 +31,21 @@ describe('table markdown alignment', () => {
 
     expect(serialized).toContain('| left | right | center |')
     expect(serialized).toMatch(/\|\s*:[-]+\s*\|\s*[-]+:\s*\|\s*:[-]+:\s*\|/)
+  })
+
+  it('should preserve <br> line breaks inside table cells during round-trip serialization', () => {
+    // We use <br> syntax inside Markdown because literal newlines break markdown tables
+    const markdown = `| desc |
+| --- |
+| foo<br>bar |`
+
+    // Parse the markdown into the editor
+    const parsed = markdownManager.parse(markdown)
+
+    // Serialize it back, it should preserve the <br> instead of collapsing it
+    const serialized = markdownManager.serialize(parsed)
+
+    expect(serialized).toContain('foo<br>bar')
+    expect(serialized).not.toContain('foo bar')
   })
 })

--- a/packages/extension-table/src/table/utilities/markdown.ts
+++ b/packages/extension-table/src/table/utilities/markdown.ts
@@ -6,7 +6,7 @@ import {
   TableCellAlign,
 } from '../../utilities/parseAlign.js'
 
-export const DEFAULT_CELL_LINE_SEPARATOR = '\u001F'
+export const DEFAULT_CELL_LINE_SEPARATOR = '<br>'
 
 function collapseWhitespace(s: string) {
   return (s || '').replace(/\s+/g, ' ').trim()
@@ -34,13 +34,22 @@ export function renderTableToMarkdown(
         let raw = ''
 
         if (cellNode.content && Array.isArray(cellNode.content) && cellNode.content.length > 1) {
-          // Render each direct child separately and join with separator so we can split again later
+          // Render each direct child separately and join with separator
           const parts = cellNode.content.map(child => h.renderChildren(child as unknown as JSONContent))
           raw = parts.join(cellSep)
         } else {
           raw = cellNode.content ? h.renderChildren(cellNode.content as unknown as JSONContent[]) : ''
         }
 
+        // COUPLING WARNING: Tiptap's extension-hard-break hardcodes its markdown output to `  \n`
+        // (defined in packages/extension-hard-break/src/hard-break.ts).
+        // Because node renderers don't receive contextual metadata (like "inside a table cell"),
+        // the hardBreak node has no way to change its output to `<br>`.
+        // We intercept `  \n` here before collapseWhitespace blindly strips it. If `extension-hard-break`
+        // ever changes its serialization string, this pattern MUST be updated.
+        const HARDBREAK_MARKDOWN_PATTERN = '  \n'
+        raw = raw.replaceAll(HARDBREAK_MARKDOWN_PATTERN, cellSep)
+        
         const text = collapseWhitespace(raw)
         const isHeader = cellNode.type === 'tableHeader'
         const align = normalizeTableCellAlignFromAttributes(cellNode.attrs)


### PR DESCRIPTION
## Changes Overview

Fixes data loss where `<br>` tags inside markdown table cells are silently dropped during re serialization via `editor.storage.markdown.getMarkdown()`, collapsing multi line cell content into a single line.

## Implementation Approach

`extension-hard-break` correctly serializes `<br>` as `  \n` (CommonMark spec). The data loss occurs in `extension-table`'s `collapseWhitespace()`, which strips all `\s+` including that `  \n` before writing the cell back to markdown.

The fix intercepts `hardBreak`'s exact output (`  \n`) and converts it to `<br>` before `collapseWhitespace()` runs:

```typescript
// COUPLING WARNING: Tiptap's extension-hard-break hardcodes its markdown output to `  \n`
// (defined in packages/extension-hard-break/src/hard-break.ts).
// Because node renderers don't receive contextual metadata (like "inside a table cell"),
// the hardBreak node has no way to change its output to `<br>` contextually.
// We intercept `  \n` here before collapseWhitespace blindly strips it.
// If extension-hard-break ever changes its serialization string, this MUST be updated.
const HARDBREAK_MARKDOWN_PATTERN = '  \n'
raw = raw.replaceAll(HARDBREAK_MARKDOWN_PATTERN, cellSep)
```

I investigated passing table cell context down to `hardBreak` so it could emit `<br>` directly, but `h.renderChildren` does not propagate `meta` across recursion boundaries that would require a broader `MarkdownManager` refactor.

Also updated `DEFAULT_CELL_LINE_SEPARATOR` from `\u001F` to `<br>` for consistency with the preserved output format.

## Testing Done

Added a round trip test in `packages/extension-table/__tests__/tableMarkdown.spec.ts`, with `HardBreak` registered in the test markdown manager:

```typescript
it('should preserve <br> line breaks inside table cells during round-trip serialization', () => {
  const markdown = `| desc |\n| --- |\n| foo<br>bar |`
  const parsed = markdownManager.parse(markdown)
  const serialized = markdownManager.serialize(parsed)
  expect(serialized).toContain('foo<br>bar')
  expect(serialized).not.toContain('foo bar')
})
```

All `extension-table` tests pass.

## Verification Steps

1. Open the Tiptap markdown editor
2. Paste the following markdown:
```
|    desc     |
|   :-----:   |
| foo<br>bar  |
```
3. Call `editor.storage.markdown.getMarkdown()`
4. Confirm the output contains `foo<br>bar` and not `foo bar`

## Additional Notes

`packages/markdown/__tests__/paragraph.spec.ts` has a pre existing failure on the upstream `develop` branch unrelated to this change verified by running it against a clean `develop` branch before and after applying this fix.

## Checklist

- [ ] I have created a [[changeset](https://github.com/changesets/changesets)](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [x] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

Closes #7731