### PR TITLE
docs: clarify common React and text-style setup

### DIFF
--- a/packages/extension-text-style/README.md
+++ b/packages/extension-text-style/README.md
@@ -13,6 +13,20 @@ Tiptap is a headless wrapper around [ProseMirror](https://ProseMirror.net) – a
 
 Documentation can be found on the [Tiptap website](https://tiptap.dev).
 
+## Related extensions
+
+`TextStyle` is commonly combined with sibling extensions from the same package
+when imported content carries richer inline formatting. Typical companions are:
+
+- `FontFamily`
+- `FontSize`
+- `LineHeight`
+- `BackgroundColor`
+
+If your content includes superscript or subscript formatting, also include the
+dedicated `@tiptap/extension-superscript` and `@tiptap/extension-subscript`
+marks in your editor schema.
+
 ## License
 
 Tiptap is open sourced software licensed under the [MIT license](https://github.com/ueberdosis/tiptap/blob/main/LICENSE.md).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,6 +13,25 @@ Tiptap is a headless wrapper around [ProseMirror](https://ProseMirror.net) – a
 
 Documentation can be found on the [Tiptap website](https://tiptap.dev).
 
+## Common React setup note
+
+When you call `useEditor({ immediatelyRender: false })`, the editor instance is
+`null` on the first render. Gate the UI until the editor exists instead of
+passing `null` into components that require a live editor instance.
+
+```tsx
+const editor = useEditor({
+  extensions: [StarterKit],
+  immediatelyRender: false,
+})
+
+if (!editor) {
+  return <div>Loading editor…</div>
+}
+
+return <EditorContent editor={editor} />
+```
+
 ## License
 
 Tiptap is open sourced software licensed under the [MIT license](https://github.com/ueberdosis/tiptap/blob/main/LICENSE.md).


### PR DESCRIPTION
## Summary
- document the null-editor guard pattern when immediatelyRender: false is used in React
- add a short companion-extension note for richer TextStyle content

## Testing
- not run (README-only change)