### PR TITLE
Fix trailing hard breaks being dropped on paste

### DIFF
--- a/.changeset/clear-hard-break-paste.md
+++ b/.changeset/clear-hard-break-paste.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-hard-break": patch
+---
+
+Preserve trailing hard breaks when pasting HTML copied from Tiptap editors.

--- a/packages/extension-hard-break/__tests__/hard-break.spec.ts
+++ b/packages/extension-hard-break/__tests__/hard-break.spec.ts
@@ -1,0 +1,31 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { __parseFromClipboard } from '@tiptap/pm/view'
+import { describe, expect, it } from 'vitest'
+
+import { HardBreak } from '../src/index.js'
+
+describe('HardBreak', () => {
+  it('preserves trailing hard breaks when pasting Tiptap clipboard HTML', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, HardBreak],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: Array.from({ length: 6 }, () => ({ type: 'hardBreak' })),
+          },
+        ],
+      },
+    })
+    const originalSlice = editor.state.doc.slice(0, editor.state.doc.content.size)
+    const { dom } = editor.view.serializeForClipboard(originalSlice)
+    const clipboardHTML = dom.innerHTML
+    const parsedSlice = __parseFromClipboard(editor.view, '', clipboardHTML, false, editor.state.selection.$from)
+
+    expect(parsedSlice.content.toJSON()).toEqual(originalSlice.content.toJSON())
+  })
+})

--- a/packages/extension-hard-break/src/hard-break.ts
+++ b/packages/extension-hard-break/src/hard-break.ts
@@ -1,5 +1,35 @@
 import { mergeAttributes, Node } from '@tiptap/core'
 
+function preserveTrailingHardBreaks(html: string): string {
+  if (!html.includes('data-pm-slice') || !/<br[\s>]/i.test(html) || typeof window === 'undefined') {
+    return html
+  }
+
+  const document = new window.DOMParser().parseFromString(html, 'text/html')
+
+  if (!document.body.querySelector('[data-pm-slice]')) {
+    return html
+  }
+
+  const preserveTrailingBreaks = (element: Element | HTMLElement) => {
+    Array.from(element.children).forEach(child => preserveTrailingBreaks(child))
+
+    const lastChild = element.lastChild
+
+    if (
+      lastChild?.nodeType === 1 &&
+      (lastChild as Element).tagName === 'BR' &&
+      !(lastChild as Element).classList.contains('ProseMirror-trailingBreak')
+    ) {
+      element.appendChild(document.createComment('tiptap-preserve-trailing-hard-break'))
+    }
+  }
+
+  preserveTrailingBreaks(document.body)
+
+  return document.body.innerHTML
+}
+
 export interface HardBreakOptions {
   /**
    * Controls if marks should be kept after being split by a hard break.
@@ -58,6 +88,10 @@ export const HardBreak = Node.create<HardBreakOptions>({
 
   renderHTML({ HTMLAttributes }) {
     return ['br', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)]
+  },
+
+  transformPastedHTML(html) {
+    return preserveTrailingHardBreaks(html)
   },
 
   renderText() {


### PR DESCRIPTION
## Changes Overview

Preserve trailing hard breaks when HTML copied from a Tiptap editor is pasted back into a Tiptap editor.

## Implementation Approach

The hard break extension now transforms ProseMirror clipboard HTML that contains `data-pm-slice`. When an actual trailing `<br>` would otherwise be treated as ProseMirror's disposable trailing break, the transform appends a comment sentinel after it so the clipboard parser keeps the hardBreak node. Existing `.ProseMirror-trailingBreak` hack nodes are still ignored.

## Testing Done

- `corepack pnpm exec vitest run packages/extension-hard-break/__tests__/hard-break.spec.ts`
- `corepack pnpm exec vitest run packages/extension-hard-break/__tests__/hard-break.spec.ts packages/core/src/__tests__/transformPastedHTML.test.ts`
- `corepack pnpm exec prettier --check packages/extension-hard-break/src/hard-break.ts packages/extension-hard-break/__tests__/hard-break.spec.ts .changeset/clear-hard-break-paste.md`
- `corepack pnpm exec eslint packages/extension-hard-break/src/hard-break.ts packages/extension-hard-break/__tests__/hard-break.spec.ts`
- `corepack pnpm --filter @tiptap/extension-hard-break build`

## Verification Steps

1. Type a paragraph that ends with multiple hard breaks.
2. Copy the paragraph from a Tiptap editor.
3. Paste it back into a Tiptap editor.
4. Confirm the pasted paragraph keeps the same number of hard breaks.

## Additional Notes

None.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
- [x] If yes, describe which tools were used and how they contributed to this PR:
  Codex was used to inspect the ProseMirror clipboard behavior, draft the patch, and run local validation commands.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #5418