### PR TITLE
Fix deleteSelection to properly handle inline nodes with text* content

### DIFF
--- a/.changeset/fix-delete-selection-inline-nodes.md
+++ b/.changeset/fix-delete-selection-inline-nodes.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fix deleteSelection to properly handle inline nodes with `text*` content. The selection is now expanded to include the entire inline node boundaries when deleting, preventing incorrect collapse of inline text nodes.

--- a/packages/core/__tests__/delete.spec.ts
+++ b/packages/core/__tests__/delete.spec.ts
@@ -1,11 +1,39 @@
-import { Editor } from '@tiptap/core'
+import { Editor, Node } from '@tiptap/core'
 import Bold from '@tiptap/extension-bold'
 import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { describe, expect, it, vi } from 'vitest'
 
 const InlineDocument = Document.extend({
   content: 'inline*',
+})
+
+// Test extension for the bug fix: inline node with text* content and node view
+const TestInlineNode = Node.create({
+  name: 'testInlineNode',
+  group: 'inline',
+  inline: true,
+  content: 'text*',
+  renderHTML() {
+    return ['span', { 'data-test-node': '' }, 0]
+  },
+  parseHTML() {
+    return [
+      {
+        tag: 'span[data-test-node]',
+      },
+    ]
+  },
+  addNodeView() {
+    return () => {
+      const dom = document.createElement('span')
+      dom.dataset.testNode = 'true'
+      const contentDOM = document.createElement('span')
+      dom.appendChild(contentDOM)
+      return { dom, contentDOM }
+    }
+  },
 })
 
 describe('delete extension', () => {
@@ -43,6 +71,89 @@ describe('delete extension', () => {
       }),
     )
 
+    editor.destroy()
+  })
+
+  it('should return false for empty selection', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>hello</p>',
+    })
+
+    // Set cursor at position 1 (empty selection)
+    editor.commands.setTextSelection({ from: 1, to: 1 })
+
+    const result = editor.commands.deleteSelection()
+    expect(result).toBe(false)
+
+    editor.destroy()
+  })
+
+  it('should delete selected text', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>hello world</p>',
+    })
+
+    // Select "hello "
+    editor.chain().setTextSelection({ from: 1, to: 7 }).deleteSelection().run()
+
+    expect(editor.getHTML()).toBe('<p>world</p>')
+    editor.destroy()
+  })
+
+  it('should delete selection across two paragraphs', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>one</p><p>two</p>',
+    })
+
+    // Select from end of first paragraph to start of second
+    editor.chain().setTextSelection({ from: 2, to: 7 }).deleteSelection().run()
+
+    expect(editor.getHTML()).toBe('<p>owo</p>')
+    editor.destroy()
+  })
+
+  it('should delete entire inline node with text* when selecting inside it', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, TestInlineNode],
+      content: '<p>before <span data-test-node>test</span> after</p>',
+    })
+
+    // Select inside the inline node (position 9-13 selects "test")
+    editor.chain().setTextSelection({ from: 9, to: 13 }).deleteSelection().run()
+
+    // The entire node should be deleted
+    expect(editor.getHTML()).toBe('<p>before  after</p>')
+    editor.destroy()
+  })
+
+  it('should keep inline node when selecting only half of its text content', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, TestInlineNode],
+      content: '<p>before <span data-test-node>test</span> after</p>',
+    })
+
+    // Select only half of the text inside the inline node (position 9-11 selects "te")
+    editor.chain().setTextSelection({ from: 9, to: 11 }).deleteSelection().run()
+
+    // The node should remain with remaining text
+    expect(editor.getHTML()).toBe('<p>before <span data-test-node="">st</span> after</p>')
+    editor.destroy()
+  })
+
+  it('should delete selection spanning around entire inline node', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text, TestInlineNode],
+      content: '<p>before <span data-test-node>test</span> after</p>',
+    })
+
+    // Select from before the inline node to after it (position 4-17)
+    editor.chain().setTextSelection({ from: 4, to: 17 }).deleteSelection().run()
+
+    // The entire selection including the inline node should be deleted
+    expect(editor.getHTML()).toBe('<p>befter</p>')
     editor.destroy()
   })
 })

--- a/packages/core/src/commands/deleteSelection.ts
+++ b/packages/core/src/commands/deleteSelection.ts
@@ -1,6 +1,61 @@
-import { deleteSelection as originalDeleteSelection } from '@tiptap/pm/commands'
+import type { ResolvedPos, Schema } from '@tiptap/pm/model'
 
 import type { RawCommands } from '../types.js'
