### PR TITLE
fix(react): enhance attribute handling in ReactRenderer and update Ma…

### DIFF
--- a/.changeset/smooth-eggs-cheer.md
+++ b/.changeset/smooth-eggs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+fix MarkView link handling

--- a/packages/react/src/ReactMarkViewRenderer.tsx
+++ b/packages/react/src/ReactMarkViewRenderer.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import type { MarkViewProps, MarkViewRenderer, MarkViewRendererOptions } from '@tiptap/core'
 import { MarkView } from '@tiptap/core'
+import type { Mark } from '@tiptap/pm/model'
 import React from 'react'
 
 // import { flushSync } from 'react-dom'
@@ -27,7 +28,7 @@ export const MarkViewContent = <T extends keyof React.JSX.IntrinsicElements = 's
 
   return (
     // @ts-ignore
-    <Tag {...rest} ref={markViewContentRef} data-mark-view-content="" />
+    <Tag {...rest} ref={markViewContentRef} />
   )
 }
 
@@ -55,6 +56,7 @@ export class ReactMarkView extends MarkView<React.ComponentType<MarkViewProps>, 
     const componentProps = { ...props, updateAttributes: this.updateAttributes.bind(this) } satisfies MarkViewProps
 
     this.contentDOMElement = document.createElement('span')
+    this.contentDOMElement.dataset.markViewContent = ''
 
     const markViewContentRef: MarkViewContextProps['markViewContentRef'] = el => {
       if (el && !el.contains(this.contentDOMElement)) {
@@ -76,13 +78,22 @@ export class ReactMarkView extends MarkView<React.ComponentType<MarkViewProps>, 
     })
 
     ReactMarkViewProvider.displayName = 'ReactMarkView'
+    const tag = props.mark.type.name === 'link' ? 'a' : as
 
     this.renderer = new ReactRenderer(ReactMarkViewProvider, {
       editor: props.editor,
       props: componentProps,
-      as,
+      as: tag,
       className: `mark-${props.mark.type.name} ${className}`.trim(),
     })
+
+    if (props.mark.type.name === 'link') {
+      this.renderer.updateAttributes({
+        href: props.mark.attrs.href,
+        target: props.mark.attrs.target,
+        rel: props.mark.attrs.rel,
+      })
+    }
 
     if (attrs) {
       this.renderer.updateAttributes(attrs)
@@ -95,6 +106,28 @@ export class ReactMarkView extends MarkView<React.ComponentType<MarkViewProps>, 
 
   get contentDOM() {
     return this.contentDOMElement
+  }
+
+  update(mark: Mark) {
+    if (mark.type !== this.mark.type) {
+      return false
+    }
+
+    this.mark = mark
+
+    this.renderer.updateProps({
+      mark,
+    })
+
+    if (mark.type.name === 'link') {
+      this.renderer.updateAttributes({
+        href: mark.attrs.href,
+        target: mark.attrs.target,
+        rel: mark.attrs.rel,
+      })
+    }
+
+    return true
   }
 }
 

--- a/packages/react/src/ReactMarkViewRenderer.tsx
+++ b/packages/react/src/ReactMarkViewRenderer.tsx
@@ -28,7 +28,7 @@ export const MarkViewContent = <T extends keyof React.JSX.IntrinsicElements = 's
 
   return (
     // @ts-ignore
-    <Tag {...rest} ref={markViewContentRef} />
+    <Tag {...rest} ref={markViewContentRef} data-mark-view-content="" />
   )
 }
 
@@ -56,7 +56,6 @@ export class ReactMarkView extends MarkView<React.ComponentType<MarkViewProps>, 
     const componentProps = { ...props, updateAttributes: this.updateAttributes.bind(this) } satisfies MarkViewProps
 
     this.contentDOMElement = document.createElement('span')
-    this.contentDOMElement.dataset.markViewContent = ''
 
     const markViewContentRef: MarkViewContextProps['markViewContentRef'] = el => {
       if (el && !el.contains(this.contentDOMElement)) {

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -273,9 +273,14 @@ export class ReactRenderer<R = unknown, P extends Record<string, any> = object> 
   /**
    * Update the attributes of the element that holds the React component.
    */
-  updateAttributes(attributes: Record<string, string>): void {
-    Object.keys(attributes).forEach(key => {
-      this.element.setAttribute(key, attributes[key])
+  updateAttributes(attributes: Record<string, string | null | undefined>): void {
+    Object.entries(attributes).forEach(([key, value]) => {
+      if (value == null) {
+        this.element.removeAttribute(key)
+        return
+      }
+
+      this.element.setAttribute(key, value)
     })
   }
 }


### PR DESCRIPTION
…rkView for link support

## Changes Overview

Fixes an issue with ReactMarkViewRenderer where typing at the end of a link could insert text outside of the link’s contentDOM, leading to DOM/state inconsistencies and cursor issues.

## Implementation Approach

The issue was caused by the mark view rendering an extra wrapper element around the semantic <a> element:

```
<span class="react-renderer mark-link">
  <a>...</a>
</span>
```

This created a DOM boundary where the browser could insert text inside the mark view wrapper but outside the actual link content, which ProseMirror does not reconcile into state.

The fix ensures that the mark view dom itself is the semantic element (e.g. <a> for link marks), removing the extra wrapper and preventing invalid insertion points. Link attributes are now applied directly to the mark view DOM, and kept in sync via the update lifecycle method.

## Testing Done

- Reproduced the issue locally by typing at the end of a link using a custom ReactMarkViewRenderer
- Verified that previously, text was inserted outside the link DOM and not reflected in editor state
- Confirmed that after the fix:
    - Typed text remains inside the link
    - Editor state and DOM remain in sync
    - Cursor behaviour is correct

## Verification Steps

- Create a custom link mark view using ReactMarkViewRenderer
- Insert a link (e.g. “world wide web”)
- Place the cursor at the end of the link text
- Type any character

Expected result:
- The typed character is appended inside the link
- The editor state reflects the change
- No text is inserted outside the <a> element

Buggy version

https://github.com/user-attachments/assets/93dda2d6-8457-46c5-a460-fdc0ae49a632

Fixed Version


https://github.com/user-attachments/assets/68330798-6481-4140-a8fd-530cb0758a3b



## Additional Notes

This change also simplifies usage for link mark views. Instead of wrapping MarkViewContent in an <a> element, the renderer now handles the outer DOM element:

ReactMarkViewRenderer(() => <MarkViewContent />)

This avoids duplicating semantic wrappers and prevents DOM structure issues.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#7771 
