### PR TITLE
Update uuid dependency versions

### DIFF
--- a/.changeset/update-uuid-version.md
+++ b/.changeset/update-uuid-version.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/extension-unique-id": patch
+"@tiptap/extension-table-of-contents": patch
+---
+
+Update uuid version

--- a/.changeset/update-uuid-version.md
+++ b/.changeset/update-uuid-version.md
@@ -3,4 +3,4 @@
 "@tiptap/extension-table-of-contents": patch
 ---
 
-Update uuid version
+Update uuid dependency to version `14.0.0`


### PR DESCRIPTION
## Summary

Closes #7778

Updates every resolved `uuid` occurrence in the workspace to `14.0.0` to address GHSA-w5hq-g745-h8pq. Direct Tiptap package dependencies are upgraded in place, and the Cypress transitive dependency from `@cypress/request` is pinned with a narrow override because the latest published Cypress path still depends on `uuid@^8.3.2`.

Adds a patch changeset for `@tiptap/extension-unique-id` and `@tiptap/extension-table-of-contents` noting the uuid version update.

## Verification
- `pnpm audit --json` no longer reports any uuid advisory
- `pnpm -r why uuid` resolves all workspace uuid occurrences to `14.0.0`
- `pnpm --filter @tiptap/extension-unique-id build`
- `pnpm --filter @tiptap/extension-table-of-contents build`
- `pnpm --filter tiptap-demos build:demos`

## Notes
Other non-uuid audit findings remain outside this PR and should be handled separately.