+
+/**
+ * Check if a node has text content based on its content specification.
+ * Returns true if the node's content spec matches text* or text+ patterns.
+ */
+const hasTextContent = (nodeSpec: { content?: string }): boolean => {
+  if (!nodeSpec.content) {
+    return false
+  }
+  const textRegex = /^text(\*|\+)/
+  return textRegex.test(nodeSpec.content)
+}
+
+/**
+ * Expand selection position for a specific side (left or right) to handle inline text nodes.
+ * This function checks if the position is within an inline node with text content and
+ * expands it to include the entire node boundaries for proper deletion.
+ * @param $pos - The resolved position to expand
+ * @param schema - The ProseMirror schema
+ * @param side - Which side to expand ('left' or 'right')
+ * @returns The expanded position for deletion
+ */
+const expandSelectionForSide = ($pos: ResolvedPos, schema: Schema, side: 'left' | 'right'): number => {
+  if (!$pos.parent.isInline) {
+    return $pos.pos
+  }
+
+  if ((side === 'left' && $pos.pos > $pos.start()) || (side === 'right' && $pos.pos < $pos.end())) {
+    return $pos.pos
+  }
+
+  const parentContent = schema.nodes[$pos.parent.type.name].spec
+  if (!hasTextContent(parentContent)) {
+    return $pos.pos
+  }
+
+  return side === 'left' ? $pos.start() - 1 : $pos.end() + 1
+}
+
+/**
+ * Expand selection range to properly handle deletion of inline text nodes.
+ * Inline text nodes don't collapse correctly when text inside is deleted,
+ * so we need to expand the selection to include the entire node.
+ * See: https://code.haverbeke.berlin/prosemirror/prosemirror/issues/1365
+ */
+const expandSelectionForInlineText = (
+  $from: ResolvedPos,
+  $to: ResolvedPos,
+  schema: Schema,
+): { from: number; to: number } => {
+  const from = expandSelectionForSide($from, schema, 'left')
+  const to = expandSelectionForSide($to, schema, 'right')
+
+  return { from, to }
+}
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -16,6 +71,15 @@ declare module '@tiptap/core' {
 
 export const deleteSelection: RawCommands['deleteSelection'] =
   () =>
-  ({ state, dispatch }) => {
-    return originalDeleteSelection(state, dispatch)
+  ({ state, tr }) => {
+    const { $from, $to } = state.selection
+    if (state.selection.empty) {
+      return false
+    }
+
+    const { from, to } = expandSelectionForInlineText($from, $to, state.schema)
+
+    tr.deleteRange(from, to).scrollIntoView()
+
+    return true
   }

--- a/packages/core/src/commands/deleteSelection.ts
+++ b/packages/core/src/commands/deleteSelection.ts
@@ -71,7 +71,7 @@ declare module '@tiptap/core' {
 
 export const deleteSelection: RawCommands['deleteSelection'] =
   () =>
-  ({ state, tr }) => {
+  ({ state, dispatch }) => {
     const { $from, $to } = state.selection
     if (state.selection.empty) {
       return false
@@ -79,7 +79,10 @@ export const deleteSelection: RawCommands['deleteSelection'] =
 
     const { from, to } = expandSelectionForInlineText($from, $to, state.schema)
 
-    tr.deleteRange(from, to).scrollIntoView()
+    if (dispatch) {
+      state.tr.deleteRange(from, to).scrollIntoView()
+      dispatch(state.tr)
+    }
 
     return true
   }


### PR DESCRIPTION
## Changes Overview

Fix deleteSelection to properly handle inline nodes with text* content. The selection is now expanded to include the entire inline node boundaries when deleting, preventing incorrect collapse of inline text nodes.

## Implementation Approach

Added utility functions (hasTextContent, expandSelectionForSide, expandSelectionForInlineText) to detect and expand selections for inline text nodes. Modified deleteSelection command to use these utilities before performing deletion.

## Testing Done

Added comprehensive unit tests to delete.spec.ts covering:
- Empty selection handling
- Text deletion
- Selection across paragraphs
- Inline node with text* deletion (entire node when selecting inside)
- Partial selection within inline node (node remains)
- Selection spanning around entire inline node

## Verification Steps

Run tests: `pnpm vitest packages/core/__tests__/delete.spec.ts`

## Additional Notes

Fixes ProseMirror issue #1365 where inline text nodes don't collapse correctly when text inside is deleted.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
- If yes, describe which tools were used and how they contributed to this PR:
  Used AI for test generation - needed too much manual testing to cover all edge cases

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #3451