### PR TITLE
fix(extension-table): sync node attribute changes to TableView DOM

### DIFF
--- a/.changeset/tableview-sync-node-attrs.md
+++ b/.changeset/tableview-sync-node-attrs.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-table": patch
+---
+
+Fix `TableView` not syncing node attribute changes (e.g. `class` set via `addGlobalAttributes`) to the `<table>` DOM element after the initial render. Previously `TableView.update()` only re-rendered column widths, so attribute changes made via `tr.setNodeAttribute()` were reflected in the ProseMirror state and serialized HTML but invisible in the live editor DOM.

--- a/packages/extension-table/__tests__/tableHTMLAttributes.spec.ts
+++ b/packages/extension-table/__tests__/tableHTMLAttributes.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { Editor } from '@tiptap/core'
+import { Editor, Extension } from '@tiptap/core'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
@@ -68,5 +68,117 @@ describe('Table HTMLAttributes', () => {
     expect(table.classList.contains('fallback-class')).toBe(true)
 
     editorEl.remove()
+  })
+})
+
+describe('Table node attribute updates (addGlobalAttributes)', () => {
+  // An extension that adds a `class` attribute to the table node type via
+  // addGlobalAttributes, mirroring how extensions like ClassLoom work.
+  const TableClassAttr = Extension.create({
+    name: 'tableClassAttr',
+    addGlobalAttributes() {
+      return [
+        {
+          types: ['table'],
+          attributes: {
+            class: {
+              default: null,
+              parseHTML: element => element.getAttribute('class') || null,
+              renderHTML: attributes => (attributes.class ? { class: attributes.class } : {}),
+            },
+          },
+        },
+      ]
+    },
+  })
+
+  let editor: Editor | null = null
+  let editorEl: HTMLDivElement
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+    editorEl?.remove()
+  })
+
+  const createEditor = (tableOptions: Parameters<typeof Table.configure>[0] = {}) => {
+    editorEl = document.createElement('div')
+    document.body.appendChild(editorEl)
+
+    editor = new Editor({
+      element: editorEl,
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        TableCell,
+        TableHeader,
+        TableRow,
+        Table.configure({ resizable: false, ...tableOptions }),
+        TableClassAttr,
+      ],
+    })
+
+    editor.commands.insertTable({ rows: 2, cols: 2, withHeaderRow: false })
+    return editor
+  }
+
+  const findTablePos = (e: Editor): number => {
+    let pos = -1
+
+    e.state.doc.descendants((node, nodePos) => {
+      if (node.type.name === 'table') {
+        pos = nodePos
+        return false
+      }
+    })
+    return pos
+  }
+
+  it('reflects a class set via setNodeAttribute on the <table> DOM element', () => {
+    createEditor()
+
+    const tablePos = findTablePos(editor!)
+    editor!.commands.command(({ tr }) => {
+      tr.setNodeAttribute(tablePos, 'class', 'dynamic-class')
+      return true
+    })
+
+    const table = editor!.view.dom.querySelector('table')!
+    expect(table.classList.contains('dynamic-class')).toBe(true)
+  })
+
+  it('removes the class from the <table> DOM element when the attribute is cleared', () => {
+    createEditor()
+
+    const tablePos = findTablePos(editor!)
+
+    editor!.commands.command(({ tr }) => {
+      tr.setNodeAttribute(tablePos, 'class', 'to-be-removed')
+      return true
+    })
+
+    expect(editor!.view.dom.querySelector('table')!.classList.contains('to-be-removed')).toBe(true)
+
+    editor!.commands.command(({ tr }) => {
+      tr.setNodeAttribute(findTablePos(editor!), 'class', null)
+      return true
+    })
+
+    expect(editor!.view.dom.querySelector('table')!.getAttribute('class')).toBeNull()
+  })
+
+  it('merges a dynamic class with the static HTMLAttributes class', () => {
+    createEditor({ HTMLAttributes: { class: 'base-class' } })
+
+    const tablePos = findTablePos(editor!)
+    editor!.commands.command(({ tr }) => {
+      tr.setNodeAttribute(tablePos, 'class', 'added-class')
+      return true
+    })
+
+    const table = editor!.view.dom.querySelector('table')!
+    expect(table.classList.contains('base-class')).toBe(true)
+    expect(table.classList.contains('added-class')).toBe(true)
   })
 })

