### PR TITLE
Update uuid dependencies

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "3.1.2",
     "@types/node": "22.10.3",
-    "@types/uuid": "^8.3.4",
     "@vitejs/plugin-react": "^1.3.2",
     "@vitejs/plugin-vue": "^5.2.1",
     "autoprefixer": "^10.4.20",
@@ -63,7 +62,7 @@
     "svelte": "^4.2.19",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
-    "uuid": "^8.3.2",
+    "uuid": "^14.0.0",
     "vite": "^5.4.20",
     "vite-plugin-checker": "^0.6.4",
     "vue": "^3.5.13",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@rollup/pluginutils": "^5.1.4",
     "@rollup/pluginutils>picomatch": "2.3.2",
     "@octokit/action>undici": "6.24.1",
+    "@cypress/request>uuid": "14.0.0",
     "anymatch>picomatch": "2.3.2",
     "glob": "^10.5.0",
     "micromatch>picomatch": "2.3.2",
@@ -119,6 +120,7 @@
     "overrides": {
       "@rollup/pluginutils>picomatch": "2.3.2",
       "@octokit/action>undici": "6.24.1",
+      "@cypress/request>uuid": "14.0.0",
       "anymatch>picomatch": "2.3.2",
       "glob": "^10.5.0",
       "micromatch>picomatch": "2.3.2",

--- a/packages/extension-table-of-contents/package.json
+++ b/packages/extension-table-of-contents/package.json
@@ -36,12 +36,11 @@
     "dist"
   ],
   "dependencies": {
-    "uuid": "^10.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@tiptap/core": "workspace:^",
-    "@tiptap/pm": "workspace:^",
-    "@types/uuid": "^10.0.0"
+    "@tiptap/pm": "workspace:^"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:*",

--- a/packages/extension-unique-id/package.json
+++ b/packages/extension-unique-id/package.json
@@ -35,12 +35,11 @@
     "@tiptap/pm": "workspace:*"
   },
   "dependencies": {
-    "uuid": "^10.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@tiptap/core": "workspace:^",
-    "@tiptap/pm": "workspace:^",
-    "@types/uuid": "^10.0.0"
+    "@tiptap/pm": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@rollup/pluginutils>picomatch': 2.3.2
   '@octokit/action>undici': 6.24.1
+  '@cypress/request>uuid': 14.0.0
   anymatch>picomatch: 2.3.2
   glob: ^10.5.0
   micromatch>picomatch: 2.3.2
@@ -285,9 +286,6 @@ importers:
       '@types/node':
         specifier: 22.10.3
         version: 22.10.3
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
       '@vitejs/plugin-react':
         specifier: ^1.3.2
         version: 1.3.2
@@ -328,8 +326,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.3
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^14.0.0
+        version: 14.0.0
       vite:
         specifier: ^5.4.20
         version: 5.4.20(@types/node@22.10.3)(sass@1.83.4)(terser@5.37.0)
@@ -875,8 +873,8 @@ importers:
   packages/extension-table-of-contents:
     dependencies:
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@tiptap/core':
         specifier: workspace:^
@@ -884,9 +882,6 @@ importers:
       '@tiptap/pm':
         specifier: workspace:^
         version: link:../pm
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/extension-text:
     devDependencies:
@@ -927,8 +922,8 @@ importers:
   packages/extension-unique-id:
     dependencies:
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@tiptap/core':
         specifier: workspace:^
@@ -936,9 +931,6 @@ importers:
       '@tiptap/pm':
         specifier: workspace:^
         version: link:../pm
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/extension-youtube:
     devDependencies:
@@ -3214,12 +3206,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-
-  '@types/uuid@8.3.4':
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -6979,12 +6965,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   validate-npm-package-name@5.0.1:
@@ -8497,7 +8479,7 @@ snapshots:
       safe-buffer: 5.2.1
       tough-cookie: 5.1.0
       tunnel-agent: 0.6.0
-      uuid: 8.3.2
+      uuid: 14.0.0
 
   '@cypress/webpack-preprocessor@6.0.2(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.97.1(esbuild@0.27.2)))(webpack@5.97.1(esbuild@0.27.2))':
     dependencies:
@@ -9624,10 +9606,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@10.0.0': {}
-
-  '@types/uuid@8.3.4': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -13758,9 +13736,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
-
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   validate-npm-package-name@5.0.1: {}
 


### PR DESCRIPTION
## Summary

Closes #7778

`pnpm audit` reports `GHSA-w5hq-g745-h8pq` for `uuid <14.0.0`. The direct Tiptap consumers use `uuid` only for `v4`, but the advisory applies to all vulnerable `uuid` versions present in the lockfile.

This PR updates every resolved `uuid` occurrence in the workspace to `14.0.0`. The direct package dependencies were upgraded in place, and the remaining transitive occurrence from `cypress > @cypress/request` is pinned with a narrow override because the latest published Cypress and `@cypress/request` releases still depend on `uuid@^8.3.2`.

## Vulnerability fixes

| Vulnerability | Severity | Affected paths before | Fix |
| --- | --- | --- | --- |
| `uuid`: missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is provided (`GHSA-w5hq-g745-h8pq`) | Moderate | `demos > uuid@8.3.2`; `packages/extension-table-of-contents > uuid@10.0.0`; `packages/extension-unique-id > uuid@10.0.0`; `. > cypress > @cypress/request > uuid@8.3.2` | Upgraded direct `uuid` dependencies to `^14.0.0`; added a narrow `@cypress/request>uuid` override to `14.0.0` for the Cypress transitive dependency. |

## Scope

This PR only fixes the `uuid` vulnerability across packages that directly or transitively resolve `uuid`.

Other `pnpm audit` findings remain outside this PR and should be handled separately. After this change, audit still reports non-uuid findings in root tooling and package/demo dependency paths, including `vite`, `postcss`, `lodash`, `svelte`, `vue`, `esbuild`, `webpack`, `yaml`, `js-yaml`, `brace-expansion`, `@octokit/*`, `markdown-it`, `mdast-util-to-hast`, `qs`, `tmp`, and `follow-redirects`.

## Verification

- `pnpm audit --json` no longer reports any `uuid` advisory.
- `pnpm -r why uuid` resolves all workspace `uuid` occurrences to `14.0.0`.
- `pnpm --filter @tiptap/extension-unique-id build`
- `pnpm --filter @tiptap/extension-table-of-contents build`
- `pnpm --filter tiptap-demos build:demos`
