### PR TITLE
fix: extra mark tokens after inline atom nodes during Markdown serialization (#7827)

### DIFF
--- a/.changeset/chilly-lamps-applaud.md
+++ b/.changeset/chilly-lamps-applaud.md
@@ -2,4 +2,4 @@
 "@tiptap/markdown": patch
 ---
 
-Fix extra mark tokens after inline atom nodes during Markdown serialization (#7827)
+Fix extra mark tokens after inline atom nodes during Markdown serialization

--- a/.changeset/chilly-lamps-applaud.md
+++ b/.changeset/chilly-lamps-applaud.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/markdown": patch
+---
+
+Fix extra mark tokens after inline atom nodes during Markdown serialization (#7827)

--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -687,6 +687,30 @@ Final paragraph.`
     })
   })
 
+  /**
+   * Regression: bold text before inline atom node must not reopen bold after atom.
+   * @see https://github.com/ueberdosis/tiptap/issues/7827
+   */
+  it('does not reopen marks after inline atom that does not carry them', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Bold ', marks: [{ type: 'bold' }] },
+            { type: 'tag', attrs: { label: 'node' } },
+            { type: 'text', text: ' some text' },
+          ],
+        },
+      ],
+    }
+
+    const markdown = markdownManager.renderNodes(doc)
+    // Trailing space is moved outside bold markers (per Issue #7180 whitespace convention)
+    expect(markdown).toBe('**Bold** [tag label="node"] some text')
+  })
+
   describe('Round-trip Tests', () => {
     beforeEach(() => {
       markdownManager = new MarkdownManager({ extensions: extendedExtensions })

--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -687,10 +687,6 @@ Final paragraph.`
     })
   })
 
-  /**
-   * Regression: bold text before inline atom node must not reopen bold after atom.
-   * @see https://github.com/ueberdosis/tiptap/issues/7827
-   */
   it('does not reopen marks after inline atom that does not carry them', () => {
     const doc = {
       type: 'doc',

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1186,8 +1186,16 @@ export class MarkdownManager {
         result.push(textContent)
       } else {
         // For non-text nodes, close all active marks before rendering, then reopen after
-        const marksToReopen = new Map(activeMarks)
-        const openingModesToReopen = new Map(markOpeningModes)
+        // Only reopen marks that the node itself carries — marks don't skip over inline atoms.
+        const nodeMarkTypes = new Set((node.marks || []).map((mark: { type: string }) => mark.type))
+        const marksToReopen = new Map<string, { type: string; attrs?: Record<string, any> }>()
+        const openingModesToReopen = new Map<string, 'markdown' | 'html'>()
+        activeMarks.forEach((mark, type) => {
+          if (nodeMarkTypes.has(type)) {
+            marksToReopen.set(type, mark)
+            openingModesToReopen.set(type, markOpeningModes.get(type) ?? 'markdown')
+          }
+        })
 
         // Close all marks before the node
         const beforeMarkdown = closeMarksBeforeNode(activeMarks, (markType, mark) => {

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -63,19 +63,18 @@ export function findMarksToCloseAtEnd(
   activeMarks: Map<string, any>,
   currentMarks: Map<string, any>,
   nextNode: any,
-  markSetsEqual: (a: Map<string, any>, b: Map<string, any>) => boolean,
+  markSetsEqual: (a: Map<string, { type: string }>, b: Map<string, { type: string }>) => boolean,
 ): string[] {
   const isLastNode = !nextNode
-  const nextNodeHasNoMarks = nextNode && nextNode.type === 'text' && (!nextNode.marks || nextNode.marks.length === 0)
+  const nextNodeHasNoMarks = nextNode && (!nextNode.marks || nextNode.marks.length === 0)
   const nextNodeHasDifferentMarks =
     nextNode &&
-    nextNode.type === 'text' &&
     nextNode.marks &&
     !markSetsEqual(currentMarks, new Map(nextNode.marks.map((mark: any) => [mark.type, mark])))
 
   const marksToCloseAtEnd: string[] = []
   if (isLastNode || nextNodeHasNoMarks || nextNodeHasDifferentMarks) {
-    if (nextNode && nextNode.type === 'text' && nextNode.marks) {
+    if (nextNode && nextNode.marks) {
       const nextMarks = new Map(nextNode.marks.map((mark: any) => [mark.type, mark]))
       Array.from(activeMarks.keys())
         .reverse()


### PR DESCRIPTION
## Changes Overview

Fix markdown serializer producing extra mark tokens (e.g. `**`) after inline atom nodes that don't carry those marks.

## Implementation Approach

Two localized fixes in the markdown serializer:

1. **`findMarksToCloseAtEnd` (`utils.ts`)** — removed `nextNode.type === 'text'` guard so non-text inline atoms without matching marks are correctly detected as mark boundaries.

2. **Non-text node handling (`MarkdownManager.ts`)** — only reopen marks after a non-text node if the node itself carries those marks (checking `node.marks`). Previously all active marks were blindly reopened.

## Testing Done

- Added regression test: bold text → inline atom (no bold) → plain text → produces `**Bold** [tag label="node"] some text`
- All 182 markdown package tests pass
- Full unit test suite: 880/880 tests, 94/95 suites pass (pre-existing `server-ai-toolkit` failure unrelated)

## Verification Steps

1. Checkout branch, run `pnpm vitest run packages/markdown`
2. Verify bold text before inline atom node serializes correctly without extra `**` tokens

## Additional Notes

The trailing space in bold text is moved outside mark delimiters per the existing Issue #7180 whitespace convention. This produces `**Bold** [tag...` rather than `**Bold **[tag...`, which is valid and intended.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7827