### PR TITLE
fix(extension-hard-break): preserve trailing breaks on paste

### DIFF
--- a/.changeset/quiet-rivers-break.md
+++ b/.changeset/quiet-rivers-break.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-hard-break": patch
+---
+
+Preserve trailing hard break nodes when pasting Tiptap clipboard HTML.

--- a/packages/extension-hard-break/__tests__/hard-break.spec.ts
+++ b/packages/extension-hard-break/__tests__/hard-break.spec.ts
@@ -1,0 +1,51 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import { HardBreak } from '@tiptap/extension-hard-break'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { __parseFromClipboard } from '@tiptap/pm/view'
+import { describe, expect, it } from 'vitest'
+
+describe('HardBreak', () => {
+  const transform = HardBreak.config.transformPastedHTML?.bind({} as any)
+
+  it('preserves trailing hard breaks through the clipboard parser', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, HardBreak],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: Array.from({ length: 6 }, () => ({ type: 'hardBreak' })),
+          },
+        ],
+      },
+    })
+    const originalSlice = editor.state.doc.slice(0, editor.state.doc.content.size)
+    const { dom } = editor.view.serializeForClipboard(originalSlice)
+    const parsedSlice = __parseFromClipboard(
+      editor.view,
+      '',
+      dom.innerHTML,
+      false,
+      editor.state.selection.$from,
+    )
+
+    expect(parsedSlice.content.toJSON()).toEqual(originalSlice.content.toJSON())
+  })
+
+  it('marks trailing hard breaks from Tiptap clipboard HTML', () => {
+    const html = '<div data-pm-slice="1 1 []"><p>Example<br><br></p></div>'
+
+    expect(transform?.(html)).toBe(
+      '<div data-pm-slice="1 1 []"><p>Example<br><br><!--tiptap-preserve-trailing-hard-break--></p></div>',
+    )
+  })
+
+  it('leaves non-Tiptap clipboard HTML unchanged', () => {
+    const html = '<p>Example<br><br></p>'
+
+    expect(transform?.(html)).toBe(html)
+  })
+})

--- a/packages/extension-hard-break/src/hard-break.ts
+++ b/packages/extension-hard-break/src/hard-break.ts
@@ -1,5 +1,31 @@
 import { mergeAttributes, Node } from '@tiptap/core'
 
+function preserveTrailingHardBreaks(html: string): string {
+  if (!html.includes('data-pm-slice') || !/<br[\s>]/i.test(html) || typeof window === 'undefined') {
+    return html
+  }
+
+  const document = new window.DOMParser().parseFromString(html, 'text/html')
+
+  if (!document.body.querySelector('[data-pm-slice]')) {
+    return html
+  }
+
+  const preserve = (element: Element) => {
+    Array.from(element.children).forEach(child => preserve(child))
+
+    const lastChild = element.lastElementChild
+
+    if (lastChild?.tagName === 'BR' && !lastChild.classList.contains('ProseMirror-trailingBreak')) {
+      element.appendChild(document.createComment('tiptap-preserve-trailing-hard-break'))
+    }
+  }
+
+  preserve(document.body)
+
+  return document.body.innerHTML
+}
+
 export interface HardBreakOptions {
   /**
    * Controls if marks should be kept after being split by a hard break.
@@ -70,6 +96,10 @@ export const HardBreak = Node.create<HardBreakOptions>({
     return {
       type: 'hardBreak',
     }
+  },
+
+  transformPastedHTML(html) {
+    return preserveTrailingHardBreaks(html)
   },
 
   addCommands() {


### PR DESCRIPTION
## Changes Overview
Fixes trailing hard-break loss when pasting Tiptap/ProseMirror clipboard HTML by marking real trailing `<br>` nodes before ProseMirror's clipboard parser can discard them as disposable trailing breaks.

## Implementation Approach
- adds a narrow `transformPastedHTML` hook to `extension-hard-break`
- only transforms Tiptap clipboard HTML that contains `data-pm-slice`
- uses DOM parsing instead of regex rewriting, and ignores `.ProseMirror-trailingBreak` hack nodes
- adds a regression spec that round-trips six trailing hard breaks through `serializeForClipboard` and `__parseFromClipboard`
- adds a patch changeset for `@tiptap/extension-hard-break`

## Testing Done
- `git diff --check origin/main...HEAD`
- `git diff --check`

I did not run the full package test suite in this workspace because dependencies are not installed and local disk is very tight.

## AI usage disclosure
This contribution was prepared with AI assistance and reviewed before submission.

Closes #5418.