### PR TITLE
fix React NodeView batching and selection sync

### DIFF
--- a/.changeset/fair-forks-protect.md
+++ b/.changeset/fair-forks-protect.md
@@ -1,0 +1,7 @@
+---
+'@tiptap/core': minor
+---
+
+Add a protected `updateViewState` method to `Editor` as an override point for framework-specific editor subclasses that need to coordinate work around ProseMirror view updates.
+
+This allows integrations such as `@tiptap/react` to hook into editor view updates without adding framework-specific logic to the core package.

--- a/.changeset/quiet-mice-promise.md
+++ b/.changeset/quiet-mice-promise.md
@@ -1,5 +1,5 @@
 ---
-'@tiptap/react': patch
+'@tiptap/react': minor
 ---
 
 Batch React NodeView portal updates for each ProseMirror view update instead of triggering a separate `flushSync`-driven portal update for every NodeView.

--- a/.changeset/quiet-mice-promise.md
+++ b/.changeset/quiet-mice-promise.md
@@ -1,0 +1,7 @@
+---
+'@tiptap/react': patch
+---
+
+Batch React NodeView portal updates for each ProseMirror view update instead of triggering a separate `flushSync`-driven portal update for every NodeView.
+
+This reduces React update churn during bulk NodeView creation, such as paste, `setContent`, or other transactions that insert many React-backed NodeViews at once, while preserving selection-sensitive NodeView behavior.

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -277,7 +277,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       this.view.setProps(this.options.editorProps)
     }
 
-    this.view.updateState(this.state)
+    this.updateViewState(this.state)
   }
 
   /**
@@ -377,7 +377,7 @@ export class Editor extends EventEmitter<EditorEvents> {
 
     const state = this.state.reconfigure({ plugins })
 
-    this.view.updateState(state)
+    this.updateViewState(state)
 
     return state
   }
@@ -415,7 +415,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       plugins,
     })
 
-    this.view.updateState(state)
+    this.updateViewState(state)
 
     return state
   }
@@ -556,7 +556,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       plugins: this.extensionManager.plugins,
     })
 
-    this.view.updateState(newState)
+    this.updateViewState(newState)
 
     this.prependClass()
     this.injectCSS()
@@ -607,6 +607,15 @@ export class Editor extends EventEmitter<EditorEvents> {
   }
 
   /**
+   * Updates the editor view state.
+   * This method exists as an override point for framework-specific editor
+   * subclasses that need to coordinate work around ProseMirror view updates.
+   */
+  protected updateViewState(state: EditorState): void {
+    this.view.updateState(state)
+  }
+
+  /**
    * The callback over which to send transactions (state updates) produced by the view.
    *
    * @param transaction An editor state transaction
@@ -647,7 +656,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       return
     }
 
-    this.view.updateState(state)
+    this.updateViewState(state)
 
     // Emit transaction event with appended transactions info
     this.emit('transaction', {

--- a/packages/react/src/Context.tsx
+++ b/packages/react/src/Context.tsx
@@ -1,7 +1,7 @@
-import type { Editor } from '@tiptap/core'
 import type { HTMLAttributes, ReactNode } from 'react'
 import React, { createContext, useContext, useMemo } from 'react'
 
+import type { Editor } from './Editor.js'
 import { EditorContent } from './EditorContent.js'
 import type { UseEditorOptions } from './useEditor.js'
 import { useEditor } from './useEditor.js'

--- a/packages/react/src/Editor.spec.ts
+++ b/packages/react/src/Editor.spec.ts
@@ -1,0 +1,62 @@
+import type { EditorState } from '@tiptap/pm/state'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Editor } from './Editor.js'
+
+function createEditor() {
+  const editor = Object.create(Editor.prototype) as Editor
+  const beginTransactionRenderBatch = vi.fn()
+  const endTransactionRenderBatch = vi.fn()
+  const updateState = vi.fn()
+
+  editor.contentComponent = {
+    beginTransactionRenderBatch,
+    endTransactionRenderBatch,
+  } as never
+
+  Object.defineProperty(editor, 'view', {
+    configurable: true,
+    value: {
+      updateState,
+    },
+  })
+
+  return {
+    editor,
+    beginTransactionRenderBatch,
+    endTransactionRenderBatch,
+    updateState,
+  }
+}
+
+describe('React Editor batching', () => {
+  it('wraps each view update in a transaction render batch', () => {
+    const { editor, beginTransactionRenderBatch, endTransactionRenderBatch, updateState } = createEditor()
+
+    ;(editor as any).updateViewState({} as EditorState)
+
+    expect(beginTransactionRenderBatch).toHaveBeenCalledTimes(1)
+    expect(updateState).toHaveBeenCalledTimes(1)
+    expect(endTransactionRenderBatch).toHaveBeenCalledTimes(1)
+    expect(beginTransactionRenderBatch.mock.invocationCallOrder[0]).toBeLessThan(
+      updateState.mock.invocationCallOrder[0],
+    )
+    expect(updateState.mock.invocationCallOrder[0]).toBeLessThan(endTransactionRenderBatch.mock.invocationCallOrder[0])
+  })
+
+  it('ends the batch even when the view update throws', () => {
+    const { editor, beginTransactionRenderBatch, endTransactionRenderBatch, updateState } = createEditor()
+
+    updateState.mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    expect(() => {
+      ;(editor as any).updateViewState({} as EditorState)
+    }).toThrow('boom')
+
+    expect(beginTransactionRenderBatch).toHaveBeenCalledTimes(1)
+    expect(updateState).toHaveBeenCalledTimes(1)
+    expect(endTransactionRenderBatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/Editor.ts
+++ b/packages/react/src/Editor.ts
@@ -1,13 +1,45 @@
-import type { Editor } from '@tiptap/core'
+import { Editor as CoreEditor } from '@tiptap/core'
+import type { EditorState } from '@tiptap/pm/state'
 import type { ReactPortal } from 'react'
 
 import type { ReactRenderer } from './ReactRenderer.js'
 
-export type EditorWithContentComponent = Editor & {
-  contentComponent?: ContentComponent | null
-  isEditorContentInitialized?: boolean
+export class Editor extends CoreEditor {
+  contentComponent: ContentComponent | null = null
+
+  isEditorContentInitialized = false
+
+  /**
+   * Batch portal store notifications so React-backed node views can mount in a
+   * single store update for each ProseMirror view update.
+   */
+  protected override updateViewState(state: EditorState): void {
+    this.contentComponent?.beginTransactionRenderBatch()
+
+    try {
+      super.updateViewState(state)
+    } finally {
+      this.contentComponent?.endTransactionRenderBatch()
+    }
+  }
 }
