### PR TITLE
fix(static-renderer): type JSON renderers so JSONContent works without casts

### DIFF
--- a/.changeset/chatty-rules-occur.md
+++ b/.changeset/chatty-rules-occur.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/static-renderer': patch
+---
+
+Fix the types of `renderJSONContentToReactElement` and `renderJSONContentToString`. They defaulted their node and mark generics to the ProseMirror-oriented `NodeType`/`MarkType`, so `node.text` did not exist in a node mapping, every node prop was typed `any`, and passing a value typed as `JSONContent` failed (`type` is optional in `JSONContent` but was required). They now default to the newly exported `JSONNodeType`/`JSONMarkType`, so `node.text` is typed `string | undefined` and a `JSONContent` document is accepted directly. The ProseMirror `pm/*` renderers are unaffected, since they parameterize explicitly with `Mark`/`Node`.

--- a/.changeset/chatty-rules-occur.md
+++ b/.changeset/chatty-rules-occur.md
@@ -2,4 +2,4 @@
 '@tiptap/static-renderer': patch
 ---
 
-Fix the types of `renderJSONContentToReactElement` and `renderJSONContentToString`. They defaulted their node and mark generics to the ProseMirror-oriented `NodeType`/`MarkType`, so `node.text` did not exist in a node mapping, every node prop was typed `any`, and passing a value typed as `JSONContent` failed (`type` is optional in `JSONContent` but was required). They now default to the newly exported `JSONNodeType`/`JSONMarkType`, so `node.text` is typed `string | undefined` and a `JSONContent` document is accepted directly. The ProseMirror `pm/*` renderers are unaffected, since they parameterize explicitly with `Mark`/`Node`.
+Fix the types of the JSON static renderers (`renderJSONContentToReactElement` and `renderJSONContentToString`): you can now pass `JSONContent` directly and read node fields like `node.text` in your mappings without type errors or casts.

--- a/packages/static-renderer/__tests__/json-string.spec.ts
+++ b/packages/static-renderer/__tests__/json-string.spec.ts
@@ -1,4 +1,3 @@
-import type { TextType } from '@tiptap/core'
 import { extensions as coreExtensions } from '@tiptap/core'
 import Bold from '@tiptap/extension-bold'
 import CodeBlock from '@tiptap/extension-code-block'
@@ -49,7 +48,9 @@ describe('static render json to string (no prosemirror)', () => {
           return `<p>${serializeChildrenToHTMLString(children)}</p>`
         },
         text: ({ node }) => {
-          return (node as unknown as TextType).text
+          // `node.text` is accessible directly (typed `string | undefined`)
+          // without casting to `TextType`.
+          return node.text ?? ''
         },
       },
       markMapping: {},
@@ -90,7 +91,9 @@ describe('static render json to string (no prosemirror)', () => {
           return `<p>${serializeChildrenToHTMLString(children)}</p>`
         },
         text: ({ node }) => {
-          return (node as unknown as TextType).text
+          // `node.text` is accessible directly (typed `string | undefined`)
+          // without casting to `TextType`.
+          return node.text ?? ''
         },
       },
       markMapping: {
@@ -178,7 +181,9 @@ describe('static render json to string (no prosemirror)', () => {
               },
             ],
           })
-          return (node as unknown as TextType).text
+          // `node.text` is accessible directly (typed `string | undefined`)
+          // without casting to `TextType`.
+          return node.text ?? ''
         },
       },
       markMapping: {
@@ -193,6 +198,25 @@ describe('static render json to string (no prosemirror)', () => {
     })({ content: json })
 
     expect(html).toBe('<doc><h2><strong>Example Text</strong></h2></doc>')
+  })
+
+  it('throws a clear "missing handler" error for a node without a type instead of crashing', () => {
+    // Node-type resolution falls back to '' for a missing/undefined `type`, so a
+    // malformed node routes through the normal "missing handler" contract rather
+    // than throwing a raw TypeError on `content.type.name`.
+    const render = renderJSONContentToString({ nodeMapping: {}, markMapping: {} })
+
+    expect(() => render({ content: {} })).toThrow(/missing handler for node type/)
+  })
+
+  it('routes a node without a type to unhandledNode when one is provided', () => {
+    const html = renderJSONContentToString({
+      nodeMapping: {},
+      markMapping: {},
+      unhandledNode: () => '<unhandled />',
+    })({ content: {} })
+
+    expect(html).toBe('<unhandled />')
   })
 })
 

