### PR TITLE
Do not run selector when editor instance is `null` in current editor

### DIFF
--- a/.changeset/clean-terms-help.md
+++ b/.changeset/clean-terms-help.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Fix `useEditorState` so selectors are not called while the editor instance is `null`.

--- a/packages/react/src/useEditorState.spec.ts
+++ b/packages/react/src/useEditorState.spec.ts
@@ -1,0 +1,68 @@
+import { act, render } from '@testing-library/react'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import React, { StrictMode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useEditor } from './useEditor.js'
+import { useEditorState } from './useEditorState.js'
+
+describe('useEditorState', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('does not call selectors with a null editor during StrictMode remounts', async () => {
+    vi.useFakeTimers()
+
+    const selector = vi.fn(ctx => ({
+      canRunCommand: ctx.editor.can().chain().run(),
+    }))
+
+    function Toolbar() {
+      const editor = useEditor({
+        extensions: [Document, Paragraph, Text],
+      })
+
+      useEditorState({
+        editor,
+        selector,
+      })
+
+      return null
+    }
+
+    render(React.createElement(StrictMode, null, React.createElement(Toolbar)))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10)
+    })
+
+    expect(selector).toHaveBeenCalled()
+    expect(selector.mock.calls.every(([ctx]) => ctx.editor !== null)).toBe(true)
+  })
+
+  it('returns null without calling the selector when the editor is null', () => {
+    const selector = vi.fn(ctx => ({
+      canRunCommand: ctx.editor.can().chain().run(),
+    }))
+    let selectedState: { canRunCommand: boolean } | null = null
+
+    function Toolbar() {
+      selectedState = useEditorState({
+        editor: null,
+        selector,
+      })
+
+      return null
+    }
+
+    render(React.createElement(Toolbar))
+
+    expect(selectedState).toBeNull()
+    expect(selector).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -80,11 +80,21 @@ class EditorStateManager<TEditor extends Editor | null = Editor | null> {
     }
   }
 
+  private notify() {
+    this.transactionNumber += 1
+    this.subscribers.forEach(callback => callback())
+  }
+
   /**
    * Watch the editor instance for changes.
    */
   watch(nextEditor: Editor | null): undefined | (() => void) {
+    const previousEditor = this.editor
+
     this.editor = nextEditor as TEditor
+    if (previousEditor !== nextEditor) {
+      this.notify()
+    }
 
     if (this.editor) {
       /**
@@ -93,8 +103,7 @@ class EditorStateManager<TEditor extends Editor | null = Editor | null> {
        * This could be more efficient, but it's a good trade-off for now.
        */
       const fn = () => {
-        this.transactionNumber += 1
-        this.subscribers.forEach(callback => callback())
+        this.notify()
       }
 
       const currentEditor = this.editor
@@ -153,14 +162,28 @@ export function useEditorState<TSelectorResult>(
   options: UseEditorStateOptions<TSelectorResult, Editor> | UseEditorStateOptions<TSelectorResult, Editor | null>,
 ): TSelectorResult | null {
   const [editorStateManager] = useState(() => new EditorStateManager(options.editor))
+  const selector = (snapshot: EditorStateSnapshot<Editor | null>) => {
+    if (snapshot.editor === null) {
+      return null
+    }
+
+    return options.selector(snapshot as EditorStateSnapshot<Editor>)
+  }
+  const equalityFn = (a: TSelectorResult | null, b: TSelectorResult | null) => {
+    if (a === null || b === null) {
+      return a === b
+    }
+
+    return (options.equalityFn ?? deepEqual)(a, b)
+  }
 
   // Using the `useSyncExternalStore` hook to sync the editor instance with the component state
   const selectedState = useSyncExternalStoreWithSelector(
     editorStateManager.subscribe,
     editorStateManager.getSnapshot,
     editorStateManager.getServerSnapshot,
-    options.selector as UseEditorStateOptions<TSelectorResult, Editor | null>['selector'],
-    options.equalityFn ?? deepEqual,
+    selector,
+    equalityFn,
   )
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
## Changes Overview

Fix `useEditorState` so nullable editor snapshots return `null` instead of invoking selectors with `ctx.editor === null`.

## Implementation Approach

`useEditorState` now wraps the user selector and equality function to handle `null` editor snapshots. The state manager also notifies subscribers when the editor instance changes, including transitions to or from `null`.

## Testing Done

Added regression test in `packages/react/src/useEditorState.spec.ts`

## Verification Steps

Run the React package tests and verify a toolbar selector that calls `ctx.editor.can()` does not throw when `useEditorState` receives a `null` editor during development StrictMode lifecycle updates.

## Additional Notes

Fixes #7849.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Used AI to inspect the issue, identify the `useEditorState` null-editor path, implement the fix, add regression coverage, and run verification commands.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7849
