### PR TITLE
fix(core): release extension parent/child graph on Editor.destroy() to prevent memory leak

### DIFF
--- a/.changeset/ninety-icons-hide.md
+++ b/.changeset/ninety-icons-hide.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fixed a memory leak where `Editor.destroy()` did not release the Extension parent/child graph. Module-scope extension singletons retained references to configured extensions, preventing garbage collection of extension options (including DOM closures). The fix also cleans up `ExtensionManager`, `schema`, and `commandManager` references on destroy.

--- a/packages/core/__tests__/extendExtensions.spec.ts
+++ b/packages/core/__tests__/extendExtensions.spec.ts
@@ -495,4 +495,40 @@ describe('parent/child cleanup on destroy', () => {
       }
     })
   })
+
+  it('should break all ancestor child links in a multi-level extend chain after editor.destroy()', () => {
+    const root = Extension.create({
+      name: 'root',
+      addOptions() {
+        return { level: 0 }
+      },
+    })
+
+    const child = root.extend({
+      addOptions() {
+        return { ...this.parent?.(), level: 1 }
+      },
+    })
+
+    const grandchild = child.extend({
+      addOptions() {
+        return { ...this.parent?.(), level: 2 }
+      },
+    })
+
+    expect(root.child).toBe(child)
+    expect(child.child).toBe(grandchild)
+    expect(grandchild.parent).toBe(child)
+    expect(child.parent).toBe(root)
+
+    const editor = new Editor({
+      element: null,
+      extensions: [Document, Paragraph, Text, grandchild],
+    })
+
+    editor.destroy()
+
+    expect(root.child).toBeNull()
+    expect(child.child).toBeNull()
+  })
 })

--- a/packages/core/__tests__/extendExtensions.spec.ts
+++ b/packages/core/__tests__/extendExtensions.spec.ts
@@ -460,10 +460,9 @@ describe('parent/child cleanup on destroy', () => {
     editor.destroy()
 
     expect(singleton.child).toBeNull()
-    expect(childExtension.parent).toBeNull()
   })
 
-  it('should clear parent/child on all extensions after editor.destroy()', () => {
+  it('should clear forward parent.child links on all extensions after editor.destroy()', () => {
     const singletonA = Extension.create({
       name: 'extA',
       addOptions() {
@@ -490,8 +489,10 @@ describe('parent/child cleanup on destroy', () => {
     editor.destroy()
 
     extensions.forEach(ext => {
-      expect(ext.parent).toBeNull()
-      expect(ext.child).toBeNull()
+      if (ext.parent?.child === ext) {
+        // This should never be true after destroy — the forward link is always broken
+        expect(ext.parent.child).toBeNull()
+      }
     })
   })
 })

--- a/packages/core/__tests__/extendExtensions.spec.ts
+++ b/packages/core/__tests__/extendExtensions.spec.ts
@@ -1,4 +1,7 @@
-import { Extension, getExtensionField, Mark, Node } from '@tiptap/core'
+import { Editor, Extension, getExtensionField, Mark, Node } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
 import { describe, expect, it } from 'vitest'
 
 declare module '@tiptap/core' {
@@ -413,6 +416,82 @@ describe('extend extensions', () => {
           overwrite: 'child',
         })
       })
+    })
+  })
+})
+
+describe('parent/child cleanup on destroy', () => {
+  it('should not leak child reference when configure() is called on a singleton', () => {
+    const singleton = Extension.create({
+      name: 'testExtension',
+      addOptions() {
+        return { foo: 'bar' }
+      },
+    })
+
+    const configuredExtension = singleton.configure({ foo: 'baz' })
+
+    expect(singleton.child).toBeNull()
+    expect(configuredExtension.parent).toBeNull()
+  })
+
+  it('should break parent/child chain when editor is destroyed (extend path)', () => {
+    const singleton = Extension.create({
+      name: 'testExtension',
+      addOptions() {
+        return { foo: 'bar' }
+      },
+    })
+
+    const childExtension = singleton.extend({
+      addOptions() {
+        return { ...this.parent?.(), foo: 'baz' }
+      },
+    })
+
+    expect(singleton.child).toBe(childExtension)
+    expect(childExtension.parent).toBe(singleton)
+
+    const editor = new Editor({
+      element: null,
+      extensions: [Document, Paragraph, Text, childExtension],
+    })
+
+    editor.destroy()
+
+    expect(singleton.child).toBeNull()
+    expect(childExtension.parent).toBeNull()
+  })
+
+  it('should clear parent/child on all extensions after editor.destroy()', () => {
+    const singletonA = Extension.create({
+      name: 'extA',
+      addOptions() {
+        return { value: 'a' }
+      },
+    })
+    const singletonB = Extension.create({
+      name: 'extB',
+      addOptions() {
+        return { value: 'b' }
+      },
+    })
+
+    const configuredA = singletonA.configure({ value: 'a-configured' })
+    const childB = singletonB.extend({ name: 'extB-child' })
+
+    const editor = new Editor({
+      element: null,
+      extensions: [Document, Paragraph, Text, configuredA, childB],
+    })
+
+    const { extensions } = editor.extensionManager
+
+    editor.destroy()
+
+    extensions.forEach(ext => {
+      expect(ext.parent).toBeNull()
+      expect(ext.child).toBeNull()
     })
   })
 })

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -769,6 +769,11 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.unmount()
 
     this.removeAllListeners()
