### PR TITLE
fix(markdown): fix markdown parsing for unknown angle-bracket tags and improve docs

### DIFF
--- a/.changeset/fix-markdown-unknown-html-tags.md
+++ b/.changeset/fix-markdown-unknown-html-tags.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Fix text inside unknown angle-bracket tags being silently swallowed during markdown parsing. HTML-like content such as `<enter existing CID here if available>` that does not map to any known element is now preserved as literal text instead of disappearing, which also prevents downstream `contentMatchAt` errors when complex schemas (Mention, Variable, Table) are in use.

--- a/packages/markdown/__tests__/unknown-html-tags.spec.ts
+++ b/packages/markdown/__tests__/unknown-html-tags.spec.ts
@@ -2,6 +2,7 @@
  * @vitest-environment happy-dom
  */
 
+import { Node } from '@tiptap/core'
 import { Document } from '@tiptap/extension-document'
 import { Heading } from '@tiptap/extension-heading'
 import { Italic } from '@tiptap/extension-italic'
@@ -102,5 +103,39 @@ describe('MarkdownManager unrecognized HTML tags', () => {
     const text = collectText(doc)
     expect(text).not.toContain('<my-mention>')
     expect(text).not.toContain('</my-mention>')
+  })
+
+  it('preserves angle-bracket text with spaces as literal text', () => {
+    const manager = new MarkdownManager({ extensions: basicExtensions })
+
+    // `<this is a placeholder>` contains spaces, so the tag name is invalid.
+    // The browser creates an HTMLUnknownElement and the manager should
+    // preserve the whole string as literal text instead of silently dropping it.
+    const doc = manager.parse('<this is a placeholder>')
+    const text = collectText(doc)
+    expect(text).toContain('<this is a placeholder>')
+  })
+
+  it('recognizes non-hyphenated custom tags declared in schema parseDOM', () => {
+    const Something = Node.create({
+      name: 'something',
+      group: 'inline',
+      inline: true,
+      content: 'text*',
+      renderHTML: () => ['something', 0],
+      parseHTML: () => [{ tag: 'something' }],
+    })
+
+    const manager = new MarkdownManager({ extensions: [...basicExtensions, Something] })
+
+    // `<something>` is not a standard HTML tag (no hyphen), so the browser would
+    // normally create an HTMLUnknownElement. However, because the schema has
+    // a registered extension declaring parseDOM `{ tag: 'something' }`, the
+    // manager should treat it as a recognized element.
+    const doc = manager.parse('<something>happy</something>')
+    const text = collectText(doc)
+    expect(text).toContain('happy')
+    expect(text).not.toContain('<something>')
+    expect(text).not.toContain('</something>')
   })
 })

--- a/packages/markdown/__tests__/unknown-html-tags.spec.ts
+++ b/packages/markdown/__tests__/unknown-html-tags.spec.ts
@@ -92,4 +92,15 @@ describe('MarkdownManager unrecognized HTML tags', () => {
       expect(text).not.toContain('</span>')
     })
   })
+
+  it('does not flag hyphenated custom elements as unrecognized', () => {
+    const manager = new MarkdownManager({ extensions: basicExtensions })
+
+    // Hyphenated tag names are valid custom elements per the HTML spec – the
+    // browser constructs them as HTMLElement, not HTMLUnknownElement.
+    const doc = manager.parse('<my-mention></my-mention>')
+    const text = collectText(doc)
+    expect(text).not.toContain('<my-mention>')
+    expect(text).not.toContain('</my-mention>')
+  })
 })

--- a/packages/markdown/__tests__/unknown-html-tags.spec.ts
+++ b/packages/markdown/__tests__/unknown-html-tags.spec.ts
@@ -77,4 +77,19 @@ describe('MarkdownManager unrecognized HTML tags', () => {
     expect(text).toContain('hello')
     expect(text).toContain('world')
   })
+
+  it('does not render raw markup for recognized but empty HTML elements', () => {
+    const manager = new MarkdownManager({ extensions: basicExtensions })
+
+    // Empty <em></em> / <span></span> have no text content and no void element,
+    // but they are still real HTML – they must not be rendered as literal text.
+    ;['<em></em>', '<em> </em>', '<span></span>'].forEach(md => {
+      const doc = manager.parse(md)
+      const text = collectText(doc)
+      expect(text).not.toContain('<em>')
+      expect(text).not.toContain('</em>')
+      expect(text).not.toContain('<span>')
+      expect(text).not.toContain('</span>')
+    })
+  })
 })

