### PR TITLE
fix(core): guard editor getters against null managers after destroy

### DIFF
--- a/.changeset/null-safe-editor-getters-after-destroy.md
+++ b/.changeset/null-safe-editor-getters-after-destroy.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Guard the `commands`, `chain()`, `can()`, `getHTML()`, and `getText()` getters against the null `commandManager` / `schema` references that `Editor.destroy()` leaves behind, so stale async callbacks racing the editor lifecycle no longer crash with `Cannot read properties of null (reading 'commands')`. The getters return safe no-op values (commands return `false`; `getHTML`/`getText` return `""`) when the editor is destroyed, restoring pre-3.23 behavior.

--- a/.changeset/null-safe-editor-getters-after-destroy.md
+++ b/.changeset/null-safe-editor-getters-after-destroy.md
@@ -2,4 +2,4 @@
 '@tiptap/core': patch
 ---
 
-Guard the `commands`, `chain()`, `can()`, `getHTML()`, and `getText()` getters against the null `commandManager` / `schema` references that `Editor.destroy()` leaves behind, so stale async callbacks racing the editor lifecycle no longer crash with `Cannot read properties of null (reading 'commands')`. The getters return safe no-op values (commands return `false`; `getHTML`/`getText` return `""`) when the editor is destroyed, restoring pre-3.23 behavior.
+Prevented crashes when editor commands or content are accessed after the editor has been destroyed.

--- a/.changeset/null-safe-editor-getters-after-destroy.md
+++ b/.changeset/null-safe-editor-getters-after-destroy.md
@@ -1,5 +1,5 @@
 ---
-"@tiptap/core": patch
+'@tiptap/core': patch
 ---
 
 Guard the `commands`, `chain()`, `can()`, `getHTML()`, and `getText()` getters against the null `commandManager` / `schema` references that `Editor.destroy()` leaves behind, so stale async callbacks racing the editor lifecycle no longer crash with `Cannot read properties of null (reading 'commands')`. The getters return safe no-op values (commands return `false`; `getHTML`/`getText` return `""`) when the editor is destroyed, restoring pre-3.23 behavior.

--- a/packages/core/__tests__/destroyed.spec.ts
+++ b/packages/core/__tests__/destroyed.spec.ts
@@ -1,0 +1,56 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { describe, expect, it } from 'vitest'
+
+const createEditor = () =>
+  new Editor({
+    element: null,
+    extensions: [Document, Paragraph, Text],
+    content: '<p>Hello</p>',
+  })
+
+describe('post-destroy access', () => {
+  it('does not throw when commands is accessed after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(() => editor.commands).not.toThrow()
+  })
+
+  it('returns false when invoking a command after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(editor.commands.setContent('<p>x</p>')).toBe(false)
+  })
+
+  it('does not throw when chain() is accessed after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(() => editor.chain()).not.toThrow()
+  })
+
+  it('returns false from chain().run() after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(editor.chain().setContent('<p>x</p>').run()).toBe(false)
+  })
+
+  it('does not throw when can() is accessed after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(() => editor.can()).not.toThrow()
+  })
+
+  it('returns "" from getHTML() after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(editor.getHTML()).toBe('')
+  })
+
+  it('returns "" from getText() after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(editor.getText()).toBe('')
+  })
+})

--- a/packages/core/__tests__/destroyed.spec.ts
+++ b/packages/core/__tests__/destroyed.spec.ts
@@ -42,6 +42,18 @@ describe('post-destroy access', () => {
     expect(() => editor.can()).not.toThrow()
   })
 
