### PR TITLE
chore(link): bump linkify to 4.3.3

### DIFF
--- a/.changeset/rotten-apes-sneeze.md
+++ b/.changeset/rotten-apes-sneeze.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-link': patch
 ---
 
-Bumped linkify to ^4.3.3 to improve link recognition & fix a bug with chinese character encoding breaking the links when followed by parantheses
+Bumped linkify to ^4.3.3 to improve link recognition & fix a bug with chinese character encoding breaking the links when followed by parentheses

--- a/.changeset/rotten-apes-sneeze.md
+++ b/.changeset/rotten-apes-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-link': patch
+---
+
+Bumped linkify to ^4.3.3 to improve link recognition & fix a bug with chinese character encoding breaking the links when followed by parantheses

--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "dependencies": {
-    "linkifyjs": "^4.3.2"
+    "linkifyjs": "^4.3.3"
   },
   "devDependencies": {
     "@tiptap/core": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -772,8 +772,8 @@ importers:
   packages/extension-link:
     dependencies:
       linkifyjs:
-        specifier: ^4.3.2
-        version: 4.3.2
+        specifier: ^4.3.3
+        version: 4.3.3
     devDependencies:
       '@tiptap/core':
         specifier: workspace:^
@@ -5467,6 +5467,9 @@ packages:
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
   lint-staged@15.4.1:
     resolution: {integrity: sha512-P8yJuVRyLrm5KxCtFx+gjI5Bil+wO7wnTl7C3bXhvtTaAFGirzeB24++D0wGoUwxrUKecNiehemgCob9YL39NA==}
@@ -12271,6 +12274,8 @@ snapshots:
       uc.micro: 2.1.0
 
   linkifyjs@4.3.2: {}
+
+  linkifyjs@4.3.3: {}
 
   lint-staged@15.4.1:
     dependencies:


### PR DESCRIPTION
## Changes Overview

Bumps linkify.js from 4.3.2 to 4.3.3.

## Implementation Approach

Updated the version in `packages/extension-link/package.json` and ran `pnpm install` to update the lockfile.

## Testing Done

Existing link tests pass.

## Verification Steps

Check that `linkifyjs` resolves to 4.3.3 in `packages/extension-link/`.

## Additional Notes

N/A

## Checklist

- [x] I have created a changeset for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

- Fixes https://github.com/ueberdosis/tiptap/issues/7632