### PR TITLE
Add test for inserting plain text content

### DIFF
--- a/packages/core/__tests__/insertContent.spec.ts
+++ b/packages/core/__tests__/insertContent.spec.ts
@@ -11,7 +11,7 @@ describe('insertContent', () => {
     editor?.destroy()
   })
 
-  it('inserts plain text object {type: "text", text: "whatever"}', () => {
+  it('inserts plain text object {type: "text", text: "world"}', () => {
     editor = new Editor({
       extensions: [Document, Paragraph, Text],
       content: '<p>hello</p>',

--- a/packages/core/__tests__/insertContent.spec.ts
+++ b/packages/core/__tests__/insertContent.spec.ts
@@ -1,0 +1,28 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+describe('insertContent', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('inserts plain text object {type: "text", text: "whatever"}', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>hello</p>',
+    })
+
+    // Place cursor at the end of "hello" (position 6)
+    editor.commands.setTextSelection(6)
+
+    const result = editor.commands.insertContent({ type: 'text', text: 'world' })
+
+    expect(result).toBe(true)
+    expect(editor.getHTML()).toBe('<p>helloworld</p>')
+  })
+})


### PR DESCRIPTION
## Changes Overview

Added a test to verify the functionality of inserting plain text content into the editor.

## Implementation Approach

Implemented a test case that initializes the editor, sets the cursor position, and checks the result of inserting plain text.

## Testing Done

Tested the insertion of plain text by asserting the expected HTML output after the operation.

## Verification Steps

Reviewers can run the test suite to ensure the new test passes and verify the insertion functionality.

## Additional Notes

No additional notes.

## AI Usage

- [ ] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
- [ ] If yes, describe which tools were used and how they contributed to this PR:
  <!-- Required if AI tools were used. Include enough detail for reviewers to understand the scope of the AI-generated contribution. -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
Related to #3008 to verify the issue is already fixed
<!-- Link the issue this PR addresses. The linked issue should also be assigned to you. PRs without a linked issue (except for trivial fixes) may be closed. -->

