### PR TITLE
fix(extension-table): apply HTMLAttributes in TableView node view

### DIFF
--- a/.changeset/2026-05-30-table-html-attributes-nodeview.md
+++ b/.changeset/2026-05-30-table-html-attributes-nodeview.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Fix `HTMLAttributes` not being applied to the `<table>` element when `resizable` is disabled (the default). The `TableView` node view (introduced in 3.23) bypassed `renderHTML` and never applied user-configured attributes like `class` or `data-*` to the rendered table element.

--- a/packages/extension-table/__tests__/tableHTMLAttributes.spec.ts
+++ b/packages/extension-table/__tests__/tableHTMLAttributes.spec.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+describe('Table HTMLAttributes', () => {
+  let editor: Editor | null = null
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+  })
+
+  it('applies HTMLAttributes to the <table> element when resizable is false (default)', () => {
+    const editorEl = document.createElement('div')
+    document.body.appendChild(editorEl)
+
+    editor = new Editor({
+      element: editorEl,
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        TableCell,
+        TableHeader,
+        TableRow,
+        Table.configure({
+          HTMLAttributes: { class: 'my-custom-table', 'data-test': 'table-test' },
+          resizable: false,
+        }),
+      ],
+    })
+    editor.commands.insertTable({ rows: 2, cols: 2, withHeaderRow: false })
+
+    const table = editor.view.dom.querySelector('table')!
+    expect(table.classList.contains('my-custom-table')).toBe(true)
+    expect(table.getAttribute('data-test')).toBe('table-test')
+
+    editorEl.remove()
+  })
+
+  it('applies HTMLAttributes to the <table> element when View is null (renderHTML fallback)', () => {
+    const editorEl = document.createElement('div')
+    document.body.appendChild(editorEl)
+
+    editor = new Editor({
+      element: editorEl,
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        TableCell,
+        TableHeader,
+        TableRow,
+        Table.configure({
+          HTMLAttributes: { class: 'fallback-class' },
+          View: null,
+        }),
+      ],
+    })
+    editor.commands.insertTable({ rows: 2, cols: 2, withHeaderRow: false })
+
+    const table = editor.view.dom.querySelector('table')!
+    expect(table.classList.contains('fallback-class')).toBe(true)
+
+    editorEl.remove()
+  })
+})

--- a/packages/extension-table/src/table/TableView.ts
+++ b/packages/extension-table/src/table/TableView.ts
@@ -1,5 +1,5 @@
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
-import type { NodeView, ViewMutationRecord } from '@tiptap/pm/view'
+import type { EditorView, NodeView, ViewMutationRecord } from '@tiptap/pm/view'
 
 import { getColStyleDeclaration } from './utilities/colStyle.js'
 
@@ -87,14 +87,33 @@ export class TableView implements NodeView {
 
   contentDOM: HTMLTableSectionElement
 
-  constructor(node: ProseMirrorNode, cellMinWidth: number) {
+  constructor(
+    node: ProseMirrorNode,
+    cellMinWidth: number,
+    _view?: EditorView,
+    HTMLAttributes: Record<string, any> = {},
+  ) {
     this.node = node
     this.cellMinWidth = cellMinWidth
     this.dom = document.createElement('div')
     this.dom.className = 'tableWrapper'
     this.table = this.dom.appendChild(document.createElement('table'))
 
-    // Apply user styles to the table element
+    // Apply extension-configured HTMLAttributes to the table element
+    // (e.g. class, data-* set via Table.configure({ HTMLAttributes }))
+    for (const [key, value] of Object.entries(HTMLAttributes)) {
+      if (value !== undefined && value !== null) {
+        if (key === 'style') {
+          this.table.style.cssText = String(value)
+        } else {
+          this.table.setAttribute(key, String(value))
+        }
+      }
+    }
+
+    // Apply user styles from the ProseMirror document node.
+    // This may come from HTML parsing (e.g. <table style="...">) and should
+    // override any style set via extension-configured HTMLAttributes above.
     if (node.attrs.style) {
       this.table.style.cssText = node.attrs.style
     }

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -85,7 +85,14 @@ export interface TableOptions {
    * The node view to render the table.
    * @default TableView
    */
-  View: (new (node: ProseMirrorNode, cellMinWidth: number, view: EditorView) => NodeView) | null
+  View:
+    | (new (
+        node: ProseMirrorNode,
+        cellMinWidth: number,
+        view: EditorView,
+        HTMLAttributes?: Record<string, any>,
+      ) => NodeView)
+    | null
 
   /**
    * Enables the resizing of the last column.
@@ -531,7 +538,11 @@ export const Table = Node.create<TableOptions>({
       return null
     }
 
-    return ({ node, view }) => new View(node, this.options.cellMinWidth, view)
+    return ({ node, view, HTMLAttributes }) => {
+      const mergedAttributes = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)
+
+      return new View(node, this.options.cellMinWidth, view, mergedAttributes) as NodeView
+    }
   },
 
   extendNodeSchema(extension) {


### PR DESCRIPTION
## Changes Overview

Fix a regression introduced in 3.23 where `Table.configure({ HTMLAttributes: { class: 'my-custom-table' } })` silently drops those attributes from the rendered `<table>` element when `resizable: false` (the default). The `TableView` node view built the DOM manually but never applied `this.options.HTMLAttributes`, bypassing the schema-level `renderHTML` which correctly merged them.

## Implementation Approach

Three minimal, backward-compatible changes:

1. **`TableView.ts`** — Updated the constructor to accept an `HTMLAttributes` parameter (4th, optional) and apply its entries to `this.table` via `setAttribute` / `style.cssText`. Existing `node.attrs.style` handling is preserved as the final override for style.

2. **`table.ts` (`addNodeView`)** — The node view function now destructures `HTMLAttributes` from the props (passed by `ExtensionManager`), merges it with `this.options.HTMLAttributes` via `mergeAttributes`, and passes the result to `TableView`. The `TableOptions.View` type was updated to reflect the new optional 4th parameter.

3. **New test file** — `tableHTMLAttributes.spec.ts` with two tests: one asserting attributes are present for the default non-resizable path, and one asserting the `View: null` workaround continues to work.

## Testing Done

- `npx vitest run packages/extension-table` — **46/46 existing tests pass** (no regressions)
- `npx vitest run packages/extension-table/__tests__/tableHTMLAttributes.spec.ts` — **2/2 new tests pass**
- `pnpm lint` — passes
- `pnpm build` — all packages build successfully, including `@tiptap/extension-table`

## Verification Steps

1. Run `pnpm build && pnpm test:unit` to confirm no regressions
2. Create an editor with `Table.configure({ HTMLAttributes: { class: 'my-custom-table' } })` and inspect the rendered DOM — the `<table>` element should have `class=\my-custom-table\`

## Additional Notes

The `resizable: true` path uses ProseMirror's `columnResizing` plugin (which has its own NodeView creation mechanism) and is a separate, orthogonal issue not addressed here.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Used to investigate the codebase, trace the HTMLAttributes data flow, write the reproduction test, and draft the implementation.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7834