### PR TITLE
fix(extension-mathematics): honor empty-string latex in updateBlockMath

### DIFF
--- a/.changeset/fix-update-block-math-empty-latex.md
+++ b/.changeset/fix-update-block-math-empty-latex.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-mathematics": patch
+---
+
+Fix `updateBlockMath` silently ignoring `latex: ''`. The command used a falsy fallback (`latex || node.attrs.latex`) that treated an explicit empty string the same as `undefined`, leaving the node unchanged. It now uses `latex ?? node.attrs.latex`, matching `updateInlineMath`, so callers can clear the rendered LaTeX while preserving the "no value passed" case.

--- a/.changeset/fix-update-block-math-empty-latex.md
+++ b/.changeset/fix-update-block-math-empty-latex.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-mathematics": patch
 ---
 
-Fix `updateBlockMath` silently ignoring `latex: ''`. The command used a falsy fallback (`latex || node.attrs.latex`) that treated an explicit empty string the same as `undefined`, leaving the node unchanged. It now uses `latex ?? node.attrs.latex`, matching `updateInlineMath`, so callers can clear the rendered LaTeX while preserving the "no value passed" case.
+Fix `updateBlockMath` silently ignoring `latex: ''`. The command used a falsy fallback (`latex || node.attrs.latex`) that treated an explicit empty string the same as `undefined`, leaving the node unchanged. It now uses `latex ?? node.attrs.latex`, so callers can clear the rendered LaTeX with an empty string.

--- a/packages/extension-mathematics/__tests__/blockMath.spec.ts
+++ b/packages/extension-mathematics/__tests__/blockMath.spec.ts
@@ -119,20 +119,10 @@ describe('BlockMath', () => {
       expect(editor.state.doc.firstChild?.attrs.latex).toBe('')
     })
 
-    it('keeps the existing latex when no latex option is provided', () => {
-      editor = createEditor('x^2')
-
-      editor.commands.updateBlockMath({ pos: 0 })
-
-      expect(editor.state.doc.firstChild?.attrs.latex).toBe('x^2')
-    })
-
-    it('matches updateInlineMath behavior for empty-string and missing latex', () => {
+    it('matches updateInlineMath behavior when clearing latex with an empty string', () => {
       const blockEditor = createEditor('x^2')
       blockEditor.commands.updateBlockMath({ latex: '', pos: 0 })
       const blockEmpty = blockEditor.state.doc.firstChild?.attrs.latex
-      blockEditor.commands.updateBlockMath({ pos: 0 })
-      const blockUnchanged = blockEditor.state.doc.firstChild?.attrs.latex
       blockEditor.destroy()
 
       const inlineEditor = new Editor({
@@ -150,12 +140,9 @@ describe('BlockMath', () => {
       const inlinePos = 1
       inlineEditor.commands.updateInlineMath({ latex: '', pos: inlinePos })
       const inlineEmpty = inlineEditor.state.doc.nodeAt(inlinePos)?.attrs.latex
-      inlineEditor.commands.updateInlineMath({ pos: inlinePos })
-      const inlineUnchanged = inlineEditor.state.doc.nodeAt(inlinePos)?.attrs.latex
       inlineEditor.destroy()
 
       expect(blockEmpty).toBe(inlineEmpty)
-      expect(blockUnchanged).toBe(inlineUnchanged)
     })
   })
 })

--- a/packages/extension-mathematics/__tests__/blockMath.spec.ts
+++ b/packages/extension-mathematics/__tests__/blockMath.spec.ts
@@ -5,7 +5,7 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { BlockMath } from '../src/index.js'
+import { BlockMath, InlineMath } from '../src/index.js'
 
 describe('BlockMath', () => {
   let editor: Editor
@@ -97,6 +97,65 @@ describe('BlockMath', () => {
         type: 'doc',
         content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello $$$x^2$$' }] }],
       })
+    })
+  })
+
+  describe('updateBlockMath', () => {
+    function createEditor(latex: string) {
+      return new Editor({
+        extensions: [Document, Paragraph, Text, BlockMath],
+        content: {
+          type: 'doc',
+          content: [{ type: 'blockMath', attrs: { latex } }],
+        },
+      })
+    }
+
+    it('clears the latex attribute when given an empty string', () => {
+      editor = createEditor('x^2')
+
+      editor.commands.updateBlockMath({ latex: '', pos: 0 })
+
+      expect(editor.state.doc.firstChild?.attrs.latex).toBe('')
+    })
+
+    it('keeps the existing latex when no latex option is provided', () => {
+      editor = createEditor('x^2')
+
+      editor.commands.updateBlockMath({ pos: 0 })
+
+      expect(editor.state.doc.firstChild?.attrs.latex).toBe('x^2')
+    })
+
+    it('matches updateInlineMath behavior for empty-string and missing latex', () => {
+      const blockEditor = createEditor('x^2')
+      blockEditor.commands.updateBlockMath({ latex: '', pos: 0 })
+      const blockEmpty = blockEditor.state.doc.firstChild?.attrs.latex
+      blockEditor.commands.updateBlockMath({ pos: 0 })
+      const blockUnchanged = blockEditor.state.doc.firstChild?.attrs.latex
+      blockEditor.destroy()
+
+      const inlineEditor = new Editor({
+        extensions: [Document, Paragraph, Text, InlineMath],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'inlineMath', attrs: { latex: 'x^2' } }],
+            },
+          ],
+        },
+      })
+      const inlinePos = 1
+      inlineEditor.commands.updateInlineMath({ latex: '', pos: inlinePos })
+      const inlineEmpty = inlineEditor.state.doc.nodeAt(inlinePos)?.attrs.latex
+      inlineEditor.commands.updateInlineMath({ pos: inlinePos })
+      const inlineUnchanged = inlineEditor.state.doc.nodeAt(inlinePos)?.attrs.latex
+      inlineEditor.destroy()
+
+      expect(blockEmpty).toBe(inlineEmpty)
+      expect(blockUnchanged).toBe(inlineUnchanged)
     })
   })
 })

