### PR TITLE
Omit toText property from serialized schema

### DIFF
--- a/.changeset/2026-05-27-serialize-schema-omit-totext.md
+++ b/.changeset/2026-05-27-serialize-schema-omit-totext.md
@@ -2,4 +2,4 @@
 '@tiptap/server-ai-toolkit': patch
 ---
 
-Exclude `toText` from serialized node specs in schema awareness so schema serialization remains JSON-safe when node specs define text extraction callbacks.
+Exclude `toText` property when serializing the schema into a JSON object, because it is a function and functions are not serializable.

--- a/.changeset/2026-05-27-serialize-schema-omit-totext.md
+++ b/.changeset/2026-05-27-serialize-schema-omit-totext.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/server-ai-toolkit': patch
+---
+
+Exclude `toText` from serialized node specs in schema awareness so schema serialization remains JSON-safe when node specs define text extraction callbacks.

--- a/packages/server-ai-toolkit/src/schema-awareness/utils/serialize-schema.ts
+++ b/packages/server-ai-toolkit/src/schema-awareness/utils/serialize-schema.ts
@@ -15,12 +15,13 @@ export type SerializedAttributeSpec = Omit<AttributeSpec, 'validate'> & {
 type SerializedAttributes = { attrs?: Record<string, SerializedAttributeSpec> }
 
 /**
- * A serialized version of NodeSpec with non-serializable properties (toDOM, parseDOM, toDebugString, leafText)
- * removed and attrs converted to SerializedAttributeSpec format.
+ * A serialized version of NodeSpec with non-serializable properties
+ * (toDOM, parseDOM, toDebugString, leafText, toText) removed and attrs converted to
+ * SerializedAttributeSpec format.
  */
 export type SerializedNodeSpec = Omit<
   NodeSpec,
-  'toDOM' | 'parseDOM' | 'toDebugString' | 'leafText' | 'attrs'
+  'toDOM' | 'parseDOM' | 'toDebugString' | 'leafText' | 'toText' | 'attrs'
 > &
   SerializedAttributes
 
@@ -70,15 +71,16 @@ function serializeAttributeSpecs(
 }
 
 /**
- * Serializes a NodeSpec by removing non-serializable properties (toDOM, parseDOM, toDebugString, leafText)
- * and converting the attrs to SerializedAttributeSpec format.
+ * Serializes a NodeSpec by removing non-serializable properties
+ * (toDOM, parseDOM, toDebugString, leafText, toText) and converting the attrs to
+ * SerializedAttributeSpec format.
  *
  * @param nodeSpec - The NodeSpec to serialize
  * @returns A SerializedNodeSpec with only JSON-serializable properties
  */
 function serializeNodeSpec(nodeSpec: NodeSpec): SerializedNodeSpec {
   return {
-    ...omit(nodeSpec, ['toDOM', 'parseDOM', 'toDebugString', 'leafText', 'attrs']),
+    ...omit(nodeSpec, ['toDOM', 'parseDOM', 'toDebugString', 'leafText', 'toText', 'attrs']),
     attrs: nodeSpec.attrs ? serializeAttributeSpecs(nodeSpec.attrs) : undefined,
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes Overview

Exclude `toText` when serializing `NodeSpec` values in `@tiptap/server-ai-toolkit` schema awareness. `toText` is a function callback (like `toDOM` and `leafText`) and must not appear in JSON-serialized schema output sent to the Server AI Toolkit.

## Implementation Approach

Updated `SerializedNodeSpec` and `serializeNodeSpec` in `packages/server-ai-toolkit/src/schema-awareness/utils/serialize-schema.ts` to omit `toText` alongside the other non-serializable node spec properties.

## Testing Done

- `pnpm -w -F @tiptap/server-ai-toolkit lint`
- `pnpm -w -F @tiptap/server-ai-toolkit build`

No dedicated unit tests exist for schema serialization in this package; the change mirrors existing handling for `toDOM`, `parseDOM`, `toDebugString`, and `leafText`.

## Verification Steps

1. Use an editor schema whose node specs define `toText`.
2. Trigger schema awareness / editor context serialization.
3. Confirm the serialized schema JSON does not include `toText` on any node spec.

## Additional Notes

Patch changeset included: `.changeset/2026-05-27-serialize-schema-omit-totext.md`.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Applied the requested `toText` omission in the schema serializer.
  - Added the changeset and opened this pull request.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d7a83be-d41d-4f1f-b612-bc700c8e1918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d7a83be-d41d-4f1f-b612-bc700c8e1918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