--- a/packages/markdown/__tests__/unknown-html-tags.spec.ts
+++ b/packages/markdown/__tests__/unknown-html-tags.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { Document } from '@tiptap/extension-document'
+import { Heading } from '@tiptap/extension-heading'
+import { Italic } from '@tiptap/extension-italic'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { MarkdownManager } from '@tiptap/markdown'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * When markdown content contains text inside angle brackets that looks
+ * like an HTML tag but is not a recognized HTML element (and is not in
+ * the schema), marked passes it through as raw HTML. The browser's DOM
+ * parser then creates an unknown element with no text content, which is
+ * silently swallowed during schema-aware parsing.
+ *
+ * The expected behavior is that unrecognized HTML-like text should be
+ * preserved as literal plain text instead of being lost.
+ */
+describe('MarkdownManager unrecognized HTML tags', () => {
+  const basicExtensions = [Document, Paragraph, Text, Heading, Italic]
+
+  const collectText = (node: any): string => {
+    if (!node) {
+      return ''
+    }
+    if (typeof node === 'string') {
+      return node
+    }
+    if (Array.isArray(node)) {
+      return node.map(collectText).join('')
+    }
+    if (node.type === 'text' && typeof node.text === 'string') {
+      return node.text
+    }
+    if (Array.isArray(node.content)) {
+      return node.content.map(collectText).join('')
+    }
+    return ''
+  }
+
+  it('does not silently swallow text inside an unknown opening tag at block level', () => {
+    const manager = new MarkdownManager({ extensions: basicExtensions })
+    const md = '<enter existing CID here if available>\n\nother text after'
+    const doc = manager.parse(md)
+
+    expect(doc.type).toBe('doc')
+    expect(Array.isArray(doc.content)).toBe(true)
+
+    // The original "enter existing CID here if available" content must survive
+    // somewhere in the parsed document - it must not be silently dropped.
+    const text = collectText(doc)
+    expect(text).toContain('enter existing CID here if available')
+    expect(text).toContain('other text after')
+  })
+
+  it('does not silently swallow text inside an unknown opening tag inline', () => {
+    const manager = new MarkdownManager({ extensions: basicExtensions })
+    const md = 'before <enter existing CID here> after'
+    const doc = manager.parse(md)
+
+    const text = collectText(doc)
+    expect(text).toContain('before')
+    expect(text).toContain('enter existing CID here')
+    expect(text).toContain('after')
+  })
+
+  it('still parses recognized inline HTML elements normally', () => {
+    const manager = new MarkdownManager({ extensions: basicExtensions })
+    const md = 'hello <em>world</em>'
+    const doc = manager.parse(md)
+
+    const text = collectText(doc)
+    expect(text).toContain('hello')
+    expect(text).toContain('world')
+  })
+})

--- a/packages/markdown/__tests__/unknown-html-tags.spec.ts
+++ b/packages/markdown/__tests__/unknown-html-tags.spec.ts
@@ -125,17 +125,30 @@ describe('MarkdownManager unrecognized HTML tags', () => {
       renderHTML: () => ['something', 0],
       parseHTML: () => [{ tag: 'something' }],
     })
+    const SomethingWithHyphen = Node.create({
+      name: 'something-with-hyphen',
+      group: 'inline',
+      inline: true,
+      content: 'text*',
+      renderHTML: () => ['something-with-hyphen', 0],
+      parseHTML: () => [{ tag: 'something-with-hyphen' }],
+    })
 
-    const manager = new MarkdownManager({ extensions: [...basicExtensions, Something] })
+    const manager = new MarkdownManager({ extensions: [...basicExtensions, Something, SomethingWithHyphen] })
 
     // `<something>` is not a standard HTML tag (no hyphen), so the browser would
     // normally create an HTMLUnknownElement. However, because the schema has
     // a registered extension declaring parseDOM `{ tag: 'something' }`, the
     // manager should treat it as a recognized element.
-    const doc = manager.parse('<something>happy</something>')
+    const doc = manager.parse(
+      '<something>happy</something><something attribute="a">happy</something><something-with-hyphen attribute="a">joyful</something-with-hyphen>',
+    )
     const text = collectText(doc)
     expect(text).toContain('happy')
+    expect(text).toContain('joyful')
     expect(text).not.toContain('<something>')
     expect(text).not.toContain('</something>')
