### PR TITLE
fix(static-renderer): escape HTML string output

### DIFF
--- a/.changeset/secure-static-renderer-html.md
+++ b/.changeset/secure-static-renderer-html.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/static-renderer': patch
+---
+
+Escape HTML string renderer text content and attribute values to prevent injected markup from untrusted content.

--- a/packages/static-renderer/__tests__/json-string.spec.ts
+++ b/packages/static-renderer/__tests__/json-string.spec.ts
@@ -1,12 +1,17 @@
 import type { TextType } from '@tiptap/core'
 import Bold from '@tiptap/extension-bold'
 import Document from '@tiptap/extension-document'
+import Link from '@tiptap/extension-link'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import Youtube from '@tiptap/extension-youtube'
 import { Mark, Node } from '@tiptap/pm/model'
-import { renderJSONContentToString, serializeChildrenToHTMLString } from '@tiptap/static-renderer/json/html-string'
-import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
+import {
+  renderJSONContentToString,
+  serializeAttrsToHTMLString,
+  serializeChildrenToHTMLString,
+} from '@tiptap/static-renderer/json/html-string'
+import { domOutputSpecToHTMLString, renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
 import { describe, expect, it } from 'vitest'
 
 describe('static render json to string (no prosemirror)', () => {
@@ -88,6 +93,17 @@ describe('static render json to string (no prosemirror)', () => {
     })({ content: json })
 
     expect(html).toBe('<doc><p><strong>Example Text</strong></p></doc>')
+  })
+
+  it('escapes serialized HTML attributes', () => {
+    const attrs = serializeAttrsToHTMLString({
+      href: 'x"><img src=x onerror=alert(document.cookie)>',
+      title: 'Tom & "Jerry"',
+    })
+
+    expect(attrs).toBe(
+      ' href="x&quot;&gt;&lt;img src=x onerror=alert(document.cookie)&gt;" title="Tom &amp; &quot;Jerry&quot;"',
+    )
   })
 
   it('gives access to the original JSON node or mark', () => {
@@ -245,6 +261,69 @@ describe('static render json to string (with prosemirror)', () => {
     })
 
     expect(html).toBe('<doc><p><b>Example Text</b></p></doc>')
+  })
+
+  it('escapes text node content', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: '<img src=x onerror=alert(document.cookie)> Tom & Jerry',
+            },
+          ],
+        },
+      ],
+    }
+
+    const html = renderToHTMLString({
+      content: json,
+      extensions: [Document, Paragraph, Text],
+    })
+
+    expect(html).toBe('<p>&lt;img src=x onerror=alert(document.cookie)&gt; Tom &amp; Jerry</p>')
+  })
+
+  it('escapes attribute values in the ProseMirror HTML string renderer', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Click here',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://tiptap.dev/?q="><img src=x onerror=alert(document.cookie)>',
+                    target: '_blank',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const html = renderToHTMLString({
+      content: json,
+      extensions: [Document, Paragraph, Text, Link],
+    })
+
+    expect(html).toContain('href="https://tiptap.dev/?q=&quot;&gt;&lt;img src=x onerror=alert(document.cookie)&gt;"')
+  })
+
+  it('escapes string DOM output specs as text content', () => {
+    const html = domOutputSpecToHTMLString('<img src=x onerror=alert(document.cookie)>')()
+
+    expect(html).toBe('&lt;img src=x onerror=alert(document.cookie)&gt;')
   })
 
   it('gives access to a prosemirror node or mark instance', () => {

--- a/packages/static-renderer/src/json/html-string/string.ts
+++ b/packages/static-renderer/src/json/html-string/string.ts
@@ -24,13 +24,31 @@ export function renderJSONContentToString<
 }
 
 /**
+ * Escape text for HTML text content.
+ * @param value The text to escape
+ * @returns The escaped text
+ */
+export function escapeHTML(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Escape values for quoted HTML attributes.
+ * @param value The attribute value to escape
+ * @returns The escaped attribute value
+ */
+export function escapeHTMLAttribute(value: string): string {
+  return escapeHTML(value).replace(/"/g, '&quot;')
+}
+
+/**
  * Serialize the attributes of a node or mark to a string
  * @param attrs The attributes to serialize
  * @returns The serialized attributes as a string
  */
 export function serializeAttrsToHTMLString(attrs: Record<string, any> | undefined | null): string {
   const output = Object.entries(attrs || {})
-    .map(([key, value]) => `${key.split(' ').at(-1)}=${JSON.stringify(value)}`)
+    .map(([key, value]) => `${key.split(' ').at(-1)}="${escapeHTMLAttribute(String(value))}"`)
     .join(' ')
 
   return output ? ` ${output}` : ''

--- a/packages/static-renderer/src/pm/html-string/html-string.ts
+++ b/packages/static-renderer/src/pm/html-string/html-string.ts
@@ -3,6 +3,7 @@ import type { DOMOutputSpecArray, Extensions, JSONContent } from '@tiptap/core'
 import type { DOMOutputSpec, Mark, Node } from '@tiptap/pm/model'
 
 import {
+  escapeHTML,
   renderJSONContentToString,
   serializeAttrsToHTMLString,
   serializeChildrenToHTMLString,
@@ -25,7 +26,7 @@ const NON_SELF_CLOSING_TAGS = new Set(['iframe', 'script', 'style', 'title', 'te
  */
 export function domOutputSpecToHTMLString(content: DOMOutputSpec): (children?: string | string[]) => string {
   if (typeof content === 'string') {
-    return () => content
+    return () => escapeHTML(content)
   }
   if (typeof content === 'object' && 'length' in content) {
     const [_tag, attrs, children, ...rest] = content as DOMOutputSpecArray
@@ -105,7 +106,7 @@ export function renderToHTMLString({
       // Map a doc node to concatenated children
       doc: ({ children }) => serializeChildrenToHTMLString(children),
       // Map a text node to its text content
-      text: ({ node }) => node.text ?? '',
+      text: ({ node }) => escapeHTML(node.text ?? ''),
     },
     content,
     extensions,


### PR DESCRIPTION
## Changes Overview

Fixes HTML string escaping in `@tiptap/static-renderer` to prevent untrusted text content and attribute values from being interpreted as executable markup.

## Implementation Approach

Added HTML text and quoted-attribute escaping helpers, used them for static renderer text nodes, string `DOMOutputSpec` values, and serialized attribute values. This keeps the fix scoped to HTML string serialization without changing React rendering or custom mapping behavior.

## Testing Done

- Added regression tests for text node injection, attribute breakout, ProseMirror link attribute serialization, and string `DOMOutputSpec` escaping.
- Ran `pnpm vitest run packages/static-renderer/__tests__/json-string.spec.ts`.
- Ran `pnpm --filter @tiptap/static-renderer lint`.
- Ran `pnpm --filter @tiptap/static-renderer build`.

## Verification Steps

- Render a text node containing `<img src=x onerror=alert(1)>` with `renderToHTMLString()` and verify it emits escaped text.
- Render a link with an `href` containing `\"><img src=x onerror=alert(1)>` and verify the quote and tag delimiters are escaped inside the attribute.
- Run `pnpm vitest run packages/static-renderer/__tests__/json-string.spec.ts`.

## Additional Notes

Custom `nodeMapping` and `markMapping` functions that return raw HTML strings remain responsible for escaping any untrusted data they include.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->