### PR TITLE
feat(extension-list-keymap): lift list item before merging on backspace

### DIFF
--- a/.changeset/2026-05-29-list-keymap-backspace-lift-first.md
+++ b/.changeset/2026-05-29-list-keymap-backspace-lift-first.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': minor
+---
+
+`ListKeymap`'s Backspace handler now lifts the current list item before merging. At the start of a non-first list item, the item is lifted out of its wrapping list (splitting the list around it) instead of immediately joining its content into the previous item. A second Backspace then hits the existing "paragraph after a list" branch and merges the lifted textblock's content into the previous list's last item. Mirrors the two-step behavior introduced for blockquote in #7891.

--- a/demos/src/Extensions/ListKeymap/index.spec.ts
+++ b/demos/src/Extensions/ListKeymap/index.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+
+import { getEditor } from '../../../test/helpers.js'
+
+const demoName = 'ListKeymap'
+const frameworkPaths = ['React']
+const demoPath = '/src/Extensions'
+
+test.describe(`${demoPath}/${demoName}`, () => {
+  frameworkPaths.forEach(frameworkPath => {
+    const fullDemoPath = `${demoPath}/${demoName}/${frameworkPath}/`
+
+    test.describe(`${frameworkPath}`, () => {
+      test.beforeEach(async ({ page }) => {
+        await page.goto(fullDemoPath)
+      })
+
+      const placeCaretBefore = async (
+        editor: Awaited<ReturnType<typeof getEditor>>,
+        content: string,
+        target: string,
+      ) => {
+        await editor.evaluate(
+          (el: any, { content: innerContent, target: innerTarget }: any) => {
+            el.editor.commands.setContent(innerContent)
+            let caret = -1
+            el.editor.state.doc.descendants((node: any, pos: number) => {
+              if (caret !== -1 || !node.isText) return
+              const offset = node.text.indexOf(innerTarget)
+              if (offset !== -1) caret = pos + offset
+            })
+            if (caret === -1) throw new Error(`Could not find "${innerTarget}" in the document`)
+            el.editor.chain().focus().setTextSelection({ from: caret, to: caret }).run()
+          },
+          { content, target },
+        )
+      }
+
+      test('backspace at the start of a non-first item lifts it out of the list', async ({
+        page,
+      }) => {
+        const editor = await getEditor(page)
+        await placeCaretBefore(editor, '<ul><li><p>A</p></li><li><p>B</p></li></ul>', 'B')
+        await editor.press('Backspace')
+        const html = await editor.evaluate((el: any) => el.editor.getHTML())
+        expect(html).toBe('<ul><li><p>A</p></li></ul><p>B</p>')
+      })
+
+      test('backspace at the start of a middle item splits the list around it', async ({
+        page,
+      }) => {
+        const editor = await getEditor(page)
+        await placeCaretBefore(
+          editor,
+          '<ul><li><p>A</p></li><li><p>B</p></li><li><p>C</p></li></ul>',
+          'B',
+        )
+        await editor.press('Backspace')
+        const html = await editor.evaluate((el: any) => el.editor.getHTML())
+        expect(html).toBe('<ul><li><p>A</p></li></ul><p>B</p><ul><li><p>C</p></li></ul>')
+      })
+
+      test('lift then merge: two backspaces collapse a child back into the previous item', async ({
+        page,
+      }) => {
+        const editor = await getEditor(page)
+        await placeCaretBefore(editor, '<ul><li><p>A</p></li><li><p>B</p></li></ul>', 'B')
+        await editor.press('Backspace')
+        await editor.press('Backspace')
+        const html = await editor.evaluate((el: any) => el.editor.getHTML())
+        expect(html).toBe('<ul><li><p>AB</p></li></ul>')
+      })
+    })
+  })
+})

--- a/packages/extension-list/src/keymap/listHelpers/handleBackspace.ts
+++ b/packages/extension-list/src/keymap/listHelpers/handleBackspace.ts
@@ -2,10 +2,7 @@ import type { Editor } from '@tiptap/core'
 import { isAtStartOfNode, isNodeActive } from '@tiptap/core'
 import type { Node } from '@tiptap/pm/model'
 
-import { findListItemPos } from './findListItemPos.js'
 import { hasListBefore } from './hasListBefore.js'
