### PR TITLE
fix: only add hash attributes to nodes

### DIFF
--- a/.changeset/fix-server-ai-toolkit-hash-marks.md
+++ b/.changeset/fix-server-ai-toolkit-hash-marks.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/server-ai-toolkit': patch
+---
+
+Only add hash attributes to nodes, not to marks.

--- a/packages/server-ai-toolkit/src/hash-extension/server-ai-toolkit-hash-extension.ts
+++ b/packages/server-ai-toolkit/src/hash-extension/server-ai-toolkit-hash-extension.ts
@@ -37,6 +37,9 @@ export const ServerAiToolkitHashExtension = Extension.create({
     const types = this.extensions
       .filter(ext => {
         if (
+          // Only add hashes to nodes, not to marks
+          ext.type !== 'node' ||
+          // Exclude certain node types
           ext.name === 'text' ||
           ext.name === 'doc' ||
           ext.name === 'tableHeader' ||


### PR DESCRIPTION
Changes Overview

This PR fixes hash generation in `@tiptap/server-ai-toolkit` so marks are excluded from the hash-attribute registration logic. The package now only adds `_hash` to node extensions, which matches the intended behavior.

## Implementation Approach

I updated the global attribute filtering in `ServerAiToolkitHashExtension` to skip marks explicitly and keep the existing node exclusions intact. I also added a changeset for the patch release.

## Testing Done

I reviewed the diff and verified the filter now returns only eligible node extensions. I did not run the full test suite.

## Verification Steps

Check that `ServerAiToolkitHashExtension` only registers `_hash` on node types and no longer includes mark extensions in the computed `types` list.

## Additional Notes

This is a patch-level behavior fix for `@tiptap/server-ai-toolkit`.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used AI to draft the PR description and summarize the code change from the repository diff.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

No related issue linked.