+
+    this.extensionManager.destroy()
+    this.extensionManager = null as any
+    this.schema = null as any
+    this.commandManager = null as any
   }
 
   /**

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -782,6 +782,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.extensionManager = null as any
     this.schema = null as any
     this.commandManager = null as any
+    this.extensionStorage = {} as Storage
   }
 
   /**

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -68,6 +68,8 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   public isFocused = false
 
+  private destroyed = false
+
   private editorState!: EditorState
 
   /**
@@ -764,6 +766,12 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Destroy the editor.
    */
   public destroy(): void {
+    if (this.destroyed) {
+      return
+    }
+
+    this.destroyed = true
+
     this.emit('destroy')
 
     this.unmount()

--- a/packages/core/src/Extendable.ts
+++ b/packages/core/src/Extendable.ts
@@ -580,6 +580,8 @@ export class Extendable<
     extension.name = this.name
     extension.parent = this.parent
 
+    this.child = null
+
     return extension
   }
 

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -369,7 +369,22 @@ export class ExtensionManager {
    */
   destroy() {
     this.extensions.forEach(extension => {
-      let current: any = extension
+      // Break the forward link from extension's parent, but only if it
+      // actually points to this extension (another editor may have since
+      // called extend/configure on the same singleton, overwriting .child).
+      if (extension.parent?.child === extension) {
+        extension.parent.child = null
+      }
+
+      // Clear references on the extension itself
+      extension.parent = null
+      extension.child = null
+
+      // Walk up the ancestor chain to clean back-references.
+      // We do NOT null ancestor.child here — that pointer may belong
+      // to a different editor's extension chain created from the same
+      // module-scope singleton.
+      let current = extension.parent
 
       while (current) {
         const parent = current.parent
@@ -379,7 +394,6 @@ export class ExtensionManager {
         }
 
         current.parent = null
-        current.child = null
         current = parent
       }
     })

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -368,12 +368,14 @@ export class ExtensionManager {
    * to prevent memory leaks through parent/child extension chains.
    *
    * Walks each extension's full parent chain and nulls every forward
-   * `parent.child → current` link. This breaks the retention path from
-   * module-scope singleton roots through deep extend() chains.
+   * `parent.child → current` link where the parent still points to the
+   * current node. This breaks the retention path from module-scope
+   * singleton roots through deep extend() chains.
    *
-   * Does NOT mutate `extension.parent`/`extension.child` on the extensions
-   * themselves — they may be shared across live editors, so their own
-   * fields must remain intact.
+   * Only ancestor `.child` links matching the current chain are cleared.
+   * The `.parent` pointer on ancestors is never touched — extensions
+   * may be shared across live editors, so their own backward references
+   * and non-matching forward links must remain intact.
    */
   destroy() {
     this.extensions.forEach(extension => {

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -364,6 +364,33 @@ export class ExtensionManager {
   }
 
   /**
+   * Destroy the extension manager and clean up all extension references
+   * to prevent memory leaks through parent/child extension chains.
+   */
+  destroy() {
+    this.extensions.forEach(extension => {
+      let current: any = extension
+
+      while (current) {
+        const parent = current.parent
+
+        if (parent?.child === current) {
+          parent.child = null
+        }
+
+        current.parent = null
+        current.child = null
+        current = parent
+      }
+    })
+
+    this.extensions = []
+    this.baseExtensions = []
+    this.schema = null as any
+    this.editor = null as any
+  }
+
+  /**
    * Go through all extensions, create extension storages & setup marks
    * & bind editor event listener.
    */

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -366,35 +366,16 @@ export class ExtensionManager {
   /**
    * Destroy the extension manager and clean up all extension references
    * to prevent memory leaks through parent/child extension chains.
+   *
+   * Only nulls the forward `parent.child → extension` link, which is the
+   * leak anchor (module-scope singletons holding child references prevents
+   * GC). Does NOT mutate `extension.parent`/`extension.child` — extensions
+   * may be shared across live editors, so their own fields must remain intact.
    */
   destroy() {
     this.extensions.forEach(extension => {
-      // Break the forward link from extension's parent, but only if it
-      // actually points to this extension (another editor may have since
-      // called extend/configure on the same singleton, overwriting .child).
       if (extension.parent?.child === extension) {
         extension.parent.child = null
-      }
-
-      // Clear references on the extension itself
-      extension.parent = null
-      extension.child = null
-
-      // Walk up the ancestor chain to clean back-references.
-      // We do NOT null ancestor.child here — that pointer may belong
-      // to a different editor's extension chain created from the same
-      // module-scope singleton.
-      let current = extension.parent
-
-      while (current) {
-        const parent = current.parent
-
-        if (parent?.child === current) {
-          parent.child = null
-        }
-
-        current.parent = null
-        current = parent
       }
     })
 

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -367,15 +367,26 @@ export class ExtensionManager {
    * Destroy the extension manager and clean up all extension references
    * to prevent memory leaks through parent/child extension chains.
    *
-   * Only nulls the forward `parent.child → extension` link, which is the
-   * leak anchor (module-scope singletons holding child references prevents
-   * GC). Does NOT mutate `extension.parent`/`extension.child` — extensions
-   * may be shared across live editors, so their own fields must remain intact.
+   * Walks each extension's full parent chain and nulls every forward
+   * `parent.child → current` link. This breaks the retention path from
+   * module-scope singleton roots through deep extend() chains.
+   *
+   * Does NOT mutate `extension.parent`/`extension.child` on the extensions
+   * themselves — they may be shared across live editors, so their own
+   * fields must remain intact.
    */
   destroy() {
     this.extensions.forEach(extension => {
-      if (extension.parent?.child === extension) {
-        extension.parent.child = null
+      let current: any = extension
+
+      while (current.parent) {
+        const parent = current.parent
+
+        if (parent.child === current) {
+          parent.child = null
+        }
+
+        current = parent
       }
     })
 


### PR DESCRIPTION
## Changes Overview

Fixes a memory leak where `Editor.destroy()` did not release the Extension parent/child graph. Module-scope extension singletons retained references to configured extensions via `Extendable.child`, preventing garbage collection of extension options (including DOM closures).

## Implementation Approach

Three changes:

1. **`Extendable.configure()`** — null `this.child` after overriding `extension.parent`. `configure()` delegates to `extend()` which sets up a bidirectional link, but then immediately breaks consistency by overriding the parent reference. The stale `child` pointer is now cleared to prevent the leak at its source.

2. **`ExtensionManager.destroy()`** — new method that walks each extension's full parent chain and nulls every forward `parent.child → current` link where the parent still points to the current node. Does NOT mutate `extension.parent`/`extension.child` on the extensions themselves (they may be shared across live editors). Also clears internal references (`extensions`, `baseExtensions`, `schema`, `editor`).

3. **`Editor.destroy()`** — calls `extensionManager.destroy()` and nulls `extensionManager`, `schema`, `commandManager`, and `extensionStorage` to prevent the Editor instance from anchoring extensions after destroy. Idempotent via a `destroyed` flag.

## Testing Done

- Added 4 new tests in `packages/core/__tests__/extendExtensions.spec.ts`:
  - `configure()` no longer leaks child reference on singletons
  - `editor.destroy()` breaks parent/child chain via `extend()` path
  - All forward `parent.child` links are cleared on destroy
  - **Multi-level extend chain**: grandchild's entire ancestor chain is cleaned (root.child → null, child.child → null)
- All 300 core tests pass (28 test files) with no regressions
- All 14 `unmounted.spec.ts` tests pass (directly exercises `Editor.destroy()`)

## Verification Steps

1. Create an extension via `Extension.create()`
2. Call `.extend()` or `.configure()` on it (creates parent/child link)
3. Create an `Editor` with the resulting extension
4. Call `editor.destroy()`
5. Verify `singleton.child === null` and all ancestor child links are cleared

## Additional Notes

Closes #7769, root cause of #538 (long-standing reported symptom).

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7769, relates to #538