-import { hasListItemBefore } from './hasListItemBefore.js'
-import { listItemHasSubList } from './listItemHasSubList.js'
 
 export const handleBackspace = (editor: Editor, name: string, parentListTypes: string[]) => {
   // this is required to still handle the undo handling
@@ -62,24 +59,8 @@ export const handleBackspace = (editor: Editor, name: string, parentListTypes: s
     return false
   }
 
-  const listItemPos = findListItemPos(name, editor.state)
-
-  if (!listItemPos) {
-    return false
-  }
-
-  const $prev = editor.state.doc.resolve(listItemPos.$pos.pos - 2)
-  const prevNode = $prev.node(listItemPos.depth)
-
-  const previousListItemHasSubList = listItemHasSubList(name, editor.state, prevNode)
-
-  // if the previous item is a list item and doesn't have a sublist, join the list items
-  if (hasListItemBefore(name, editor.state) && !previousListItemHasSubList) {
-    return editor.commands.joinItemBackward()
-  }
-
-  // otherwise in the end, a backspace should
-  // always just lift the list item if
-  // joining / merging is not possible
+  // At the start of a list item, lift it out. Top-level items split the
+  // wrapping list around them; nested items get promoted into the outer
+  // list. A second backspace then falls through to the merge branch above.
   return editor.chain().liftListItem(name).run()
 }


### PR DESCRIPTION
## Changes Overview

Make `ListKeymap`'s Backspace at the start of a non-first list item _lift_ the item out of its wrapping list, splitting the list around it, instead of immediately joining its content into the previous item. A second Backspace then hits the existing "paragraph after a list" branch and merges the lifted textblock's content into the previous list's last item.

**Mirrors the two-step behavior introduced for blockquote in #7891.**

Before:


https://github.com/user-attachments/assets/4e59d3f6-6c05-4a5c-a631-1fa0bfb5a7aa


After (Notion-style):


https://github.com/user-attachments/assets/5354364e-a6f4-44d7-b2dd-0962393db9f3



## Implementation Approach

`handleBackspace` previously branched on whether the previous sibling list item had a sublist:

```ts
if (hasListItemBefore(name, editor.state) && !previousListItemHasSubList) {
  return editor.commands.joinItemBackward()
}
return editor.chain().liftListItem(name).run()
```

The "join immediately" path is now removed — the handler always calls `liftListItem`, which:

- splits the wrapping list around the current item when it's a top-level list item (via `liftOutOfList` in `prosemirror-schema-list`), and
- promotes a nested item into its outer list when the current item is in a sublist.

The earlier `hasListBefore` branch — which fires when the cursor sits at the start of a top-level textblock immediately after a list — already merges the textblock's content into the list's last item, so the second Backspace press is handled there without extra code.

`findListItemPos`, `hasListItemBefore`, and `listItemHasSubList` are no longer used inside `handleBackspace`, but they're still re-exported from `listHelpers/index.ts` as public API and remain in place.

## Testing Done

Added Playwright tests in `demos/src/Extensions/ListKeymap/index.spec.ts` (the demo that actually loads `ListKeymap`):

- Backspace at the start of a non-first item lifts it out: `<ul><li>A</li><li>|B</li></ul>` → `<ul><li>A</li></ul><p>|B</p>`.
- Backspace at the start of a middle item splits the list around it: `<ul><li>A</li><li>|B</li><li>C</li></ul>` → `<ul><li>A</li></ul><p>|B</p><ul><li>C</li></ul>`.
- Lift-then-merge: two backspaces collapse a child back into the previous item: `<ul><li>A</li><li>|B</li></ul>` → `<ul><li>AB</li></ul>` (after two presses).

All existing list specs (BulletList, OrderedList, TaskList) continue to pass — 47 chromium tests pass overall. The cursor positions in the new tests are computed by walking `doc.descendants` for the target text rather than using hardcoded offsets, so they remain valid if the schema changes.

`pnpm check` (lint + format) is clean.

## Verification Steps

1. `pnpm install`
2. `pnpm test:e2e --grep "ListKeymap|BulletList|OrderedList|TaskList"`
3. Manually in the ListKeymap demo: open `/src/Extensions/ListKeymap/React/`, set content to `<ul><li>A</li><li>B</li><li>C</li></ul>`, place caret at the start of `B`, press Backspace once → list splits around `B`; press Backspace again → `B` merges back into the previous item.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.