### PR TITLE
fix(markdown): preserve mark order when serializing link label emphasis

### DIFF
--- a/.changeset/twelve-bags-mix.md
+++ b/.changeset/twelve-bags-mix.md
@@ -2,4 +2,4 @@
 '@tiptap/markdown': patch
 ---
 
-Fixed a bug in Markdown serialization where partial formatting at mark boundaries could produce invalid nesting, such as italic or bold markers being emitted outside link labels. The serializer now orders marks using extension priority (matching ProseMirror's schema rank) so that wrapping marks like links are always placed outermost.
+Fixed two Markdown serialization bugs: overlapping marks (e.g. bold+italic that start and end at different positions) now serialize with the correct delimiter order, and marks that all close on the same node now close in LIFO order to produce valid nesting.

--- a/.changeset/twelve-bags-mix.md
+++ b/.changeset/twelve-bags-mix.md
@@ -2,4 +2,4 @@
 '@tiptap/markdown': patch
 ---
 
-Fixed a bug in Markdown serialization where partial formatting at mark boundaries could produce invalid nesting, such as italic or bold markers being emitted outside link labels. The Markdown manager now preserves document mark order by default while adjusting boundary openings so continuing marks stay as the outer wrapper.
+Fixed a bug in Markdown serialization where partial formatting at mark boundaries could produce invalid nesting, such as italic or bold markers being emitted outside link labels. The serializer now orders marks using extension priority (matching ProseMirror's schema rank) so that wrapping marks like links are always placed outermost.

--- a/.changeset/twelve-bags-mix.md
+++ b/.changeset/twelve-bags-mix.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Fixed a bug that caused Marks to be applied in incorrect order. Now the Markdown manager will rank mark extensions based off their priorities & schema initialization order

--- a/.changeset/twelve-bags-mix.md
+++ b/.changeset/twelve-bags-mix.md
@@ -2,4 +2,4 @@
 '@tiptap/markdown': patch
 ---
 
-Fixed a bug that caused marks to be applied in the incorrect order. The Markdown manager now ranks mark extensions by schema initialization order.
+Fixed a bug in Markdown serialization where partial formatting at mark boundaries could produce invalid nesting, such as italic or bold markers being emitted outside link labels. The Markdown manager now preserves document mark order by default while adjusting boundary openings so continuing marks stay as the outer wrapper.

--- a/.changeset/twelve-bags-mix.md
+++ b/.changeset/twelve-bags-mix.md
@@ -2,4 +2,4 @@
 '@tiptap/markdown': patch
 ---
 
-Fixed a bug that caused Marks to be applied in incorrect order. Now the Markdown manager will rank mark extensions based off their priorities & schema initialization order
+Fixed a bug that caused marks to be applied in the incorrect order. The Markdown manager now ranks mark extensions by schema initialization order.

--- a/packages/markdown/__tests__/conversion.spec.ts
+++ b/packages/markdown/__tests__/conversion.spec.ts
@@ -49,12 +49,7 @@ describe('Markdown Conversion Tests', () => {
     }),
   ]
 
-  const markdownManager = new MarkdownManager()
-  extensions.forEach(extension => {
-    markdownManager.registerExtension(extension as Extension)
-  })
-
-  const conversionExtensions = [] as Extension[]
+  const conversionExtensions: Extension[] = []
 
   Object.values(conversionfiles).forEach((file: any) => {
     if (!file?.extensions) {
@@ -64,9 +59,7 @@ describe('Markdown Conversion Tests', () => {
     conversionExtensions.push(...file.extensions)
   })
 
-  conversionExtensions.forEach(extension => {
-    markdownManager.registerExtension(extension as Extension)
-  })
+  const markdownManager = new MarkdownManager({ extensions: [...extensions, ...conversionExtensions] })
 
   describe('convert simple taskList from and to markdown', () => {
     const simpleMarkdown = `

--- a/packages/markdown/__tests__/extensions/blockquote.spec.ts
+++ b/packages/markdown/__tests__/extensions/blockquote.spec.ts
@@ -1,4 +1,3 @@
-import type { Extension } from '@tiptap/core'
 import { Blockquote } from '@tiptap/extension-blockquote'
 import { Document } from '@tiptap/extension-document'
 import { Heading } from '@tiptap/extension-heading'
@@ -11,10 +10,8 @@ describe('Blockquote Markdown Conversion', () => {
   let markdownManager: MarkdownManager
 
   beforeEach(() => {
-    markdownManager = new MarkdownManager()
-    const extensions = [Document, Paragraph, Text, Blockquote, Heading]
-    extensions.forEach(extension => {
-      markdownManager.registerExtension(extension as Extension)
+    markdownManager = new MarkdownManager({
+      extensions: [Document, Paragraph, Text, Blockquote, Heading],
     })
   })
 

--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -133,9 +133,7 @@ describe('MarkdownManager Direct Tests', () => {
 
   describe('Basic Markdown Parsing', () => {
     beforeEach(() => {
-      markdownManager = new MarkdownManager()
-
-      basicExtensions.forEach(ext => markdownManager.registerExtension(ext))
+      markdownManager = new MarkdownManager({ extensions: basicExtensions })
     })
 
     it('should parse simple text', () => {
@@ -210,17 +208,14 @@ Second paragraph.`
 **After** ordered list`
       const isolatedManager = new MarkdownManager({
         marked: new Marked() as unknown as typeof import('marked').marked,
-        extensions: [],
+        extensions: basicExtensions,
       })
-
-      basicExtensions.forEach(ext => isolatedManager.registerExtension(ext))
 
       expect(markdownManager.parse(markdown)).toEqual(isolatedManager.parse(markdown))
     })
 
     it('keeps later inline parsing stable after a custom tokenizer uses inlineTokens', () => {
-      const manager = new MarkdownManager()
-      ;[...basicExtensions, TestProbe].forEach(ext => manager.registerExtension(ext))
+      const manager = new MarkdownManager({ extensions: [...basicExtensions, TestProbe] })
 
       const markdown = `:::probe **Probe** text :::
 
@@ -261,9 +256,7 @@ Second paragraph.`
   })
   describe('simple nested Marks parsing', () => {
     beforeEach(() => {
-      markdownManager = new MarkdownManager()
-
-      basicExtensions.forEach(ext => markdownManager.registerExtension(ext))
+      markdownManager = new MarkdownManager({ extensions: basicExtensions })
     })
     const nestedMarkdown = `**...++abc++**`
 
@@ -299,9 +292,7 @@ Second paragraph.`
   })
   describe('complex nested Marks parsing', () => {
     beforeEach(() => {
-      markdownManager = new MarkdownManager()
-
-      basicExtensions.forEach(ext => markdownManager.registerExtension(ext))
+      markdownManager = new MarkdownManager({ extensions: basicExtensions })
     })
     const nestedMarkdown = `**...~~++abc*abc*++~~**`
 
@@ -342,8 +333,7 @@ Second paragraph.`
   })
   describe('Extended Markdown Parsing', () => {
     beforeEach(() => {
-      markdownManager = new MarkdownManager()
-      extendedExtensions.forEach(ext => markdownManager.registerExtension(ext))
+      markdownManager = new MarkdownManager({ extensions: extendedExtensions })
     })
 
     it('should parse mentions', () => {
@@ -391,8 +381,7 @@ Final paragraph.`
 
   describe('Markdown Rendering', () => {
     beforeEach(() => {
-      markdownManager = new MarkdownManager()
-      extendedExtensions.forEach(ext => markdownManager.registerExtension(ext))
+      markdownManager = new MarkdownManager({ extensions: extendedExtensions })
     })
 
     it('should render simple text', () => {
@@ -700,8 +689,7 @@ Final paragraph.`
 
   describe('Round-trip Tests', () => {
     beforeEach(() => {
-      markdownManager = new MarkdownManager()
-      extendedExtensions.forEach(ext => markdownManager.registerExtension(ext))
+      markdownManager = new MarkdownManager({ extensions: extendedExtensions })
     })
 
     const testCases = [
@@ -745,15 +733,13 @@ Final paragraph.`
     it('should work with different extension combinations', () => {
       // Test with minimal extensions
       const minimalExtensions = [Document, Paragraph, Text]
-      const minimalManager = new MarkdownManager()
-      minimalExtensions.forEach(ext => minimalManager.registerExtension(ext))
+      const minimalManager = new MarkdownManager({ extensions: minimalExtensions })
 
       const simpleDoc = minimalManager.parse('Hello world')
       expect(simpleDoc.content![0].type).toBe('paragraph')
 
       // Test with extended extensions
-      const extendedManager = new MarkdownManager()
-      extendedExtensions.forEach(ext => extendedManager.registerExtension(ext))
+      const extendedManager = new MarkdownManager({ extensions: extendedExtensions })
 
       const complexDoc = extendedManager.parse('# Title\n\n[@ id="user" label="User"]')
       expect(complexDoc.content![0].type).toBe('heading')
@@ -761,8 +747,7 @@ Final paragraph.`
     })
 
     it('should handle unknown markdown gracefully', () => {
-      const manager = new MarkdownManager()
-      basicExtensions.forEach(ext => manager.registerExtension(ext))
+      const manager = new MarkdownManager({ extensions: basicExtensions })
 
       // Test various unknown markdown patterns that should be preserved as text
       const testCases = [
@@ -784,8 +769,7 @@ Final paragraph.`
 
   describe('Performance Tests', () => {
     beforeEach(() => {
-      markdownManager = new MarkdownManager()
-      extendedExtensions.forEach(ext => markdownManager.registerExtension(ext))
+      markdownManager = new MarkdownManager({ extensions: extendedExtensions })
     })
 
     it('should handle large documents efficiently', () => {

--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -584,7 +584,10 @@ Final paragraph.`
     })
 
     it('should render nested marks with correct tag order', () => {
-      // Test case: bold inside strike should render as ~~**text**~~
+      // Marks come in ProseMirror's canonical order (rank ascending) — Bold is
+      // registered before Strike so it gets the lower rank. The serializer
+      // places lower-rank marks outermost, mirroring how a real editor would
+      // wrap the text: bold outer, strike inner.
       const doc = {
         type: 'doc',
         content: [
@@ -633,8 +636,8 @@ Final paragraph.`
         ],
       }
 
-      expect(markdownManager.renderNodes(doc)).to.equal('Test: ~~**abcd**~~ end.')
-      expect(markdownManager.renderNodes(docAtEnd)).to.equal('~~**abcd**~~')
+      expect(markdownManager.renderNodes(doc)).to.equal('Test: **~~abcd~~** end.')
+      expect(markdownManager.renderNodes(docAtEnd)).to.equal('**~~abcd~~**')
     })
 
     it('should render headings', () => {

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -150,6 +150,119 @@ describe('Overlapping marks serialization', () => {
     expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
   })
 
+  it('serializes italic inside a same-node link label when link mark comes first', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'google',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+                { type: 'italic' },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    expect(result).toBe('[*google*](https://google.com)')
+    expect(result).not.toBe('*[google](https://google.com)*')
+    expect(normalizeMarks(markdownManager.parse(result))).toEqual(
+      normalizeMarks({
+        ...json,
+        content: [
+          {
+            ...json.content[0],
+            content: [
+              {
+                ...json.content[0].content[0],
+                marks: [
+                  { type: 'italic' },
+                  {
+                    type: 'link',
+                    attrs: {
+                      href: 'https://google.com',
+                      title: null,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+  })
+
+  it('serializes bold inside a same-node link label when link mark comes first', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'google',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+                { type: 'bold' },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    expect(result).toBe('[**google**](https://google.com)')
+    expect(normalizeMarks(markdownManager.parse(result))).toEqual(
+      normalizeMarks({
+        ...json,
+        content: [
+          {
+            ...json.content[0],
+            content: [
+              {
+                ...json.content[0].content[0],
+                marks: [
+                  { type: 'bold' },
+                  {
+                    type: 'link',
+                    attrs: {
+                      href: 'https://google.com',
+                      title: null,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+  })
+
   it('keeps html-reopened italic open across later text nodes before closing', () => {
     const json = {
       type: 'doc',

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -470,7 +470,7 @@ describe('Overlapping marks serialization', () => {
    * When bold, italic, and strike all close on the same node they must close
    * LIFO (last-opened first-closed) to produce valid nesting.
    */
-  it('closes multiple simultaneously-ending marks in LIFO order', () => {
+  it('closes multiple simultaneously-ending marks in LIFO order (simple path)', () => {
     const markdownManagerWithStrike = new MarkdownManager({
       extensions: [Document, Paragraph, Text, Bold, Italic, Strike],
     })
@@ -491,6 +491,43 @@ describe('Overlapping marks serialization', () => {
     const result = markdownManagerWithStrike.serialize(json)
 
     expect(result).toBe('**bold *italics ~~strike~~***')
+    expect(normalizeMarks(markdownManagerWithStrike.parse(result))).toEqual(normalizeMarks(json))
+  })
+
+  /**
+   * Regression test for the crossed-boundary LIFO bug.
+   * Bold (outer) and strike (inner) are both active; italic opens while both
+   * close at the same boundary. Previously-active marks must still close in
+   * LIFO order (strike first, bold last) even though a new mark is opening.
+   *
+   * Buggy output:  **~~abc*def***~~*ghi*  (bold closes before strike — invalid)
+   * Correct output: **~~abc*def*~~***ghi* (strike closes before bold — valid)
+   */
+  it('closes previously-active marks in LIFO order on a crossed boundary', () => {
+    const markdownManagerWithStrike = new MarkdownManager({
+      extensions: [Document, Paragraph, Text, Bold, Italic, Strike],
+    })
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'abc', marks: [{ type: 'bold' }, { type: 'strike' }] },
+            { type: 'text', text: 'def', marks: [{ type: 'bold' }, { type: 'strike' }, { type: 'italic' }] },
+            { type: 'text', text: 'ghi', marks: [{ type: 'italic' }] },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManagerWithStrike.serialize(json)
+
+    // Strike must close before bold (LIFO). Bold then closes, and italic for
+    // "ghi" reopens with <em> to avoid the ambiguous *** sequence.
+    expect(result).toBe('**~~abc*def*~~**<em>ghi</em>')
+    // Buggy output (bold closes before strike): '**~~abc*def***~~<em>ghi</em>'
+    expect(result).not.toBe('**~~abc*def***~~<em>ghi</em>')
     expect(normalizeMarks(markdownManagerWithStrike.parse(result))).toEqual(normalizeMarks(json))
   })
 })

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -464,4 +464,33 @@ describe('Overlapping marks serialization', () => {
 
     editor.destroy()
   })
+
+  /**
+   * Regression test for issue #7728.
+   * When bold, italic, and strike all close on the same node they must close
+   * LIFO (last-opened first-closed) to produce valid nesting.
+   */
+  it('closes multiple simultaneously-ending marks in LIFO order', () => {
+    const markdownManagerWithStrike = new MarkdownManager({
+      extensions: [Document, Paragraph, Text, Bold, Italic, Strike],
+    })
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'bold ', marks: [{ type: 'bold' }] },
+            { type: 'text', text: 'italics ', marks: [{ type: 'bold' }, { type: 'italic' }] },
+            { type: 'text', text: 'strike', marks: [{ type: 'bold' }, { type: 'italic' }, { type: 'strike' }] },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManagerWithStrike.serialize(json)
+
+    expect(result).toBe('**bold *italics ~~strike~~***')
+    expect(normalizeMarks(markdownManagerWithStrike.parse(result))).toEqual(normalizeMarks(json))
+  })
 })

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -1,16 +1,19 @@
+import { Editor } from '@tiptap/core'
 import { Bold } from '@tiptap/extension-bold'
 import { Document } from '@tiptap/extension-document'
 import { HardBreak } from '@tiptap/extension-hard-break'
 import { Italic } from '@tiptap/extension-italic'
+import { Link } from '@tiptap/extension-link'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import Strike from '@tiptap/extension-strike'
 import { Text } from '@tiptap/extension-text'
+import { Markdown } from '@tiptap/markdown'
 import { describe, expect, it } from 'vitest'
 
 import { MarkdownManager } from '../src/MarkdownManager.js'
 
 describe('Overlapping marks serialization', () => {
-  const extensions = [Document, Paragraph, Text, Bold, Italic]
+  const extensions = [Document, Paragraph, Text, Bold, Italic, Link]
   const markdownManager = new MarkdownManager({ extensions })
   const normalizeMarks = (node: any): any => {
     if (Array.isArray(node)) {
@@ -233,5 +236,164 @@ describe('Overlapping marks serialization', () => {
 
     expect(result).toBe('*abc~~def~~*~~ghi~~')
     expect(normalizeMarks(markdownManagerWithStrike.parse(result))).toEqual(normalizeMarks(json))
+  })
+
+  it('serializes italic on the leading subset of link text inside the link label', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'google',
+              marks: [
+                { type: 'italic' },
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+              ],
+            },
+            {
+              type: 'text',
+              text: ' search',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    expect(result).toBe('[*google* search](https://google.com)')
+    expect(result).not.toBe('*[google* search](https://google.com)')
+    expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
+  })
+
+  it('serializes bold on the leading subset of link text inside the link label', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'google',
+              marks: [
+                { type: 'bold' },
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+              ],
+            },
+            {
+              type: 'text',
+              text: ' search',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    expect(result).toBe('[**google** search](https://google.com)')
+    expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
+  })
+
+  it('serializes partial italic in link text correctly from editor commands', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, Bold, Italic, Link, Markdown],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'google search' }],
+          },
+        ],
+      },
+    })
+
+    editor.commands.selectAll()
+    editor.commands.setLink({ href: 'https://google.com' })
+    editor.commands.setTextSelection({ from: 1, to: 7 })
+    editor.commands.setItalic()
+
+    const json = editor.getJSON()
+    const result = editor.getMarkdown()
+    const directResult = markdownManager.serialize(json)
+    const expectedRoundtripJson = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'google',
+              marks: [
+                { type: 'italic' },
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+              ],
+            },
+            {
+              type: 'text',
+              text: ' search',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://google.com',
+                    title: null,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(result).toBe('[*google* search](https://google.com)')
+    expect(result).not.toBe('*[google* search](https://google.com)')
+    expect(directResult).toBe(result)
+    expect(normalizeMarks(editor.markdown?.parse(result))).toEqual(normalizeMarks(expectedRoundtripJson))
+
+    editor.destroy()
   })
 })

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -150,6 +150,9 @@ describe('Overlapping marks serialization', () => {
     expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
   })
 
+  // Mark order matches what a real editor emits: Link has priority 1000, so
+  // ProseMirror assigns it the lowest rank and stores it first in the marks
+  // array. The serializer must still place link as the outermost wrapper.
   it('serializes italic inside a same-node link label', () => {
     const json = {
       type: 'doc',
@@ -161,7 +164,6 @@ describe('Overlapping marks serialization', () => {
               type: 'text',
               text: 'google',
               marks: [
-                { type: 'italic' },
                 {
                   type: 'link',
                   attrs: {
@@ -169,6 +171,7 @@ describe('Overlapping marks serialization', () => {
                     title: null,
                   },
                 },
+                { type: 'italic' },
               ],
             },
           ],
@@ -194,7 +197,6 @@ describe('Overlapping marks serialization', () => {
               type: 'text',
               text: 'google',
               marks: [
-                { type: 'bold' },
                 {
                   type: 'link',
                   attrs: {
@@ -202,6 +204,7 @@ describe('Overlapping marks serialization', () => {
                     title: null,
                   },
                 },
+                { type: 'bold' },
               ],
             },
           ],

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -150,7 +150,7 @@ describe('Overlapping marks serialization', () => {
     expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
   })
 
-  it('serializes italic inside a same-node link label when link mark comes first', () => {
+  it('serializes italic inside a same-node link label', () => {
     const json = {
       type: 'doc',
       content: [
@@ -161,6 +161,7 @@ describe('Overlapping marks serialization', () => {
               type: 'text',
               text: 'google',
               marks: [
+                { type: 'italic' },
                 {
                   type: 'link',
                   attrs: {
@@ -168,7 +169,6 @@ describe('Overlapping marks serialization', () => {
                     title: null,
                   },
                 },
-                { type: 'italic' },
               ],
             },
           ],
@@ -180,34 +180,10 @@ describe('Overlapping marks serialization', () => {
 
     expect(result).toBe('[*google*](https://google.com)')
     expect(result).not.toBe('*[google](https://google.com)*')
-    expect(normalizeMarks(markdownManager.parse(result))).toEqual(
-      normalizeMarks({
-        ...json,
-        content: [
-          {
-            ...json.content[0],
-            content: [
-              {
-                ...json.content[0].content[0],
-                marks: [
-                  { type: 'italic' },
-                  {
-                    type: 'link',
-                    attrs: {
-                      href: 'https://google.com',
-                      title: null,
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }),
-    )
+    expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
   })
 
-  it('serializes bold inside a same-node link label when link mark comes first', () => {
+  it('serializes bold inside a same-node link label', () => {
     const json = {
       type: 'doc',
       content: [
@@ -218,6 +194,7 @@ describe('Overlapping marks serialization', () => {
               type: 'text',
               text: 'google',
               marks: [
+                { type: 'bold' },
                 {
                   type: 'link',
                   attrs: {
@@ -225,7 +202,6 @@ describe('Overlapping marks serialization', () => {
                     title: null,
                   },
                 },
-                { type: 'bold' },
               ],
             },
           ],
@@ -236,31 +212,7 @@ describe('Overlapping marks serialization', () => {
     const result = markdownManager.serialize(json)
 
     expect(result).toBe('[**google**](https://google.com)')
-    expect(normalizeMarks(markdownManager.parse(result))).toEqual(
-      normalizeMarks({
-        ...json,
-        content: [
-          {
-            ...json.content[0],
-            content: [
-              {
-                ...json.content[0].content[0],
-                marks: [
-                  { type: 'bold' },
-                  {
-                    type: 'link',
-                    attrs: {
-                      href: 'https://google.com',
-                      title: null,
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }),
-    )
+    expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
   })
 
   it('keeps html-reopened italic open across later text nodes before closing', () => {

--- a/packages/markdown/__tests__/paragraph.spec.ts
+++ b/packages/markdown/__tests__/paragraph.spec.ts
@@ -1,4 +1,3 @@
-import type { AnyExtension } from '@tiptap/core'
 import { Blockquote } from '@tiptap/extension-blockquote'
 import { Document } from '@tiptap/extension-document'
 import { Heading } from '@tiptap/extension-heading'
@@ -12,19 +11,8 @@ describe('Paragraph Markdown Rendering', () => {
   let markdownManager: MarkdownManager
 
   beforeEach(() => {
-    markdownManager = new MarkdownManager()
-    const extensions: AnyExtension[] = [
-      Document,
-      Paragraph,
-      Text,
-      Heading,
-      Blockquote,
-      BulletList,
-      OrderedList,
-      ListItem,
-    ]
-    extensions.forEach(extension => {
-      markdownManager.registerExtension(extension)
+    markdownManager = new MarkdownManager({
+      extensions: [Document, Paragraph, Text, Heading, Blockquote, BulletList, OrderedList, ListItem],
     })
   })
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -34,6 +34,7 @@ export class MarkdownManager {
   private activeParseLexer: Lexer | null = null
   private registry: Map<string, MarkdownExtensionSpec[]>
   private nodeTypeRegistry: Map<string, MarkdownExtensionSpec[]>
+  private extensionRanks: Map<string, number>
   private indentStyle: 'space' | 'tab'
   private indentSize: number
   private baseExtensions: AnyExtension[] = []
@@ -65,6 +66,7 @@ export class MarkdownManager {
 
     this.registry = new Map()
     this.nodeTypeRegistry = new Map()
+    this.extensionRanks = new Map()
 
     // If extensions were provided, register them now
     if (options?.extensions) {
@@ -127,6 +129,10 @@ export class MarkdownManager {
     const markdownCfg = (getExtensionField(extension, 'markdownOptions') ?? null) as ExtendableConfig['markdownOptions']
     const isIndenting = markdownCfg?.indentsContent ?? false
     const htmlReopen = markdownCfg?.htmlReopen
+
+    if (!this.extensionRanks.has(name)) {
+      this.extensionRanks.set(name, this.extensionRanks.size)
+    }
 
     const spec: MarkdownExtensionSpec = {
       tokenName,
@@ -1018,7 +1024,7 @@ export class MarkdownManager {
 
       if (node.type === 'text') {
         let textContent = this.encodeTextForMarkdown(node.text || '', node, parentNode)
-        const currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
+        const currentMarks = new Map(this.sortMarksForSerialization(node.marks).map(mark => [mark.type, mark]))
 
         // Find marks that need to be closed and opened
         const marksToOpen = findMarksToOpen(activeMarks, currentMarks)
@@ -1292,6 +1298,23 @@ export class MarkdownManager {
     }
 
     return Array.from(marks1.keys()).every(type => marks2.has(type))
+  }
+
+  private sortMarksForSerialization(marks?: any[]): any[] {
+    if (!marks?.length) {
+      return []
+    }
+
+    return [...marks].sort((markA, markB) => {
+      const rankA = this.extensionRanks.get(markA.type) ?? Number.MAX_SAFE_INTEGER
+      const rankB = this.extensionRanks.get(markB.type) ?? Number.MAX_SAFE_INTEGER
+
+      if (rankA !== rankB) {
+        return rankA - rankB
+      }
+
+      return markA.type.localeCompare(markB.type)
+    })
   }
 }
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1297,18 +1297,30 @@ export class MarkdownManager {
   private getMarksToOpenForSerialization(activeMarks: Map<string, any>, currentMarks: Map<string, any>, nextNode: any) {
     const marksToOpen = findMarksToOpen(activeMarks, currentMarks)
 
-    if (marksToOpen.length <= 1 || !nextNode?.marks?.length) {
+    if (marksToOpen.length <= 1) {
       return marksToOpen
     }
 
-    const nextMarkTypes = new Set(nextNode.marks.map((mark: any) => mark.type))
+    const nextMarkTypes = new Set((nextNode?.marks || []).map((mark: any) => mark.type))
+
+    const orderedMarksToOpen = [
+      ...marksToOpen.filter(mark => !nextMarkTypes.has(mark.type)),
+      ...marksToOpen.filter(mark => nextMarkTypes.has(mark.type)),
+    ]
 
     // Marks that end on this node need to open first so marks that continue
     // into the next node become the outer wrapper around them.
     return [
-      ...marksToOpen.filter(mark => !nextMarkTypes.has(mark.type)),
-      ...marksToOpen.filter(mark => nextMarkTypes.has(mark.type)),
+      ...orderedMarksToOpen.filter(mark => !this.shouldOpenMarkAfterSiblings(mark.type, mark.mark)),
+      ...orderedMarksToOpen.filter(mark => this.shouldOpenMarkAfterSiblings(mark.type, mark.mark)),
     ]
+  }
+
+  private shouldOpenMarkAfterSiblings(markType: string, mark: any): boolean {
+    const opening = this.getMarkOpening(markType, mark)
+    const closing = this.getMarkClosing(markType, mark)
+
+    return opening.endsWith('[') && /^\]\([^\s].*\)$/.test(closing)
   }
 }
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1142,9 +1142,17 @@ export class MarkdownManager {
             }
           })
 
+          // Sort the previously-active closures in LIFO order: the mark that
+          // was opened last (innermost) must close first. activeMarks preserves
+          // insertion order, so a higher indexOf means opened later = inner.
+          const activeMarkKeys = Array.from(activeMarks.keys())
+          const activeMarksClosingHereLifo = activeMarksClosingHere
+            .slice()
+            .sort((a, b) => activeMarkKeys.indexOf(b) - activeMarkKeys.indexOf(a))
+
           marksToCloseAtEnd = [
             ...marksToOpen.map(m => m.type), // inner (opened here) — close first
-            ...activeMarksClosingHere, // outer (were active before) — close last
+            ...activeMarksClosingHereLifo, // outer (were active before) — close last, LIFO
           ]
         } else {
           marksToCloseAtEnd = findMarksToCloseAtEnd(activeMarks, currentMarks, nextNode, this.markSetsEqual.bind(this))

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1069,22 +1069,26 @@ export class MarkdownManager {
         }
 
         if (!hasCrossedBoundary) {
-          // Normal path: close marks that are ending here (no new marks opening simultaneously)
-          marksToClose.forEach(markType => {
-            if (!activeMarks.has(markType)) {
-              return
-            }
+          // Normal path: close marks that are ending here (no new marks opening simultaneously).
+          // Reverse so the last-opened mark closes first (LIFO), preserving valid nesting.
+          marksToClose
+            .slice()
+            .reverse()
+            .forEach(markType => {
+              if (!activeMarks.has(markType)) {
+                return
+              }
 
-            const mark = currentMarks.get(markType)
-            const closeMarkdown = this.getMarkClosing(markType, mark, markOpeningModes.get(markType))
-            if (closeMarkdown) {
-              textContent += closeMarkdown
-            }
-            if (activeMarks.has(markType)) {
-              activeMarks.delete(markType)
-              markOpeningModes.delete(markType)
-            }
-          })
+              const mark = currentMarks.get(markType)
+              const closeMarkdown = this.getMarkClosing(markType, mark, markOpeningModes.get(markType))
+              if (closeMarkdown) {
+                textContent += closeMarkdown
+              }
+              if (activeMarks.has(markType)) {
+                activeMarks.delete(markType)
+                markOpeningModes.delete(markType)
+              }
+            })
         }
 
         // Open new marks (should be at the beginning)

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -16,6 +16,7 @@ import {
   flattenExtensions,
   generateJSON,
   getExtensionField,
+  sortExtensions,
 } from '@tiptap/core'
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
 
@@ -34,6 +35,17 @@ export class MarkdownManager {
   private activeParseLexer: Lexer | null = null
   private registry: Map<string, MarkdownExtensionSpec[]>
   private nodeTypeRegistry: Map<string, MarkdownExtensionSpec[]>
+  /**
+   * Order in which extensions were registered. Used to resolve mark nesting
+   * deterministically when several marks open on the same text node.
+   *
+   * The flattened extensions passed to the manager are pre-sorted by Tiptap's
+   * extension priority (descending), which is also the order ProseMirror uses
+   * to assign mark ranks. Recording that index here lets the serializer place
+   * higher-priority / lower-rank marks (e.g. link with priority 1000) on the
+   * outside without inspecting any rendered markdown output.
+   */
+  private extensionRanks: Map<string, number> = new Map()
   private indentStyle: 'space' | 'tab'
   private indentSize: number
   private baseExtensions: AnyExtension[] = []
@@ -66,10 +78,13 @@ export class MarkdownManager {
     this.registry = new Map()
     this.nodeTypeRegistry = new Map()
 
-    // If extensions were provided, register them now
+    // If extensions were provided, register them now. Sort by Tiptap priority
+    // first (matching how the editor builds its schema) so the registration
+    // index lines up with ProseMirror's mark rank — this is what the
+    // serializer relies on to nest higher-priority marks like link outermost.
     if (options?.extensions) {
       this.baseExtensions = options.extensions
-      const flattened = flattenExtensions(options.extensions)
+      const flattened = sortExtensions(flattenExtensions(options.extensions))
       flattened.forEach(ext => this.registerExtension(ext))
     }
   }
@@ -111,6 +126,10 @@ export class MarkdownManager {
 
     if (isCode) {
       this.codeTypes.add(name)
+    }
+
+    if (!this.extensionRanks.has(name)) {
+      this.extensionRanks.set(name, this.extensionRanks.size)
     }
     const tokenName =
       (getExtensionField(extension, 'markdownTokenName') as ExtendableConfig['markdownTokenName']) || name
@@ -1297,16 +1316,20 @@ export class MarkdownManager {
   /**
    * Decide the order in which marks open on the current text node.
    *
-   * The mark array on a node is assumed to be in ProseMirror's canonical
-   * order (rank ascending, where rank = extension registration index).
-   * This serializer treats array-last as outermost, so a higher-rank mark
-   * naturally becomes the outer wrapper — link, registered after bold/italic
-   * in any reasonable inline-mark stack, ends up outside other delimiters
-   * without inspecting rendered markdown.
+   * The returned array is iterated head-first when prepending opening
+   * delimiters, so the first entry becomes the innermost mark in the emitted
+   * markdown and the last becomes the outermost. Two stable signals drive
+   * the order — neither one inspects any rendered markdown:
    *
-   * The only adjustment is partitioning by lifetime: marks that end on this
-   * node must be inner relative to marks that continue into the next node,
-   * otherwise the delimiters interleave instead of nesting.
+   *   1. Marks that end on this node must be inner relative to marks that
+   *      continue into the next node, otherwise the delimiters interleave
+   *      instead of nesting.
+   *   2. Within each lifetime group, marks are sorted so that lower
+   *      registration ranks (i.e. higher Tiptap extension priorities) end up
+   *      outermost. ProseMirror assigns mark ranks in the same priority-aware
+   *      order Tiptap uses when building the schema, so link (priority 1000)
+   *      naturally wraps bold/italic without the serializer needing to peek
+   *      at how any particular mark renders.
    */
   private getMarksToOpenForSerialization(activeMarks: Map<string, any>, currentMarks: Map<string, any>, nextNode: any) {
     const marksToOpen = findMarksToOpen(activeMarks, currentMarks)
@@ -1317,10 +1340,24 @@ export class MarkdownManager {
 
     const nextMarkTypes = new Set((nextNode?.marks || []).map((mark: any) => mark.type))
 
-    return [
-      ...marksToOpen.filter(mark => !nextMarkTypes.has(mark.type)),
-      ...marksToOpen.filter(mark => nextMarkTypes.has(mark.type)),
-    ]
+    // Higher rank → earlier in the array → innermost mark. Marks without a
+    // recorded rank fall back to MAX_SAFE_INTEGER so they sort innermost,
+    // matching the implicit "registered last" assumption for ad-hoc marks.
+    const byRankInnerFirst = (a: { type: string }, b: { type: string }) => {
+      const rankA = this.extensionRanks.get(a.type) ?? Number.MAX_SAFE_INTEGER
+      const rankB = this.extensionRanks.get(b.type) ?? Number.MAX_SAFE_INTEGER
+
+      if (rankA !== rankB) {
+        return rankB - rankA
+      }
+
+      return a.type.localeCompare(b.type)
+    }
+
+    const endingHere = marksToOpen.filter(mark => !nextMarkTypes.has(mark.type)).sort(byRankInnerFirst)
+    const continuing = marksToOpen.filter(mark => nextMarkTypes.has(mark.type)).sort(byRankInnerFirst)
+
+    return [...endingHere, ...continuing]
   }
 }
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -34,7 +34,6 @@ export class MarkdownManager {
   private activeParseLexer: Lexer | null = null
   private registry: Map<string, MarkdownExtensionSpec[]>
   private nodeTypeRegistry: Map<string, MarkdownExtensionSpec[]>
-  private extensionRanks: Map<string, number>
   private indentStyle: 'space' | 'tab'
   private indentSize: number
   private baseExtensions: AnyExtension[] = []
@@ -66,7 +65,6 @@ export class MarkdownManager {
 
     this.registry = new Map()
     this.nodeTypeRegistry = new Map()
-    this.extensionRanks = new Map()
 
     // If extensions were provided, register them now
     if (options?.extensions) {
@@ -129,10 +127,6 @@ export class MarkdownManager {
     const markdownCfg = (getExtensionField(extension, 'markdownOptions') ?? null) as ExtendableConfig['markdownOptions']
     const isIndenting = markdownCfg?.indentsContent ?? false
     const htmlReopen = markdownCfg?.htmlReopen
-
-    if (!this.extensionRanks.has(name)) {
-      this.extensionRanks.set(name, this.extensionRanks.size)
-    }
 
     const spec: MarkdownExtensionSpec = {
       tokenName,
@@ -1024,10 +1018,10 @@ export class MarkdownManager {
 
       if (node.type === 'text') {
         let textContent = this.encodeTextForMarkdown(node.text || '', node, parentNode)
-        const currentMarks = new Map(this.sortMarksForSerialization(node.marks).map(mark => [mark.type, mark]))
+        const currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
 
         // Find marks that need to be closed and opened
-        const marksToOpen = findMarksToOpen(activeMarks, currentMarks)
+        const marksToOpen = this.getMarksToOpenForSerialization(activeMarks, currentMarks, nextNode)
         const marksToClose = findMarksToClose(currentMarks, nextNode)
 
         // When marks simultaneously close (old) AND open (new) at this boundary, the naive
@@ -1300,21 +1294,21 @@ export class MarkdownManager {
     return Array.from(marks1.keys()).every(type => marks2.has(type))
   }
 
-  private sortMarksForSerialization(marks?: any[]): any[] {
-    if (!marks?.length) {
-      return []
+  private getMarksToOpenForSerialization(activeMarks: Map<string, any>, currentMarks: Map<string, any>, nextNode: any) {
+    const marksToOpen = findMarksToOpen(activeMarks, currentMarks)
+
+    if (marksToOpen.length <= 1 || !nextNode?.marks?.length) {
+      return marksToOpen
     }
 
-    return [...marks].sort((markA, markB) => {
-      const rankA = this.extensionRanks.get(markA.type) ?? Number.MAX_SAFE_INTEGER
-      const rankB = this.extensionRanks.get(markB.type) ?? Number.MAX_SAFE_INTEGER
+    const nextMarkTypes = new Set(nextNode.marks.map((mark: any) => mark.type))
 
-      if (rankA !== rankB) {
-        return rankA - rankB
-      }
-
-      return markA.type.localeCompare(markB.type)
-    })
+    // Marks that end on this node need to open first so marks that continue
+    // into the next node become the outer wrapper around them.
+    return [
+      ...marksToOpen.filter(mark => !nextMarkTypes.has(mark.type)),
+      ...marksToOpen.filter(mark => nextMarkTypes.has(mark.type)),
+    ]
   }
 }
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1294,6 +1294,20 @@ export class MarkdownManager {
     return Array.from(marks1.keys()).every(type => marks2.has(type))
   }
 
+  /**
+   * Decide the order in which marks open on the current text node.
+   *
+   * The mark array on a node is assumed to be in ProseMirror's canonical
+   * order (rank ascending, where rank = extension registration index).
+   * This serializer treats array-last as outermost, so a higher-rank mark
+   * naturally becomes the outer wrapper — link, registered after bold/italic
+   * in any reasonable inline-mark stack, ends up outside other delimiters
+   * without inspecting rendered markdown.
+   *
+   * The only adjustment is partitioning by lifetime: marks that end on this
+   * node must be inner relative to marks that continue into the next node,
+   * otherwise the delimiters interleave instead of nesting.
+   */
   private getMarksToOpenForSerialization(activeMarks: Map<string, any>, currentMarks: Map<string, any>, nextNode: any) {
     const marksToOpen = findMarksToOpen(activeMarks, currentMarks)
 
@@ -1303,24 +1317,10 @@ export class MarkdownManager {
 
     const nextMarkTypes = new Set((nextNode?.marks || []).map((mark: any) => mark.type))
 
-    const orderedMarksToOpen = [
+    return [
       ...marksToOpen.filter(mark => !nextMarkTypes.has(mark.type)),
       ...marksToOpen.filter(mark => nextMarkTypes.has(mark.type)),
     ]
-
-    // Marks that end on this node need to open first so marks that continue
-    // into the next node become the outer wrapper around them.
-    return [
-      ...orderedMarksToOpen.filter(mark => !this.shouldOpenMarkAfterSiblings(mark.type, mark.mark)),
-      ...orderedMarksToOpen.filter(mark => this.shouldOpenMarkAfterSiblings(mark.type, mark.mark)),
-    ]
-  }
-
-  private shouldOpenMarkAfterSiblings(markType: string, mark: any): boolean {
-    const opening = this.getMarkOpening(markType, mark)
-    const closing = this.getMarkClosing(markType, mark)
-
-    return opening.endsWith('[') && /^\]\([^\s].*\)$/.test(closing)
   }
 }
 


### PR DESCRIPTION
## Changes Overview

Fix markdown serialization for overlapping marks when a link contains partially emphasized text at the start of its label. The markdown serializer now normalizes marks using the markdown manager's extension registration order, which keeps serialization aligned with the schema order produced by Tiptap/ProseMirror.

This fixes the reported case where applying italic to the leading portion of link text could serialize as `*[google* search](https://google.com)` instead of `[*google* search](https://google.com)`.

## Implementation Approach

I reproduced the bug with an editor-driven regression test that follows the reported command sequence, then updated `MarkdownManager` to sort marks for serialization by extension load order instead of relying on the incidental order of `node.marks`.

The test coverage includes:
- direct serializer regressions for partial italic and bold inside link text
- an editor-level repro using `Editor`, `Link`, `Italic`, and `Markdown`
- roundtrip validation against the markdown-relevant JSON shape

## Testing Done

- `pnpm vitest run packages/markdown/__tests__/overlapping-marks.spec.ts`

## Verification Steps

1. Create an editor with `Document`, `Paragraph`, `Text`, `Link`, `Italic`, and `Markdown`.
2. Insert `google search`.
3. Select all text and apply a link with `https://google.com`.
4. Select only `google` and apply italic.
5. Call `editor.getMarkdown()`.
6. Verify the result is `[*google* search](https://google.com)`.
7. Reparse the markdown and verify the emphasized text remains inside the link label.

## Additional Notes

A JSON-only serializer test did not reproduce the issue until the test matched the editor-produced mark ordering. The failing case came from the editor producing `[link, italic]` on the first text node, which exposed that serialization was order-sensitive in a way it should not be.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

- Closes #7553