### PR TITLE
fix(extension-image): ensure HTMLAttributes are applied in editor DOM when resize is enabled

### DIFF
--- a/.changeset/2026-05-30-image-htmlattributes-resize.md
+++ b/.changeset/2026-05-30-image-htmlattributes-resize.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-image': patch
+---
+
+Fix `HTMLAttributes` not being applied to the editor DOM when `resize` is enabled. The `addNodeView` path was using only the resolved node attributes and skipping the user-configured `HTMLAttributes` option. Now it merges them consistently with how `renderHTML` already works.

--- a/packages/extension-image/__tests__/image.spec.ts
+++ b/packages/extension-image/__tests__/image.spec.ts
@@ -1,0 +1,221 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Image from '@tiptap/extension-image'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { Markdown } from '@tiptap/markdown'
+import { describe, expect, it } from 'vitest'
+
+describe('extension-image', () => {
+  const editorElClass = 'tiptap'
+  let editor: Editor | null = null
+
+  const createEditorEl = () => {
+    const editorEl = document.createElement('div')
+
+    editorEl.classList.add(editorElClass)
+    document.body.appendChild(editorEl)
+
+    return editorEl
+  }
+
+  const getEditorEl = () => document.querySelector(`.${editorElClass}`)
+
+  const imgSrc = 'https://example.com/image.jpg'
+
+  it('should apply HTMLAttributes via renderHTML when resize is disabled', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Image.configure({
+          HTMLAttributes: {
+            class: 'my-classname',
+          },
+        }),
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'image',
+            attrs: { src: imgSrc, alt: 'test-alt' },
+          },
+        ],
+      },
+    })
+
+    expect(editor.getHTML()).toContain('class="my-classname"')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
+  it('should apply HTMLAttributes in the editor DOM when resize is disabled', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Image.configure({
+          HTMLAttributes: {
+            class: 'my-classname',
+          },
+        }),
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'image',
+            attrs: { src: imgSrc, alt: 'test-alt' },
+          },
+        ],
+      },
+    })
+
+    const img = editor.view.dom.querySelector('img')
+    expect(img).not.toBeNull()
+    // ProseMirror may add additional classes like 'ProseMirror-selectednode'
+    expect(img?.getAttribute('class')).toContain('my-classname')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
+  it('should apply HTMLAttributes via renderHTML when resize is enabled', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Image.configure({
+          HTMLAttributes: {
+            class: 'my-classname',
+          },
+          resize: {
+            enabled: true,
+          },
+        }),
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'image',
+            attrs: { src: imgSrc, alt: 'test-alt' },
+          },
+        ],
+      },
+    })
+
+    // getHTML() goes through renderHTML which already correctly merges HTMLAttributes
+    expect(editor.getHTML()).toContain('class="my-classname"')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
+  it('should apply HTMLAttributes in the editor DOM when resize is enabled', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Image.configure({
+          HTMLAttributes: {
+            class: 'my-classname',
+            'data-test': 'value',
+          },
+          resize: {
+            enabled: true,
+          },
+        }),
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'image',
+            attrs: { src: imgSrc, alt: 'test-alt' },
+          },
+        ],
+      },
+    })
+
+    const img = editor.view.dom.querySelector('img')
+    expect(img).not.toBeNull()
+    // THIS IS THE BUG: when resize is enabled, addNodeView takes over DOM creation
+    // and does NOT apply this.options.HTMLAttributes - only the node's resolved attrs
+    expect(img?.getAttribute('class')).toBe('my-classname')
+    expect(img?.getAttribute('data-test')).toBe('value')
+    expect(img?.getAttribute('src')).toBe(imgSrc)
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
+  it('should apply HTMLAttributes in the editor DOM when resize is enabled and content is markdown', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Markdown,
+        Image.configure({
+          HTMLAttributes: {
+            class: 'my-classname',
+          },
+          resize: {
+            enabled: true,
+          },
+        }),
+      ],
+      content: '![Image](https://example.com/image.jpg)',
+      contentType: 'markdown',
+    })
+
+    const img = editor.view.dom.querySelector('img')
+    expect(img).not.toBeNull()
+    // THIS IS THE BUG: same issue - node view doesn't apply options.HTMLAttributes
+    expect(img?.getAttribute('class')).toBe('my-classname')
+    expect(img?.getAttribute('src')).toBe('https://example.com/image.jpg')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
+  it('should apply HTMLAttributes via renderHTML when resize is enabled and content is markdown', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Markdown,
+        Image.configure({
+          HTMLAttributes: {
+            class: 'my-classname',
+          },
+          resize: {
+            enabled: true,
+          },
+        }),
+      ],
+      content: '![Image](https://example.com/image.jpg)',
+      contentType: 'markdown',
+    })
+
+    // getHTML() goes through renderHTML which already correctly merges HTMLAttributes
+    expect(editor.getHTML()).toContain('class="my-classname"')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+})

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -153,7 +153,9 @@ export const Image = Node.create<ImageOptions>({
     return ({ node, getPos, HTMLAttributes, editor }) => {
       const el = document.createElement('img')
 
-      Object.entries(HTMLAttributes).forEach(([key, value]) => {
+      const mergedAttributes = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)
+
+      Object.entries(mergedAttributes).forEach(([key, value]) => {
         if (value != null) {
           switch (key) {
             case 'width':
@@ -166,7 +168,7 @@ export const Image = Node.create<ImageOptions>({
         }
       })
 
-      el.src = HTMLAttributes.src
+      el.src = mergedAttributes.src
 
       const nodeView = new ResizableNodeView({
         element: el,

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -168,7 +168,9 @@ export const Image = Node.create<ImageOptions>({
         }
       })
 
-      el.src = mergedAttributes.src
+      if (mergedAttributes.src !== null) {
+        el.src = mergedAttributes.src
+      }
 
       const nodeView = new ResizableNodeView({
         element: el,


### PR DESCRIPTION
## Changes Overview

Fixes a bug where `HTMLAttributes` configured on the Image extension (e.g., `class: "my-classname"`) were silently dropped from the editor DOM when `resize.enabled` is `true`.

## Implementation Approach

The Image extension has two rendering paths:

- **`renderHTML`** — used by `editor.getHTML()` and copy/paste — already correctly merged `this.options.HTMLAttributes` with node attributes via `mergeAttributes()`.
- **`addNodeView`** — used for live editor DOM rendering when `resize.enabled: true` — was iterating only the resolved ProseMirror node attributes (src, alt, title) and skipping the user-configured HTMLAttributes entirely.

The fix applies the same `mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)` merge at the top of the `addNodeView` node view factory, mirroring what `renderHTML` already does.

## Testing Done

- Added 6 new unit tests in `packages/extension-image/__tests__/image.spec.ts`:
  - `renderHTML` path with and without resize (baseline — already worked)
  - Editor DOM path with resize enabled (JSON content) — **was failing, now fixed**
  - Editor DOM path with resize enabled (markdown content) — **was failing, now fixed**
- Full test suite: **1070 tests pass** (6 new + 1064 existing)
- Lint: clean
- Build: successful

## Verification Steps

1. Configure the Image extension with both `HTMLAttributes` and `resize.enabled: true`
2. Insert an image (via command, markdown, or HTML)
3. Inspect the `<img>` element in the editor DOM — it should have the configured HTML attributes

## Additional Notes

N/A

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - AI assisted with root cause analysis, test writing, and fix implementation for the Tiptap monorepo.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes https://github.com/ueberdosis/tiptap/issues/7240