### PR TITLE
fix(markdown): SSR-safe unrecognized HTML detection

### DIFF
--- a/.changeset/ssr-html-tag-detection.md
+++ b/.changeset/ssr-html-tag-detection.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Fix unrecognized HTML detection during markdown parsing to work without `window.DOMParser` or `HTMLUnknownElement`, so angle-bracket placeholders are preserved as literal text in SSR and Node environments.

--- a/packages/markdown/__tests__/htmlTagDetection.spec.ts
+++ b/packages/markdown/__tests__/htmlTagDetection.spec.ts
@@ -39,6 +39,15 @@ describe('htmlTagDetection', () => {
       expect(isHtmlUnknownTagName('my-mention')).toBe(false)
       expect(isHtmlUnknownTagName('my-el')).toBe(false)
     })
+
+    it('treats common SVG child elements as known', () => {
+      expect(isHtmlUnknownTagName('circle')).toBe(false)
+      expect(isHtmlUnknownTagName('path')).toBe(false)
+      expect(isHtmlUnknownTagName('g')).toBe(false)
+      expect(isHtmlUnknownTagName('rect')).toBe(false)
+      expect(isHtmlUnknownTagName('linearGradient')).toBe(false)
+      expect(isHtmlUnknownTagName('clipPath')).toBe(false)
+    })
   })
 
   describe('htmlContainsUnrecognizedTag', () => {
@@ -66,6 +75,13 @@ describe('htmlTagDetection', () => {
 
     it('returns false when no tags are present', () => {
       expect(htmlContainsUnrecognizedTag('no tags here', emptySchema)).toBe(false)
+    })
+
+    it('returns false for SVG elements', () => {
+      expect(
+        htmlContainsUnrecognizedTag('<svg><circle cx="10" cy="10" r="5"/></svg>', emptySchema),
+      ).toBe(false)
+      expect(htmlContainsUnrecognizedTag('<svg><path d="M0 0"/></svg>', emptySchema)).toBe(false)
     })
   })
 })

--- a/packages/markdown/__tests__/htmlTagDetection.spec.ts
+++ b/packages/markdown/__tests__/htmlTagDetection.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment node
+ */
+
+import {
+  extractHtmlTagNames,
+  htmlContainsUnrecognizedTag,
+  isHtmlUnknownTagName,
+} from '../src/utils/htmlTagDetection.js'
+import { describe, expect, it } from 'vitest'
+
+describe('htmlTagDetection', () => {
+  describe('extractHtmlTagNames', () => {
+    it('extracts tag names from opening and closing tags', () => {
+      expect(extractHtmlTagNames('<em>hi</em>')).toEqual(['em', 'em'])
+    })
+
+    it('extracts the first token as tag name for unknown angle-bracket text', () => {
+      expect(extractHtmlTagNames('<enter foo bar>')).toEqual(['enter'])
+    })
+
+    it('returns an empty array when no tags are present', () => {
+      expect(extractHtmlTagNames('plain text')).toEqual([])
+    })
+  })
+
+  describe('isHtmlUnknownTagName', () => {
+    it('treats non-standard non-hyphenated tags as unknown', () => {
+      expect(isHtmlUnknownTagName('enter')).toBe(true)
+    })
+
+    it('treats standard HTML tags as known', () => {
+      expect(isHtmlUnknownTagName('em')).toBe(false)
+      expect(isHtmlUnknownTagName('br')).toBe(false)
+      expect(isHtmlUnknownTagName('span')).toBe(false)
+    })
+
+    it('treats hyphenated tag names as known custom elements', () => {
+      expect(isHtmlUnknownTagName('my-mention')).toBe(false)
+      expect(isHtmlUnknownTagName('my-el')).toBe(false)
+    })
+  })
+
+  describe('htmlContainsUnrecognizedTag', () => {
+    const emptySchema = new Set<string>()
+
+    it('returns true for unknown angle-bracket placeholders', () => {
+      expect(htmlContainsUnrecognizedTag('<enter foo bar>', emptySchema)).toBe(true)
+      expect(htmlContainsUnrecognizedTag('<this is a placeholder>', emptySchema)).toBe(true)
+    })
+
+    it('returns false for standard HTML elements', () => {
+      expect(htmlContainsUnrecognizedTag('<em></em>', emptySchema)).toBe(false)
+      expect(htmlContainsUnrecognizedTag('<em>hi</em>', emptySchema)).toBe(false)
+      expect(htmlContainsUnrecognizedTag('<br>', emptySchema)).toBe(false)
+    })
+
+    it('returns false for hyphenated custom elements', () => {
+      expect(htmlContainsUnrecognizedTag('<my-el></my-el>', emptySchema)).toBe(false)
+    })
+
+    it('returns false when schema declares a non-standard tag', () => {
+      const schemaTags = new Set(['something'])
+      expect(htmlContainsUnrecognizedTag('<something>happy</something>', schemaTags)).toBe(false)
+    })
+
+    it('returns false when no tags are present', () => {
+      expect(htmlContainsUnrecognizedTag('no tags here', emptySchema)).toBe(false)
+    })
+  })
+})

