### PR TITLE
fix(react): respect explicit immediatelyRender on client-side Next.js

### DIFF
--- a/.changeset/fix-react-respect-immediately-render-on-next.md
+++ b/.changeset/fix-react-respect-immediately-render-on-next.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Respect explicit `immediatelyRender: true` in client-side Next.js. Previously, when running under Next.js (`window.next` present), the `immediatelyRender` option was forced to `false` even when the user explicitly passed `true`, breaking client-only Next.js apps that rely on the editor existing on the first render. The hook now only forces `false` when actual SSR is detected (`typeof window === 'undefined'`), or when running under Next.js with no explicit value.

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -93,12 +93,20 @@ class EditorInstanceManager {
   }
 
   private getInitialEditor() {
-    let immediatelyRender = this.options.current.immediatelyRender ?? true
+    const explicit = this.options.current.immediatelyRender
+    let immediatelyRender = explicit ?? true
 
-    if (immediatelyRender && (isSSR || isNext)) {
+    if (isSSR) {
+      if (immediatelyRender && isDev) {
+        console.warn('SSR detected. `immediatelyRender` has been set to false to avoid hydration mismatches')
+      }
+      immediatelyRender = false
+    } else if (isNext && explicit === undefined) {
       immediatelyRender = false
       if (isDev) {
-        console.warn('SSR detected. `immediatelyRender` has been set to false to avoid hydration mismatches')
+        console.warn(
+          'Next.js detected. `immediatelyRender` defaults to false to avoid hydration mismatches. Pass `immediatelyRender: true` explicitly if you are rendering the editor only on the client.',
+        )
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #7761. That PR made `useEditor` default `immediatelyRender` to `false` whenever `isSSR || isNext` was true, including when the user **explicitly** passed `immediatelyRender: true`. That broke client-only Next.js apps that mount the editor only on the client and rely on it existing on the first render.

## The bug

`isNext` is true on the client whenever `window.next` is set, which is essentially every Next.js app — SSR or not. The previous logic:

```ts
let immediatelyRender = this.options.current.immediatelyRender ?? true

if (immediatelyRender && (isSSR || isNext)) {
  immediatelyRender = false
  // …warn
}
```

ignored the user's explicit value entirely whenever `isNext` was true. There is no way to opt back in to immediate rendering in a Next.js client component.

## The fix

- **SSR (`typeof window === 'undefined'`)**: always force `immediatelyRender = false` (crashes otherwise). Warn in dev if the user explicitly asked for `true`.
- **Client + Next.js, no explicit value**: default to `false` for safety, warn in dev with a hint about how to opt in.
- **Client + Next.js, explicit `true`**: respect the user's choice. No warning, no override.
- **Plain client (non-Next)**: unchanged — defaults to `true`.

```ts
const explicit = this.options.current.immediatelyRender
let immediatelyRender = explicit ?? true

if (isSSR) {
  if (immediatelyRender && isDev) {
    console.warn('SSR detected. `immediatelyRender` has been set to false to avoid hydration mismatches')
  }
  immediatelyRender = false
} else if (isNext && explicit === undefined) {
  immediatelyRender = false
  if (isDev) {
    console.warn(
      'Next.js detected. `immediatelyRender` defaults to false to avoid hydration mismatches. Pass `immediatelyRender: true` explicitly if you are rendering the editor only on the client.',
    )
  }
}
```

## Why

A common Next.js pattern is client-only components (e.g. `'use client'` with the editor mounted in a hook/effect, or behind a dynamic import with `ssr: false`). In those cases SSR genuinely doesn't run and `immediatelyRender: true` is the correct value — devs explicitly pass it to avoid the `editor === null` ergonomic tax on the first render. Silently overriding their explicit value made #7761 a regression for that use case.

The safer default (`false` for Next.js without an explicit value) is preserved. The only change is restoring the ability to opt back in.