### PR TITLE
Fix duplicate onUpdate invocation in TableOfContents

### DIFF
--- a/.changeset/fix-toc-onupdate-react-render.md
+++ b/.changeset/fix-toc-onupdate-react-render.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table-of-contents': patch
+---
+
+Fix duplicate `onUpdate` invocation per document change in the `TableOfContents` extension.

--- a/packages/extension-table-of-contents/src/tableOfContents.ts
+++ b/packages/extension-table-of-contents/src/tableOfContents.ts
@@ -77,7 +77,7 @@ const setTocData = (options: {
   storage: TableOfContentsStorage
   onUpdate?: (data: TableOfContentData, isCreate?: boolean) => void | undefined
 }) => {
-  const { editor, onUpdate } = options
+  const { editor } = options
 
   if (editor.isDestroyed) {
     return
@@ -155,12 +155,6 @@ const setTocData = (options: {
   })
 
   anchors = addTocActiveStatesAndGetItems(anchors, options)
-
-  if (onUpdate) {
-    const isInitialCreation = options.storage.content.length === 0
-
-    onUpdate(anchors, isInitialCreation)
-  }
 
   options.storage.anchors = anchorEls
   options.storage.content = anchors


### PR DESCRIPTION
## Bug

The `TableOfContents` extension's `onUpdate` callback was being called **twice** per document change. `setTocData` passed `onUpdate` through to `addTocActiveStatesAndGetItems` (which called it), and then `setTocData` called it again itself.

## Fix

`setTocData` no longer has its own `onUpdate` invocation. It delegates entirely to `addTocActiveStatesAndGetItems`, which is the single call site for `onUpdate` on document changes. The scroll handler path (which calls `addTocActiveStatesAndGetItems` directly) is unaffected.