### PR TITLE
Relax peer dependency requirements of Server AI Toolkit library

### DIFF
--- a/.changeset/lazy-games-ring.md
+++ b/.changeset/lazy-games-ring.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/server-ai-toolkit': patch
+---
+
+Relax peer dependency requirements so that the library is compatible with any version of Tiptap 3

--- a/packages/server-ai-toolkit/package.json
+++ b/packages/server-ai-toolkit/package.json
@@ -34,8 +34,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "@tiptap/core": "workspace:*",
-    "@tiptap/pm": "workspace:*"
+    "@tiptap/core": "^3.0.1",
+    "@tiptap/pm": "^3.0.1"
   },
   "devDependencies": {
     "@tiptap/core": "workspace:^",


### PR DESCRIPTION
## Changes Overview

Relax peer dependency requirements so that the library is compatible with any version of Tiptap 3

## Implementation Approach

Edit peerDependencies field

## Testing Done

ran `pnpm i` and verified that nothing changed in the lockfile

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
