### PR TITLE
fix(markdown): serialize adjacent marks with different attributes separately

### DIFF
--- a/.changeset/silent-baboons-explain.md
+++ b/.changeset/silent-baboons-explain.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/markdown": patch
+---
+
+Fix adjacent marks of the same type with different attributes being merged during Markdown serialization

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -12,24 +12,30 @@ import { describe, expect, it } from 'vitest'
 
 import { MarkdownManager } from '../src/MarkdownManager.js'
 
+/**
+ * Normalize marks order for deterministic comparison. Marks in the same position
+ * can be stored in any order by ProseMirror; sorting by type ensures
+ * deep-equality assertions don't flake on array ordering.
+ */
+const normalizeMarks = (node: any): any => {
+  if (Array.isArray(node)) {
+    return node.map(normalizeMarks)
+  }
+
+  if (!node || typeof node !== 'object') {
+    return node
+  }
+
+  return {
+    ...node,
+    marks: node.marks ? [...node.marks].sort((a: any, b: any) => a.type.localeCompare(b.type)) : node.marks,
+    content: node.content ? node.content.map(normalizeMarks) : node.content,
+  }
+}
+
 describe('Overlapping marks serialization', () => {
   const extensions = [Document, Paragraph, Text, Bold, Italic, Link]
   const markdownManager = new MarkdownManager({ extensions })
-  const normalizeMarks = (node: any): any => {
-    if (Array.isArray(node)) {
-      return node.map(normalizeMarks)
-    }
-
-    if (!node || typeof node !== 'object') {
-      return node
-    }
-
-    return {
-      ...node,
-      marks: node.marks ? [...node.marks].sort((a, b) => a.type.localeCompare(b.type)) : node.marks,
-      content: node.content ? node.content.map(normalizeMarks) : node.content,
-    }
-  }
 
   /**
    * Regression test for the original bug report.
@@ -541,19 +547,6 @@ describe('Overlapping marks serialization', () => {
 describe('adjacent marks with different attributes', () => {
   const extensions = [Document, Paragraph, Text, Link]
   const markdownManager = new MarkdownManager({ extensions })
-  const normalizeMarks = (node: any): any => {
-    if (Array.isArray(node)) {
-      return node.map(normalizeMarks)
-    }
-    if (!node || typeof node !== 'object') {
-      return node
-    }
-    return {
-      ...node,
-      marks: node.marks ? [...node.marks].sort((a: any, b: any) => a.type.localeCompare(b.type)) : node.marks,
-      content: node.content ? node.content.map(normalizeMarks) : node.content,
-    }
-  }
 
   it('should serialize adjacent links with different href values as separate links', () => {
     const json = {

--- a/packages/markdown/__tests__/overlapping-marks.spec.ts
+++ b/packages/markdown/__tests__/overlapping-marks.spec.ts
@@ -531,3 +531,128 @@ describe('Overlapping marks serialization', () => {
     expect(normalizeMarks(markdownManagerWithStrike.parse(result))).toEqual(normalizeMarks(json))
   })
 })
+
+/**
+ * Regression tests for issue #7682.
+ *
+ * Adjacent marks of the same type (e.g. links) with different attributes must
+ * be serialized as separate marks instead of being merged into one.
+ */
+describe('adjacent marks with different attributes', () => {
+  const extensions = [Document, Paragraph, Text, Link]
+  const markdownManager = new MarkdownManager({ extensions })
+  const normalizeMarks = (node: any): any => {
+    if (Array.isArray(node)) {
+      return node.map(normalizeMarks)
+    }
+    if (!node || typeof node !== 'object') {
+      return node
+    }
+    return {
+      ...node,
+      marks: node.marks ? [...node.marks].sort((a: any, b: any) => a.type.localeCompare(b.type)) : node.marks,
+      content: node.content ? node.content.map(normalizeMarks) : node.content,
+    }
+  }
+
+  it('should serialize adjacent links with different href values as separate links', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'example',
+              marks: [{ type: 'link', attrs: { href: 'https://example.com', title: null } }],
+            },
+            {
+              type: 'text',
+              text: 'github',
+              marks: [{ type: 'link', attrs: { href: 'https://github.com', title: null } }],
+            },
+            {
+              type: 'text',
+              text: 'tiptap',
+              marks: [{ type: 'link', attrs: { href: 'https://tiptap.dev', title: null } }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    // Each adjacent link must be rendered with its own URL — not merged into one
+    expect(result).toBe('[example](https://example.com)[github](https://github.com)[tiptap](https://tiptap.dev)')
+    // Verify round-trip fidelity
+    expect(normalizeMarks(markdownManager.parse(result))).toEqual(normalizeMarks(json))
+  })
+
+  it('should keep links with the same href and attributes merged', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'the same',
+              marks: [{ type: 'link', attrs: { href: 'https://example.com', title: null } }],
+            },
+            {
+              type: 'text',
+              text: ' link',
+              marks: [{ type: 'link', attrs: { href: 'https://example.com', title: null } }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    // Links with the same href and attributes are merged into one
+    expect(result).toBe('[the same link](https://example.com)')
+
+    // Verify re-serialization stability: parse then re-serialize produces the same output
+    const parsed = markdownManager.parse(result)
+    expect(markdownManager.serialize(parsed)).toBe(result)
+  })
+
+  it('should handle adjacent links with titles alongside links without titles', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'with title',
+              marks: [{ type: 'link', attrs: { href: 'https://example.com', title: 'Example' } }],
+            },
+            {
+              type: 'text',
+              text: ' no title',
+              marks: [{ type: 'link', attrs: { href: 'https://example.org', title: null } }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    // Note: the leading space in " no title" is extracted outside the link
+    // brackets by the serializer's whitespace handling, resulting in a space
+    // between the two link markdown fragments.
+    expect(result).toBe('[with title](https://example.com "Example") [no title](https://example.org)')
+
+    // Verify re-serialization stability: parse then re-serialize produces the same output
+    const parsed = markdownManager.parse(result)
+    expect(markdownManager.serialize(parsed)).toBe(result)
+  })
+})

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1325,9 +1325,6 @@ export class MarkdownManager {
   }
 
   /**
-   * Check if two mark sets are equal.
-   */
-  /**
    * Check if two mark sets are equal (same types and matching attributes).
    */
   private markSetsEqual(marks1: Map<string, any>, marks2: Map<string, any>): boolean {
@@ -1366,7 +1363,13 @@ export class MarkdownManager {
       return marksToOpen
     }
 
-    const nextMarkTypes = new Set((nextNode?.marks || []).map((mark: any) => mark.type))
+    const nextMarks = nextNode?.marks || []
+
+    // Helper: check if the next node has a mark with the same type AND
+    // matching attributes. Two marks of the same type but with different
+    // attributes are logically distinct and must not be treated as continuing.
+    const continuesInNextNode = (markType: string, attrs: any) =>
+      nextMarks.some((m: any) => m.type === markType && attrsEqual(m.attrs, attrs))
 
     // Higher rank → earlier in the array → innermost mark. Marks without a
     // recorded rank fall back to MAX_SAFE_INTEGER so they sort innermost,
@@ -1382,8 +1385,12 @@ export class MarkdownManager {
       return a.type.localeCompare(b.type)
     }
 
-    const endingHere = marksToOpen.filter(mark => !nextMarkTypes.has(mark.type)).sort(byRankInnerFirst)
-    const continuing = marksToOpen.filter(mark => nextMarkTypes.has(mark.type)).sort(byRankInnerFirst)
+    const endingHere = marksToOpen
+      .filter(mark => !continuesInNextNode(mark.type, mark.mark.attrs))
+      .sort(byRankInnerFirst)
+    const continuing = marksToOpen
+      .filter(mark => continuesInNextNode(mark.type, mark.mark.attrs))
+      .sort(byRankInnerFirst)
 
     return [...endingHere, ...continuing]
   }

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -21,6 +21,7 @@ import {
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
 
 import {
+  attrsEqual,
   closeMarksBeforeNode,
   findMarksToClose,
   findMarksToCloseAtEnd,
@@ -1326,12 +1327,18 @@ export class MarkdownManager {
   /**
    * Check if two mark sets are equal.
    */
+  /**
+   * Check if two mark sets are equal (same types and matching attributes).
+   */
   private markSetsEqual(marks1: Map<string, any>, marks2: Map<string, any>): boolean {
     if (marks1.size !== marks2.size) {
       return false
     }
 
-    return Array.from(marks1.keys()).every(type => marks2.has(type))
+    return Array.from(marks1.entries()).every(([type, mark]) => {
+      const otherMark = marks2.get(type)
+      return otherMark && attrsEqual(mark.attrs, otherMark.attrs)
+    })
   }
 
   /**

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -26,7 +26,8 @@ export function wrapInMarkdownBlock(prefix: string, content: string) {
 
 /**
  * Compare two attribute objects for equality.
- * Handles null/undefined and compares all keys.
+ * Handles null/undefined and asserts key presence in both objects so that
+ * `{ foo: undefined }` and `{ bar: undefined }` are not treated as equal.
  */
 export function attrsEqual(
   a: Record<string, any> | null | undefined,
@@ -46,7 +47,7 @@ export function attrsEqual(
     return false
   }
 
-  return keysA.every(key => a[key] === b[key])
+  return keysA.every(key => Object.prototype.hasOwnProperty.call(b, key) && Object.is(a[key], b[key]))
 }
 
 /**

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -25,13 +25,50 @@ export function wrapInMarkdownBlock(prefix: string, content: string) {
 }
 
 /**
+ * Compare two attribute objects for equality.
+ * Handles null/undefined and compares all keys.
+ */
+export function attrsEqual(
+  a: Record<string, any> | null | undefined,
+  b: Record<string, any> | null | undefined,
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+
+  if (keysA.length !== keysB.length) {
+    return false
+  }
+
+  return keysA.every(key => a[key] === b[key])
+}
+
+/**
  * Identifies marks that need to be closed, based on the marks in the next node.
+ * Compares both mark type and attributes — two marks of the same type with
+ * different attributes are treated as distinct and need to be closed/reopened.
  */
 export function findMarksToClose(currentMarks: Map<string, any>, nextNode: any): string[] {
   const marksToClose: string[] = []
 
-  Array.from(currentMarks.keys()).forEach(markType => {
-    if (!nextNode || !nextNode.marks || !nextNode.marks.map((mark: any) => mark.type).includes(markType)) {
+  Array.from(currentMarks.entries()).forEach(([markType, currentMark]) => {
+    if (!nextNode) {
+      marksToClose.push(markType)
+      return
+    }
+
+    // Check if the next node has a mark of the same type with matching attributes
+    const nextMark = (nextNode.marks || []).find(
+      (mark: any) => mark.type === markType && attrsEqual(mark.attrs, currentMark.attrs),
+    )
+
+    if (!nextMark) {
       marksToClose.push(markType)
     }
   })
@@ -39,7 +76,10 @@ export function findMarksToClose(currentMarks: Map<string, any>, nextNode: any):
 }
 
 /**
- * Identifies marks that need to be opened (in current node but not active).
+ * Identifies marks that need to be opened (in current node but not active, or
+ * active with different attributes). Two marks of the same type with different
+ * attributes are treated as distinct — the old one must be closed and the new
+ * one reopened.
  */
 export function findMarksToOpen(
   activeMarks: Map<string, any>,
@@ -47,7 +87,10 @@ export function findMarksToOpen(
 ): Array<{ type: string; mark: any }> {
   const marksToOpen: Array<{ type: string; mark: any }> = []
   Array.from(currentMarks.entries()).forEach(([markType, mark]) => {
-    if (!activeMarks.has(markType)) {
+    const activeMark = activeMarks.get(markType)
+
+    // Open if the mark type is not active, or if the attributes differ
+    if (!activeMark || !attrsEqual(activeMark.attrs, mark.attrs)) {
       marksToOpen.push({ type: markType, mark })
     }
   })
@@ -58,6 +101,8 @@ export function findMarksToOpen(
  * Determines which marks need to be closed at the end of the current text node.
  * This handles cases where marks end at node boundaries or when transitioning
  * to nodes with different mark sets.
+ * Compares both mark type and attributes — two marks of the same type with
+ * different attributes are treated as distinct and trigger a close/reopen.
  */
 export function findMarksToCloseAtEnd(
   activeMarks: Map<string, any>,
@@ -75,11 +120,12 @@ export function findMarksToCloseAtEnd(
   const marksToCloseAtEnd: string[] = []
   if (isLastNode || nextNodeHasNoMarks || nextNodeHasDifferentMarks) {
     if (nextNode && nextNode.marks) {
-      const nextMarks = new Map(nextNode.marks.map((mark: any) => [mark.type, mark]))
-      Array.from(activeMarks.keys())
+      Array.from(activeMarks.entries())
         .reverse()
-        .forEach(markType => {
-          if (!nextMarks.has(markType)) {
+        .forEach(([markType, activeMark]) => {
+          // Check if nextNode has a mark of the same type with matching attrs
+          const nextMark = nextNode.marks.find((m: any) => m.type === markType && attrsEqual(m.attrs, activeMark.attrs))
+          if (!nextMark) {
             marksToCloseAtEnd.push(markType)
           }
         })


### PR DESCRIPTION
## Changes Overview

Fix adjacent marks of the same type (e.g., links) with different attributes being merged into one when serializing to markdown. Three consecutive links with different URLs no longer produce `[examplegithubtiptap](https://tiptap.dev)` — instead they correctly render as `[example](https://example.com)[github](https://github.com)[tiptap](https://tiptap.dev)`.

## Implementation Approach

The mark boundary comparison logic (`findMarksToClose`, `findMarksToOpen`, `findMarksToCloseAtEnd`, `markSetsEqual`) only compared marks by **type name** — a `link` is a `link` regardless of its `href`. Added an `attrsEqual` helper and made all four comparison points **attr-aware**, so two marks of the same type with different attributes are correctly treated as distinct and closed/reopened at node boundaries.

## Testing Done

- Added 3 regression tests covering: different `href` values, same `href`/attributes (still merged), and links with/without titles
- All 185 tests pass across 11 test files
- All existing overlapping-marks tests continue to pass

## Verification Steps

1. Serialize a JSON document containing adjacent text nodes with link marks that have different `href` values
2. Verify each link produces its own `[...](url)` fragment
3. Verify links with identical `href`/attributes remain merged
4. Run the full test suite: `npx vitest run packages/markdown`

## Additional Notes

Fixes https://github.com/ueberdosis/tiptap/issues/7682

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7682