--- a/packages/markdown/__tests__/server-side-parsing.spec.ts
+++ b/packages/markdown/__tests__/server-side-parsing.spec.ts
@@ -146,6 +146,24 @@ describe('MarkdownManager Server-side Parsing', () => {
     expect(strikeTextNode).toBeDefined()
   })
 
+  it('preserves unknown angle-bracket placeholders as literal text in server environment', () => {
+    const md = '<enter existing CID here if available>\n\nother text after'
+    const doc = manager.parse(md)
+
+    expect(doc.type).toBe('doc')
+    expect(Array.isArray(doc.content)).toBe(true)
+
+    const allText = doc
+      .content!.flatMap((node: any) =>
+        node.content ? node.content.filter((n: any) => n.type === 'text') : [],
+      )
+      .map((n: any) => n.text)
+      .join('')
+
+    expect(allText).toContain('enter existing CID here if available')
+    expect(allText).toContain('other text after')
+  })
+
   it('parses HTML tags as plain text in server environment', () => {
     const md = '<p>Hello</p>'
 

--- a/packages/markdown/__tests__/server-side-parsing.spec.ts
+++ b/packages/markdown/__tests__/server-side-parsing.spec.ts
@@ -152,16 +152,21 @@ describe('MarkdownManager Server-side Parsing', () => {
 
     expect(doc.type).toBe('doc')
     expect(Array.isArray(doc.content)).toBe(true)
+    expect(doc.content).toHaveLength(2)
 
-    const allText = doc
-      .content!.flatMap((node: any) =>
-        node.content ? node.content.filter((n: any) => n.type === 'text') : [],
-      )
-      .map((n: any) => n.text)
-      .join('')
+    // angle-bracket placeholder preserved as literal text
+    const firstPara = doc.content![0]
+    expect(firstPara.type).toBe('paragraph')
+    expect(firstPara.content).toHaveLength(1)
+    expect(firstPara.content![0].type).toBe('text')
+    expect(firstPara.content![0].text).toBe('<enter existing CID here if available>')
 
-    expect(allText).toContain('enter existing CID here if available')
-    expect(allText).toContain('other text after')
+    // trailing text after the blank line
+    const secondPara = doc.content![1]
+    expect(secondPara.type).toBe('paragraph')
+    expect(secondPara.content).toHaveLength(1)
+    expect(secondPara.content![0].type).toBe('text')
+    expect(secondPara.content![0].text).toBe('other text after')
   })
 
   it('parses HTML tags as plain text in server environment', () => {

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -949,7 +949,7 @@ export class MarkdownManager {
     }
 
     // generateJSON requires window.DOMParser – treat recognized HTML as literal on the server
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || typeof window.DOMParser === 'undefined') {
       return this.htmlAsLiteralText(html, !!token.block)
     }
 
@@ -984,9 +984,8 @@ export class MarkdownManager {
   }
 
   /**
-   * Returns true when the HTML contains a tag that would be classified as
-   * `HTMLUnknownElement` in a browser – unless a registered extension declares
-   * the tag name in its parseDOM rules.
+   * Returns true when the HTML contains a tag that is neither a standard
+   * HTML/SVG element nor declared in a registered extension's parseDOM rules.
    *
    * Recognized but empty elements such as `<em></em>` or `<span></span>`,
    * and hyphenated custom elements like `<my-mention>`, are not considered

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -32,22 +32,7 @@ import {
   reopenMarksAfterNode,
   wrapInMarkdownBlock,
 } from './utils.js'
-
-/**
- * Returns true when the element's tag is not a recognized standard HTML
- * element. Note: the calling code further cross-references this result
- * against schema parseDOM tags, so non-standard tags that are declared
- * by registered extensions are still treated as valid.
- *
- * Browsers expose this classification natively: any non-hyphenated tag that
- * is not part of the HTML/SVG/MathML namespaces is constructed as an
- * `HTMLUnknownElement`. Standard tags (`<em>`, `<div>`, …) and custom
- * elements (`<my-el>`, must contain a hyphen) are `HTMLElement` instances.
- */
-const isHtmlUnknownElement = (element: Element): boolean => {
-  const ctor = (window as any).HTMLUnknownElement
-  return typeof ctor === 'function' && element instanceof ctor
-}
+import { htmlContainsUnrecognizedTag } from './utils/htmlTagDetection.js'
 
 export class MarkdownManager {
   private markedInstance: typeof marked
@@ -957,31 +942,14 @@ export class MarkdownManager {
       return null
     }
 
-    // Check if we're in a server-side environment (no window object)
-    // If so, fall back to treating HTML as plain text to avoid runtime errors
-    if (typeof window === 'undefined') {
-      // For block-level HTML, wrap in a paragraph to maintain valid document structure
-      if (token.block) {
-        return {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: html,
-            },
-          ],
-        }
-      }
-      // For inline HTML, return plain text
-      return {
-        type: 'text',
-        text: html,
-      }
-    }
-
     // If the HTML would parse to nothing meaningful, keep the original
     // characters as literal text instead of dropping them.
     if (this.isUnrecognizedHtml(html)) {
+      return this.htmlAsLiteralText(html, !!token.block)
+    }
+
+    // generateJSON requires window.DOMParser – treat recognized HTML as literal on the server
+    if (typeof window === 'undefined') {
       return this.htmlAsLiteralText(html, !!token.block)
     }
 
@@ -1016,10 +984,9 @@ export class MarkdownManager {
   }
 
   /**
-   * Returns true when the HTML contains an element the browser classifies as
-   * `HTMLUnknownElement` – unless a registered extension declares the tag
-   * name in its parseDOM rules, in which case it is treated as a known
-   * custom element.
+   * Returns true when the HTML contains a tag that would be classified as
+   * `HTMLUnknownElement` in a browser – unless a registered extension declares
+   * the tag name in its parseDOM rules.
    *
    * Recognized but empty elements such as `<em></em>` or `<span></span>`,
    * and hyphenated custom elements like `<my-mention>`, are not considered
@@ -1034,31 +1001,7 @@ export class MarkdownManager {
    *   isUnrecognizedHtml('<br>')             // → false
    */
   private isUnrecognizedHtml(html: string): boolean {
-    if (typeof window === 'undefined' || typeof window.DOMParser === 'undefined') {
-      // Can't reliably detect without DOMParser, so assume it's recognized to avoid false positives
-      return false
-    }
-
-    const dom = new window.DOMParser().parseFromString(`<body>${html}</body>`, 'text/html').body
-    const elements = dom.querySelectorAll('*')
-
-    if (elements.length === 0) {
-      return false
-    }
-
-    const schemaTags = this.getSchemaParseDomTags()
-
-    return Array.from(elements).some(el => {
-      if (!isHtmlUnknownElement(el)) {
-        return false
-      }
-
-      // If the tag is declared by a registered extension's parseDOM rule,
-      // treat it as recognized even though the browser doesn't know it.
-      const tagName = el.tagName.toLowerCase()
-
-      return !schemaTags.has(tagName)
-    })
+    return htmlContainsUnrecognizedTag(html, this.getSchemaParseDomTags())
   }
 
   /**
@@ -1101,7 +1044,7 @@ export class MarkdownManager {
       Object.values(schema.marks).forEach(type => collect((type as any).spec))
     } catch {
       // If schema construction fails, leave the set empty – detection then
-      // falls back to the HTMLUnknownElement check alone.
+      // falls back to the standard HTML tag list only.
     }
 
     this.schemaParseDomTagsCache = tags

--- a/packages/markdown/src/utils/htmlTagDetection.ts
+++ b/packages/markdown/src/utils/htmlTagDetection.ts
@@ -1,0 +1,172 @@
+/**
+ * Standard HTML element names. Used to tell apart real (but possibly empty)
+ * elements like `<em></em>` from genuinely unknown angle-bracket text such
+ * as `<enter foo bar>` so the latter can be preserved as literal text.
+ *
+ * Mirrors browser `HTMLUnknownElement` classification without DOM APIs:
+ * non-hyphenated tags not in this set are treated as unknown unless declared
+ * in the schema's parseDOM rules.
+ */
+export const STANDARD_HTML_TAGS = new Set([
+  'a',
+  'abbr',
+  'address',
+  'area',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'base',
+  'bdi',
+  'bdo',
+  'blockquote',
+  'body',
+  'br',
+  'button',
+  'canvas',
+  'caption',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dialog',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'embed',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'head',
+  'header',
+  'hgroup',
+  'hr',
+  'html',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'link',
+  'main',
+  'map',
+  'mark',
+  'menu',
+  'meta',
+  'meter',
+  'nav',
+  'noscript',
+  'object',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'param',
+  'picture',
+  'pre',
+  'progress',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'script',
+  'search',
+  'section',
+  'select',
+  'slot',
+  'small',
+  'source',
+  'span',
+  'strong',
+  'style',
+  'sub',
+  'summary',
+  'sup',
+  'svg',
+  'table',
+  'tbody',
+  'td',
+  'template',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'title',
+  'tr',
+  'track',
+  'u',
+  'ul',
+  'var',
+  'video',
+  'wbr',
+])
+
+const HTML_TAG_NAME_PATTERN = /<\/?([a-zA-Z][\w-]*)/g
+
+/**
+ * Extract lower-cased tag names from an HTML fragment (opening and closing tags).
+ */
+export function extractHtmlTagNames(html: string): string[] {
+  const tagNames: string[] = []
+
+  let match: RegExpExecArray | null
+
+  while ((match = HTML_TAG_NAME_PATTERN.exec(html)) !== null) {
+    tagNames.push(match[1].toLowerCase())
+  }
+
+  return tagNames
+}
+
+/**
+ * Returns true when the tag name would be classified as `HTMLUnknownElement`
+ * in a browser (non-hyphenated and not a standard HTML element).
+ */
+export function isHtmlUnknownTagName(tagName: string): boolean {
+  const lower = tagName.toLowerCase()
+
+  if (lower.includes('-')) {
+    return false
+  }
+
+  return !STANDARD_HTML_TAGS.has(lower)
+}
+
+/**
+ * Returns true when the HTML contains a tag that is neither a standard HTML
+ * element nor declared in the schema's parseDOM rules.
+ */
+export function htmlContainsUnrecognizedTag(html: string, schemaTags: Set<string>): boolean {
+  const tagNames = extractHtmlTagNames(html)
+
+  return tagNames.some(tagName => {
+    if (!isHtmlUnknownTagName(tagName)) {
+      return false
+    }
+
+    return !schemaTags.has(tagName)
+  })
+}

--- a/packages/markdown/src/utils/htmlTagDetection.ts
+++ b/packages/markdown/src/utils/htmlTagDetection.ts
@@ -1,11 +1,13 @@
 /**
- * Standard HTML element names. Used to tell apart real (but possibly empty)
- * elements like `<em></em>` from genuinely unknown angle-bracket text such
- * as `<enter foo bar>` so the latter can be preserved as literal text.
+ * Standard HTML and common SVG element names. Used to tell apart real
+ * (but possibly empty) elements like `<em></em>` from genuinely unknown
+ * angle-bracket text such as `<enter foo bar>` so the latter can be
+ * preserved as literal text.
  *
- * Mirrors browser `HTMLUnknownElement` classification without DOM APIs:
- * non-hyphenated tags not in this set are treated as unknown unless declared
- * in the schema's parseDOM rules.
+ * Non-hyphenated tags not in this set are treated as unknown unless
+ * declared in the schema's parseDOM rules. This does not claim full
+ * parity with browser `HTMLUnknownElement` classification across all
+ * namespaces (e.g. rare SVG filter elements, MathML).
  */
 export const STANDARD_HTML_TAGS = new Set([
   'a',
@@ -105,6 +107,27 @@ export const STANDARD_HTML_TAGS = new Set([
   'summary',
   'sup',
   'svg',
+  'circle',
+  'clippath',
+  'defs',
+  'ellipse',
+  'foreignobject',
+  'g',
+  'image',
+  'line',
+  'lineargradient',
+  'mask',
+  'path',
+  'polygon',
+  'polyline',
+  'radialgradient',
+  'rect',
+  'stop',
+  'switch',
+  'symbol',
+  'textpath',
+  'tspan',
+  'use',
   'table',
   'tbody',
   'td',
@@ -142,8 +165,8 @@ export function extractHtmlTagNames(html: string): string[] {
 }
 
 /**
- * Returns true when the tag name would be classified as `HTMLUnknownElement`
- * in a browser (non-hyphenated and not a standard HTML element).
+ * Returns true when the tag name is non-hyphenated and not in the
+ * STANDARD_HTML_TAGS allowlist (i.e. would be treated as unrecognized).
  */
 export function isHtmlUnknownTagName(tagName: string): boolean {
   const lower = tagName.toLowerCase()


### PR DESCRIPTION
## Changes Overview

Follow-up to #7864 / #7861: unrecognized HTML detection no longer uses `window.DOMParser` or `HTMLUnknownElement`, so markdown parsing works in SSR and Node without DOM APIs.

Angle-bracket placeholders like `<enter existing CID here if available>` are still preserved as literal text instead of being swallowed.

## Implementation Approach

- Added [`packages/markdown/src/utils/htmlTagDetection.ts`](packages/markdown/src/utils/htmlTagDetection.ts) with:
  - `STANDARD_HTML_TAGS` allowlist (same set as the earlier #7864 iteration)
  - Regex-based `extractHtmlTagNames()`
  - `isHtmlUnknownTagName()` — mirrors browser rules: standard tags and hyphenated custom elements are known; everything else is unknown unless declared in schema `parseDOM`
  - `htmlContainsUnrecognizedTag()` — combines tag extraction with schema tags
- `MarkdownManager.isUnrecognizedHtml()` delegates to that module (no DOM)
- `parseHTMLToken()` flow: unrecognized → literal text; no `window` → literal text (since `generateJSON` still needs `window.DOMParser` in core); browser → existing `generateJSON` path

## Testing Done

- `pnpm test:unit packages/markdown/__tests__/htmlTagDetection.spec.ts` — Node unit tests for helpers
- `pnpm test:unit packages/markdown/__tests__/unknown-html-tags.spec.ts` — browser integration regressions (unchanged behavior)
- `pnpm test:unit packages/markdown/__tests__/server-side-parsing.spec.ts` — includes issue #7861 reproduction under Node
- `pnpm lint` — clean

## Verification Steps

1. Check out `refactor/7861` and run `pnpm install`
2. Run: `pnpm test:unit packages/markdown/__tests__/htmlTagDetection.spec.ts packages/markdown/__tests__/unknown-html-tags.spec.ts packages/markdown/__tests__/server-side-parsing.spec.ts`
3. In Node (no `window`), parse: `<enter existing CID here if available>\n\nother text after` — both placeholder and trailing text should appear in the document
4. In browser (happy-dom), confirm `<em>world</em>` still parses as italic and unknown tags stay literal

## Additional Notes

- Recognized HTML on the server is still kept as literal text because `@tiptap/core`'s `generateJSON` requires `window.DOMParser` — unchanged from #7864
- Known limitation: nested SVG tags (e.g. `<circle>` inside `<svg>`) may be treated as unrecognized and preserved literally; no tests cover this today

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Used AI to implement SSR-safe tag detection per plan, add tests, and draft this PR description

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7861