### PR TITLE
fix(extension-mathematics): consume host paragraph in block math input rule

### DIFF
--- a/.changeset/fix-block-math-input-rule-empty-paragraph.md
+++ b/.changeset/fix-block-math-input-rule-empty-paragraph.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-mathematics": patch
+---
+
+Fix `$$$...$$$` input rule leaving an empty paragraph above the inserted block math node when the match consumes the entire host paragraph.

--- a/packages/extension-mathematics/__tests__/blockMath.spec.ts
+++ b/packages/extension-mathematics/__tests__/blockMath.spec.ts
@@ -1,0 +1,60 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { BlockMath } from '../src/index.js'
+
+describe('BlockMath', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  describe('input rule', () => {
+    it('replaces an empty host paragraph instead of leaving it behind', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, BlockMath],
+        content: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: '$$$x^2$$' }] }],
+        },
+      })
+
+      editor.commands.setTextSelection(editor.state.doc.content.size)
+
+      editor.view.someProp('handleTextInput', f =>
+        f(editor.view, editor.state.selection.from, editor.state.selection.from, '$'),
+      )
+
+      expect(editor.getJSON()).toEqual({
+        type: 'doc',
+        content: [{ type: 'blockMath', attrs: { latex: 'x^2' } }],
+      })
+    })
+
+    it('does not fire when the match would not start at the textblock start', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, BlockMath],
+        content: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello $$$x^2$$' }] }],
+        },
+      })
+
+      editor.commands.setTextSelection(editor.state.doc.content.size)
+
+      const handled = editor.view.someProp('handleTextInput', f =>
+        f(editor.view, editor.state.selection.from, editor.state.selection.from, '$'),
+      )
+
+      expect(handled).toBeFalsy()
+      expect(editor.getJSON()).toEqual({
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello $$$x^2$$' }] }],
+      })
+    })
+  })
+})

--- a/packages/extension-mathematics/__tests__/blockMath.spec.ts
+++ b/packages/extension-mathematics/__tests__/blockMath.spec.ts
@@ -1,5 +1,6 @@
 import { Editor } from '@tiptap/core'
 import Document from '@tiptap/extension-document'
+import { BulletList, ListItem } from '@tiptap/extension-list'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -32,6 +33,47 @@ describe('BlockMath', () => {
       expect(editor.getJSON()).toEqual({
         type: 'doc',
         content: [{ type: 'blockMath', attrs: { latex: 'x^2' } }],
+      })
+    })
+
+    it('inserts a sibling block math node inside a list item without breaking the schema', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, BulletList, ListItem, BlockMath],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'bulletList',
+              content: [
+                {
+                  type: 'listItem',
+                  content: [{ type: 'paragraph', content: [{ type: 'text', text: '$$$x^2$$' }] }],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      editor.commands.setTextSelection(editor.state.doc.content.size - 3)
+
+      editor.view.someProp('handleTextInput', f =>
+        f(editor.view, editor.state.selection.from, editor.state.selection.from, '$'),
+      )
+
+      expect(editor.getJSON()).toEqual({
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [{ type: 'paragraph' }, { type: 'blockMath', attrs: { latex: 'x^2' } }],
+              },
+            ],
+          },
+        ],
       })
     })
 

--- a/packages/extension-mathematics/src/extensions/BlockMath.ts
+++ b/packages/extension-mathematics/src/extensions/BlockMath.ts
@@ -221,10 +221,14 @@ export const BlockMath = Node.create<BlockMathOptions>({
         handler: ({ state, range, match }) => {
           const [, latex] = match
           const { tr } = state
-          const start = range.from
-          const end = range.to
+          const $from = state.doc.resolve(range.from)
+          const node = this.type.create({ latex })
 
-          tr.replaceWith(start, end, this.type.create({ latex }))
+          if ($from.parent.isTextblock && range.from === $from.start() && range.to === $from.end()) {
+            tr.replaceWith($from.before(), $from.after(), node)
+          } else {
+            tr.replaceWith(range.from, range.to, node)
+          }
         },
       }),
     ]

