### PR TITLE
Default immediatelyRender to false in SSR environments

### DIFF
--- a/.changeset/react-ssr-immediately-render.md
+++ b/.changeset/react-ssr-immediately-render.md
@@ -1,0 +1,7 @@
+---
+'@tiptap/react': patch
+---
+
+Default `immediatelyRender` to `false` in SSR environments instead of throwing an error
+
+Previously, omitting `immediatelyRender` in an SSR environment (e.g. Next.js) would throw an error in development and silently return `null` in production. This was a common source of crashes, especially when AI-generated code set up the editor without explicitly passing `immediatelyRender: false`. The hook now defaults `immediatelyRender` to `true`, but automatically sets it to `false` when SSR is detected, logging a warning in development instead of throwing.

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -93,38 +93,16 @@ class EditorInstanceManager {
   }
 
   private getInitialEditor() {
-    if (this.options.current.immediatelyRender === undefined) {
-      if (isSSR || isNext) {
-        if (isDev) {
-          /**
-           * Throw an error in development, to make sure the developer is aware that tiptap cannot be SSR'd
-           * and that they need to set `immediatelyRender` to `false` to avoid hydration mismatches.
-           */
-          throw new Error(
-            'Tiptap Error: SSR has been detected, please set `immediatelyRender` explicitly to `false` to avoid hydration mismatches.',
-          )
-        }
+    let immediatelyRender = this.options.current.immediatelyRender ?? true
 
-        // Best faith effort in production, run the code in the legacy mode to avoid hydration mismatches and errors in production
-        return null
+    if (immediatelyRender && (isSSR || isNext)) {
+      immediatelyRender = false
+      if (isDev) {
+        console.warn('SSR detected. `immediatelyRender` has been set to false to avoid hydration mismatches')
       }
-
-      // Default to immediately rendering when client-side rendering
-      return this.createEditor()
     }
 
-    if (this.options.current.immediatelyRender && isSSR && isDev) {
-      // Warn in development, to make sure the developer is aware that tiptap cannot be SSR'd, set `immediatelyRender` to `false` to avoid hydration mismatches.
-      throw new Error(
-        'Tiptap Error: SSR has been detected, and `immediatelyRender` has been set to `true` this is an unsupported configuration that may result in errors, explicitly set `immediatelyRender` to `false` to avoid hydration mismatches.',
-      )
-    }
-
-    if (this.options.current.immediatelyRender) {
-      return this.createEditor()
-    }
-
-    return null
+    return immediatelyRender ? this.createEditor() : null
   }
 
   /**


### PR DESCRIPTION
## Summary

When using `useEditor` in an SSR environment (e.g. Next.js), omitting the `immediatelyRender` option would throw an error in development and silently return `null` in production. This was a very common pitfall — especially when AI coding agents set up the editor without explicitly passing `immediatelyRender: false`, causing the entire page to crash.

## What changed

- `immediatelyRender` now defaults to `true`, but is automatically set to `false` when SSR is detected (server-side or Next.js environment)
- In development, a `console.warn` is logged instead of throwing an error
- The logic is simplified from multiple branches with different throw/return paths into a single, clear flow

## Why

The previous behavior was too strict — throwing in dev and silently degrading in prod made debugging harder and created a sharp edge for new users and automated tooling. A warning is sufficient to inform developers while keeping the app functional.