### PR TITLE
fix(core): exclude unselected cells from plain-text copy of cell selections

### DIFF
--- a/.changeset/angry-donuts-study.md
+++ b/.changeset/angry-donuts-study.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix plain-text copy of table cell selections including content from unselected cells in between. Each selected range is now serialized independently and joined in document order, so dragging upward (reverse selection) also produces output in document order.

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ yarn-error.log*
 # Turbo cache
 .turbo
 
+# Linter caches
+.eslintcache
+
 .rpt2_cache
 .rts2_cache
 .rts2_cache_cjs

--- a/packages/core/__tests__/clipboardTextSerializer.spec.ts
+++ b/packages/core/__tests__/clipboardTextSerializer.spec.ts
@@ -1,0 +1,67 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { TextSelection } from '@tiptap/pm/state'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const callClipboardTextSerializer = (editor: Editor): string => {
+  const serializer = editor.view.someProp('clipboardTextSerializer') as
+    | ((slice: ReturnType<typeof editor.state.selection.content>) => string)
+    | undefined
+
+  if (!serializer) {
+    throw new Error('clipboardTextSerializer prop not registered')
+  }
+
+  return serializer(editor.state.selection.content())
+}
+
+describe('clipboardTextSerializer', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('serializes the selected substring of a single TextSelection', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>hello world</p>',
+    })
+
+    const { state, view } = editor
+    const from = state.doc.resolve(1)
+    const to = state.doc.resolve(6)
+    view.dispatch(state.tr.setSelection(new TextSelection(from, to)))
+
+    expect(callClipboardTextSerializer(editor)).toBe('hello')
+  })
+
+  it('joins multiple paragraphs with the default block separator', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>first</p><p>second</p>',
+    })
+
+    const { state, view } = editor
+    view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 0, state.doc.content.size)))
+
+    expect(callClipboardTextSerializer(editor)).toBe('first\n\nsecond')
+  })
+
+  it('honors a custom blockSeparator option', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>first</p><p>second</p>',
+      coreExtensionOptions: {
+        clipboardTextSerializer: { blockSeparator: ' | ' },
+      },
+    })
+
+    const { state, view } = editor
+    view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 0, state.doc.content.size)))
+
+    expect(callClipboardTextSerializer(editor)).toBe('first | second')
+  })
+})

--- a/packages/core/src/extensions/clipboardTextSerializer.ts
+++ b/packages/core/src/extensions/clipboardTextSerializer.ts
@@ -26,18 +26,25 @@ export const ClipboardTextSerializer = Extension.create<ClipboardTextSerializerO
             const { editor } = this
             const { state, schema } = editor
             const { doc, selection } = state
-            const { ranges } = selection
-            const from = Math.min(...ranges.map(range => range.$from.pos))
-            const to = Math.max(...ranges.map(range => range.$to.pos))
             const textSerializers = getTextSerializersFromSchema(schema)
-            const range = { from, to }
-
-            return getTextBetween(doc, range, {
-              ...(this.options.blockSeparator !== undefined
-                ? { blockSeparator: this.options.blockSeparator }
-                : {}),
+            const { blockSeparator } = this.options
+            const options = {
+              ...(blockSeparator !== undefined ? { blockSeparator } : {}),
               textSerializers,
-            })
+            }
+
+            // Serialize each selection range independently and join the results.
+            // CellSelection exposes one range per selected cell; flattening to
+            // min(from)/max(to) would pull in unselected cells between them.
+            // Sort by document position so reverse selections (e.g. dragging
+            // upward) still emit text in document order.
+            const sortedRanges = [...selection.ranges].sort((a, b) => a.$from.pos - b.$from.pos)
+
+            return sortedRanges
+              .map(({ $from, $to }) =>
+                getTextBetween(doc, { from: $from.pos, to: $to.pos }, options),
+              )
+              .join(blockSeparator ?? '\n\n')
           },
         },
       }),

