### PR TITLE
fix: prevent inline image drag creating a duplicate (file-handler + image + ResizableNodeView)

### DIFF
--- a/.changeset/2026-05-29-file-handler-inline-image-drag-duplicate.md
+++ b/.changeset/2026-05-29-file-handler-inline-image-drag-duplicate.md
@@ -1,0 +1,9 @@
+---
+'@tiptap/core': patch
+'@tiptap/extension-file-handler': patch
+'@tiptap/extension-image': patch
+---
+
+Fix: dragging an inline/resizable image within the editor no longer creates a duplicate
+
+When the `Image` extension was configured with `inline: true` or `resize` enabled, dragging an image within the editor could insert a duplicate at the drop position instead of moving it. This happened because the browser's native image drag behavior could populate `dataTransfer.files`, causing the FileHandler extension to intercept the drop before ProseMirror's internal move logic could run.

--- a/packages/core/src/lib/ResizableNodeView.ts
+++ b/packages/core/src/lib/ResizableNodeView.ts
@@ -405,6 +405,7 @@ export class ResizableNodeView {
     this.node = options.node
     this.editor = options.editor
     this.element = options.element
+    this.element.draggable = false
     this.contentElement = options.contentElement
 
     this.getPos = options.getPos

--- a/packages/extension-file-handler/src/FileHandlePlugin.ts
+++ b/packages/extension-file-handler/src/FileHandlePlugin.ts
@@ -18,6 +18,13 @@ export const FileHandlePlugin = ({
           return false
         }
 
+        // If the drop contains ProseMirror internal slice data, let ProseMirror
+        // handle it — this is an internal content drag (e.g. moving an image),
+        // not an external file drop
+        if (event.dataTransfer?.types.includes('application/x-prosemirror-slice')) {
+          return false
+        }
+
         if (!event.dataTransfer?.files.length) {
           return false
         }

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -152,6 +152,7 @@ export const Image = Node.create<ImageOptions>({
 
     return ({ node, getPos, HTMLAttributes, editor }) => {
       const el = document.createElement('img')
+      el.draggable = false
 
       Object.entries(HTMLAttributes).forEach(([key, value]) => {
         if (value != null) {


### PR DESCRIPTION
## Changes Overview

When the `Image` extension is configured with `inline: true` or `resize` enabled, dragging an image within the editor inserts a duplicate at the drop position instead of moving it. The bug only affects the `inline`/`resize` configuration — default block images work correctly.

## Implementation Approach

The fix addresses the issue at **three levels** for defense in depth:

- **`@tiptap/extension-file-handler`**: Check for ProseMirrors internal slice type (`application/x-prosemirror-slice`) in `dataTransfer.types` before checking `files.length`. If the slice is present, the drop is an internal content drag and ProseMirror should handle it — not the FileHandler.
- **`@tiptap/extension-image`**: Set `draggable="false"` on the `<img>` element in the node view. This prevents the browser from adding native drag data to `dataTransfer.files` when an inline image is dragged, consistent with the pattern already used by the emoji extension.
- **`@tiptap/core` (ResizableNodeView)**: Set `element.draggable = false` in the constructor as a general safeguard for all resizable node views.

The key insight is that ProseMirror calls plugin `handleDrop` handlers **before** its own default drop handler (see `prosemirror-view/src/input.ts` line 720). The FileHandler was seeing `dataTransfer.files.length > 0` (from the browsers native `<img>` drag behavior) and intercepting the drop, preventing ProseMirror from performing the move.

Setting `draggable="false"` on the inner element does **not** affect ProseMirror drag initiation — ProseMirror works through the node views `dom` (the container), where it temporarily sets `draggable="true"` via the `MouseDown.mightDrag.addAttr` mechanism (`prosemirror-view/src/input.ts` lines 333-351).

## Testing Done

- [x] `pnpm lint` — passes clean
- [x] `pnpm build` — `@tiptap/core`, `@tiptap/extension-file-handler`, and `@tiptap/extension-image` all build successfully

## Verification Steps

1. Configure an editor with `Image` (`inline: true`, `resize: { enabled: true }`) and `FileHandler`
2. Insert an image into the editor
3. Drag the image to a new position within the editor
4. Verify the image **moves** to the new position (original should not remain)
5. Verify the same scenario works without `inline` and `resize` (default config)
6. Verify resize handles still work correctly

## Additional Notes

The emoji extension already uses the same `draggable="false"` pattern on its fallback `<img>` elements (`packages/extension-emoji/src/emoji.ts` line 224).

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - AI assisted with root cause analysis by tracing ProseMirror drag-and-drop internals
  - AI helped write the implementation and changeset

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7023