### PR TITLE
Ignore private packages when creating the changelog

### DIFF
--- a/scripts/aggregate-changeset.js
+++ b/scripts/aggregate-changeset.js
@@ -389,7 +389,8 @@ async function main() {
           ...pkg,
         }
       })
-      .filter(release => release.type !== 'none')
+      // Ignore private packages like the demos package
+      .filter(release => release.type !== 'none' && !release.packageJson.private)
 
     const changesetsWithCommits = await addCommitsToChangesets(cwd, plan.changesets)
     const aggregateConfig = {


### PR DESCRIPTION
## Changes Overview

Exclude private workspace packages from the aggregated release notes so `tiptap-demos` no longer appears in the changelog output.

## Implementation Approach

Kept the workspace metadata lookup broad enough to resolve `demos/package.json`, then filtered out any release whose package is marked `private: true` before rendering the changelog section.

## Testing Done

Validated the changelog generation path locally after the change.

## Verification Steps

Run `pnpm run changelog` and confirm private workspace packages are skipped in the generated release notes.

## Additional Notes

This only affects changelog aggregation. It does not change package publication behavior.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used AI to debug the release-note behavior, identify the private-package filtering approach, and prepare the PR description.

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

None.
