### PR TITLE
fix(details): prevent ghost details node after drag-and-drop

### DIFF
--- a/packages/extension-details/src/details.ts
+++ b/packages/extension-details/src/details.ts
@@ -8,7 +8,7 @@ import {
   Node,
 } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
-import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state'
+import { Plugin, PluginKey, Selection, TextSelection, NodeSelection } from '@tiptap/pm/state'
 import type { ViewMutationRecord } from '@tiptap/pm/view'
 
 import { findClosestVisibleNode } from './helpers/findClosestVisibleNode.js'
@@ -443,6 +443,54 @@ export const Details = Node.create<DetailsOptions>({
       // The cursor is moved to the next visible position.
       new Plugin({
         key: new PluginKey('detailsSelection'),
+        // Ensure dragging from a summary moves the entire details node
+        props: {
+          handleDOMEvents: {
+            dragstart: (view, event) => {
+              const target = event.target
+
+              const element =
+                target instanceof HTMLElement
+                  ? target
+                  : target instanceof Text
+                    ? target.parentElement
+                    : null
+
+              if (!element) {
+                return false
+              }
+
+              const summary = element.closest('summary')
+
+              if (!summary) {
+                return false
+              }
+
+              const { $from } = view.state.selection
+
+              for (let depth = $from.depth; depth > 0; depth--) {
+                const node = $from.node(depth)
+
+                if (node.type.name === 'details') {
+                  const detailsPos = $from.before(depth)
+
+                  const selection = NodeSelection.create(
+                    view.state.doc,
+                    detailsPos,
+                  )
+
+                  view.dispatch(
+                    view.state.tr.setSelection(selection),
+                  )
+
+                  break
+                }
+              }
+
+              return false
+            },
+          },
+        },
         appendTransaction: (transactions, oldState, newState) => {
           const { editor, type } = this
           const isComposing = editor.view.composing


### PR DESCRIPTION
## Changes Overview

Fixes an issue where dragging selected text from a `detailsSummary`
would leave behind an empty details node.

## Implementation Approach

Dragging text inside a summary was previously treated as a text selection drag,
causing ProseMirror to reconstruct a new details node at the drop location
while leaving the original details structure behind.

This fix upgrades drags originating inside a `<summary>` to a
`NodeSelection` for the parent `details` node before the drag operation proceeds.

This ensures the entire details node is moved instead of only the selected text slice.

## Testing Done

Tested locally using the official Tiptap details-summary demo.

Verified:
- dragging partial summary text
- dragging full summary text
- dragging expanded details blocks
- dragging nested details blocks
- normal paragraph dragging remains unaffected

## Verification Steps

1. Open the details-summary demo
2. Select text inside a summary
3. Drag the selection
4. Verify the entire details node moves correctly
5. Verify no empty duplicated details node remains behind

## Additional Notes

The fix preserves ProseMirror drag behavior by upgrading the selection
to a `NodeSelection` before the drag operation proceeds.

## AI Assistance

Used AI assistance for debugging discussion and reasoning while implementing and testing the fix locally.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues

Closes #7824