### PR TITLE
fix(markdown): handle empty initial markdown content

### DIFF
--- a/.changeset/clean-bobcats-double.md
+++ b/.changeset/clean-bobcats-double.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Fix editor becoming unresponsive when initialized with empty markdown content and `contentType: 'markdown'`

--- a/packages/markdown/__tests__/empty-content.spec.ts
+++ b/packages/markdown/__tests__/empty-content.spec.ts
@@ -1,0 +1,55 @@
+import { Editor } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { Markdown } from '@tiptap/markdown'
+import { describe, expect, it } from 'vitest'
+
+describe('empty markdown content', () => {
+  it('should create a valid document when initial content is an empty string', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, Markdown],
+      content: '',
+      contentType: 'markdown',
+    })
+
+    const json = editor.getJSON()
+
+    expect(json.type).toBe('doc')
+    expect(json.content).toBeDefined()
+    expect(json.content).toHaveLength(1)
+    expect(json.content![0].type).toBe('paragraph')
+
+    editor.destroy()
+  })
+
+  it('should allow inserting text after initialization with empty markdown content', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, Markdown],
+      content: '',
+      contentType: 'markdown',
+    })
+
+    editor.commands.insertContent('Hello')
+
+    const json = editor.getJSON()
+    expect(json.content![0].content![0].text).toBe('Hello')
+
+    editor.destroy()
+  })
+
+  it('should allow inserting text with a paragraph command after initialization with empty markdown content', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, Markdown],
+      content: '',
+      contentType: 'markdown',
+    })
+
+    editor.commands.insertContentAt(0, { type: 'text', text: 'Hello' })
+
+    const json = editor.getJSON()
+    expect(json.content![0].content![0].text).toBe('Hello')
+
+    editor.destroy()
+  })
+})

--- a/packages/markdown/__tests__/empty-content.spec.ts
+++ b/packages/markdown/__tests__/empty-content.spec.ts
@@ -1,13 +1,20 @@
 import { Editor } from '@tiptap/core'
+import { Bold } from '@tiptap/extension-bold'
 import { Document } from '@tiptap/extension-document'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
 import { Markdown } from '@tiptap/markdown'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 describe('empty markdown content', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
   it('should create a valid document when initial content is an empty string', () => {
-    const editor = new Editor({
+    editor = new Editor({
       extensions: [Document, Paragraph, Text, Markdown],
       content: '',
       contentType: 'markdown',
@@ -19,12 +26,10 @@ describe('empty markdown content', () => {
     expect(json.content).toBeDefined()
     expect(json.content).toHaveLength(1)
     expect(json.content![0].type).toBe('paragraph')
-
-    editor.destroy()
   })
 
   it('should allow inserting text after initialization with empty markdown content', () => {
-    const editor = new Editor({
+    editor = new Editor({
       extensions: [Document, Paragraph, Text, Markdown],
       content: '',
       contentType: 'markdown',
@@ -33,13 +38,11 @@ describe('empty markdown content', () => {
     editor.commands.insertContent('Hello')
 
     const json = editor.getJSON()
-    expect(json.content![0].content![0].text).toBe('Hello')
-
-    editor.destroy()
+    expect((json.content![0].content![0] as any).text).toBe('Hello')
   })
 
   it('should allow inserting text with a paragraph command after initialization with empty markdown content', () => {
-    const editor = new Editor({
+    editor = new Editor({
       extensions: [Document, Paragraph, Text, Markdown],
       content: '',
       contentType: 'markdown',
@@ -48,8 +51,38 @@ describe('empty markdown content', () => {
     editor.commands.insertContentAt(0, { type: 'text', text: 'Hello' })
 
     const json = editor.getJSON()
-    expect(json.content![0].content![0].text).toBe('Hello')
+    expect((json.content![0].content![0] as any).text).toBe('Hello')
+  })
 
-    editor.destroy()
+  it('should allow inserting markdown-formatted content after initialization with empty markdown content', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Bold, Markdown],
+      content: '',
+      contentType: 'markdown',
+    })
+
+    editor.commands.insertContent('**bold**', { contentType: 'markdown' })
+
+    const json = editor.getJSON()
+    const textNode = json.content![0].content![0] as any
+    expect(textNode.type).toBe('text')
+    expect(textNode.text).toBe('bold')
+    expect(textNode.marks?.[0]?.type).toBe('bold')
+  })
+
+  it('should allow inserting markdown-formatted content at a specific position after empty initialization', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Bold, Markdown],
+      content: '',
+      contentType: 'markdown',
+    })
+
+    editor.commands.insertContentAt(0, '**bold**', { contentType: 'markdown' })
+
+    const json = editor.getJSON()
+    const textNode = json.content![0].content![0] as any
+    expect(textNode.type).toBe('text')
+    expect(textNode.text).toBe('bold')
+    expect(textNode.marks?.[0]?.type).toBe('bold')
   })
 })

--- a/packages/markdown/src/Extension.ts
+++ b/packages/markdown/src/Extension.ts
@@ -208,6 +208,12 @@ export const Markdown = Extension.create<MarkdownExtensionOptions, MarkdownExten
     }
 
     const json = this.editor.markdown.parse(this.editor.options.content as string)
-    this.editor.options.content = json
+
+    // If the parsed markdown produced no content, leave options.content
+    // as-is (empty string) so that createDoc / DOMParser.parse can fill in
+    // the required block node via ProseMirror's ContentMatch.fillBefore.
+    if (json.content?.length) {
+      this.editor.options.content = json
+    }
   },
 })


### PR DESCRIPTION
## Changes Overview

Fixes an issue where using the `Markdown` extension with `contentType: 'markdown'` and an empty string as initial content would produce an invalid ProseMirror document, making the editor unresponsive to typing.

## Implementation Approach

`MarkdownManager.parse('')` returns `{ type: 'doc', content: [] }` — a document with no children. This violates the `doc` schema's `block+` content expression, so any subsequent transaction is rejected.

Rather than manually inserting a paragraph, the fix lets ProseMirror's own `DOMParser` handle empty content. When the parsed markdown produces zero children, the `onBeforeCreate` hook no longer overrides `this.editor.options.content`, leaving it as the original empty string. The normal `createDoc` → `DOMParser.parse` path then calls `ContentMatch.fillBefore(Fragment.empty, true)`, which automatically inserts the required default block node to satisfy the schema.

## Testing Done

- Added 3 regression tests in `packages/markdown/__tests__/empty-content.spec.ts` covering:
  - Editor creates a valid doc from empty markdown content
  - Editor accepts `insertContent` after init
  - Editor accepts `insertContentAt` after init
- All 297 core tests pass
- All 178 markdown tests pass (1 pre-existing failure in `paragraph.spec.ts` is unrelated)

## Verification Steps

1. Create an Editor with `contentType: 'markdown'` and `content: ''`
2. Verify `editor.getJSON()` returns a document with a single paragraph node
3. Verify `editor.commands.insertContent('Hello')` works

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

Closes #7157