+  it('does not throw when can().chain() is chained after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(() => editor.can().chain().toggleBold()).not.toThrow()
+  })
+
+  it('returns false from can().chain().<cmd>().run() after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect(editor.can().chain().toggleBold().run()).toBe(false)
+  })
+
   it('returns "" from getHTML() after destroy', () => {
     const editor = createEditor()
     editor.destroy()

--- a/packages/core/__tests__/destroyed.spec.ts
+++ b/packages/core/__tests__/destroyed.spec.ts
@@ -54,6 +54,23 @@ describe('post-destroy access', () => {
     expect(editor.can().chain().toggleBold().run()).toBe(false)
   })
 
+  it('does not expose a callable `then` on the no-op proxies after destroy', () => {
+    const editor = createEditor()
+    editor.destroy()
+    expect((editor.commands as any).then).toBeUndefined()
+    expect((editor.chain() as any).then).toBeUndefined()
+    expect((editor.can() as any).then).toBeUndefined()
+    expect((editor.can().chain() as any).then).toBeUndefined()
+  })
+
+  it('settles when awaiting the no-op proxies after destroy', async () => {
+    const editor = createEditor()
+    editor.destroy()
+    await expect(Promise.resolve(editor.commands)).resolves.toBeDefined()
+    await expect(Promise.resolve(editor.chain())).resolves.toBeDefined()
+    await expect(Promise.resolve(editor.can())).resolves.toBeDefined()
+  })
+
   it('returns "" from getHTML() after destroy', () => {
     const editor = createEditor()
     editor.destroy()

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -247,6 +247,25 @@ export class Editor extends EventEmitter<EditorEvents> {
   }
 
   /**
+   * Create a no-op command chain used after `destroy()`, where every chainable method
+   * returns the chain itself and `.run()` returns `false`.
+   */
+  private createNoopChain(): ChainedCommands {
+    const noopChain: ChainedCommands = new Proxy(
+      { run: () => false },
+      {
+        get(target: { run: () => boolean }, prop: string | symbol) {
+          if (prop === 'run') {
+            return target.run
+          }
+          return () => noopChain
+        },
+      },
+    ) as unknown as ChainedCommands
+    return noopChain
+  }
+
+  /**
    * Create a command chain to call multiple commands at once.
    *
    * After `destroy()` returns a no-op chain where every chainable method returns the
@@ -254,18 +273,7 @@ export class Editor extends EventEmitter<EditorEvents> {
    */
   public chain(): ChainedCommands {
     if (!this.commandManager) {
-      const noopChain: ChainedCommands = new Proxy(
-        { run: () => false },
-        {
-          get(target: { run: () => boolean }, prop: string | symbol) {
-            if (prop === 'run') {
-              return target.run
-            }
-            return () => noopChain
-          },
-        },
-      ) as unknown as ChainedCommands
-      return noopChain
+      return this.createNoopChain()
     }
     return this.commandManager.chain()
   }
@@ -273,11 +281,24 @@ export class Editor extends EventEmitter<EditorEvents> {
   /**
    * Check if a command or a command chain can be executed. Without executing it.
    *
-   * After `destroy()` returns a no-op proxy whose checks always resolve to `false`.
+   * After `destroy()` returns a no-op proxy whose single-command checks resolve to
+   * `false` and whose `chain()` returns a no-op chain (so the
+   * `editor.can().chain().<cmd>().run()` pattern stays safe instead of throwing).
    */
   public can(): CanCommands {
     if (!this.commandManager) {
-      return new Proxy({}, { get: () => () => false }) as CanCommands
+      const createNoopChain = () => this.createNoopChain()
+      return new Proxy(
+        {},
+        {
+          get: (_target, prop) => {
+            if (prop === 'chain') {
+              return createNoopChain
+            }
+            return () => false
+          },
+        },
+      ) as CanCommands
     }
     return this.commandManager.can()
   }

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -233,22 +233,52 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   /**
    * An object of all registered commands.
+   *
+   * After `destroy()` the underlying `commandManager` is released, so this returns a no-op
+   * proxy whose properties resolve to functions returning `false`. This prevents
+   * `TypeError: Cannot read properties of null (reading 'commands')` when stale async
+   * callbacks (effects, subscriptions, scheduled tasks) race the editor lifecycle.
    */
   public get commands(): SingleCommands {
+    if (!this.commandManager) {
+      return new Proxy({}, { get: () => () => false }) as SingleCommands
+    }
     return this.commandManager.commands
   }
 
   /**
    * Create a command chain to call multiple commands at once.
+   *
+   * After `destroy()` returns a no-op chain where every chainable method returns the
+   * chain itself and `.run()` returns `false`.
    */
   public chain(): ChainedCommands {
+    if (!this.commandManager) {
+      const noopChain: ChainedCommands = new Proxy(
+        { run: () => false },
+        {
+          get(target: { run: () => boolean }, prop: string | symbol) {
+            if (prop === 'run') {
+              return target.run
+            }
+            return () => noopChain
+          },
+        },
+      ) as unknown as ChainedCommands
+      return noopChain
+    }
     return this.commandManager.chain()
   }
 
   /**
    * Check if a command or a command chain can be executed. Without executing it.
+   *
+   * After `destroy()` returns a no-op proxy whose checks always resolve to `false`.
    */
   public can(): CanCommands {
+    if (!this.commandManager) {
+      return new Proxy({}, { get: () => () => false }) as CanCommands
+    }
     return this.commandManager.can()
   }
 
@@ -764,18 +794,30 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   /**
    * Get the document as HTML.
+   *
+   * After `destroy()` the schema is released; returns an empty string instead of
+   * throwing on `getHTMLFromFragment(..., null)`.
    */
   public getHTML(): string {
+    if (!this.schema) {
+      return ''
+    }
     return getHTMLFromFragment(this.state.doc.content, this.schema)
   }
 
   /**
    * Get the document as text.
+   *
+   * After `destroy()` the schema is released; returns an empty string instead of
+   * throwing inside `getTextSerializersFromSchema(null)`.
    */
   public getText(options?: {
     blockSeparator?: string
     textSerializers?: Record<string, TextSerializer>
   }): string {
+    if (!this.schema) {
+      return ''
+    }
     const { blockSeparator = '\n\n', textSerializers = {} } = options || {}
 
     return getText(this.state.doc, {

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -233,15 +233,15 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   /**
    * An object of all registered commands.
-   *
-   * After `destroy()` the underlying `commandManager` is released, so this returns a no-op
-   * proxy whose properties resolve to functions returning `false`. This prevents
-   * `TypeError: Cannot read properties of null (reading 'commands')` when stale async
-   * callbacks (effects, subscriptions, scheduled tasks) race the editor lifecycle.
    */
   public get commands(): SingleCommands {
     if (!this.commandManager) {
-      return new Proxy({}, { get: () => () => false }) as SingleCommands
+      return new Proxy(
+        {},
+        {
+          get: (_target, prop) => (prop === 'then' ? undefined : () => false),
+        },
+      ) as SingleCommands
     }
     return this.commandManager.commands
   }
@@ -258,6 +258,9 @@ export class Editor extends EventEmitter<EditorEvents> {
           if (prop === 'run') {
             return target.run
           }
+          if (prop === 'then') {
+            return undefined
+          }
           return () => noopChain
         },
       },
@@ -267,9 +270,6 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   /**
    * Create a command chain to call multiple commands at once.
-   *
-   * After `destroy()` returns a no-op chain where every chainable method returns the
-   * chain itself and `.run()` returns `false`.
    */
   public chain(): ChainedCommands {
     if (!this.commandManager) {
@@ -294,6 +294,9 @@ export class Editor extends EventEmitter<EditorEvents> {
           get: (_target, prop) => {
             if (prop === 'chain') {
               return createNoopChain
+            }
+            if (prop === 'then') {
+              return undefined
             }
             return () => false
           },
@@ -815,9 +818,6 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   /**
    * Get the document as HTML.
-   *
-   * After `destroy()` the schema is released; returns an empty string instead of
-   * throwing on `getHTMLFromFragment(..., null)`.
    */
   public getHTML(): string {
     if (!this.schema) {
@@ -828,9 +828,6 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   /**
    * Get the document as text.
-   *
-   * After `destroy()` the schema is released; returns an empty string instead of
-   * throwing inside `getTextSerializersFromSchema(null)`.
    */
   public getText(options?: {
     blockSeparator?: string


### PR DESCRIPTION
## Description

The 3.23.0 memory-leak fix introduced this cleanup inside `Editor.destroy()`:

```ts
this.extensionManager.destroy()
this.extensionManager = null as any
this.schema = null as any
this.commandManager = null as any
```

The matching getters (`commands`, `chain`, `can`, `getHTML`, `getText`) were not updated to handle the null state. Any post-destroy access now throws `TypeError: Cannot read properties of null (reading 'commands')` instead of the silent no-op behavior of 3.18 and earlier.

This is a real-world hazard, not a theoretical one: in React, `@tiptap/react`'s `useEditor` schedules `destroy()` via `setTimeout(…, 1)` on unmount and also destroys + recreates when its dep array changes. Any `useEffect`, Relay/Apollo subscription callback, Yjs awareness update, or other async handler that holds a reference to the previous editor and reaches for `editor.commands.X(...)` between the schedule and the next mount will crash the entire React tree. We hit this in production after upgrading from 3.18.0 → 3.23.6 — multiple users could no longer load pages containing reflections rendered with TipTap.

## Fix

Restore the prior forgiveness by returning safe no-op values from the affected getters when the backing manager is null:

- `commands` / `can()` → a `Proxy` whose properties resolve to `() => false`
- `chain()` → a chainable `Proxy` whose `.run()` returns `false`
- `getHTML()` / `getText()` → empty string

No behavior change while the editor is alive — the guards only kick in when the manager has been nulled by `destroy()`.

## Test plan

Adds `packages/core/__tests__/destroyed.spec.ts` covering each getter after `destroy()`:

```
 ✓ does not throw when commands is accessed after destroy
 ✓ returns false when invoking a command after destroy
 ✓ does not throw when chain() is accessed after destroy
 ✓ returns false from chain().run() after destroy
 ✓ does not throw when can() is accessed after destroy
 ✓ returns "" from getHTML() after destroy
 ✓ returns "" from getText() after destroy
```

`pnpm run test:unit packages/core/__tests__/destroyed.spec.ts` → **7/7 passed**. Full suite remains green.

## Notes

- I deliberately did not change `destroy()` itself — keeping the memory-leak fix intact is important. The fix lives where the references are read.
- Happy to add a deprecation-style warning (`console.warn` once) if you'd prefer the getters to alert in dev when accessed post-destroy; let me know.