### PR TITLE
chore: add licensing information around ProseMirror to pm package

### DIFF
--- a/.changeset/dull-feet-tickle.md
+++ b/.changeset/dull-feet-tickle.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/pm': patch
+---
+
+Added licensing information & missing prosemirror-inputrules

--- a/.changeset/dull-feet-tickle.md
+++ b/.changeset/dull-feet-tickle.md
@@ -2,4 +2,4 @@
 '@tiptap/pm': patch
 ---
 
-Added licensing information & missing prosemirror-inputrules
+Add missing `@tiptap/pm/inputrules` export

--- a/packages/pm/LICENSE
+++ b/packages/pm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025, Tiptap GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -11,7 +11,7 @@ Tiptap is a headless wrapper around [ProseMirror](https://ProseMirror.net) – a
 
 ## What is this `pm` package?
 
-The `pm` package is a wrapper package for [ProseMirror](https://ProseMirror.net). This includes all ProseMirror packages that are required to run Tiptap.
+The `pm` package re-exports [ProseMirror](https://ProseMirror.net) packages under a single version range. It bundles all ProseMirror packages that are required to run Tiptap into one consistent dependency, so you don't need to install and align multiple ProseMirror packages yourself.
 
 ## Official Documentation
 

--- a/packages/pm/THIRD_PARTY_LICENSES.md
+++ b/packages/pm/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,47 @@
+# Third-party licenses
+
+This package re-exports packages from the [ProseMirror](https://prosemirror.net) project.
+
+ProseMirror is licensed under the MIT License.
+
+Copyright (C) Marijn Haverbeke <marijn@haverbeke.berlin> and others
+
+The following ProseMirror packages are re-exported by this package:
+
+- prosemirror-changeset
+- prosemirror-commands
+- prosemirror-dropcursor
+- prosemirror-gapcursor
+- prosemirror-history
+- prosemirror-inputrules
+- prosemirror-keymap
+- prosemirror-model
+- prosemirror-schema-list
+- prosemirror-state
+- prosemirror-tables
+- prosemirror-transform
+- prosemirror-view
+
+---
+
+## [MIT License (ProseMirror)](https://code.haverbeke.berlin/prosemirror/prosemirror/src/branch/main/LICENSE)
+
+Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/pm/inputrules/index.ts
+++ b/packages/pm/inputrules/index.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-inputrules'

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -38,6 +38,14 @@
       "import": "./dist/dropcursor/index.js",
       "require": "./dist/dropcursor/index.cjs"
     },
+    "./inputrules": {
+      "types": {
+        "import": "./dist/inputrules/index.d.ts",
+        "require": "./dist/inputrules/index.d.cts"
+      },
+      "import": "./dist/inputrules/index.js",
+      "require": "./dist/inputrules/index.cjs"
+    },
     "./gapcursor": {
       "types": {
         "import": "./dist/gapcursor/index.d.ts",
@@ -118,13 +126,16 @@
     "dropcursor/**",
     "gapcursor/**",
     "history/**",
+    "inputrules/**",
     "keymap/**",
     "model/**",
     "schema-list/**",
     "state/**",
     "tables/**",
     "transform/**",
-    "view/**"
+    "view/**",
+    "LICENSE",
+    "THIRD_PARTY_LICENSES.md"
   ],
   "dependencies": {
     "prosemirror-changeset": "^2.3.0",
@@ -132,6 +143,7 @@
     "prosemirror-dropcursor": "^1.8.1",
     "prosemirror-gapcursor": "^1.3.2",
     "prosemirror-history": "^1.4.1",
+    "prosemirror-inputrules": "^1.4.0",
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-model": "^1.24.1",
     "prosemirror-schema-list": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -991,6 +991,9 @@ importers:
       prosemirror-history:
         specifier: ^1.4.1
         version: 1.4.1
+      prosemirror-inputrules:
+        specifier: ^1.4.0
+        version: 1.4.0
       prosemirror-keymap:
         specifier: ^1.2.2
         version: 1.2.2


### PR DESCRIPTION
## Changes Overview

Add licensing information to the `@tiptap/pm` package, including a `LICENSE` file, a `THIRD_PARTY_LICENSES.md` document acknowledging the ProseMirror project, and export the missing `prosemirror-inputrules` package.

## Implementation Approach

- Added `packages/pm/LICENSE` (MIT) under Tiptap GmbH
- Added `packages/pm/THIRD_PARTY_LICENSES.md` listing all re-exported ProseMirror packages with their MIT license
- Updated the README description for the pm package to clarify its purpose
- Added `prosemirror-inputrules` as a dependency and created the corresponding re-export at `packages/pm/inputrules/index.ts`
- Updated package.json exports, files array, and lockfile

## Testing Done

- `pnpm build` passes
- No unit tests directly affected (packaging change only)

## Verification Steps

- Verify `packages/pm/LICENSE` and `packages/pm/THIRD_PARTY_LICENSES.md` exist and have correct content
- Verify `@tiptap/pm/inputrules` can be imported and resolves correctly
- Confirm the package builds cleanly with `pnpm build`

## Additional Notes

This also adds the missing `prosemirror-inputrules` re-export, which was previously absent from the pm wrapper package.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Opencode to write the PR message automatically from the changes made

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

N/A — packaging/licensing improvement.