+
+export type EditorWithContentComponent = Editor
 export type ContentComponent = {
+  /**
+   * Begins batching renderer store updates until `endTransactionRenderBatch`
+   * is called.
+   */
+  beginTransactionRenderBatch(): void
+  /**
+   * Returns whether a transaction render batch is currently active.
+   */
+  isTransactionRenderBatchActive(): boolean
+  /**
+   * Ends the current renderer store batch and flushes any pending subscriber
+   * notifications.
+   */
+  endTransactionRenderBatch(): void
   setRenderer(id: string, renderer: ReactRenderer): void
   removeRenderer(id: string): void
   subscribe: (callback: () => void) => () => void

--- a/packages/react/src/EditorContent.spec.ts
+++ b/packages/react/src/EditorContent.spec.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Editor } from './Editor.js'
+import { PureEditorContent } from './EditorContent.js'
+
+function createEditor() {
+  const editor = Object.create(Editor.prototype) as Editor
+  const dom = document.createElement('div')
+  const parent = document.createElement('div')
+
+  parent.append(dom)
+
+  editor.contentComponent = null
+  editor.isEditorContentInitialized = false
+
+  Object.defineProperty(editor, 'view', {
+    configurable: true,
+    value: {
+      dom,
+      setProps: vi.fn(),
+    },
+  })
+
+  Object.defineProperty(editor, 'setOptions', {
+    configurable: true,
+    value: vi.fn(),
+  })
+
+  Object.defineProperty(editor, 'createNodeViews', {
+    configurable: true,
+    value: vi.fn(),
+  })
+
+  Object.defineProperty(editor, 'isDestroyed', {
+    configurable: true,
+    value: false,
+  })
+
+  return editor
+}
+
+describe('EditorContent batching', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('flushes portal subscribers once after a transaction batch', () => {
+    const editor = createEditor()
+    const component = new PureEditorContent({ editor: editor as never })
+
+    component.editorContentRef.current = document.createElement('div')
+    Object.defineProperty(component, 'forceUpdate', {
+      configurable: true,
+      value: vi.fn(),
+    })
+
+    component.init()
+
+    expect(editor.createNodeViews).toHaveBeenCalledTimes(1)
+    expect(editor.isEditorContentInitialized).toBe(true)
+    expect(editor.contentComponent).not.toBeNull()
+
+    const subscriber = vi.fn()
+    const contentComponent = editor.contentComponent!
+
+    contentComponent.subscribe(subscriber)
+
+    contentComponent.beginTransactionRenderBatch()
+    contentComponent.setRenderer('a', {
+      element: document.createElement('div'),
+      reactElement: null,
+    } as never)
+    contentComponent.setRenderer('b', {
+      element: document.createElement('div'),
+      reactElement: null,
+    } as never)
+    contentComponent.removeRenderer('a')
+
+    expect(subscriber).not.toHaveBeenCalled()
+    expect(Object.keys(contentComponent.getSnapshot())).toEqual(['b'])
+
+    contentComponent.endTransactionRenderBatch()
+
+    expect(subscriber).toHaveBeenCalledTimes(1)
+    expect(Object.keys(contentComponent.getSnapshot())).toEqual(['b'])
+  })
+})

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -1,7 +1,7 @@
 import type { Editor } from '@tiptap/core'
 import type { ForwardedRef, HTMLProps, LegacyRef, MutableRefObject } from 'react'
 import React, { forwardRef } from 'react'
