### PR TITLE
Do not run useEditorState selector if editor is null (approach 2)

### DIFF
--- a/.changeset/preserve-null-editor-snapshot.md
+++ b/.changeset/preserve-null-editor-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Fix `useEditorState` so transient `null` editor snapshots preserve the previous selected state instead of calling selectors.

--- a/packages/react/src/useEditorState.spec.ts
+++ b/packages/react/src/useEditorState.spec.ts
@@ -1,0 +1,68 @@
+import { act, render } from '@testing-library/react'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import React, { StrictMode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useEditor } from './useEditor.js'
+import { useEditorState } from './useEditorState.js'
+
+describe('useEditorState', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('does not call selectors with a null editor during StrictMode remounts', async () => {
+    vi.useFakeTimers()
+
+    const selector = vi.fn(ctx => ({
+      canRunCommand: ctx.editor.can().chain().run(),
+    }))
+
+    function Toolbar() {
+      const editor = useEditor({
+        extensions: [Document, Paragraph, Text],
+      })
+
+      useEditorState({
+        editor,
+        selector,
+      })
+
+      return null
+    }
+
+    render(React.createElement(StrictMode, null, React.createElement(Toolbar)))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10)
+    })
+
+    expect(selector).toHaveBeenCalled()
+    expect(selector.mock.calls.every(([ctx]) => ctx.editor !== null)).toBe(true)
+  })
+
+  it('returns null without calling the selector when the editor was never available', () => {
+    const selector = vi.fn(ctx => ({
+      canRunCommand: ctx.editor.can().chain().run(),
+    }))
+    let selectedState: { canRunCommand: boolean } | null = null
+
+    function Toolbar() {
+      selectedState = useEditorState({
+        editor: null,
+        selector,
+      })
+
+      return null
+    }
+
+    render(React.createElement(Toolbar))
+
+    expect(selectedState).toBeNull()
+    expect(selector).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -25,6 +25,9 @@ export type UseEditorStateOptions<TSelectorResult, TEditor extends Editor | null
   editor: TEditor
   /**
    * A selector function to determine the value to compare for re-rendering.
+   *
+   * When the editor snapshot is briefly `null`, this function is not called. If a
+   * previous selection was cached, the last successful result is returned instead.
    */
   selector: (context: EditorStateSnapshot<TEditor>) => TSelectorResult
   /**
@@ -149,6 +152,12 @@ export function useEditorState<TSelectorResult>(
 /**
  * This hook allows you to watch for changes on the editor instance.
  * It will allow you to select a part of the editor state and re-render the component when it changes.
+ *
+ * @remarks When the editor snapshot is briefly `null` (for example during React StrictMode
+ * remounts), the `selector` is not called. If a previous selection exists, the last successful
+ * result is returned instead. This can surface a briefly stale value until the editor is
+ * available again. If no selection was cached yet, `null` is returned.
+ *
  * @example
  * ```tsx
  * const editor = useEditor({...options})

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -1,6 +1,6 @@
 import type { Editor } from '@tiptap/core'
 import { deepEqual } from 'fast-equals'
-import { useDebugValue, useEffect, useLayoutEffect, useState } from 'react'
+import { useCallback, useDebugValue, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector.js'
 
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
@@ -153,13 +153,32 @@ export function useEditorState<TSelectorResult>(
   options: UseEditorStateOptions<TSelectorResult, Editor> | UseEditorStateOptions<TSelectorResult, Editor | null>,
 ): TSelectorResult | null {
   const [editorStateManager] = useState(() => new EditorStateManager(options.editor))
+  const selectorRef = useRef(options.selector)
+  selectorRef.current = options.selector
+
+  const lastSelectedStateRef = useRef<TSelectorResult | undefined>(undefined)
+
+  const selector = useCallback((snapshot: EditorStateSnapshot<Editor | null>) => {
+    if (snapshot.editor === null) {
+      if (lastSelectedStateRef.current !== undefined) {
+        return lastSelectedStateRef.current
+      }
+
+      return null
+    }
+
+    const result = selectorRef.current(snapshot as EditorStateSnapshot<Editor>)
+    lastSelectedStateRef.current = result
+
+    return result
+  }, [])
 
   // Using the `useSyncExternalStore` hook to sync the editor instance with the component state
   const selectedState = useSyncExternalStoreWithSelector(
     editorStateManager.subscribe,
     editorStateManager.getSnapshot,
     editorStateManager.getServerSnapshot,
-    options.selector as UseEditorStateOptions<TSelectorResult, Editor | null>['selector'],
+    selector,
     options.equalityFn ?? deepEqual,
   )
 

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -5,6 +5,14 @@ import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/w
 
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
+type CachedSelectedState<TSelectorResult> = { stored: false } | { stored: true; value: TSelectorResult }
+
+function isCachedSelectedStateStored<TSelectorResult>(
+  cache: CachedSelectedState<TSelectorResult>,
+): cache is { stored: true; value: TSelectorResult } {
+  return cache.stored
+}
+
 export type EditorStateSnapshot<TEditor extends Editor | null = Editor | null> = {
   editor: TEditor
   transactionNumber: number
@@ -153,25 +161,35 @@ export function useEditorState<TSelectorResult>(
   options: UseEditorStateOptions<TSelectorResult, Editor> | UseEditorStateOptions<TSelectorResult, Editor | null>,
 ): TSelectorResult | null {
   const [editorStateManager] = useState(() => new EditorStateManager(options.editor))
-  const selectorRef = useRef(options.selector)
-  selectorRef.current = options.selector
+  const lastSelectedStateRef = useRef<CachedSelectedState<TSelectorResult>>({ stored: false })
 
-  const lastSelectedStateRef = useRef<TSelectorResult | undefined>(undefined)
+  const selector = useCallback(
+    (snapshot: EditorStateSnapshot<Editor | null>) => {
+      if (snapshot.editor === null) {
+        if (isCachedSelectedStateStored(lastSelectedStateRef.current)) {
+          return lastSelectedStateRef.current.value
+        }
 
-  const selector = useCallback((snapshot: EditorStateSnapshot<Editor | null>) => {
-    if (snapshot.editor === null) {
-      if (lastSelectedStateRef.current !== undefined) {
-        return lastSelectedStateRef.current
+        return null
       }
 
-      return null
-    }
+      const result = options.selector(snapshot as EditorStateSnapshot<Editor>)
+      lastSelectedStateRef.current = { stored: true, value: result }
 
-    const result = selectorRef.current(snapshot as EditorStateSnapshot<Editor>)
-    lastSelectedStateRef.current = result
+      return result
+    },
+    [options.selector],
+  )
 
-    return result
-  }, [])
+  const equalityFn = useCallback(
+    (a: TSelectorResult | null, b: TSelectorResult | null) => {
+      if (a === null) {
+        return a === b
+      }
+      return (options.equalityFn ?? deepEqual)(a, b)
+    },
+    [options.equalityFn],
+  )
 
   // Using the `useSyncExternalStore` hook to sync the editor instance with the component state
   const selectedState = useSyncExternalStoreWithSelector(
@@ -179,7 +197,7 @@ export function useEditorState<TSelectorResult>(
     editorStateManager.getSnapshot,
     editorStateManager.getServerSnapshot,
     selector,
-    options.equalityFn ?? deepEqual,
+    equalityFn,
   )
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
## Changes Overview

Fix `useEditorState` so selectors are not called when the editor snapshot briefly becomes `null` during teardown (for example in React StrictMode).

## Implementation Approach

Wrap the user selector and cache the last successful result in a discriminated `CachedSelectedState` ref (`stored: false` | `stored: true` with `value`). When the snapshot editor is `null` and nothing is cached yet, return `null` without calling the selector. When a cached value exists, return it via an `isCachedSelectedStateStored` type guard.

The selector `useCallback` depends on `options.selector`. A wrapped `equalityFn` treats `null` selections consistently during transient null snapshots.

This avoids the broader changes proposed in #7869 (no subscriber notifications on editor instance changes).

## Testing Done

Added `packages/react/src/useEditorState.spec.ts` covering:

- StrictMode remounts: selectors are never called with a `null` editor
- Permanently `null` editor: returns `null` without calling the selector

Ran `pnpm exec vitest run packages/react/src/useEditorState.spec.ts`.

## Verification Steps

Run the React package tests and verify a toolbar using `useEditorState` with `editor.can()` does not throw during StrictMode remounts.

## Additional Notes

Alternative to #7869 with a smaller surface area.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Used AI to investigate #7849 and #7869, implement the fix, add regression tests, run verification commands, and refine the cache typing.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7849