### PR TITLE
fix: preserve numeric bullet list item markdown

### DIFF
--- a/.changeset/fix-bullet-list-numeric-punctuation.md
+++ b/.changeset/fix-bullet-list-numeric-punctuation.md
@@ -1,0 +1,7 @@
+---
+"@tiptap/core": patch
+"@tiptap/extension-list": patch
+"@tiptap/markdown": patch
+---
+
+Fix markdown parsing for bullet list items whose text looks like an ordered-list marker, such as `- 123.`, so extraction no longer loses the item content.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -903,8 +903,8 @@ export type MarkdownHelpers = {
 export type MarkdownParseHelpers = {
   /** Parse an array of inline tokens into text nodes with marks */
   parseInline: (tokens: MarkdownToken[]) => JSONContent[]
-  /** Tokenize source text as inline markdown */
-  tokenizeInline: (src: string) => MarkdownToken[]
+  /** Tokenize source text as inline markdown when supported by the markdown parser */
+  tokenizeInline?: (src: string) => MarkdownToken[]
   /** Parse an array of block-level tokens */
   parseChildren: (tokens: MarkdownToken[]) => JSONContent[]
   /** Parse block-level tokens while preserving implicit empty paragraphs from blank lines */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -903,6 +903,8 @@ export type MarkdownHelpers = {
 export type MarkdownParseHelpers = {
   /** Parse an array of inline tokens into text nodes with marks */
   parseInline: (tokens: MarkdownToken[]) => JSONContent[]
+  /** Tokenize source text as inline markdown */
+  tokenizeInline: (src: string) => MarkdownToken[]
   /** Parse an array of block-level tokens */
   parseChildren: (tokens: MarkdownToken[]) => JSONContent[]
   /** Parse block-level tokens while preserving implicit empty paragraphs from blank lines */

--- a/packages/extension-list/__tests__/listItemMarkdown.spec.ts
+++ b/packages/extension-list/__tests__/listItemMarkdown.spec.ts
@@ -1,0 +1,46 @@
+import type { MarkdownParseHelpers, MarkdownToken } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+
+import { ListItem } from '../src/index.js'
+
+describe('ListItem markdown parsing', () => {
+  it('falls back to plain text tokens when tokenizeInline is not available', () => {
+    const token: MarkdownToken = {
+      type: 'list_item',
+      text: '1. Nested item',
+      tokens: [
+        {
+          type: 'list',
+          ordered: true,
+          raw: '1. Nested item',
+        },
+      ],
+    }
+    const helpers: MarkdownParseHelpers = {
+      parseInline: tokens =>
+        tokens.map(inlineToken => ({
+          type: 'text',
+          text: inlineToken.text,
+        })),
+      parseChildren: () => [],
+      createTextNode: text => ({ type: 'text', text }),
+      createNode: (type, attrs, content) => ({ type, attrs, content }),
+      applyMark: (mark, content) => ({ mark, content }),
+    }
+
+    expect(ListItem.config.parseMarkdown?.(token, helpers)).toEqual({
+      type: 'listItem',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: '1. Nested item',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/packages/extension-list/src/item/list-item.ts
+++ b/packages/extension-list/src/item/list-item.ts
@@ -1,4 +1,5 @@
-import { type MarkdownToken, mergeAttributes, Node, renderNestedMarkdownContent } from '@tiptap/core'
+import type { JSONContent, MarkdownParseHelpers, MarkdownToken } from '@tiptap/core'
+import { mergeAttributes, Node, renderNestedMarkdownContent } from '@tiptap/core'
 
 export interface ListItemOptions {
   /**
@@ -33,6 +34,20 @@ function isSameLineOrderedListToken(token: MarkdownToken): boolean {
       nestedToken.ordered &&
       nestedToken.raw === token.text,
   )
+}
+
+function parseSameLineOrderedListText(text: string, helpers: MarkdownParseHelpers): JSONContent[] {
+  if (helpers.tokenizeInline) {
+    return helpers.parseInline(helpers.tokenizeInline(text))
+  }
+
+  return helpers.parseInline([
+    {
+      type: 'text',
+      raw: text,
+      text,
+    },
+  ])
 }
 
 /**
@@ -83,7 +98,7 @@ export const ListItem = Node.create<ListItemOptions>({
           content: [
             {
               type: 'paragraph',
-              content: helpers.parseInline(helpers.tokenizeInline(token.text || '')),
+              content: parseSameLineOrderedListText(token.text || '', helpers),
             },
           ],
         }

--- a/packages/extension-list/src/item/list-item.ts
+++ b/packages/extension-list/src/item/list-item.ts
@@ -1,4 +1,4 @@
-import { mergeAttributes, Node, renderNestedMarkdownContent } from '@tiptap/core'
+import { type MarkdownToken, mergeAttributes, Node, renderNestedMarkdownContent } from '@tiptap/core'
 
 export interface ListItemOptions {
   /**
@@ -21,6 +21,18 @@ export interface ListItemOptions {
    * @example 'myCustomOrderedList'
    */
   orderedListTypeName: string
+}
+
+function isSameLineOrderedListToken(token: MarkdownToken): boolean {
+  const nestedToken = token.tokens?.[0]
+
+  return Boolean(
+    token.text &&
+      token.tokens?.length === 1 &&
+      nestedToken?.type === 'list' &&
+      nestedToken.ordered &&
+      nestedToken.raw === token.text,
+  )
 }
 
 /**
@@ -65,6 +77,18 @@ export const ListItem = Node.create<ListItemOptions>({
     let content: any[] = []
 
     if (token.tokens && token.tokens.length > 0) {
+      if (isSameLineOrderedListToken(token)) {
+        return {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: helpers.parseInline(helpers.tokenizeInline(token.text || '')),
+            },
+          ],
+        }
+      }
+
       // Check if we have paragraph tokens (complex list items)
       const hasParagraphTokens = token.tokens.some(t => t.type === 'paragraph')
 

--- a/packages/markdown/__tests__/conversion-files/bullet-list-numeric-punctuation.ts
+++ b/packages/markdown/__tests__/conversion-files/bullet-list-numeric-punctuation.ts
@@ -1,0 +1,70 @@
+export const name = 'Bullet List with Numeric Punctuation'
+
+export const expectedInput = `
+- 123
+  - 123
+  - 123
+- 123
+- 123.
+`.trim()
+
+export const expectedOutput = {
+  type: 'doc',
+  content: [
+    {
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: '123' }],
+            },
+            {
+              type: 'bulletList',
+              content: [
+                {
+                  type: 'listItem',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: '123' }],
+                    },
+                  ],
+                },
+                {
+                  type: 'listItem',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: '123' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: '123' }],
+            },
+          ],
+        },
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: '123.' }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/packages/markdown/__tests__/conversion-files/index.ts
+++ b/packages/markdown/__tests__/conversion-files/index.ts
@@ -1,4 +1,5 @@
 export * as bulletList from './bullet-list.js'
+export * as bulletListNumericPunctuation from './bullet-list-numeric-punctuation.js'
 export * as customAtom from './custom-atom.js'
 export * as customBlock from './custom-block.js'
 export * as customInline from './custom-inline.js'

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -601,6 +601,7 @@ export class MarkdownManager {
   private createParseHelpers(): MarkdownParseHelpers {
     return {
       parseInline: (tokens: MarkdownToken[]) => this.parseInlineTokens(tokens),
+      tokenizeInline: (src: string) => this.tokenizeInline(src),
       parseChildren: (tokens: MarkdownToken[]) => this.parseTokens(tokens),
       parseBlockChildren: (tokens: MarkdownToken[]) => this.parseTokens(tokens, true),
       createTextNode: (text: string, marks?: Array<{ type: string; attrs?: any }>) => {


### PR DESCRIPTION
## Changes Overview

Fix markdown parsing for bullet list items whose text looks like an ordered-list marker, such as `- 123.`, so markdown extraction no longer loses the item content.

## Implementation Approach

Added inline tokenization to markdown parse helpers and used it in the list item parser when marked.js mis-tokenizes same-line numeric punctuation as a nested ordered list. Added a conversion fixture that verifies parsing and serialization for the reported list shape.

## Testing Done

- `pnpm exec vitest run packages/markdown/__tests__/conversion.spec.ts --testNamePattern "Bullet List with Numeric Punctuation"`
- `pnpm exec vitest run packages/markdown/__tests__/conversion.spec.ts packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts`
- `pnpm --filter @tiptap/core lint`
- `pnpm --filter @tiptap/extension-list lint`
- `pnpm --filter @tiptap/markdown lint`

## Verification Steps

Parse and extract markdown containing:

```md
- 123
  - 123
  - 123
- 123
- 123.
```

Verify the final `- 123.` item remains paragraph text and is preserved after extraction.

## Additional Notes

A full `pnpm exec vitest run packages/markdown/__tests__` run still shows the existing isolated failure in `paragraph.spec.ts` for consecutive empty paragraphs inside bullet list items; it also fails when run alone and is unrelated to this fix.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7776