### PR TITLE
fix(extensions/selection): hide native selection while editor is blurred

### DIFF
--- a/.changeset/little-shrimps-explain.md
+++ b/.changeset/little-shrimps-explain.md
@@ -1,0 +1,6 @@
+---
+'@tiptap/extensions': patch
+'tiptap-demos': patch
+---
+
+Fix the `Selection` extension highlighting beyond the selected text on multi-line selections: the native browser selection is now hidden while the editor is blurred, so only the styled `.selection` decoration is shown.

--- a/demos/src/Extensions/Selection/React/index.tsx
+++ b/demos/src/Extensions/Selection/React/index.tsx
@@ -24,12 +24,12 @@ export default () => {
     ],
     content: `
         <p>
-          The selection extension adds a class to the selection when the editor is blurred. That enables you to visually preserve the selection even though the editor is blurred. By default, it’ll add <code>.selection</code> classname.
+          The Selection extension adds a class to the current text selection when the editor is blurred, which lets you keep the selected text highlighted even after the editor loses focus. This is especially useful when a selection spans multiple wrapped lines, where only the selected text should be highlighted rather than the empty space at the end of each line. By default it adds a <code>.selection</code> classname that you can style.
         </p>
       `,
 
     onCreate: ctx => {
-      ctx.editor.commands.setTextSelection({ from: 5, to: 30 })
+      ctx.editor.commands.setTextSelection({ from: 5, to: 280 })
     },
   })
 

--- a/demos/src/Extensions/Selection/Vue/index.vue
+++ b/demos/src/Extensions/Selection/Vue/index.vue
@@ -37,11 +37,11 @@ export default {
       ],
       content: `
         <p>
-          The selection extension adds a class to the selection when the editor is blurred. That enables you to visually preserve the selection even though the editor is blurred. By default, it’ll add <code>.selection</code> classname.
+          The Selection extension adds a class to the current text selection when the editor is blurred, which lets you keep the selected text highlighted even after the editor loses focus. This is especially useful when a selection spans multiple wrapped lines, where only the selected text should be highlighted rather than the empty space at the end of each line. By default it adds a <code>.selection</code> classname that you can style.
         </p>
       `,
       onCreate: ({ editor }) => {
-        editor.commands.setTextSelection({ from: 5, to: 30 })
+        editor.commands.setTextSelection({ from: 5, to: 280 })
       },
     })
   },

--- a/packages/extensions/__tests__/selection.spec.ts
+++ b/packages/extensions/__tests__/selection.spec.ts
@@ -1,0 +1,45 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { Selection } from '@tiptap/extensions'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const styleSelector = 'style[data-tiptap-style-selection]'
+
+describe('extension-selection', () => {
+  let editor: Editor | null = null
+
+  afterEach(() => {
+    if (editor) {
+      editor.destroy()
+      editor = null
+    }
+
+    document.querySelectorAll(styleSelector).forEach(node => node.remove())
+  })
+
+  it('injects a stylesheet that hides the native selection while the editor is blurred', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Selection],
+      content: '<p>Hello world</p>',
+    })
+
+    const styleTag = document.querySelector(styleSelector)
+
+    expect(styleTag).not.toBeNull()
+    expect(styleTag?.textContent).toContain('.ProseMirror:not(.ProseMirror-focused) *::selection')
+    expect(styleTag?.textContent).toContain('*::-moz-selection')
+    expect(styleTag?.textContent).toContain('background: transparent')
+  })
+
+  it('does not inject the stylesheet when injectCSS is disabled', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Selection],
+      content: '<p>Hello world</p>',
+      injectCSS: false,
+    })
+
+    expect(document.querySelector(styleSelector)).toBeNull()
+  })
+})

--- a/packages/extensions/src/selection/selection.ts
+++ b/packages/extensions/src/selection/selection.ts
@@ -1,6 +1,14 @@
-import { Extension, isNodeSelection } from '@tiptap/core'
+import { createStyleTag, Extension, isNodeSelection } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+const selectionStyle = `.ProseMirror:not(.ProseMirror-focused) *::selection {
+  background: transparent;
+}
+
+.ProseMirror:not(.ProseMirror-focused) *::-moz-selection {
+  background: transparent;
+}`
 
 export type SelectionOptions = {
   /**
@@ -26,6 +34,10 @@ export const Selection = Extension.create<SelectionOptions>({
 
   addProseMirrorPlugins() {
     const { editor, options } = this
+
+    if (editor.options.injectCSS && typeof document !== 'undefined') {
+      createStyleTag(selectionStyle, editor.options.injectNonce, 'selection')
+    }
 
     return [
       new Plugin({


### PR DESCRIPTION
## Changes Overview

The `Selection` extension now hides the native browser selection while the editor is blurred, so only its styled `.selection` decoration is shown; previously a multi-line selection left the native highlight bleeding to the full width of each wrapped line, beyond the selected text.

## Implementation Approach

On editor creation the extension injects a small scoped stylesheet (via core's existing `createStyleTag` utility, honoring the editor's `injectCSS`/`injectNonce` options) that makes `::selection` transparent on a blurred editor (`.ProseMirror:not(.ProseMirror-focused)`), mirroring core's existing `ProseMirror-hideselection` pattern.

## Testing Done

Added `packages/extensions/__tests__/selection.spec.ts` asserting the stylesheet is injected (and skipped when `injectCSS: false`); lint, build, the extensions unit tests, and the existing Selection e2e on Chromium + Firefox all pass.

## Verification Steps

Open the Selection demo, select text spanning multiple lines, then blur the editor (e.g. focus another element); the highlight should hug only the selected text instead of filling the empty space at the end of each wrapped line.

## Additional Notes

The React/Vue demos were updated to multi-line content and a multi-line selection so the behavior is visible; the suppression applies to any blurred ProseMirror editor on the page, matching core's global `ProseMirror-hideselection` approach.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Used Claude Code to reproduce and verify the bug, implement the CSS-injection fix, add the unit test, and update the React/Vue demos.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7006