--- a/packages/extension-table/__tests__/tableClipboard.spec.ts
+++ b/packages/extension-table/__tests__/tableClipboard.spec.ts
@@ -1,0 +1,131 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import { TableKit } from '@tiptap/extension-table'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const callClipboardTextSerializer = (editor: Editor): string => {
+  const serializer = editor.view.someProp('clipboardTextSerializer') as
+    | ((slice: ReturnType<typeof editor.state.selection.content>) => string)
+    | undefined
+
+  if (!serializer) {
+    throw new Error('clipboardTextSerializer prop not registered')
+  }
+
+  return serializer(editor.state.selection.content())
+}
+
+const collectCellPositions = (editor: Editor): number[] => {
+  const positions: number[] = []
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+      positions.push(pos)
+    }
+  })
+  return positions
+}
+
+describe('Table plain-text clipboard serialization', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('only serializes selected cells when CellSelection spans non-adjacent rows', () => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    editor = new Editor({
+      element,
+      extensions: [Document, Paragraph, Text, TableKit],
+      content: `
+        <table>
+          <tbody>
+            <tr><td>A1</td><td>B1</td></tr>
+            <tr><td>A2</td><td>B2</td></tr>
+            <tr><td>A3</td><td>B3</td></tr>
+          </tbody>
+        </table>
+      `,
+    })
+
+    // Document order: A1, B1, A2, B2, A3, B3
+    const cells = collectCellPositions(editor)
+
+    // Select column 0 across all three rows: A1 -> A3.
+    // ProseMirror's CellSelection turns this into a rectangular selection
+    // covering A1, A2, A3 only. The bug was that the plain-text serializer
+    // also pulled in B1 and B2 because they sit between A1 and A3 in doc order.
+    editor.chain().focus().setCellSelection({ anchorCell: cells[0], headCell: cells[4] }).run()
+
+    const result = callClipboardTextSerializer(editor)
+
+    expect(result).toContain('A1')
+    expect(result).toContain('A2')
+    expect(result).toContain('A3')
+    expect(result).not.toContain('B1')
+    expect(result).not.toContain('B2')
+    expect(result).not.toContain('B3')
+  })
+
+  it('emits cells in document order even when CellSelection is built bottom-up', () => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    editor = new Editor({
+      element,
+      extensions: [Document, Paragraph, Text, TableKit],
+      content: `
+        <table>
+          <tbody>
+            <tr><td>A1</td><td>B1</td></tr>
+            <tr><td>A2</td><td>B2</td></tr>
+            <tr><td>A3</td><td>B3</td></tr>
+          </tbody>
+        </table>
+      `,
+    })
+
+    const cells = collectCellPositions(editor)
+
+    // Reverse selection: anchor on the bottom cell, head on the top cell.
+    // Simulates a user dragging upward. ranges may not be in doc order.
+    editor.chain().focus().setCellSelection({ anchorCell: cells[4], headCell: cells[0] }).run()
+
+    const result = callClipboardTextSerializer(editor)
+
+    expect(result.indexOf('A1')).toBeLessThan(result.indexOf('A2'))
+    expect(result.indexOf('A2')).toBeLessThan(result.indexOf('A3'))
+  })
+
+  it('serializes adjacent cells in a row without dropping content', () => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    editor = new Editor({
+      element,
+      extensions: [Document, Paragraph, Text, TableKit],
+      content: `
+        <table>
+          <tbody>
+            <tr><td>A1</td><td>B1</td><td>C1</td></tr>
+            <tr><td>A2</td><td>B2</td><td>C2</td></tr>
+          </tbody>
+        </table>
+      `,
+    })
+
+    // Document order: A1, B1, C1, A2, B2, C2
+    const cells = collectCellPositions(editor)
+
+    // Select A1 and B1 (same row, adjacent).
+    editor.chain().focus().setCellSelection({ anchorCell: cells[0], headCell: cells[1] }).run()
+
+    const result = callClipboardTextSerializer(editor)
+
+    expect(result).toContain('A1')
+    expect(result).toContain('B1')
+    expect(result).not.toContain('C1')
+    expect(result).not.toContain('A2')
+  })
+})


### PR DESCRIPTION
## Changes Overview

Fixes #6867: copying a table `CellSelection` and pasting as plain text included text from cells between the selected ones.

## Implementation Approach

`clipboardTextSerializer` no longer flattens `selection.ranges` to a single `min/max` window — it serializes each range independently and joins them with `blockSeparator`, sorted by document position so reverse drags also emit in doc order.

## Testing Done

Added 6 vitest specs (3 in core, 3 in extension-table) covering single `TextSelection` regression paths, the bug scenario (non-adjacent rows), reverse drag ordering, and adjacent cells; full suite passes 1064/1064.

## Verification Steps

Run `pnpm dev`, open the Table React demo, drag-select two cells in the same column and paste as plain text (Cmd+Shift+V) — only the selected cells should appear.

## Additional Notes

`@tiptap/core` patch; no public API change. `NodeRangeSelection` (the other multi-range `Selection` consumer) still produces identical output because its ranges are contiguous in document order.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude to investigate the root cause in `clipboardTextSerializer.ts`, plan the per-range fix, write unit tests, and audit blast radius across `Selection` subclasses.

## Related Issues

Fixes #6867