### PR TITLE
Fix details toggle at document start

### DIFF
--- a/.changeset/fix-details-summary-focus.md
+++ b/.changeset/fix-details-summary-focus.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-details": patch
+---
+
+Fix persisted details toggles when the details node is at the start of the document.

--- a/packages/extension-details/__tests__/details.spec.ts
+++ b/packages/extension-details/__tests__/details.spec.ts
@@ -101,6 +101,47 @@ describe('Details', () => {
     expect(getToggleButton()?.getAttribute('aria-label')).toBe('Collapse SummaryContent')
   })
 
+  it('updates a persisted details node at the start of the document when toggled', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Details.configure({ persist: true }), DetailsSummary, DetailsContent],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'details',
+            attrs: {
+              open: true,
+            },
+            content: [
+              {
+                type: 'detailsSummary',
+                content: [{ type: 'text', text: 'Summary' }],
+              },
+              {
+                type: 'detailsContent',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Content' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const toggleButton = editor.view.dom.querySelector<HTMLButtonElement>('div[data-type="details"] > button')
+
+    toggleButton?.click()
+
+    expect(editor.state.doc.firstChild?.attrs.open).toBe(false)
+    expect(editor.getHTML()).toBe(
+      '<details><summary>Summary</summary><div data-type="detailsContent"><p>Content</p></div></details>',
+    )
+  })
+
   it('ignores button attribute mutations triggered by renderToggleButton', async () => {
     let renderToggleButtonCallCount = 0
 

--- a/packages/extension-details/src/details.ts
+++ b/packages/extension-details/src/details.ts
@@ -212,7 +212,7 @@ export const Details = Node.create<DetailsOptions>({
             .command(({ tr }) => {
               const pos = getPos()
 
-              if (!pos) {
+              if (typeof pos !== 'number') {
                 return false
               }
 


### PR DESCRIPTION
## Changes Overview

Fixes persisted details toggle handling when a details node is located at document position 0. Adds a regression test for toggling a persisted details node at the start of the document and includes a patch changeset for `@tiptap/extension-details`.

## Implementation Approach

The details node view already reads `getPos()` before updating the persisted `open` attribute. The bug was caused by treating position `0` as invalid with a falsy check, so details nodes at the start of the document toggled the DOM but skipped the ProseMirror transaction and focus restoration. The guard now rejects only non-number positions.

## Testing Done

- `corepack pnpm vitest run packages/extension-details/__tests__/details.spec.ts packages/extension-details/__tests__/details-commands.spec.ts`
- `corepack pnpm --filter @tiptap/extension-details lint`
- `corepack pnpm prettier packages/extension-details/__tests__/details.spec.ts .changeset/fix-details-summary-focus.md --check`

## Verification Steps

1. Insert a persisted details node as the first node in the editor.
2. Edit the summary text.
3. Click the details toggle.
4. Confirm the details node remains focused and the persisted `open` attribute updates correctly.

## Additional Notes

The regression test covers the document-start case by asserting that clicking the toggle changes the first details node from `open: true` to `open: false`.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Used AI assistance to investigate the issue, implement the fix, add the regression test, and prepare this PR description.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7865