--- a/packages/extension-table/__tests__/tableHTMLAttributes.spec.ts
+++ b/packages/extension-table/__tests__/tableHTMLAttributes.spec.ts
@@ -139,6 +139,7 @@ describe('Table node attribute updates (addGlobalAttributes)', () => {
     createEditor()
 
     const tablePos = findTablePos(editor!)
+    // editor.commands.command dispatches the transaction when the callback returns true.
     editor!.commands.command(({ tr }) => {
       tr.setNodeAttribute(tablePos, 'class', 'dynamic-class')
       return true

--- a/packages/extension-table/src/table/TableView.ts
+++ b/packages/extension-table/src/table/TableView.ts
@@ -145,8 +145,18 @@ export class TableView implements NodeView {
     // created. Attributes added via addGlobalAttributes (e.g. a class set
     // through a custom command) live in node.attrs and are computed into
     // HTMLAttributes by getRenderedAttributes, but TableView.update() never
-    // received them before this fix. updateColumns() already handles
-    // width/minWidth via table.style, so we leave the style attribute to it.
+    // received them before this fix.
+    //
+    // Note on style: updateColumns() manages table.style.width/minWidth after
+    // this block runs. Overwriting style.cssText here would undo that work, so
+    // style updates from addGlobalAttributes are deliberately not synced. This
+    // is a known limitation; the constructor handles the initial style correctly.
+    //
+    // Note on attribute ownership: this NodeView fully owns the non-style keys
+    // it tracks in managedHTMLAttributeKeys. Plugins that need to add attributes
+    // (e.g. extra classes) should do so via addGlobalAttributes so they are
+    // included in the mergeAttributes call inside getHTMLAttributes rather than
+    // writing to the DOM directly.
     if (this.getHTMLAttributes) {
       const freshHTMLAttributes = this.getHTMLAttributes(node)
       const freshKeys = new Set<string>()

--- a/packages/extension-table/src/table/TableView.ts
+++ b/packages/extension-table/src/table/TableView.ts
@@ -90,6 +90,10 @@ export class TableView implements NodeView {
   /** Optional callback that returns fresh merged HTMLAttributes for a given node. */
   private getHTMLAttributes?: (node: ProseMirrorNode) => Record<string, any>
 
+  /** Tracks the non-style attribute keys applied by this NodeView so that only
+   *  those are ever removed — other plugins may set their own attributes. */
+  private managedHTMLAttributeKeys: Set<string> = new Set()
+
   constructor(
     node: ProseMirrorNode,
     cellMinWidth: number,
@@ -112,6 +116,7 @@ export class TableView implements NodeView {
           this.table.style.cssText = String(value)
         } else {
           this.table.setAttribute(key, String(value))
+          this.managedHTMLAttributeKeys.add(key)
         }
       }
     }
@@ -144,24 +149,26 @@ export class TableView implements NodeView {
     // width/minWidth via table.style, so we leave the style attribute to it.
     if (this.getHTMLAttributes) {
       const freshHTMLAttributes = this.getHTMLAttributes(node)
+      const freshKeys = new Set<string>()
 
       // Apply new or changed non-style attributes
       for (const [key, value] of Object.entries(freshHTMLAttributes)) {
         if (key === 'style') continue
         if (value !== undefined && value !== null) {
           this.table.setAttribute(key, String(value))
-        } else {
+          freshKeys.add(key)
+        }
+      }
+
+      // Remove only keys that this NodeView previously applied and that are
+      // no longer present — avoids touching attributes set by other plugins.
+      for (const key of this.managedHTMLAttributeKeys) {
+        if (!freshKeys.has(key)) {
           this.table.removeAttribute(key)
         }
       }
 
-      // Remove attributes that are no longer present
-      for (const { name } of Array.from(this.table.attributes)) {
-        if (name === 'style') continue
-        if (!(name in freshHTMLAttributes) || freshHTMLAttributes[name] == null) {
-          this.table.removeAttribute(name)
-        }
-      }
+      this.managedHTMLAttributeKeys = freshKeys
     }
 
     return true

--- a/packages/extension-table/src/table/TableView.ts
+++ b/packages/extension-table/src/table/TableView.ts
@@ -87,17 +87,22 @@ export class TableView implements NodeView {
 
   contentDOM: HTMLTableSectionElement
 
+  /** Optional callback that returns fresh merged HTMLAttributes for a given node. */
+  private getHTMLAttributes?: (node: ProseMirrorNode) => Record<string, any>
+
   constructor(
     node: ProseMirrorNode,
     cellMinWidth: number,
     _view?: EditorView,
     HTMLAttributes: Record<string, any> = {},
+    getHTMLAttributes?: (node: ProseMirrorNode) => Record<string, any>,
   ) {
     this.node = node
     this.cellMinWidth = cellMinWidth
     this.dom = document.createElement('div')
     this.dom.className = 'tableWrapper'
     this.table = this.dom.appendChild(document.createElement('table'))
+    this.getHTMLAttributes = getHTMLAttributes
 
     // Apply extension-configured HTMLAttributes to the table element
     // (e.g. class, data-* set via Table.configure({ HTMLAttributes }))
@@ -130,6 +135,34 @@ export class TableView implements NodeView {
 
     this.node = node
     updateColumns(node, this.colgroup, this.table, this.cellMinWidth)
+
+    // Re-sync HTML attributes that may have changed since the NodeView was
+    // created. Attributes added via addGlobalAttributes (e.g. a class set
+    // through a custom command) live in node.attrs and are computed into
+    // HTMLAttributes by getRenderedAttributes, but TableView.update() never
+    // received them before this fix. updateColumns() already handles
+    // width/minWidth via table.style, so we leave the style attribute to it.
+    if (this.getHTMLAttributes) {
+      const freshHTMLAttributes = this.getHTMLAttributes(node)
+
+      // Apply new or changed non-style attributes
+      for (const [key, value] of Object.entries(freshHTMLAttributes)) {
+        if (key === 'style') continue
+        if (value !== undefined && value !== null) {
+          this.table.setAttribute(key, String(value))
+        } else {
+          this.table.removeAttribute(key)
+        }
+      }
+
+      // Remove attributes that are no longer present
+      for (const { name } of Array.from(this.table.attributes)) {
+        if (name === 'style') continue
+        if (!(name in freshHTMLAttributes) || freshHTMLAttributes[name] == null) {
+          this.table.removeAttribute(name)
+        }
+      }
+    }
 
     return true
   }

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -556,6 +556,11 @@ export const Table = Node.create<TableOptions>({
         // Callback used by TableView.update() to recompute merged HTMLAttributes
         // from the updated node, so attribute changes (e.g. via addGlobalAttributes
         // and setNodeAttribute) are reflected in the live DOM.
+        //
+        // The `HTMLAttributes` argument passed into this factory by ExtensionManager
+        // is itself the result of getRenderedAttributes(node, extensionAttributes), so
+        // the callback below mirrors that computation exactly — no extra static attrs
+        // are lost between the initial render and subsequent updates.
         (updatedNode: ProseMirrorNode) =>
           mergeAttributes(
             this.options.HTMLAttributes,

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -542,6 +542,12 @@ export const Table = Node.create<TableOptions>({
     return ({ node, view, HTMLAttributes }) => {
       const mergedAttributes = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)
 
+      // Precompute once: the node type is stable for the lifetime of this NodeView.
+      const nodeTypeName = node.type.name
+      const nodeExtensionAttributes = this.editor.extensionManager.attributes.filter(
+        attr => attr.type === nodeTypeName,
+      )
+
       return new View(
         node,
         this.options.cellMinWidth,
@@ -553,12 +559,7 @@ export const Table = Node.create<TableOptions>({
         (updatedNode: ProseMirrorNode) =>
           mergeAttributes(
             this.options.HTMLAttributes,
-            getRenderedAttributes(
-              updatedNode,
-              this.editor.extensionManager.attributes.filter(
-                attr => attr.type === updatedNode.type.name,
-              ),
-            ),
+            getRenderedAttributes(updatedNode, nodeExtensionAttributes),
           ),
       ) as NodeView
     }

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -5,6 +5,7 @@ import {
   type MarkdownToken,
   callOrReturn,
   getExtensionField,
+  getRenderedAttributes,
   mergeAttributes,
   Node,
 } from '@tiptap/core'
@@ -541,7 +542,25 @@ export const Table = Node.create<TableOptions>({
     return ({ node, view, HTMLAttributes }) => {
       const mergedAttributes = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)
 
-      return new View(node, this.options.cellMinWidth, view, mergedAttributes) as NodeView
+      return new View(
+        node,
+        this.options.cellMinWidth,
+        view,
+        mergedAttributes,
+        // Callback used by TableView.update() to recompute merged HTMLAttributes
+        // from the updated node, so attribute changes (e.g. via addGlobalAttributes
+        // and setNodeAttribute) are reflected in the live DOM.
+        (updatedNode: ProseMirrorNode) =>
+          mergeAttributes(
+            this.options.HTMLAttributes,
+            getRenderedAttributes(
+              updatedNode,
+              this.editor.extensionManager.attributes.filter(
+                attr => attr.type === updatedNode.type.name,
+              ),
+            ),
+          ),
+      ) as NodeView
     }
   },
 


### PR DESCRIPTION
## Changes Overview

`TableView.update()` re-rendered column widths but never re-applied `HTMLAttributes` when node attributes changed after the initial render. Attributes added via `addGlobalAttributes` and updated with `tr.setNodeAttribute()` were correctly reflected in the ProseMirror state and serialized HTML but the live `<table>` DOM element was not updated.

This is a follow-up to #7896, which fixed the constructor path (initial render) but left the update path unhandled.

## Implementation Approach

1. **`TableView.ts`** — Added an optional `getHTMLAttributes` callback as a 5th constructor parameter. When provided, `update()` calls it to obtain fresh merged `HTMLAttributes` for the updated node and syncs all non-`style` attributes to `this.table`. The `style` attribute is left to `updateColumns()` which already manages `width`/`minWidth`.

2. **`table.ts` (`addNodeView`)** — Passes a callback that recomputes the merged `HTMLAttributes` via `getRenderedAttributes(updatedNode, extensionAttributes)` merged with `this.options.HTMLAttributes`, mirroring exactly what the constructor receives at creation time.

## Testing Done

- Extended `tableHTMLAttributes.spec.ts` with 3 new tests under `Table node attribute updates (addGlobalAttributes)`:
  - reflects a class set via `setNodeAttribute` on the `<table>` DOM element
  - removes the class from the `<table>` DOM element when the attribute is cleared
  - merges a dynamic class with the static `HTMLAttributes` class
- All 1166 existing tests continue to pass.

## Verification Steps

1. `pnpm test:unit` — all tests pass
2. Create an editor with an extension that adds a `class` attribute to the `table` type via `addGlobalAttributes`, insert a table, then call `tr.setNodeAttribute(pos, 'class', 'my-class')` — the `<table>` element should immediately reflect the class in the live DOM.

## Additional Notes

The fix is backward-compatible: `getHTMLAttributes` is optional, so existing `TableView` subclasses are unaffected. The `style` attribute is deliberately excluded from syncing since `updateColumns()` manages `width`/`minWidth` on the element's style.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - Used Claude to help identify the root cause, write the fix, and write the tests.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Follow-up to #7896.