--- a/packages/static-renderer/src/json/html-string/string.ts
+++ b/packages/static-renderer/src/json/html-string/string.ts
@@ -1,22 +1,20 @@
 /* oslint-disableno-explicit-any */
-import type { MarkType, NodeType } from '@tiptap/core'
-
-import type { TiptapStaticRendererOptions } from '../renderer.js'
+import type { JSONMarkType, JSONNodeType, TiptapStaticRendererOptions } from '../renderer.js'
 import { TiptapStaticRenderer } from '../renderer.js'
 
 export function renderJSONContentToString<
   /**
    * A mark type is either a JSON representation of a mark or a Prosemirror mark instance
    */
-  TMarkType extends { type: any } = MarkType,
+  TMarkType extends { type: any } = JSONMarkType,
   /**
    * A node type is either a JSON representation of a node or a Prosemirror node instance
    */
   TNodeType extends {
     content?: { forEach: (cb: (node: TNodeType) => void) => void }
     marks?: readonly TMarkType[]
-    type: string | { name: string }
-  } = NodeType,
+    type?: string | { name: string }
+  } = JSONNodeType<TMarkType>,
 >(options: TiptapStaticRendererOptions<string, TMarkType, TNodeType>) {
   return TiptapStaticRenderer(ctx => {
     return ctx.component(ctx.props as any)

--- a/packages/static-renderer/src/json/react/react.ts
+++ b/packages/static-renderer/src/json/react/react.ts
@@ -1,24 +1,23 @@
 /* oslint-disableno-explicit-any */
 
-import type { MarkType, NodeType } from '@tiptap/core'
 import React from 'react'
 
-import type { TiptapStaticRendererOptions } from '../renderer.js'
+import type { JSONMarkType, JSONNodeType, TiptapStaticRendererOptions } from '../renderer.js'
 import { TiptapStaticRenderer } from '../renderer.js'
 
 export function renderJSONContentToReactElement<
   /**
    * A mark type is either a JSON representation of a mark or a Prosemirror mark instance
    */
-  TMarkType extends { type: any } = MarkType,
+  TMarkType extends { type: any } = JSONMarkType,
   /**
    * A node type is either a JSON representation of a node or a Prosemirror node instance
    */
   TNodeType extends {
     content?: { forEach: (cb: (node: TNodeType) => void) => void }
     marks?: readonly TMarkType[]
-    type: string | { name: string }
-  } = NodeType,
+    type?: string | { name: string }
+  } = JSONNodeType<TMarkType>,
 >(options: TiptapStaticRendererOptions<React.ReactNode, TMarkType, TNodeType>) {
   let key = 0
 

--- a/packages/static-renderer/src/json/renderer.ts
+++ b/packages/static-renderer/src/json/renderer.ts
@@ -1,5 +1,31 @@
 /* oslint-disableno-explicit-any */
-import type { MarkType, NodeType } from '@tiptap/core'
+import type { JSONContent } from '@tiptap/core'
+
+/**
+ * A JSON representation of a mark (a Tiptap/ProseMirror mark serialized to JSON).
+ */
+export type JSONMarkType = NonNullable<JSONContent['marks']>[number]
+
+/**
+ * A JSON representation of a node (a Tiptap/ProseMirror node serialized to JSON).
+ *
+ * `marks` is tied to the `TMark` type parameter so the node<->mark relationship
+ * stays sound. This is also why we cannot simply default `TNodeType` to
+ * `JSONContent`: the generic constraint references `TMarkType` via
+ * `marks?: readonly TMarkType[]`, and `JSONContent.marks` is a *concrete* array,
+ * which TypeScript rejects ("TMarkType could be instantiated with a different
+ * subtype of constraint"). Parameterizing the node type by the same `TMark`
+ * avoids that bivariance error. Please don't "simplify" this back to
+ * `JSONContent` — it won't type-check.
+ */
+export type JSONNodeType<TMark extends { type: string | { name: string } } = JSONMarkType> = {
+  type?: string
+  attrs?: Record<string, any>
+  content?: JSONNodeType<TMark>[]
+  marks?: readonly TMark[]
+  text?: string
+  [key: string]: any
+}
 
 /**
  * Props for a node renderer
@@ -62,15 +88,15 @@ export type TiptapStaticRendererOptions<
   /**
    * A mark type is either a JSON representation of a mark or a Prosemirror mark instance
    */
-  TMarkType extends { type: any } = MarkType,
+  TMarkType extends { type: any } = JSONMarkType,
   /**
    * A node type is either a JSON representation of a node or a Prosemirror node instance
    */
   TNodeType extends {
     content?: { forEach: (cb: (node: TNodeType) => void) => void }
     marks?: readonly TMarkType[]
-    type: string | { name: string }
-  } = NodeType,
+    type?: string | { name: string }
+  } = JSONNodeType<TMarkType>,
   /**
    * A node renderer is a function that takes a node and its children and returns the rendered output
    */
@@ -123,15 +149,15 @@ export function TiptapStaticRenderer<
   /**
    * A mark type is either a JSON representation of a mark or a Prosemirror mark instance
    */
-  TMarkType extends { type: string | { name: string } } = MarkType,
+  TMarkType extends { type: string | { name: string } } = JSONMarkType,
   /**
    * A node type is either a JSON representation of a node or a Prosemirror node instance
    */
   TNodeType extends {
     content?: { forEach: (cb: (node: TNodeType) => void) => void }
     marks?: readonly TMarkType[]
-    type: string | { name: string }
-  } = NodeType,
+    type?: string | { name: string }
+  } = JSONNodeType<TMarkType>,
   /**
    * A node renderer is a function that takes a node and its children and returns the rendered output
    */
@@ -184,7 +210,7 @@ export function TiptapStaticRenderer<
      */
     parent?: TNodeType
   }): TReturnType {
-    const nodeType = typeof content.type === 'string' ? content.type : content.type.name
+    const nodeType = typeof content.type === 'string' ? content.type : (content.type?.name ?? '')
     const NodeHandler = nodeMapping[nodeType] ?? unhandledNode
 
     if (!NodeHandler) {


### PR DESCRIPTION
## Changes Overview

`renderJSONContentToReactElement` and `renderJSONContentToString` defaulted their node/mark generics to the ProseMirror-oriented `NodeType`/`MarkType`. As a result, in JSON node mappings `node.text` errored, every node prop was typed `any`, and passing a value typed as `JSONContent` failed (`type` is optional in `JSONContent` but was required). They now default to the newly exported `JSONNodeType`/`JSONMarkType`, so `node.text` is typed `string | undefined` and a `JSONContent` document is accepted directly.

## Implementation Approach

Added `JSONNodeType<TMark>` and `JSONMarkType` to `json/renderer.ts` and used them as the generic defaults in both JSON wrappers. `JSONNodeType` keeps `marks` tied to the mark type parameter so the node↔mark relationship stays sound — a plain `JSONContent` default hits a `readonly TMarkType[]` bivariance error. The node `type` constraint was relaxed to optional, and node-type resolution now tolerates a missing `type` (falling back to the normal "missing handler" error instead of a raw TypeError). The ProseMirror `pm/*` renderers are unaffected since they parameterize explicitly with `Mark`/`Node`.

## Testing Done

`pnpm -F @tiptap/static-renderer build` (incl. DTS), `pnpm test:unit` (34/34 pass), `pnpm lint`, and `pnpm format` all pass. The three existing tests that cast via `as unknown as TextType` were simplified to read `node.text` directly (a regression signal), and two tests were added covering the missing-`type` behavior.

## Verification Steps

In a consumer `.ts` file: `const render = renderJSONContentToString({ nodeMapping: { text: ({ node }) => node.text ?? '' }, markMapping: {} })` then `render({ content })` with `content: JSONContent`. This type-checks with the fix and errors without it (TS2339 on `node.text`, TS2322 on `content`).

## Additional Notes

New exported types `JSONNodeType` and `JSONMarkType` are additive to the package's public API.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude to investigate and reproduce the issue, design and adversarially review the type fix, implement it, and run the validation (build/tests/lint/format).

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7175
