### PR TITLE
Remove circular dependencies by importing from specific modules

### DIFF
--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -8,6 +8,7 @@ import {
   flattenExtensions,
   getAttributesFromExtensions,
   getExtensionField,
+  getMarkType,
   getNodeType,
   getRenderedAttributes,
   getSchemaByResolvedExtensions,
@@ -17,18 +18,13 @@ import {
   sortExtensions,
   splitExtensions,
 } from './helpers/index.js'
-import {
-  type MarkConfig,
-  type NodeConfig,
-  type Storage,
-  getMarkType,
-  updateMarkViewAttributes,
-} from './index.js'
+import { updateMarkViewAttributes } from './MarkView.js'
 import { inputRulesPlugin } from './InputRule.js'
-import { Mark } from './Mark.js'
+import { Mark, type MarkConfig } from './Mark.js'
 import { pasteRulesPlugin } from './PasteRule.js'
-import type { AnyConfig, Extensions, RawCommands } from './types.js'
+import type { AnyConfig, Extensions, RawCommands, Storage } from './types.js'
 import { callOrReturn } from './utilities/callOrReturn.js'
+import { type NodeConfig } from './Node.js'
 
 export class ExtensionManager {
   editor: Editor

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,9 +20,3 @@ export * from './pasteRules/index.js'
 export * from './Tracker.js'
 export * from './types.js'
 export * from './utilities/index.js'
-
-// oxlint-disable-next-line
-export interface Commands<ReturnType = any> {}
-
-// oxlint-disable-next-line
-export interface Storage {}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1099,8 +1099,7 @@ export type Utils = {
   createMappablePosition: (position: number) => MappablePosition
 }
 
-// oxlint-disable-next-line
+// oxlint-disable-next-line no-unused-vars
 export interface Commands<ReturnType = any> {}
 
-// oxlint-disable-next-line
 export interface Storage {}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,16 +20,10 @@ import type {
 
 import type { Editor } from './Editor.js'
 import type { Extendable } from './Extendable.js'
-import type {
-  Commands,
-  ExtensionConfig,
-  GetUpdatedPositionResult,
-  MappablePosition,
-  MarkConfig,
-  NodeConfig,
-} from './index.js'
-import type { Mark } from './Mark.js'
-import type { Node } from './Node.js'
+import type { ExtensionConfig } from './Extension.js'
+import type { GetUpdatedPositionResult, MappablePosition } from './helpers/MappablePosition.js'
+import type { Mark, MarkConfig } from './Mark.js'
+import type { Node, NodeConfig } from './Node.js'
 
 export type AnyConfig = ExtensionConfig | NodeConfig | MarkConfig
 export type AnyExtension = Extendable
@@ -1104,3 +1098,9 @@ export type Utils = {
    */
   createMappablePosition: (position: number) => MappablePosition
 }
+
+// oxlint-disable-next-line
+export interface Commands<ReturnType = any> {}
+
+// oxlint-disable-next-line
+export interface Storage {}


### PR DESCRIPTION
## Changes Overview

Refactored imports in the core package to eliminate circular dependencies by importing directly from specific modules instead of the barrel index file. Additionally moved the `Commands` and `Storage` type declarations from `index.ts` to `types.ts`.

## Implementation Approach

Changed imports in `ExtensionManager.ts` and `types.ts` to import types and functions from their source files (`Mark.ts`, `Node.ts`, `Extension.ts`, etc.) rather than from the barrel export. This breaks the circular dependency chain. The `Commands` and `Storage` interfaces were moved to `types.ts` to avoid importing from the barrel in type files.

## Testing Done

No tests were added as this is a refactoring that does not change behavior. Existing tests should continue to pass.

## Verification Steps

Run the test suite for the core package to ensure all tests pass. Verify that the build succeeds without circular dependency warnings.

## Additional Notes

This PR addresses circular dependency issues that could cause runtime errors in certain environments. A changeset is not required as this is purely a refactoring.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  I composed this PR with AI

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
N/A
