### PR TITLE
fix(extension-floating-menu): guard updatePosition against destroyed editor view

### DIFF
--- a/.changeset/angry-bees-prove.md
+++ b/.changeset/angry-bees-prove.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-floating-menu': patch
+---
+
+Added a safeguard to avoid `TypeError: Cannot read properties of null (reading 'domFromPos')` being thrown when the editor was being destroyed

--- a/packages/extension-floating-menu/__tests__/floating-menu-plugin.spec.ts
+++ b/packages/extension-floating-menu/__tests__/floating-menu-plugin.spec.ts
@@ -232,13 +232,17 @@ describe('FloatingMenuView destroy safety', () => {
     const view = createFloatingMenuView(editor)
     const coordsSpy = vi.spyOn(editor.view, 'coordsAtPos')
 
-    // Simulate the real-world teardown race: the editor is destroyed while a
-    // pending updatePosition call (debounced resize/scroll) is still in flight.
-    // ProseMirror's destroy removes view.dom from its parent and nulls docView;
-    // without a guard, posToDOMRect -> coordsAtPos throws on the null docView.
-    editor.destroy()
+    try {
+      // Simulate the real-world teardown race: the editor is destroyed while a
+      // pending updatePosition call (debounced resize/scroll) is still in flight.
+      // ProseMirror's destroy removes view.dom from its parent and nulls docView;
+      // without a guard, posToDOMRect -> coordsAtPos throws on the null docView.
+      editor.destroy()
 
-    expect(() => view.updatePosition()).not.toThrow()
-    expect(coordsSpy).not.toHaveBeenCalled()
+      expect(() => view.updatePosition()).not.toThrow(/Cannot read properties of null \(reading 'domFromPos'\)/)
+      expect(coordsSpy).not.toHaveBeenCalled()
+    } finally {
+      view.destroy()
+    }
   })
 })

--- a/packages/extension-floating-menu/__tests__/floating-menu-plugin.spec.ts
+++ b/packages/extension-floating-menu/__tests__/floating-menu-plugin.spec.ts
@@ -238,7 +238,7 @@ describe('FloatingMenuView destroy safety', () => {
     // without a guard, posToDOMRect -> coordsAtPos throws on the null docView.
     editor.destroy()
 
-    expect(() => view.updatePosition()).not.toThrow(/Cannot read properties of null \(reading 'domFromPos'\)/)
+    expect(() => view.updatePosition()).not.toThrow()
     expect(coordsSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/extension-floating-menu/__tests__/floating-menu-plugin.spec.ts
+++ b/packages/extension-floating-menu/__tests__/floating-menu-plugin.spec.ts
@@ -225,3 +225,20 @@ describe('FloatingMenuView cross-contamination', () => {
     editor.destroy()
   })
 })
+
+describe('FloatingMenuView destroy safety', () => {
+  it('updatePosition should not call coordsAtPos when the editor view is detached from the DOM', () => {
+    const editor = createEditor()
+    const view = createFloatingMenuView(editor)
+    const coordsSpy = vi.spyOn(editor.view, 'coordsAtPos')
+
+    // Simulate the real-world teardown race: the editor is destroyed while a
+    // pending updatePosition call (debounced resize/scroll) is still in flight.
+    // ProseMirror's destroy removes view.dom from its parent and nulls docView;
+    // without a guard, posToDOMRect -> coordsAtPos throws on the null docView.
+    editor.destroy()
+
+    expect(() => view.updatePosition()).not.toThrow(/Cannot read properties of null \(reading 'domFromPos'\)/)
+    expect(coordsSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -432,6 +432,10 @@ export class FloatingMenuView {
   }
 
   updatePosition() {
+    if (!this.view?.dom?.parentNode) {
+      return
+    }
+
     const { selection } = this.editor.state
 
     const domRect = posToDOMRect(this.view, selection.from, selection.to)


### PR DESCRIPTION
## Changes Overview

Adds a null-guard at the top of `FloatingMenuView.updatePosition()` to prevent `TypeError: Cannot read properties of null (reading 'domFromPos')` when `updatePosition` is called after the editor has been destroyed. Mirrors the fix applied to `extension-bubble-menu` in #7433.

A pending debounced call (resize or scroll handler) can fire during teardown after ProseMirror has removed `view.dom` from its parent and nulled `docView` internally. The guard early-returns when `this.view?.dom?.parentNode` is falsy, consistent with how `BubbleMenuView` handles the same condition.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7064