+    expect(text).not.toContain('<something-with-hyphen>')
+    expect(text).not.toContain('</something-with-hyphen>')
   })
 })

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -893,6 +893,14 @@ export class MarkdownManager {
       }
     }
 
+    // Detect "bogus" HTML – e.g. text wrapped in unknown tags like
+    // `<enter existing CID here if available>` – which the browser parses as an
+    // unknown element with no text content. Without this check, schema-aware
+    // parsing produces an empty document and the original characters are lost.
+    if (this.isUnrecognizedHtml(html)) {
+      return this.htmlAsLiteralText(html, !!token.block)
+    }
+
     // Use generateJSON to parse the HTML using extensions' parseHTML rules
     try {
       const parsed = generateJSON(html, this.baseExtensions)
@@ -917,6 +925,50 @@ export class MarkdownManager {
     } catch (error) {
       throw new Error(`Failed to parse HTML in markdown: ${error}`)
     }
+  }
+
+  /**
+   * Browser-parses the HTML and returns true when nothing meaningful would
+   * survive schema-aware parsing: no visible text content and no recognized
+   * HTML void element (br, hr, img, …). In that case the original characters
+   * should be preserved as literal text instead of silently disappearing.
+   */
+  private isUnrecognizedHtml(html: string): boolean {
+    const dom = new window.DOMParser().parseFromString(`<body>${html}</body>`, 'text/html').body
+
+    if ((dom.textContent || '').trim() !== '') {
+      return false
+    }
+
+    // Void elements legitimately have no text content; if any are present
+    // the HTML is recognized and should go through the regular path.
+    if (dom.querySelector('br, hr, img, input, embed, area, col, source, track, wbr')) {
+      return false
+    }
+
+    return true
+  }
+
+  /**
+   * Build a JSONContent that preserves the original HTML markup as literal
+   * text. Used when the HTML would otherwise be silently dropped during
+   * schema-aware parsing.
+   */
+  private htmlAsLiteralText(html: string, isBlock: boolean): JSONContent | JSONContent[] | null {
+    const text = html.replace(/\s+$/, '')
+
+    if (!text) {
+      return null
+    }
+
+    if (isBlock) {
+      return {
+        type: 'paragraph',
+        content: [{ type: 'text', text }],
+      }
+    }
+
+    return { type: 'text', text }
   }
 
   /**

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -16,6 +16,7 @@ import {
   flattenExtensions,
   generateJSON,
   getExtensionField,
+  getSchema,
   sortExtensions,
 } from '@tiptap/core'
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
@@ -32,7 +33,10 @@ import {
 } from './utils.js'
 
 /**
- * Returns true when the element's tag is not a recognized HTML element.
+ * Returns true when the element's tag is not a recognized standard HTML
+ * element. Note: the calling code further cross-references this result
+ * against schema parseDOM tags, so non-standard tags that are declared
+ * by registered extensions are still treated as valid.
  *
  * Browsers expose this classification natively: any non-hyphenated tag that
  * is not part of the HTML/SVG/MathML namespaces is constructed as an
@@ -66,6 +70,8 @@ export class MarkdownManager {
   private extensions: AnyExtension[] = []
   /** Set of extension names whose `code` spec property is truthy (nodes and marks). */
   private codeTypes: Set<string> = new Set()
