### PR TITLE
fix(core): allow ids and classes starting with a number in parseAttributes

### DIFF
--- a/.changeset/2026-06-03-parse-attributes-numeric-ids.md
+++ b/.changeset/2026-06-03-parse-attributes-numeric-ids.md
@@ -2,4 +2,4 @@
 '@tiptap/core': patch
 ---
 
-`parseAttributes` no longer silently strips ids and classes that start with a number (e.g. `#2123` or `.2xl`). HTML5 allows ids to start with any non-whitespace character, so Pandoc-style attribute strings like `{#2123 .foo}` now parse to `{ id: '2123', class: 'foo' }` instead of dropping the id.
+`parseAttributes` now supports any non-white character at the start of classes or id attributes.

--- a/.changeset/2026-06-03-parse-attributes-numeric-ids.md
+++ b/.changeset/2026-06-03-parse-attributes-numeric-ids.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+`parseAttributes` no longer silently strips ids and classes that start with a number (e.g. `#2123` or `.2xl`). HTML5 allows ids to start with any non-whitespace character, so Pandoc-style attribute strings like `{#2123 .foo}` now parse to `{ id: '2123', class: 'foo' }` instead of dropping the id.

--- a/.changeset/2026-06-03-parse-attributes-numeric-ids.md
+++ b/.changeset/2026-06-03-parse-attributes-numeric-ids.md
@@ -2,4 +2,4 @@
 '@tiptap/core': patch
 ---
 
-`parseAttributes` now supports any non-white character at the start of classes or id attributes.
+`parseAttributes` now supports any word characters at the start of classes or id attributes.

--- a/packages/core/__tests__/parseAttributes.spec.ts
+++ b/packages/core/__tests__/parseAttributes.spec.ts
@@ -1,0 +1,52 @@
+import { parseAttributes } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+
+describe('parseAttributes', () => {
+  it('should return an empty object for empty input', () => {
+    expect(parseAttributes('')).toEqual({})
+    expect(parseAttributes('   ')).toEqual({})
+  })
+
+  it('should parse classes', () => {
+    expect(parseAttributes('.btn .primary')).toEqual({ class: 'btn primary' })
+  })
+
+  it('should parse ids', () => {
+    expect(parseAttributes('#submit')).toEqual({ id: 'submit' })
+  })
+
+  it('should parse key-value pairs', () => {
+    expect(parseAttributes('type="button"')).toEqual({ type: 'button' })
+  })
+
+  it('should parse boolean attributes', () => {
+    expect(parseAttributes('disabled')).toEqual({ disabled: true })
+  })
+
+  it('should parse mixed attribute strings', () => {
+    expect(parseAttributes('.btn #submit disabled type="button"')).toEqual({
+      class: 'btn',
+      id: 'submit',
+      disabled: true,
+      type: 'button',
+    })
+  })
+
+  it('should not parse classes or ids inside quoted values', () => {
+    expect(parseAttributes('title="#not-an-id .not-a-class"')).toEqual({
+      title: '#not-an-id .not-a-class',
+    })
+  })
+
+  it('should parse ids starting with a number', () => {
+    expect(parseAttributes('#2123 .foo')).toEqual({ class: 'foo', id: '2123' })
+  })
+
+  it('should parse ids with a leading number followed by letters', () => {
+    expect(parseAttributes('#5hello .foo')).toEqual({ class: 'foo', id: '5hello' })
+  })
+
+  it('should parse classes starting with a number', () => {
+    expect(parseAttributes('.2xl #foo')).toEqual({ class: '2xl', id: 'foo' })
+  })
+})

--- a/packages/core/src/utilities/markdown/attributeUtils.ts
+++ b/packages/core/src/utilities/markdown/attributeUtils.ts
@@ -38,14 +38,14 @@ export function parseAttributes(attrString: string): Record<string, any> {
   })
 
   // Parse classes (.className) - only outside of quoted strings
-  const classMatches = tempString.match(/(?:^|\s)\.([a-zA-Z][\w-]*)/g)
+  const classMatches = tempString.match(/(?:^|\s)\.([\w-]+)/g)
   if (classMatches) {
     const classes = classMatches.map(match => match.trim().slice(1)) // Remove the dot
     attributes.class = classes.join(' ')
   }
 
   // Parse IDs (#myId) - only outside of quoted strings
-  const idMatch = tempString.match(/(?:^|\s)#([a-zA-Z][\w-]*)/)
+  const idMatch = tempString.match(/(?:^|\s)#([\w-]+)/)
   if (idMatch) {
     attributes.id = idMatch[1]
   }
@@ -64,8 +64,8 @@ export function parseAttributes(attrString: string): Record<string, any> {
 
   // Parse boolean attributes (standalone words that aren't classes/IDs)
   const cleanString = tempString
-    .replace(/(?:^|\s)\.([a-zA-Z][\w-]*)/g, '') // Remove classes
-    .replace(/(?:^|\s)#([a-zA-Z][\w-]*)/g, '') // Remove IDs
+    .replace(/(?:^|\s)\.([\w-]+)/g, '') // Remove classes
+    .replace(/(?:^|\s)#([\w-]+)/g, '') // Remove IDs
     .replace(/([a-zA-Z][\w-]*)\s*=\s*__QUOTED_\d+__/g, '') // Remove key-value pairs
     .trim()
 


### PR DESCRIPTION
## Changes Overview

`parseAttributes` silently stripped ids and classes whose first character is a digit (e.g. `#2123` or `.2xl`):

```js
parseAttributes('#2123 .foo')  // before: { class: 'foo' } — id silently dropped
parseAttributes('#2123 .foo')  // after:  { class: 'foo', id: '2123' }
```

This PR loosens the class/id parsing regexes from `[a-zA-Z][\w-]*` (a leftover from the HTML4 id rule) to `[\w-]+`, since HTML5 allows ids to start with any non-whitespace character.

## Implementation Approach

- Updated the class and id parsing regexes in `packages/core/src/utilities/markdown/attributeUtils.ts`, including their copies in the boolean-attribute cleanup step (otherwise `#2123` would leak into the boolean-attribute stage).
- Attribute-name regexes (key-value pairs and boolean attributes) are intentionally left untouched — HTML attribute names must still start with a letter.

## Testing Done

- Added `packages/core/__tests__/parseAttributes.spec.ts`: first direct unit coverage of `parseAttributes`, written test-first (the numeric id/class cases failed before the fix, all 10 pass after). Includes characterization tests for existing behavior (classes, ids, key-value pairs, boolean attributes, quoted strings) to guard against regressions.
- Full monorepo unit suite passes: 129 files, 1173 tests.
- `pnpm lint` and `pnpm format` are clean.

## Verification Steps

1. Run `pnpm vitest run packages/core/__tests__/parseAttributes.spec.ts`
2. Or revert `attributeUtils.ts` and observe the three numeric-prefix tests fail, matching the issue's repro.

## Additional Notes

The same first-character restriction also affected classes (`.2xl` was silently dropped), so this PR fixes both, while the issue only mentions ids.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude Code to analyze the issue, write the tests (test-first), apply the regex fix, and run the validation checklist, reviewing each step manually.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7345

🤖 Generated with [Claude Code](https://claude.com/claude-code)