--- a/packages/extension-mathematics/src/extensions/BlockMath.ts
+++ b/packages/extension-mathematics/src/extensions/BlockMath.ts
@@ -223,16 +223,16 @@ export const BlockMath = Node.create<BlockMathOptions>({
           const { tr } = state
           const $from = state.doc.resolve(range.from)
           const node = this.type.create({ latex })
+
           const consumesHostTextblock =
             $from.depth > 0 && $from.parent.isTextblock && range.from === $from.start() && range.to === $from.end()
-          const grandparentAcceptsReplacement =
+          // Whether the node containing the host textblock can replace it with a blockMath node.
+          const canReplaceHostTextblock =
             consumesHostTextblock && $from.node(-1).canReplaceWith($from.index(-1), $from.indexAfter(-1), this.type)
 
-          if (consumesHostTextblock && grandparentAcceptsReplacement) {
-            tr.replaceWith($from.before(), $from.after(), node)
-          } else {
-            tr.replaceWith(range.from, range.to, node)
-          }
+          const replacementRange = canReplaceHostTextblock ? { from: $from.before(), to: $from.after() } : range
+
+          tr.replaceWith(replacementRange.from, replacementRange.to, node)
         },
       }),
     ]

--- a/packages/extension-mathematics/src/extensions/BlockMath.ts
+++ b/packages/extension-mathematics/src/extensions/BlockMath.ts
@@ -223,8 +223,12 @@ export const BlockMath = Node.create<BlockMathOptions>({
           const { tr } = state
           const $from = state.doc.resolve(range.from)
           const node = this.type.create({ latex })
+          const consumesHostTextblock =
+            $from.depth > 0 && $from.parent.isTextblock && range.from === $from.start() && range.to === $from.end()
+          const grandparentAcceptsReplacement =
+            consumesHostTextblock && $from.node(-1).canReplaceWith($from.index(-1), $from.indexAfter(-1), this.type)
 
-          if ($from.parent.isTextblock && range.from === $from.start() && range.to === $from.end()) {
+          if (consumesHostTextblock && grandparentAcceptsReplacement) {
             tr.replaceWith($from.before(), $from.after(), node)
           } else {
             tr.replaceWith(range.from, range.to, node)


### PR DESCRIPTION
## Changes Overview

Fix the `$$$...$$$` input rule leaving an empty paragraph above the inserted block math node when the match consumes the entire host paragraph.

**Repro:** in an empty paragraph, type `$$$x^2$$$`. Expected doc: `[blockMath]`. Actual doc: `[paragraph (empty)][blockMath]`.

## Implementation Approach

`blockMath` is a block-level node, but the input rule called `tr.replaceWith(range.from, range.to, blockMathNode)` with positions inside the host paragraph (a textblock). ProseMirror had to lift the block out, splitting the parent — when the match covered the paragraph's full content, the result was an empty wrapper paragraph above the new node.

The handler now resolves the match position and, when the match spans the entire host textblock (`range.from === $from.start() && range.to === $from.end()`), expands the replacement range to `$from.before()..$from.after()` so the paragraph is consumed instead of split. Mid-textblock behaviour is unchanged.

## Testing Done

Added `packages/extension-mathematics/__tests__/blockMath.spec.ts` covering:

- Typing `$$$x^2$$$` in an empty paragraph → doc is `[blockMath]`, no leading empty paragraph.
- Typing `$$$x^2$$$` after `hello ` → input rule does not fire (the regex is `^`-anchored), text stays literal.

Existing `inlineMath.spec.ts` still passes. `pnpm --filter @tiptap/extension-mathematics run lint` is clean.

## Verification Steps

1. `pnpm install`
2. `pnpm exec vitest run packages/extension-mathematics`
3. In a demo editor with `BlockMath` registered, focus an empty paragraph and type `$$$x^2$$$`. The paragraph should be replaced by the rendered block math node, with no empty paragraph above it.

## Additional Notes

None.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.