+  /** Lazy cache of tag names declared by the registered schema's parseDOM rules. */
+  private schemaParseDomTagsCache: Set<string> | null = null
 
   /**
    * Create a MarkdownManager.
@@ -946,9 +952,13 @@ export class MarkdownManager {
 
   /**
    * Returns true when the HTML contains an element the browser classifies as
-   * `HTMLUnknownElement` – e.g. `<enter foo bar>`. Recognized but empty
-   * elements such as `<em></em>` or `<span></span>`, and hyphenated custom
-   * elements like `<my-mention>`, are not considered unrecognized.
+   * `HTMLUnknownElement` – unless a registered extension declares the tag
+   * name in its parseDOM rules, in which case it is treated as a known
+   * custom element.
+   *
+   * Recognized but empty elements such as `<em></em>` or `<span></span>`,
+   * and hyphenated custom elements like `<my-mention>`, are not considered
+   * unrecognized.
    *
    * @param html Raw HTML string from a marked token.
    * @example
@@ -966,7 +976,66 @@ export class MarkdownManager {
       return false
     }
 
-    return Array.from(elements).some(el => isHtmlUnknownElement(el))
+    const schemaTags = this.getSchemaParseDomTags()
+
+    return Array.from(elements).some(el => {
+      if (!isHtmlUnknownElement(el)) {
+        return false
+      }
+
+      // If the tag is declared by a registered extension's parseDOM rule,
+      // treat it as recognized even though the browser doesn't know it.
+      const tagName = el.tagName.toLowerCase()
+
+      return !schemaTags.has(tagName)
+    })
+  }
+
+  /**
+   * Collect the lower-cased tag names declared by the registered extensions'
+   * parseDOM rules, so custom node/mark elements that use non-hyphenated,
+   * non-standard tag names are treated as recognized HTML. Result is cached for the
+   * lifetime of the manager since extensions don't change after registration.
+   *
+   * @example
+   *   // After registering an extension with parseDOM [{ tag: 'something' }]
+   *   getSchemaParseDomTags().has('something') // → true
+   */
+  private getSchemaParseDomTags(): Set<string> {
+    if (this.schemaParseDomTagsCache) {
+      return this.schemaParseDomTagsCache
+    }
+
+    const tags = new Set<string>()
+
+    try {
+      const schema = getSchema(this.baseExtensions)
+
+      const collect = (spec: any) => {
+        const parseDOM = spec?.parseDOM
+        if (!Array.isArray(parseDOM)) {
+          return
+        }
+        parseDOM.forEach((rule: any) => {
+          if (typeof rule?.tag === 'string') {
+            // Extract the bare tag name from selectors like "something.example"
+            const match = rule.tag.match(/^[a-zA-Z][\w-]*/)
+            if (match) {
+              tags.add(match[0].toLowerCase())
+            }
+          }
+        })
+      }
+
+      Object.values(schema.nodes).forEach(type => collect((type as any).spec))
+      Object.values(schema.marks).forEach(type => collect((type as any).spec))
+    } catch {
+      // If schema construction fails, leave the set empty – detection then
+      // falls back to the HTMLUnknownElement check alone.
+    }
+
+    this.schemaParseDomTagsCache = tags
+    return tags
   }
 
   /**

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -31,6 +31,8 @@ import {
   wrapInMarkdownBlock,
 } from './utils.js'
 
+const VOID_HTML_TAG_SELECTOR = 'br, hr, img, input, embed, area, col, source, track, wbr'
+
 export class MarkdownManager {
   private markedInstance: typeof marked
   private activeParseLexer: Lexer | null = null
@@ -893,10 +895,8 @@ export class MarkdownManager {
       }
     }
 
-    // Detect "bogus" HTML – e.g. text wrapped in unknown tags like
-    // `<enter existing CID here if available>` – which the browser parses as an
-    // unknown element with no text content. Without this check, schema-aware
-    // parsing produces an empty document and the original characters are lost.
+    // If the HTML would parse to nothing meaningful, keep the original
+    // characters as literal text instead of dropping them.
     if (this.isUnrecognizedHtml(html)) {
       return this.htmlAsLiteralText(html, !!token.block)
     }
@@ -928,10 +928,9 @@ export class MarkdownManager {
   }
 
   /**
-   * Browser-parses the HTML and returns true when nothing meaningful would
-   * survive schema-aware parsing: no visible text content and no recognized
-   * HTML void element (br, hr, img, …). In that case the original characters
-   * should be preserved as literal text instead of silently disappearing.
+   * Returns true when the HTML has no visible text and no recognized
+   * void element (br, hr, img, …) – i.e. there's nothing for the schema
+   * to keep.
    */
   private isUnrecognizedHtml(html: string): boolean {
     const dom = new window.DOMParser().parseFromString(`<body>${html}</body>`, 'text/html').body
@@ -940,9 +939,7 @@ export class MarkdownManager {
       return false
     }
 
-    // Void elements legitimately have no text content; if any are present
-    // the HTML is recognized and should go through the regular path.
-    if (dom.querySelector('br, hr, img, input, embed, area, col, source, track, wbr')) {
+    if (dom.querySelector(VOID_HTML_TAG_SELECTOR)) {
       return false
     }
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -16,7 +16,6 @@ import {
   flattenExtensions,
   generateJSON,
   getExtensionField,
-  getSchema,
   sortExtensions,
 } from '@tiptap/core'
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
@@ -33,126 +32,17 @@ import {
 } from './utils.js'
 
 /**
- * Standard HTML element names. Used to tell apart real (but possibly empty)
- * elements like `<em></em>` from genuinely unknown angle-bracket text such
- * as `<enter foo bar>` so the latter can be preserved as literal text.
+ * Returns true when the element's tag is not a recognized HTML element.
+ *
+ * Browsers expose this classification natively: any non-hyphenated tag that
+ * is not part of the HTML/SVG/MathML namespaces is constructed as an
+ * `HTMLUnknownElement`. Standard tags (`<em>`, `<div>`, …) and custom
+ * elements (`<my-el>`, must contain a hyphen) are `HTMLElement` instances.
  */
-const STANDARD_HTML_TAGS = new Set([
-  'a',
-  'abbr',
-  'address',
-  'area',
-  'article',
-  'aside',
-  'audio',
-  'b',
-  'base',
-  'bdi',
-  'bdo',
-  'blockquote',
-  'body',
-  'br',
-  'button',
-  'canvas',
-  'caption',
-  'cite',
-  'code',
-  'col',
-  'colgroup',
-  'data',
-  'datalist',
-  'dd',
-  'del',
-  'details',
-  'dfn',
-  'dialog',
-  'div',
-  'dl',
-  'dt',
-  'em',
-  'embed',
-  'fieldset',
-  'figcaption',
-  'figure',
-  'footer',
-  'form',
-  'h1',
-  'h2',
-  'h3',
-  'h4',
-  'h5',
-  'h6',
-  'head',
-  'header',
-  'hgroup',
-  'hr',
-  'html',
-  'i',
-  'iframe',
-  'img',
-  'input',
-  'ins',
-  'kbd',
-  'label',
-  'legend',
-  'li',
-  'link',
-  'main',
-  'map',
-  'mark',
-  'menu',
-  'meta',
-  'meter',
-  'nav',
-  'noscript',
-  'object',
-  'ol',
-  'optgroup',
-  'option',
-  'output',
-  'p',
-  'param',
-  'picture',
-  'pre',
-  'progress',
-  'q',
-  'rp',
-  'rt',
-  'ruby',
-  's',
-  'samp',
-  'script',
-  'search',
-  'section',
-  'select',
-  'slot',
-  'small',
-  'source',
-  'span',
-  'strong',
-  'style',
-  'sub',
-  'summary',
-  'sup',
-  'svg',
-  'table',
-  'tbody',
-  'td',
-  'template',
-  'textarea',
-  'tfoot',
-  'th',
-  'thead',
-  'time',
-  'title',
-  'tr',
-  'track',
-  'u',
-  'ul',
-  'var',
-  'video',
-  'wbr',
-])
+const isHtmlUnknownElement = (element: Element): boolean => {
+  const ctor = (window as any).HTMLUnknownElement
+  return typeof ctor === 'function' && element instanceof ctor
+}
 
 export class MarkdownManager {
   private markedInstance: typeof marked
@@ -176,8 +66,6 @@ export class MarkdownManager {
   private extensions: AnyExtension[] = []
   /** Set of extension names whose `code` spec property is truthy (nodes and marks). */
   private codeTypes: Set<string> = new Set()
-  /** Lazy cache of tag names declared by the registered schema's parseDOM rules. */
-  private schemaParseDomTagsCache: Set<string> | null = null
 
   /**
    * Create a MarkdownManager.
@@ -1057,17 +945,18 @@ export class MarkdownManager {
   }
 
   /**
-   * Returns true when the HTML contains an element whose tag name is neither
-   * a standard HTML element nor declared by any registered extension – e.g.
-   * `<enter foo bar>`. Recognized but empty elements such as `<em></em>` or
-   * `<span></span>` are not considered unrecognized.
+   * Returns true when the HTML contains an element the browser classifies as
+   * `HTMLUnknownElement` – e.g. `<enter foo bar>`. Recognized but empty
+   * elements such as `<em></em>` or `<span></span>`, and hyphenated custom
+   * elements like `<my-mention>`, are not considered unrecognized.
    *
    * @param html Raw HTML string from a marked token.
    * @example
-   *   isUnrecognizedHtml('<enter foo bar>') // → true
-   *   isUnrecognizedHtml('<em></em>')       // → false (empty, but real tag)
-   *   isUnrecognizedHtml('<em>hi</em>')     // → false
-   *   isUnrecognizedHtml('<br>')            // → false
+   *   isUnrecognizedHtml('<enter foo bar>')  // → true
+   *   isUnrecognizedHtml('<em></em>')        // → false (empty, but real tag)
+   *   isUnrecognizedHtml('<em>hi</em>')      // → false
+   *   isUnrecognizedHtml('<my-el></my-el>')  // → false (valid custom element)
+   *   isUnrecognizedHtml('<br>')             // → false
    */
   private isUnrecognizedHtml(html: string): boolean {
     const dom = new window.DOMParser().parseFromString(`<body>${html}</body>`, 'text/html').body
@@ -1077,57 +966,7 @@ export class MarkdownManager {
       return false
     }
 
-    const schemaTags = this.getSchemaParseDomTags()
-
-    return Array.from(elements).some(el => {
-      const tagName = el.tagName.toLowerCase()
-      return !STANDARD_HTML_TAGS.has(tagName) && !schemaTags.has(tagName)
-    })
-  }
-
-  /**
-   * Collect the lower-cased tag names declared by the registered extensions'
-   * `parseDOM` rules, so custom node/mark elements (e.g. `<my-mention>`) are
-   * treated as recognized HTML. Result is cached for the lifetime of the
-   * manager since extensions don't change after registration.
-   *
-   * @example
-   *   // After registering an extension with parseDOM `[{ tag: 'my-mention' }]`
-   *   getSchemaParseDomTags().has('my-mention') // → true
-   */
-  private getSchemaParseDomTags(): Set<string> {
-    if (this.schemaParseDomTagsCache) {
-      return this.schemaParseDomTagsCache
-    }
-
-    const tags = new Set<string>()
-
-    try {
-      const schema = getSchema(this.baseExtensions)
-      const collect = (spec: any) => {
-        const parseDOM = spec?.parseDOM
-        if (!Array.isArray(parseDOM)) {
-          return
-        }
-        parseDOM.forEach((rule: any) => {
-          if (typeof rule?.tag === 'string') {
-            const match = rule.tag.match(/^[a-zA-Z][\w-]*/)
-            if (match) {
-              tags.add(match[0].toLowerCase())
-            }
-          }
-        })
-      }
-
-      Object.values(schema.nodes).forEach(type => collect((type as any).spec))
-      Object.values(schema.marks).forEach(type => collect((type as any).spec))
-    } catch {
-      // If schema construction fails for any reason, leave the set empty –
-      // detection then falls back to the standard HTML tag list only.
-    }
-
-    this.schemaParseDomTagsCache = tags
-    return tags
+    return Array.from(elements).some(el => isHtmlUnknownElement(el))
   }
 
   /**

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -863,8 +863,14 @@ export class MarkdownManager {
   }
 
   /**
-   * Parse HTML tokens using extensions' parseHTML methods.
-   * This allows HTML within markdown to be parsed according to extension rules.
+   * Parse an HTML token from marked into JSONContent using the registered
+   * extensions' `parseHTML` rules. Falls back to literal text when the HTML
+   * has nothing for the schema to keep.
+   *
+   * @param token Marked HTML token (block or inline).
+   * @example
+   *   parseHTMLToken({ type: 'html', raw: '<em>hi</em>', block: false })
+   *   // → text node with an italic mark
    */
   private parseHTMLToken(token: MarkdownToken): JSONContent | JSONContent[] | null {
     const html = token.text || token.raw || ''
@@ -931,6 +937,12 @@ export class MarkdownManager {
    * Returns true when the HTML has no visible text and no recognized
    * void element (br, hr, img, …) – i.e. there's nothing for the schema
    * to keep.
+   *
+   * @param html Raw HTML string from a marked token.
+   * @example
+   *   isUnrecognizedHtml('<enter foo bar>') // → true
+   *   isUnrecognizedHtml('<em>hi</em>')     // → false
+   *   isUnrecognizedHtml('<br>')            // → false
    */
   private isUnrecognizedHtml(html: string): boolean {
     const dom = new window.DOMParser().parseFromString(`<body>${html}</body>`, 'text/html').body
@@ -950,8 +962,17 @@ export class MarkdownManager {
    * Build a JSONContent that preserves the original HTML markup as literal
    * text. Used when the HTML would otherwise be silently dropped during
    * schema-aware parsing.
+   *
+   * @param html Raw HTML string to preserve verbatim.
+   * @param isBlock Whether to wrap the text in a paragraph node (block tokens)
+   *   or return it as a bare text node (inline tokens).
+   * @example
+   *   htmlAsLiteralText('<enter foo>', true)
+   *   // → { type: 'paragraph', content: [{ type: 'text', text: '<enter foo>' }] }
    */
   private htmlAsLiteralText(html: string, isBlock: boolean): JSONContent | JSONContent[] | null {
+    // Strip trailing whitespace/newlines that marked appends to block HTML
+    // tokens so the rendered text doesn't end with stray blank lines.
     const text = html.replace(/\s+$/, '')
 
     if (!text) {

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -16,6 +16,7 @@ import {
   flattenExtensions,
   generateJSON,
   getExtensionField,
+  getSchema,
   sortExtensions,
 } from '@tiptap/core'
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
@@ -31,7 +32,127 @@ import {
   wrapInMarkdownBlock,
 } from './utils.js'
 
-const VOID_HTML_TAG_SELECTOR = 'br, hr, img, input, embed, area, col, source, track, wbr'
+/**
+ * Standard HTML element names. Used to tell apart real (but possibly empty)
+ * elements like `<em></em>` from genuinely unknown angle-bracket text such
+ * as `<enter foo bar>` so the latter can be preserved as literal text.
+ */
+const STANDARD_HTML_TAGS = new Set([
+  'a',
+  'abbr',
+  'address',
+  'area',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'base',
+  'bdi',
+  'bdo',
+  'blockquote',
+  'body',
+  'br',
+  'button',
+  'canvas',
+  'caption',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dialog',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'embed',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'head',
+  'header',
+  'hgroup',
+  'hr',
+  'html',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'link',
+  'main',
+  'map',
+  'mark',
+  'menu',
+  'meta',
+  'meter',
+  'nav',
+  'noscript',
+  'object',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'param',
+  'picture',
+  'pre',
+  'progress',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'script',
+  'search',
+  'section',
+  'select',
+  'slot',
+  'small',
+  'source',
+  'span',
+  'strong',
+  'style',
+  'sub',
+  'summary',
+  'sup',
+  'svg',
+  'table',
+  'tbody',
+  'td',
+  'template',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'title',
+  'tr',
+  'track',
+  'u',
+  'ul',
+  'var',
+  'video',
+  'wbr',
+])
 
 export class MarkdownManager {
   private markedInstance: typeof marked
@@ -55,6 +176,8 @@ export class MarkdownManager {
   private extensions: AnyExtension[] = []
   /** Set of extension names whose `code` spec property is truthy (nodes and marks). */
   private codeTypes: Set<string> = new Set()
+  /** Lazy cache of tag names declared by the registered schema's parseDOM rules. */
+  private schemaParseDomTagsCache: Set<string> | null = null
 
   /**
    * Create a MarkdownManager.
@@ -934,28 +1057,77 @@ export class MarkdownManager {
   }
 
   /**
-   * Returns true when the HTML has no visible text and no recognized
-   * void element (br, hr, img, …) – i.e. there's nothing for the schema
-   * to keep.
+   * Returns true when the HTML contains an element whose tag name is neither
+   * a standard HTML element nor declared by any registered extension – e.g.
+   * `<enter foo bar>`. Recognized but empty elements such as `<em></em>` or
+   * `<span></span>` are not considered unrecognized.
    *
    * @param html Raw HTML string from a marked token.
    * @example
    *   isUnrecognizedHtml('<enter foo bar>') // → true
+   *   isUnrecognizedHtml('<em></em>')       // → false (empty, but real tag)
    *   isUnrecognizedHtml('<em>hi</em>')     // → false
    *   isUnrecognizedHtml('<br>')            // → false
    */
   private isUnrecognizedHtml(html: string): boolean {
     const dom = new window.DOMParser().parseFromString(`<body>${html}</body>`, 'text/html').body
+    const elements = dom.querySelectorAll('*')
 
-    if ((dom.textContent || '').trim() !== '') {
+    if (elements.length === 0) {
       return false
     }
 
-    if (dom.querySelector(VOID_HTML_TAG_SELECTOR)) {
-      return false
+    const schemaTags = this.getSchemaParseDomTags()
+
+    return Array.from(elements).some(el => {
+      const tagName = el.tagName.toLowerCase()
+      return !STANDARD_HTML_TAGS.has(tagName) && !schemaTags.has(tagName)
+    })
+  }
+
+  /**
+   * Collect the lower-cased tag names declared by the registered extensions'
+   * `parseDOM` rules, so custom node/mark elements (e.g. `<my-mention>`) are
+   * treated as recognized HTML. Result is cached for the lifetime of the
+   * manager since extensions don't change after registration.
+   *
+   * @example
+   *   // After registering an extension with parseDOM `[{ tag: 'my-mention' }]`
+   *   getSchemaParseDomTags().has('my-mention') // → true
+   */
+  private getSchemaParseDomTags(): Set<string> {
+    if (this.schemaParseDomTagsCache) {
+      return this.schemaParseDomTagsCache
     }
 
-    return true
+    const tags = new Set<string>()
+
+    try {
+      const schema = getSchema(this.baseExtensions)
+      const collect = (spec: any) => {
+        const parseDOM = spec?.parseDOM
+        if (!Array.isArray(parseDOM)) {
+          return
+        }
+        parseDOM.forEach((rule: any) => {
+          if (typeof rule?.tag === 'string') {
+            const match = rule.tag.match(/^[a-zA-Z][\w-]*/)
+            if (match) {
+              tags.add(match[0].toLowerCase())
+            }
+          }
+        })
+      }
+
+      Object.values(schema.nodes).forEach(type => collect((type as any).spec))
+      Object.values(schema.marks).forEach(type => collect((type as any).spec))
+    } catch {
+      // If schema construction fails for any reason, leave the set empty –
+      // detection then falls back to the standard HTML tag list only.
+    }
+
+    this.schemaParseDomTagsCache = tags
+    return tags
   }
 
   /**


### PR DESCRIPTION
## Changes Overview

Fixes #7861. Text inside unknown angle-bracket tags (e.g. `<enter existing CID here if available>`) is no longer silently swallowed during markdown parsing. The original characters are now preserved as literal text, which also prevents the downstream `Called contentMatchAt on a node with invalid content` crash that complex schemas (Mention, Variable, Table) hit when the surrounding document ends up structurally invalid.

## Implementation Approach

The issue happens in `MarkdownManager.parseHTMLToken`: marked emits an `html` token for content like `<enter ...>`, and `generateJSON` then produces an empty document because no schema rule matches the unknown element, so the original characters disappear.

The fix adds a guard before the `generateJSON` call: if browser-parsing the HTML yields no visible text **and** no recognized void element (`br`, `hr`, `img`, …), the HTML is treated as "nothing for the schema to keep" and returned as a literal text node (or paragraph for block tokens). Recognized HTML (`<em>`, `<br>`, etc.) keeps going through the existing path unchanged.

New helpers on `MarkdownManager`:
- `isUnrecognizedHtml(html)` — the detection check.
- `htmlAsLiteralText(html, isBlock)` — wraps the raw markup as a text/paragraph node.

The void-element list is extracted to a module-level `VOID_HTML_TAG_SELECTOR` constant.

## Testing Done

Added `packages/markdown/__tests__/unknown-html-tags.spec.ts` with three cases:

1. Unknown opening tag at block level — text inside the brackets must survive into the parsed document.
2. Unknown opening tag inline — surrounding text + the bracketed text both survive.
3. Recognized inline HTML (`<em>world</em>`) still parses normally (regression guard).

Full validation:
- `pnpm test:unit` — 1030/1030 passing (188/188 in `@tiptap/markdown`).
- `pnpm -F @tiptap/markdown lint` — clean.

## Verification Steps

1. Check out the branch and run `pnpm install`.
2. Run the new spec: `pnpm test:unit packages/markdown/__tests__/unknown-html-tags.spec.ts` — should be green.
3. Reproduce manually with the snippet from the issue (StackBlitz link in #7861):
   - Before this fix: the `<enter ...>` text is missing from the rendered output.
   - After this fix: the literal `<enter existing CID here if available>` text is preserved in the editor and no `contentMatchAt` crash occurs when clicking around.

## Additional Notes

- Detection runs at the `parseHTMLToken` level, so it covers both block and inline HTML tokens.
- There is a small perf cost: `isUnrecognizedHtml` does an extra `DOMParser.parseFromString` for each HTML token, on top of the one inside `generateJSON`. Negligible for typical docs (HTML tokens are rare), but happy to follow up with a lazy variant that only runs the check when `generateJSON` returns empty content.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude Code to investigate the bug in `MarkdownManager.parseHTMLToken`, write the regression test, implement the `isUnrecognizedHtml` / `htmlAsLiteralText` helpers, add the JSDoc, and run the local test/lint loop.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7861.