### PR TITLE
fix(table): preserve newlines in markdown tables

### DIFF
--- a/demos/src/Markdown/Full/React/index.tsx
+++ b/demos/src/Markdown/Full/React/index.tsx
@@ -108,7 +108,11 @@ export default () => {
         parent: window.location.hostname,
       }),
       Image,
-      TableKit,
+      TableKit.configure({
+        table: {
+          cellLineSeparator: '<br>',
+        },
+      }),
       Highlight,
       Mention.configure({
         HTMLAttributes: {

--- a/packages/extension-table/__tests__/tableMarkdown.spec.ts
+++ b/packages/extension-table/__tests__/tableMarkdown.spec.ts
@@ -1,4 +1,5 @@
 import Document from '@tiptap/extension-document'
+import HardBreak from '@tiptap/extension-hard-break'
 import Paragraph from '@tiptap/extension-paragraph'
 import { TableKit } from '@tiptap/extension-table'
 import Text from '@tiptap/extension-text'
@@ -7,7 +8,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('table markdown alignment', () => {
   const markdownManager = new MarkdownManager({
-    extensions: [Document, Paragraph, Text, TableKit],
+    extensions: [Document, HardBreak, Paragraph, Text, TableKit],
   })
 
   it('should parse and serialize left/right/center table alignment', () => {
@@ -30,5 +31,15 @@ describe('table markdown alignment', () => {
 
     expect(serialized).toContain('| left | right | center |')
     expect(serialized).toMatch(/\|\s*:[-]+\s*\|\s*[-]+:\s*\|\s*:[-]+:\s*\|/)
+  })
+
+  it('should preserve <br> line breaks inside table cells (round-trip)', () => {
+    const markdown = `| desc |
+| --- |
+| a<br>b<br>c |`
+
+    const serialized = markdownManager.serialize(markdownManager.parse(markdown))
+
+    expect(serialized).toContain('a<br>b<br>c')
   })
 })

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -36,7 +36,7 @@ import { TableView } from './TableView.js'
 import { createColGroup } from './utilities/createColGroup.js'
 import { createTable } from './utilities/createTable.js'
 import { deleteTableWhenAllCellsSelected } from './utilities/deleteTableWhenAllCellsSelected.js'
-import renderTableToMarkdown from './utilities/markdown.js'
+import renderTableToMarkdown, { DEFAULT_CELL_LINE_SEPARATOR } from './utilities/markdown.js'
 
 type MarkdownTableToken = {
   align?: Array<TableCellAlign | null>
@@ -100,6 +100,14 @@ export interface TableOptions {
    * @example true
    */
   allowTableNodeSelection: boolean
+
+  /**
+   * The separator used to join multiple paragraphs inside a table cell
+   * when serializing to Markdown. Defaults to U+001F (Unit Separator).
+   * @default '\u001F'
+   * @example '<br>'
+   */
+  cellLineSeparator: string
 }
 
 declare module '@tiptap/core' {
@@ -264,6 +272,7 @@ export const Table = Node.create<TableOptions>({
       View: TableView,
       lastColumnResizable: true,
       allowTableNodeSelection: false,
+      cellLineSeparator: DEFAULT_CELL_LINE_SEPARATOR,
     }
   },
 
@@ -339,8 +348,10 @@ export const Table = Node.create<TableOptions>({
     return h.createNode('table', undefined, rows)
   },
 
-  renderMarkdown: (node, h) => {
-    return renderTableToMarkdown(node, h)
+  renderMarkdown(this: { options: TableOptions }, node, h) {
+    return renderTableToMarkdown(node, h, {
+      cellLineSeparator: this.options.cellLineSeparator,
+    })
   },
 
   addCommands() {

--- a/packages/extension-table/src/table/utilities/markdown.ts
+++ b/packages/extension-table/src/table/utilities/markdown.ts
@@ -9,7 +9,12 @@ import {
 export const DEFAULT_CELL_LINE_SEPARATOR = '\u001F'
 
 function collapseWhitespace(s: string) {
-  return (s || '').replace(/\s+/g, ' ').trim()
+  // Table cells cannot contain real newlines (that would break the row syntax),
+  // so hardBreak ("  \n") is converted to an inline <br> tag instead.
+  return (s || '')
+    .replace(/ {2}\n/g, '<br>')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 export function renderTableToMarkdown(

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -112,13 +112,16 @@ export class MarkdownManager {
     if (isCode) {
       this.codeTypes.add(name)
     }
+    const extensionContext = { name, options: extension.options, storage: extension.storage }
     const tokenName =
       (getExtensionField(extension, 'markdownTokenName') as ExtendableConfig['markdownTokenName']) || name
-    const parseMarkdown = getExtensionField(extension, 'parseMarkdown') as ExtendableConfig['parseMarkdown'] | undefined
-    const renderMarkdown = getExtensionField(extension, 'renderMarkdown') as
+    const parseMarkdown = getExtensionField(extension, 'parseMarkdown', extensionContext) as
+      | ExtendableConfig['parseMarkdown']
+      | undefined
+    const renderMarkdown = getExtensionField(extension, 'renderMarkdown', extensionContext) as
       | ExtendableConfig['renderMarkdown']
       | undefined
-    const tokenizer = getExtensionField(extension, 'markdownTokenizer') as
+    const tokenizer = getExtensionField(extension, 'markdownTokenizer', extensionContext) as
       | ExtendableConfig['markdownTokenizer']
       | undefined
 


### PR DESCRIPTION
## Changes Overview

Add a cellLineSeparator option to the Table extension that controls how multi-line content inside table cells is serialized to Markdown. Hard breaks (\n) within a cell are now converted to inline `<br>` tags instead of being collapsed to spaces, preserving newlines in the Markdown output.

## Implementation Approach

- New cellLineSeparator option on TableOptions: configures the separator used to join multiple paragraphs in a cell when serializing (default: '\u001F' / Unit Separator; set to `<br>` for HTML-friendly output).

- collapseWhitespace fix in markdown.ts: ProseMirror hard-break markup ( \n) is now replaced with `<br>` before collapsing remaining whitespace, so real newlines survive the round-trip.

- renderMarkdown converted from arrow function to method in table.ts: enables access to this.options.cellLineSeparator at serialization time.

- getExtensionField now receives extensionContext in MarkdownManager.ts: passes { name, options, storage } as the binding context so renderMarkdown (and sibling fields) can read extension options via this.

## Testing Done

- Added a unit test in tableMarkdown.spec.ts that verifies `<br>` line breaks survive a full parse → serialize round-trip.

- Updated the Markdown full demo to configure cellLineSeparator: `<br>`, enabling manual verification in the browser.

## Verification Steps

1. Run the table markdown unit tests:

```
pnpm test --filter @tiptap/extension-table
```

2. Start the demo dev server and open the Markdown / Full demo.

3. Insert a table, type content with line breaks inside a cell (e.g. via Shift+Enter), and confirm the Markdown output contains `<br>` rather than collapsed spaces.

4. Paste Markdown containing `<br>` inside table cells and confirm it round-trips correctly.

## Additional Notes

The default value of cellLineSeparator is kept as '\u001F' (the existing behaviour) to avoid breaking changes. Consumers who want HTML-compatible multi-line cells should opt in by setting cellLineSeparator: `<br>`.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/7731