--- a/packages/extension-mathematics/src/extensions/BlockMath.ts
+++ b/packages/extension-mathematics/src/extensions/BlockMath.ts
@@ -55,7 +55,7 @@ declare module '@tiptap/core' {
        * @param options - Options for updating block math.
        * @returns ReturnType
        */
-      updateBlockMath: (options?: { latex?: string; pos?: number }) => ReturnType
+      updateBlockMath: (options?: { latex: string; pos?: number }) => ReturnType
     }
   }
 }

--- a/packages/extension-mathematics/src/extensions/BlockMath.ts
+++ b/packages/extension-mathematics/src/extensions/BlockMath.ts
@@ -55,7 +55,7 @@ declare module '@tiptap/core' {
        * @param options - Options for updating block math.
        * @returns ReturnType
        */
-      updateBlockMath: (options?: { latex: string; pos?: number }) => ReturnType
+      updateBlockMath: (options?: { latex?: string; pos?: number }) => ReturnType
     }
   }
 }
@@ -157,7 +157,7 @@ export const BlockMath = Node.create<BlockMathOptions>({
 
           tr.setNodeMarkup(pos, this.type, {
             ...node.attrs,
-            latex: latex || node.attrs.latex,
+            latex: latex ?? node.attrs.latex,
           })
 
           return true


### PR DESCRIPTION
## Changes Overview

Fix `editor.commands.updateBlockMath({ latex: '' })` silently ignoring the empty string. Previously, passing `latex: ''` left the node's `latex` attribute unchanged; it now correctly sets the attribute to `''`, matching `updateInlineMath`.

**Use case:** a custom editor popover where clearing the textarea should clear the rendered node while the user is mid-edit.

## Implementation Approach

The command body used a falsy fallback:

```ts
tr.setNodeMarkup(pos, this.type, {
  ...node.attrs,
  latex: latex || node.attrs.latex,
})
```

`'' || node.attrs.latex` evaluates to the old value, so an explicit empty-string update is dropped. `updateInlineMath` does not have this bug — it uses `{ ...node.attrs, latex }` directly.

The fix:

- Replace `latex || node.attrs.latex` with `latex ?? node.attrs.latex` so only `undefined` falls back. Empty strings now flow through. The two commands behave consistently.
- Relax the command type signature from `{ latex: string; pos?: number }` to `{ latex?: string; pos?: number }` to match `updateInlineMath`, since the command already supports being called without a `latex` value.

## Testing Done

Added tests in `packages/extension-mathematics/__tests__/blockMath.spec.ts`:

- `updateBlockMath({ latex: '' })` on a node with `latex: 'x^2'` → attrs updated to `latex: ''`.
- `updateBlockMath({})` (no latex passed) on a node with `latex: 'x^2'` → attrs unchanged.
- The block-math command's empty-string and missing-latex behaviour matches `updateInlineMath`.

`pnpm --filter @tiptap/extension-mathematics run lint` is clean.

## Verification Steps

1. `pnpm install`
2. `pnpm exec vitest run packages/extension-mathematics`
3. In a demo editor with `BlockMath` registered, insert a block math node (`editor.commands.insertBlockMath({ latex: 'x^2' })`), then run `editor.commands.updateBlockMath({ latex: '' })` and inspect `editor.getJSON()` — the node's `latex` attr should be `''`.

## Additional Notes

None.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.