### PR TITLE
Include demos in release metadata scan

### DIFF
--- a/scripts/aggregate-changeset.js
+++ b/scripts/aggregate-changeset.js
@@ -112,10 +112,13 @@ async function addCommitsToChangesets(cwd, changesets) {
 }
 
 async function loadWorkspacePackages(cwd) {
-  const packageFiles = await fg(['packages/*/package.json', 'packages-deprecated/*/package.json'], {
-    cwd,
-    absolute: true,
-  })
+  const packageFiles = await fg(
+    ['packages/*/package.json', 'packages-deprecated/*/package.json', 'demos/package.json'],
+    {
+      cwd,
+      absolute: true,
+    },
+  )
 
   const packages = new Map()
 


### PR DESCRIPTION
## Changes Overview

Fixed issue that caused the `Publish` workflow to fail after commit https://github.com/ueberdosis/tiptap/commit/1c6619eccb6a9cdee46da3e8823a407acbe9e4d9

Fix the publish changelog aggregation script so it can resolve metadata for the private `demos` workspace package.

## Implementation Approach

Extended workspace package discovery in `scripts/aggregate-changeset.js` to include `demos/package.json`, which keeps the release-plan lookup aligned with the packages Changesets can emit.

## Testing Done

Ran `pnpm run changelog` locally and verified it now completes instead of failing on `Could not find package metadata for tiptap-demos`.

## Verification Steps

Run the publish/version path that previously failed in CI and confirm the changelog aggregation step completes successfully.

## Additional Notes

This change only touches release metadata discovery. No public package APIs changed.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used AI to debug the failing publish workflow, identify the missing `demos` package metadata lookup, and draft the fix and validation steps.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

None.