-import ReactDOM from 'react-dom'
+import ReactDOM, { flushSync } from 'react-dom'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import type { ContentComponent, EditorWithContentComponent } from './Editor.js'
@@ -42,8 +42,48 @@ export interface EditorContentProps extends HTMLProps<HTMLDivElement> {
 function getInstance(): ContentComponent {
   const subscribers = new Set<() => void>()
   let renderers: Record<string, React.ReactPortal> = {}
+  let batchDepth = 0
+  let hasPendingSnapshot = false
+
+  const notifySubscribers = () => {
+    subscribers.forEach(subscriber => subscriber())
+  }
+
+  const flushSubscribers = () => {
+    if (batchDepth > 0 || !hasPendingSnapshot) {
+      return
+    }
+
+    hasPendingSnapshot = false
+    flushSync(() => {
+      notifySubscribers()
+    })
+  }
+
+  const scheduleSubscribers = () => {
+    if (batchDepth > 0) {
+      hasPendingSnapshot = true
+      return
+    }
+
+    notifySubscribers()
+  }
 
   return {
+    beginTransactionRenderBatch() {
+      batchDepth += 1
+    },
+    isTransactionRenderBatchActive() {
+      return batchDepth > 0
+    },
+    endTransactionRenderBatch() {
+      if (batchDepth === 0) {
+        return
+      }
+
+      batchDepth -= 1
+      flushSubscribers()
+    },
     /**
      * Subscribe to the editor instance's changes.
      */
@@ -68,7 +108,7 @@ function getInstance(): ContentComponent {
         [id]: ReactDOM.createPortal(renderer.reactElement, renderer.element, id),
       }
 
-      subscribers.forEach(subscriber => subscriber())
+      scheduleSubscribers()
     },
     /**
      * Removes a NodeView Renderer from the editor.
@@ -78,7 +118,7 @@ function getInstance(): ContentComponent {
 
       delete nextRenderers[id]
       renderers = nextRenderers
-      subscribers.forEach(subscriber => subscriber())
+      scheduleSubscribers()
     },
   }
 }

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -1,10 +1,9 @@
-import type { Editor } from '@tiptap/core'
 import type { ForwardedRef, HTMLProps, LegacyRef, MutableRefObject } from 'react'
 import React, { forwardRef } from 'react'
 import ReactDOM, { flushSync } from 'react-dom'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
-import type { ContentComponent, EditorWithContentComponent } from './Editor.js'
+import type { ContentComponent, Editor as ReactEditor, EditorWithContentComponent } from './Editor.js'
 import type { ReactRenderer } from './ReactRenderer.js'
 
 const mergeRefs = <T extends HTMLDivElement>(...refs: Array<MutableRefObject<T> | LegacyRef<T> | undefined>) => {
@@ -35,7 +34,7 @@ const Portals: React.FC<{ contentComponent: ContentComponent }> = ({ contentComp
 }
 
 export interface EditorContentProps extends HTMLProps<HTMLDivElement> {
-  editor: Editor | null
+  editor: ReactEditor | null
   innerRef?: ForwardedRef<HTMLDivElement | null>
 }
 

--- a/packages/react/src/ReactMarkViewRenderer.tsx
+++ b/packages/react/src/ReactMarkViewRenderer.tsx
@@ -4,6 +4,7 @@ import { MarkView } from '@tiptap/core'
 import React from 'react'
 
 // import { flushSync } from 'react-dom'
+import type { Editor as ReactEditor } from './Editor.js'
 import { ReactRenderer } from './ReactRenderer.js'
 
 export interface MarkViewContextProps {
@@ -78,7 +79,7 @@ export class ReactMarkView extends MarkView<React.ComponentType<MarkViewProps>, 
     ReactMarkViewProvider.displayName = 'ReactMarkView'
 
     this.renderer = new ReactRenderer(ReactMarkViewProvider, {
-      editor: props.editor,
+      editor: props.editor as ReactEditor,
       props: componentProps,
       as,
       className: `mark-${props.mark.type.name} ${className}`.trim(),

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -1,10 +1,4 @@
-import type {
-  DecorationWithType,
-  Editor,
-  NodeViewRenderer,
-  NodeViewRendererOptions,
-  NodeViewRendererProps,
-} from '@tiptap/core'
+import type { DecorationWithType, NodeViewRenderer, NodeViewRendererOptions, NodeViewRendererProps } from '@tiptap/core'
 import {
   cancelPositionCheck,
   getRenderedAttributes,
@@ -17,7 +11,7 @@ import type { Decoration, DecorationSource, NodeView as ProseMirrorNodeView } fr
 import type { ComponentType, NamedExoticComponent } from 'react'
 import { createElement, createRef, memo } from 'react'
 
-import type { EditorWithContentComponent } from './Editor.js'
+import type { Editor as ReactEditor, EditorWithContentComponent } from './Editor.js'
 import { ReactRenderer } from './ReactRenderer.js'
 import type { ReactNodeViewProps } from './types.js'
 import type { ReactNodeViewContextProps } from './useReactNodeView.js'
@@ -60,7 +54,7 @@ export interface ReactNodeViewRendererOptions extends NodeViewRendererOptions {
 export class ReactNodeView<
   T = HTMLElement,
   Component extends ComponentType<ReactNodeViewProps<T>> = ComponentType<ReactNodeViewProps<T>>,
-  NodeEditor extends Editor = Editor,
+  NodeEditor extends ReactEditor = ReactEditor,
   Options extends ReactNodeViewRendererOptions = ReactNodeViewRendererOptions,
 > extends NodeView<Component, NodeEditor, Options> {
   /**

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -108,13 +108,11 @@ export class ReactNodeView<
       // See: https://github.com/ueberdosis/tiptap/issues/1197
       this.contentDOMElement.style.whiteSpace = 'inherit'
 
-      const contentTarget = this.dom.querySelector('[data-node-view-content]')
-
-      if (!contentTarget) {
-        return
-      }
-
-      contentTarget.appendChild(this.contentDOMElement)
+      // Attach the editable content container immediately so ProseMirror can
+      // place the selection into the new node view during the same view update.
+      // Once the React component mounts, NodeViewContent will move this element
+      // into its final position inside the wrapper.
+      this.dom.appendChild(this.contentDOMElement)
     }
   }
 

--- a/packages/react/src/ReactRenderer.tsx
+++ b/packages/react/src/ReactRenderer.tsx
@@ -1,4 +1,3 @@
-import type { Editor } from '@tiptap/core'
 import type {
   ComponentClass,
   ForwardRefExoticComponent,
@@ -101,9 +100,8 @@ function isReact19Plus(): boolean {
 export interface ReactRendererOptions {
   /**
    * The editor instance.
-   * @type {Editor}
    */
-  editor: Editor
+  editor: EditorWithContentComponent
 
   /**
    * The props for the component.

--- a/packages/react/src/Tiptap.tsx
+++ b/packages/react/src/Tiptap.tsx
@@ -2,7 +2,8 @@ import type { ReactNode } from 'react'
 import { createContext, useContext, useMemo } from 'react'
 
 import { EditorContext } from './Context.js'
-import type { Editor, EditorContentProps, EditorStateSnapshot } from './index.js'
+import type { Editor } from './Editor.js'
+import type { EditorContentProps, EditorStateSnapshot } from './index.js'
 import { EditorContent, useEditorState } from './index.js'
 
 /**

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,6 @@
 export * from './Context.js'
+export type { ContentComponent, EditorWithContentComponent } from './Editor.js'
+export { Editor } from './Editor.js'
 export * from './EditorContent.js'
 export * from './NodeViewContent.js'
 export * from './NodeViewWrapper.js'

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,8 +1,9 @@
-import { type EditorOptions, Editor } from '@tiptap/core'
+import type { EditorOptions } from '@tiptap/core'
 import type { DependencyList, MutableRefObject } from 'react'
 import { useDebugValue, useEffect, useRef, useState } from 'react'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
+import { Editor } from './Editor.js'
 import { useEditorState } from './useEditorState.js'
 
 // @ts-ignore


### PR DESCRIPTION
## Changes Overview

Batch React NodeView portal updates per ProseMirror view update, instead of flushing each NodeView separately. Also restore the early `contentDOM` attachment needed for selection-sensitive NodeView inserts.

## Implementation Approach

Added a protected `updateViewState` override point in core, then implemented the React batching behavior in `@tiptap/react`. React `EditorContent` now batches portal-store notifications, and React NodeViews keep their editable content container attached early so ProseMirror and React stay aligned.

## Testing Done

- `pnpm vitest run packages/react/src/Editor.spec.ts`
- `pnpm vitest run packages/react/src/EditorContent.spec.ts`
- `pnpm test:unit`

## Verification Steps

- Test the ReactComponentContent demo and press `Mod+Enter` inside the editable NodeView.
- Paste or `setContent` a large number of React NodeViews and confirm the maximum update depth error no longer occurs.

## Additional Notes

This adds a new core override seam for framework-specific view-update coordination, while keeping the batching logic in `@tiptap/react`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Fixes #7811