### PR TITLE
fix: resolve drag-and-drop duplication issue during collaboration

### DIFF
--- a/.changeset/2026-06-10-node-range-selection-json-id.md
+++ b/.changeset/2026-06-10-node-range-selection-json-id.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-node-range": patch
 ---
 
-Fixed drag-and-drop duplicating blocks during collaboration. When a remote collaborator edited the document mid-drag, dropping left an empty copy of the dragged block at its original position. This fix also requires updating `@tiptap/y-tiptap` to the latest version.
+Fixed drag-and-drop duplicating blocks during collaboration. When a remote collaborator edited the document mid-drag, dropping left an empty copy of the dragged block at its original position. This fix also requires a version of `@tiptap/y-tiptap` that restores node range selections across remote updates.

--- a/.changeset/2026-06-10-node-range-selection-json-id.md
+++ b/.changeset/2026-06-10-node-range-selection-json-id.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-node-range": patch
+---
+
+Fixed drag-and-drop duplicating blocks during collaboration. When a remote collaborator edited the document mid-drag, dropping left an empty copy of the dragged block at its original position. This fix also requires updating `@tiptap/y-tiptap` to the latest version.

--- a/.changeset/2026-06-10-restore-node-range-after-drop.md
+++ b/.changeset/2026-06-10-restore-node-range-after-drop.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-drag-handle": patch
+---
+
+Restore the node range selection after dragging multiple blocks. Previously, dropping a multi-block drag left a text selection inside the moved content instead of keeping the dragged blocks selected.

--- a/.changeset/gorgeous-terms-sell.md
+++ b/.changeset/gorgeous-terms-sell.md
@@ -1,0 +1,8 @@
+---
+'@tiptap/extension-collaboration-caret': patch
+'@tiptap/extension-collaboration': patch
+'@tiptap/extension-drag-handle': patch
+'@tiptap/extension-node-range': patch
+---
+
+Bump `@tiptap/y-tiptap` to version ^3.0.5

--- a/demos/package.json
+++ b/demos/package.json
@@ -16,7 +16,7 @@
     "@lexical/react": "^0.36.2",
     "@lifeomic/attempt": "3.1.0",
     "@shikijs/core": "1.10.3",
-    "@tiptap/y-tiptap": "^3.0.0",
+    "@tiptap/y-tiptap": "^3.0.5",
     "d3": "^7.9.0",
     "fast-glob": "^3.3.2",
     "highlight.js": "^11.11.1",

--- a/packages/extension-collaboration-caret/package.json
+++ b/packages/extension-collaboration-caret/package.json
@@ -49,12 +49,12 @@
     "@tiptap/extension-table-row": "workspace:^",
     "@tiptap/extension-text": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.2",
+    "@tiptap/y-tiptap": "^3.0.5",
     "yjs": "^13.6.23"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:*",
     "@tiptap/pm": "workspace:*",
-    "@tiptap/y-tiptap": "^3.0.2"
+    "@tiptap/y-tiptap": "^3.0.5"
   }
 }

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -41,12 +41,12 @@
   "devDependencies": {
     "@tiptap/core": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.4"
+    "@tiptap/y-tiptap": "^3.0.5"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:*",
     "@tiptap/pm": "workspace:*",
-    "@tiptap/y-tiptap": "^3.0.4",
+    "@tiptap/y-tiptap": "^3.0.5",
     "yjs": "^13"
   }
 }

--- a/packages/extension-drag-handle/__tests__/nodeRangeDrop.spec.ts
+++ b/packages/extension-drag-handle/__tests__/nodeRangeDrop.spec.ts
@@ -1,0 +1,105 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import { isNodeRangeSelection, NodeRangeSelection } from '@tiptap/extension-node-range'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { TextSelection } from '@tiptap/pm/state'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  createDroppedNodeRangeSelection,
+  getActiveDragRange,
+} from '../src/helpers/nodeRangeDrop.js'
+
+describe('nodeRangeDrop helpers', () => {
+  let editor: Editor | null = null
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+  })
+
+  function createEditor(content: string): Editor {
+    editor = new Editor({
+      element: document.body,
+      extensions: [Document, Paragraph, Text],
+      content,
+    })
+
+    return editor
+  }
+
+  describe('getActiveDragRange', () => {
+    it('captures the node count and depth of a node range selection', () => {
+      const { state } = createEditor('<p>First</p><p>Second</p><p>Third</p>')
+      const firstSize = state.doc.child(0).nodeSize
+      const selection = NodeRangeSelection.create(state.doc, 1, firstSize + 1, 0)
+
+      expect(getActiveDragRange(selection)).toEqual({
+        nodeCount: selection.ranges.length,
+        depth: 0,
+      })
+    })
+
+    it('returns null for a non node range selection', () => {
+      const { state } = createEditor('<p>First</p>')
+      const selection = TextSelection.create(state.doc, 1)
+
+      expect(getActiveDragRange(selection)).toBeNull()
+    })
+  })
+
+  describe('createDroppedNodeRangeSelection', () => {
+    it('rebuilds a node range over the first two blocks', () => {
+      const { state } = createEditor('<p>First</p><p>Second</p><p>Third</p>')
+      const firstSize = state.doc.child(0).nodeSize
+      const secondSize = state.doc.child(1).nodeSize
+
+      const selection = createDroppedNodeRangeSelection(state.doc, 1, 2, 0)
+
+      expect(selection && isNodeRangeSelection(selection)).toBe(true)
+      expect(selection?.ranges).toHaveLength(2)
+      expect(selection?.from).toBe(0)
+      expect(selection?.to).toBe(firstSize + secondSize)
+    })
+
+    it('selects the blocks following the drop position', () => {
+      const { state } = createEditor('<p>First</p><p>Second</p><p>Third</p>')
+      const firstSize = state.doc.child(0).nodeSize
+
+      const selection = createDroppedNodeRangeSelection(state.doc, firstSize + 1, 2, 0)
+
+      expect(selection?.from).toBe(firstSize)
+      expect(selection?.to).toBe(state.doc.content.size)
+    })
+
+    it('clamps to the last blocks when the drop lands past the end', () => {
+      const { state } = createEditor('<p>First</p><p>Second</p><p>Third</p>')
+      const firstSize = state.doc.child(0).nodeSize
+
+      const selection = createDroppedNodeRangeSelection(state.doc, state.doc.content.size, 2, 0)
+
+      expect(selection?.from).toBe(firstSize)
+      expect(selection?.to).toBe(state.doc.content.size)
+    })
+
+    it('rebuilds a single-block range', () => {
+      const { state } = createEditor('<p>First</p><p>Second</p>')
+      const firstSize = state.doc.child(0).nodeSize
+
+      const selection = createDroppedNodeRangeSelection(state.doc, 1, 1, 0)
+
+      expect(selection?.ranges).toHaveLength(1)
+      expect(selection?.from).toBe(0)
+      expect(selection?.to).toBe(firstSize)
+    })
+
+    it('returns null when fewer blocks are available than were dragged', () => {
+      const { state } = createEditor('<p>Only</p>')
+
+      const selection = createDroppedNodeRangeSelection(state.doc, 1, 2, 0)
+
+      expect(selection).toBeNull()
+    })
+  })
+})

--- a/packages/extension-drag-handle/package.json
+++ b/packages/extension-drag-handle/package.json
@@ -47,13 +47,13 @@
     "@tiptap/extension-collaboration": "workspace:^",
     "@tiptap/extension-node-range": "workspace:^",
     "@tiptap/pm": "workspace:^",
-    "@tiptap/y-tiptap": "^3.0.2"
+    "@tiptap/y-tiptap": "^3.0.5"
   },
   "peerDependencies": {
     "@tiptap/core": "workspace:*",
     "@tiptap/extension-collaboration": "workspace:*",
     "@tiptap/extension-node-range": "workspace:*",
     "@tiptap/pm": "workspace:*",
-    "@tiptap/y-tiptap": "^3.0.2"
+    "@tiptap/y-tiptap": "^3.0.5"
   }
 }

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -203,7 +203,11 @@ export const DragHandlePlugin = ({
     }
   }
 
-  function onDrop() {
+  function onDrop(e: DragEvent) {
+    if (!e.target || !editor.view.dom.contains(e.target as HTMLElement)) {
+      return
+    }
+
     // Firefox has a bug where the caret becomes invisible after drag and drop.
     // This workaround forces Firefox to re-render the caret by toggling contentEditable.
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1327834

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -222,10 +222,11 @@ export const DragHandlePlugin = ({
     const pendingRestore = activeDragRange
 
     if (pendingRestore) {
+      const { selection, doc } = editor.state
       // wait for the drop to commit before recomputing the dropped block range
       restoreRafId = requestAnimationFrame(() => {
         restoreRafId = null
-        restoreNodeRangeSelection(pendingRestore, editor.state.selection, editor.state.doc)
+        restoreNodeRangeSelection(pendingRestore, selection, doc)
       })
     }
   }

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -12,6 +12,11 @@ import {
 
 import { dragHandler } from './helpers/dragHandler.js'
 import { findElementNextToCoords } from './helpers/findNextElementFromCursor.js'
+import {
+  type ActiveDragRange,
+  createDroppedNodeRangeSelection,
+  getActiveDragRange,
+} from './helpers/nodeRangeDrop.js'
 import { getOuterNode, getOuterNodePos } from './helpers/getOuterNode.js'
 import { removeNode } from './helpers/removeNode.js'
 import type { NormalizedNestedOptions } from './types/options.js'
@@ -97,7 +102,9 @@ export const DragHandlePlugin = ({
   // biome-ignore lint/suspicious/noExplicitAny: See above - relative positions in y-prosemirror are not typed
   let currentNodeRelPos: any
   let rafId: number | null = null
+  let restoreRafId: number | null = null
   let pendingMouseCoords: { x: number; y: number } | null = null
+  let activeDragRange: ActiveDragRange | null = null
 
   function hideHandle() {
     if (!element) {
@@ -149,6 +156,9 @@ export const DragHandlePlugin = ({
       dragImageProperties,
     )
 
+    // remember a multi-block node range so it can be restored after drop
+    activeDragRange = getActiveDragRange(editor.state.selection)
+
     if (element) {
       element.dataset.dragging = 'true'
     }
@@ -162,10 +172,32 @@ export const DragHandlePlugin = ({
 
   function onDragEnd(e: DragEvent) {
     onElementDragEnd?.(e)
+    activeDragRange = null
     hideHandle()
     if (element) {
       element.style.pointerEvents = 'auto'
       element.dataset.dragging = 'false'
+    }
+  }
+
+  // ProseMirror leaves a TextSelection inside the dropped content, so rebuild the
+  // node range over the freshly dropped blocks to keep the selection consistent.
+  function restoreNodeRangeSelection({ nodeCount, depth }: ActiveDragRange) {
+    const { selection, doc } = editor.state
+
+    if (selection.empty) {
+      return
+    }
+
+    const nodeRangeSelection = createDroppedNodeRangeSelection(
+      doc,
+      selection.from,
+      nodeCount,
+      depth,
+    )
+
+    if (nodeRangeSelection) {
+      editor.view.dispatch(editor.state.tr.setSelection(nodeRangeSelection))
     }
   }
 
@@ -184,20 +216,41 @@ export const DragHandlePlugin = ({
         }
       })
     }
+
+    const pendingRestore = activeDragRange
+
+    if (pendingRestore) {
+      // wait for the drop to commit before recomputing the dropped block range
+      restoreRafId = requestAnimationFrame(() => {
+        restoreRafId = null
+        restoreNodeRangeSelection(pendingRestore)
+      })
+    }
+  }
+
+  // shared teardown for both the unbind() handle and the plugin view destroy
+  function cleanup() {
+    element.removeEventListener('dragstart', onDragStart)
+    element.removeEventListener('dragend', onDragEnd)
+    document.removeEventListener('drop', onDrop)
+
+    if (rafId) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+      pendingMouseCoords = null
+    }
+
+    if (restoreRafId) {
+      cancelAnimationFrame(restoreRafId)
+      restoreRafId = null
+    }
   }
 
   wrapper.appendChild(element)
 
   return {
     unbind() {
-      element.removeEventListener('dragstart', onDragStart)
-      element.removeEventListener('dragend', onDragEnd)
-      document.removeEventListener('drop', onDrop)
-      if (rafId) {
-        cancelAnimationFrame(rafId)
-        rafId = null
-        pendingMouseCoords = null
-      }
+      cleanup()
     },
     plugin: new Plugin({
       key: typeof pluginKey === 'string' ? new PluginKey(pluginKey) : pluginKey,
@@ -336,15 +389,7 @@ export const DragHandlePlugin = ({
 
           // TODO: Kills even on hot reload
           destroy() {
-            element.removeEventListener('dragstart', onDragStart)
-            element.removeEventListener('dragend', onDragEnd)
-            document.removeEventListener('drop', onDrop)
-
-            if (rafId) {
-              cancelAnimationFrame(rafId)
-              rafId = null
-              pendingMouseCoords = null
-            }
+            cleanup()
 
             if (element) {
               removeNode(wrapper)

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -2,7 +2,7 @@ import { type ComputePositionConfig, type VirtualElement, computePosition } from
 import { type Editor, isFirefox } from '@tiptap/core'
 import { isChangeOrigin } from '@tiptap/extension-collaboration'
 import type { Node } from '@tiptap/pm/model'
-import { type EditorState, type Transaction, Plugin, PluginKey } from '@tiptap/pm/state'
+import { type EditorState, type Transaction, Plugin, PluginKey, Selection } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
 import {
   absolutePositionToRelativePosition,
@@ -182,9 +182,11 @@ export const DragHandlePlugin = ({
 
   // ProseMirror leaves a TextSelection inside the dropped content, so rebuild the
   // node range over the freshly dropped blocks to keep the selection consistent.
-  function restoreNodeRangeSelection({ nodeCount, depth }: ActiveDragRange) {
-    const { selection, doc } = editor.state
-
+  function restoreNodeRangeSelection(
+    { nodeCount, depth }: ActiveDragRange,
+    selection: Selection,
+    doc: Node,
+  ) {
     if (selection.empty) {
       return
     }
@@ -223,7 +225,7 @@ export const DragHandlePlugin = ({
       // wait for the drop to commit before recomputing the dropped block range
       restoreRafId = requestAnimationFrame(() => {
         restoreRafId = null
-        restoreNodeRangeSelection(pendingRestore)
+        restoreNodeRangeSelection(pendingRestore, editor.state.selection, editor.state.doc)
       })
     }
   }

--- a/packages/extension-drag-handle/src/helpers/nodeRangeDrop.ts
+++ b/packages/extension-drag-handle/src/helpers/nodeRangeDrop.ts
@@ -1,0 +1,86 @@
+import { isNodeRangeSelection, NodeRangeSelection } from '@tiptap/extension-node-range'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import type { Selection } from '@tiptap/pm/state'
+
+export interface ActiveDragRange {
+  nodeCount: number
+  depth: number
+}
+
+interface DroppedBlockRange {
+  anchor: number
+  head: number
+  count: number
+}
+
+function sumNodeSizes(parent: ProseMirrorNode, from: number, to: number): number {
+  let size = 0
+
+  for (let i = from; i < to; i += 1) {
+    size += parent.child(i).nodeSize
+  }
+
+  return size
+}
+
+// Captures a multi-block node range at dragstart so it can be restored after drop.
+export function getActiveDragRange(selection: Selection): ActiveDragRange | null {
+  if (!isNodeRangeSelection(selection)) {
+    return null
+  }
+
+  return { nodeCount: selection.ranges.length, depth: selection.depth ?? 0 }
+}
+
+/**
+ * Computes the position range of the freshly dropped blocks so a
+ * `NodeRangeSelection` can be restored over them after a drag-and-drop.
+ */
+function getDroppedBlockRange(
+  doc: ProseMirrorNode,
+  anchorPos: number,
+  nodeCount: number,
+  depth: number,
+): DroppedBlockRange | null {
+  const $pos = doc.resolve(anchorPos)
+  const parent = $pos.node(depth)
+  let index = $pos.index(depth)
+
+  // the drop can land past the last child, so clamp the index back into range
+  if (index >= parent.childCount) {
+    index = Math.max(0, parent.childCount - nodeCount)
+  }
+
+  const count = Math.min(nodeCount, parent.childCount - index)
+
+  if (count <= 0) {
+    return null
+  }
+
+  const blockStart = $pos.start(depth) + sumNodeSizes(parent, 0, index)
+  const blockEnd = blockStart + sumNodeSizes(parent, index, index + count)
+
+  return { anchor: blockStart, head: blockEnd, count }
+}
+
+// Rebuilds the dragged node range over the dropped blocks, or null when unsafe.
+export function createDroppedNodeRangeSelection(
+  doc: ProseMirrorNode,
+  anchorPos: number,
+  nodeCount: number,
+  depth: number,
+): NodeRangeSelection | null {
+  try {
+    const range = getDroppedBlockRange(doc, anchorPos, nodeCount, depth)
+
+    if (!range) {
+      return null
+    }
+
+    const selection = NodeRangeSelection.create(doc, range.anchor, range.head, depth)
+
+    return selection.ranges.length === nodeCount ? selection : null
+  } catch {
+    return null
+  }
+}

--- a/packages/extension-node-range/__tests__/NodeRangeSelection.spec.ts
+++ b/packages/extension-node-range/__tests__/NodeRangeSelection.spec.ts
@@ -65,7 +65,7 @@ describe('NodeRangeSelection serialization', () => {
     const { state } = createEditor('<p>First</p><p>Second</p><p>Third</p>')
     const firstParagraphSize = state.doc.child(0).nodeSize
     const secondParagraphSize = state.doc.child(1).nodeSize
-    // Span from inside the first paragraph to inside the second paragraph.
+    // anchor inside the first paragraph, head at the boundary after the second
     const selection = NodeRangeSelection.create(
       state.doc,
       1,
@@ -79,5 +79,15 @@ describe('NodeRangeSelection serialization', () => {
     expect(isNodeRangeSelection(restored)).toBe(true)
     expect(restored.eq(selection)).toBe(true)
     expect((restored as NodeRangeSelection).ranges).toHaveLength(2)
+  })
+
+  it('keeps depth when mapped through a transaction', () => {
+    const { state } = createEditor('<p>First</p><p>Second</p>')
+    const selection = NodeRangeSelection.create(state.doc, 1, 1, 0)
+
+    const tr = state.tr.insertText('x', 1)
+    const mapped = selection.map(tr.doc, tr.mapping)
+
+    expect(mapped.depth).toBe(0)
   })
 })

--- a/packages/extension-node-range/__tests__/NodeRangeSelection.spec.ts
+++ b/packages/extension-node-range/__tests__/NodeRangeSelection.spec.ts
@@ -1,0 +1,83 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { Selection } from '@tiptap/pm/state'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { isNodeRangeSelection } from '../src/helpers/isNodeRangeSelection.js'
+import { NodeRangeSelection } from '../src/helpers/NodeRangeSelection.js'
+
+describe('NodeRangeSelection serialization', () => {
+  let editor: Editor | null = null
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+  })
+
+  function createEditor(content: string): Editor {
+    editor = new Editor({
+      element: document.body,
+      extensions: [Document, Paragraph, Text],
+      content,
+    })
+
+    return editor
+  }
+
+  it('registers the "nodeRange" JSON id', () => {
+    const { state } = createEditor('<p>First</p><p>Second</p>')
+    // jsonID is set on the prototype at registration but not in the Selection type
+    const selection = NodeRangeSelection.create(state.doc, 1, 1) as NodeRangeSelection & {
+      jsonID?: string
+    }
+
+    expect(selection.jsonID).toBe('nodeRange')
+  })
+
+  it('round-trips through the generic Selection.fromJSON dispatcher', () => {
+    // This is the regression: without `Selection.jsonID('nodeRange', …)`,
+    // `Selection.fromJSON` cannot resolve the `nodeRange` type and throws.
+    const { state } = createEditor('<p>First</p><p>Second</p>')
+    const selection = NodeRangeSelection.create(state.doc, 1, 1)
+
+    const restored = Selection.fromJSON(state.doc, selection.toJSON())
+
+    expect(isNodeRangeSelection(restored)).toBe(true)
+    expect(restored.eq(selection)).toBe(true)
+  })
+
+  it('preserves depth across toJSON → fromJSON', () => {
+    const { state } = createEditor('<p>First</p><p>Second</p>')
+    const selection = NodeRangeSelection.create(state.doc, 1, 1, 0)
+
+    const json = selection.toJSON()
+
+    expect(json.depth).toBe(0)
+
+    const restored = NodeRangeSelection.fromJSON(state.doc, json)
+
+    expect(restored.depth).toBe(0)
+  })
+
+  it('round-trips a multi-block selection without losing its ranges', () => {
+    const { state } = createEditor('<p>First</p><p>Second</p><p>Third</p>')
+    const firstParagraphSize = state.doc.child(0).nodeSize
+    const secondParagraphSize = state.doc.child(1).nodeSize
+    // Span from inside the first paragraph to inside the second paragraph.
+    const selection = NodeRangeSelection.create(
+      state.doc,
+      1,
+      firstParagraphSize + secondParagraphSize,
+    )
+
+    expect(selection.ranges).toHaveLength(2)
+
+    const restored = Selection.fromJSON(state.doc, selection.toJSON())
+
+    expect(isNodeRangeSelection(restored)).toBe(true)
+    expect(restored.eq(selection)).toBe(true)
+    expect((restored as NodeRangeSelection).ranges).toHaveLength(2)
+  })
+})

--- a/packages/extension-node-range/src/helpers/NodeRangeBookmark.ts
+++ b/packages/extension-node-range/src/helpers/NodeRangeBookmark.ts
@@ -5,16 +5,17 @@ import { NodeRangeSelection } from './NodeRangeSelection.js'
 
 export class NodeRangeBookmark {
   anchor!: number
-
   head!: number
+  depth!: number
 
-  constructor(anchor: number, head: number) {
+  constructor(anchor: number, head: number, depth: number | undefined) {
     this.anchor = anchor
     this.head = head
+    this.depth = depth ?? 0
   }
 
   map(mapping: Mappable) {
-    return new NodeRangeBookmark(mapping.map(this.anchor), mapping.map(this.head))
+    return new NodeRangeBookmark(mapping.map(this.anchor), mapping.map(this.head), this.depth)
   }
 
   resolve(doc: ProseMirrorNode) {

--- a/packages/extension-node-range/src/helpers/NodeRangeSelection.ts
+++ b/packages/extension-node-range/src/helpers/NodeRangeSelection.ts
@@ -58,7 +58,7 @@ export class NodeRangeSelection extends Selection {
     const $anchor = doc.resolve(mapping.map(this.anchor))
     const $head = doc.resolve(mapping.map(this.head))
 
-    return new NodeRangeSelection($anchor, $head)
+    return new NodeRangeSelection($anchor, $head, this.depth)
   }
 
   toJSON() {

--- a/packages/extension-node-range/src/helpers/NodeRangeSelection.ts
+++ b/packages/extension-node-range/src/helpers/NodeRangeSelection.ts
@@ -130,7 +130,7 @@ export class NodeRangeSelection extends Selection {
   }
 
   getBookmark(): NodeRangeBookmark {
-    return new NodeRangeBookmark(this.anchor, this.head)
+    return new NodeRangeBookmark(this.anchor, this.head, this.depth)
   }
 }
 

--- a/packages/extension-node-range/src/helpers/NodeRangeSelection.ts
+++ b/packages/extension-node-range/src/helpers/NodeRangeSelection.ts
@@ -66,6 +66,7 @@ export class NodeRangeSelection extends Selection {
       type: 'nodeRange',
       anchor: this.anchor,
       head: this.head,
+      depth: this.depth,
     }
   }
 
@@ -111,8 +112,11 @@ export class NodeRangeSelection extends Selection {
     return new NodeRangeSelection(this.$anchor, $to, this.depth)
   }
 
-  static fromJSON(doc: ProseMirrorNode, json: any): NodeRangeSelection {
-    return new NodeRangeSelection(doc.resolve(json.anchor), doc.resolve(json.head))
+  static fromJSON(
+    doc: ProseMirrorNode,
+    json: { anchor: number; head: number; depth?: number },
+  ): NodeRangeSelection {
+    return new NodeRangeSelection(doc.resolve(json.anchor), doc.resolve(json.head), json.depth)
   }
 
   static create(
@@ -131,3 +135,11 @@ export class NodeRangeSelection extends Selection {
 }
 
 NodeRangeSelection.prototype.visible = false
+
+// register the JSON id so collaboration can restore the selection on remote updates
+// guarded because Selection.jsonID throws if the id is already registered (dual ESM/CJS builds)
+try {
+  Selection.jsonID('nodeRange', NodeRangeSelection)
+} catch {
+  // already registered — safe to ignore
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         version: 2.15.0(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
       '@hocuspocus/transformer':
         specifier: ^2.15.0
-        version: 2.15.2(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23))(yjs@13.6.23)
+        version: 2.15.2(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23))(yjs@13.6.23)
       '@lexical/react':
         specifier: ^0.36.2
         version: 0.36.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(yjs@13.6.23)
@@ -158,8 +158,8 @@ importers:
         specifier: 1.10.3
         version: 1.10.3
       '@tiptap/y-tiptap':
-        specifier: ^3.0.0
-        version: 3.0.0(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.5
+        version: 3.0.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -477,8 +477,8 @@ importers:
         specifier: workspace:^
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^3.0.4
-        version: 3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.5
+        version: 3.0.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-collaboration-caret:
     devDependencies:
@@ -513,8 +513,8 @@ importers:
         specifier: workspace:^
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^3.0.2
-        version: 3.0.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.5
+        version: 3.0.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
       yjs:
         specifier: ^13.6.23
         version: 13.6.23
@@ -562,8 +562,8 @@ importers:
         specifier: workspace:^
         version: link:../pm
       '@tiptap/y-tiptap':
-        specifier: ^3.0.2
-        version: 3.0.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
+        specifier: ^3.0.5
+        version: 3.0.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
 
   packages/extension-drag-handle-react:
     devDependencies:
@@ -3189,10 +3189,10 @@ packages:
     peerDependencies:
       '@tiptap/pm': ^2.7.0
 
-  '@tiptap/core@3.24.0':
-    resolution: {integrity: sha512-GTAsXAI32p4hEZgPzvUv2RPrObxamy9AFhmhG10fXSvN/cDUs8naEYVIqDV3Sh99jMwQEbTFKW1E1mcspsY6ow==}
+  '@tiptap/core@3.26.0':
+    resolution: {integrity: sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==}
     peerDependencies:
-      '@tiptap/pm': 3.24.0
+      '@tiptap/pm': 3.26.0
 
   '@tiptap/extension-blockquote@2.14.0':
     resolution: {integrity: sha512-AwqPP0jLYNioKxakiVw0vlfH/ceGFbV+SGoqBbPSGFPRdSbHhxHDNBlTtiThmT3N2PiVwXAD9xislJV+WY4GUA==}
@@ -3297,34 +3297,14 @@ packages:
   '@tiptap/pm@2.14.0':
     resolution: {integrity: sha512-cnsfaIlvTFCDtLP/A2Fd3LmpttgY0O/tuTM2fC71vetONz83wUTYT+aD9uvxdX0GkSocoh840b0TsEazbBxhpA==}
 
-  '@tiptap/pm@3.24.0':
-    resolution: {integrity: sha512-QQP/78ryOZDN99gNBV7dgh69/8AYaOYQYFklq/iR+ZRFaaL3+qqHFvPVJapGkzPdymBgNJ34xjFM8n5pJ4QmMg==}
+  '@tiptap/pm@3.26.0':
+    resolution: {integrity: sha512-q4RDeWwVrhOL0jJCGRgGxLSdjOYwzQ4h2InURZVhC66433ipcHd6f3bqSOhcXZ4r0sFmMNsuF7aZmUntjWLc7w==}
 
   '@tiptap/starter-kit@2.14.0':
     resolution: {integrity: sha512-Z1bKAfHl14quRI3McmdU+bs675jp6/iexEQTI9M9oHa6l3McFF38g9N3xRpPPX02MX83DghsUPupndUW/yJvEQ==}
 
-  '@tiptap/y-tiptap@3.0.0':
-    resolution: {integrity: sha512-HIeJZCj+KYJde2x6fONzo4o6kd7gW7eonwhQsv2p2VQnUgwNXMVhN+D6Z3AH/2i541Sq33y1PO4U/1ThCPjqbA==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
-    peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
-      y-protocols: ^1.0.1
-      yjs: ^13.5.38
-
-  '@tiptap/y-tiptap@3.0.2':
-    resolution: {integrity: sha512-flMn/YW6zTbc6cvDaUPh/NfLRTXDIqgpBUkYzM74KA1snqQwhOMjnRcnpu4hDFrTnPO6QGzr99vRyXEA7M44WA==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
-    peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
-      y-protocols: ^1.0.1
-      yjs: ^13.5.38
-
-  '@tiptap/y-tiptap@3.0.4':
-    resolution: {integrity: sha512-I7NnntIPR9PgCuBEjZ0hco+eeLvTpMDnXxsyhwn8z7Se0/Ac6RIq903wn6KoMn7FRVXpTtXAfZphFtpErjabVw==}
+  '@tiptap/y-tiptap@3.0.5':
+    resolution: {integrity: sha512-WoK5z3jMW+9nzumcWAxEDRCSC7yQmdq4NN0157MaxQBl9dGWwjxJx3+11mb+WAqR37oDeAMKMmSNy+/hm2XGlA==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
       prosemirror-model: ^1.7.1
@@ -4980,11 +4960,6 @@ packages:
 
   lexical@0.36.2:
     resolution: {integrity: sha512-gIDJCmSAhtxD7h95WK17Nz19wCZu92Zn0p1/R45X01S/KAsLCwEtVJ2fTvIJNFTyx3QNJTuGcm5mYgRMUwq8rg==}
-
-  lib0@0.2.104:
-    resolution: {integrity: sha512-1tqKRANSPTcjs/yjPoKh52oRM2u5AYdd8jie8sDiN8/5kpWWiQSHUGgtB4VEXLw1chVL3QPSPp8q9RWqzSn2FA==}
-    engines: {node: '>=16'}
-    hasBin: true
 
   lib0@0.2.114:
     resolution: {integrity: sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==}
@@ -8182,10 +8157,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@hocuspocus/transformer@2.15.2(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23))(yjs@13.6.23)':
+  '@hocuspocus/transformer@2.15.2(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23))(yjs@13.6.23)':
     dependencies:
-      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
-      '@tiptap/pm': 3.24.0
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
       '@tiptap/starter-kit': 2.14.0
       y-prosemirror: 1.3.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)
       yjs: 13.6.23
@@ -8850,9 +8825,9 @@ snapshots:
     dependencies:
       '@tiptap/pm': 2.14.0
 
-  '@tiptap/core@3.24.0(@tiptap/pm@3.24.0)':
+  '@tiptap/core@3.26.0(@tiptap/pm@3.26.0)':
     dependencies:
-      '@tiptap/pm': 3.24.0
+      '@tiptap/pm': 3.26.0
 
   '@tiptap/extension-blockquote@2.14.0(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))':
     dependencies:
@@ -8956,7 +8931,7 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
-  '@tiptap/pm@3.24.0':
+  '@tiptap/pm@3.26.0':
     dependencies:
       prosemirror-changeset: 2.3.0
       prosemirror-commands: 1.6.2
@@ -8996,25 +8971,7 @@ snapshots:
       '@tiptap/extension-text-style': 2.14.0(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))
       '@tiptap/pm': 2.14.0
 
-  '@tiptap/y-tiptap@3.0.0(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
-    dependencies:
-      lib0: 0.2.104
-      prosemirror-model: 1.25.7
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.8
-      y-protocols: 1.0.6(yjs@13.6.23)
-      yjs: 13.6.23
-
-  '@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
-    dependencies:
-      lib0: 0.2.117
-      prosemirror-model: 1.25.7
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.8
-      y-protocols: 1.0.6(yjs@13.6.23)
-      yjs: 13.6.23
-
-  '@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
+  '@tiptap/y-tiptap@3.0.5(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.6(yjs@13.6.23))(yjs@13.6.23)':
     dependencies:
       lib0: 0.2.117
       prosemirror-model: 1.25.7
@@ -10725,10 +10682,6 @@ snapshots:
   kleur@4.1.5: {}
 
   lexical@0.36.2: {}
-
-  lib0@0.2.104:
-    dependencies:
-      isomorphic.js: 0.2.5
 
   lib0@0.2.114:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ allowBuilds:
   '@parcel/watcher': true
   esbuild: true
   iframe-resizer: true
+minimumReleaseAgeExclude:
+  - '@tiptap/y-tiptap@3.0.5'
 overrides:
   '@rollup/pluginutils>picomatch': '2.3.2'
   '@octokit/action>undici': '6.24.1'


### PR DESCRIPTION
## Changes Overview

Fixes drag-and-drop duplicating blocks during collaboration. When a remote collaborator edited the document while a drag was in progress, dropping left an empty copy of the dragged block at its original position.

The root cause is that `NodeRangeSelection` never registered a JSON id, so `selection.jsonID` was `undefined`. On every remote Yjs update, `@tiptap/y-tiptap` could not recognize the selection and downgraded it to a `TextSelection`. On drop, ProseMirror deletes the current selection to move the block — a downgraded `TextSelection` does not remove the whole block, so the original stays behind as an empty shell.

This PR is the `@tiptap/extension-node-range` half of the fix. The companion change in `@tiptap/y-tiptap` (a `nodeRange` branch in `restoreRelativeSelection`) is required for the full fix and ships separately.

**Important**: This change requires https://github.com/ueberdosis/y-tiptap/pull/35 to be merged and released as without this yjs changes will still drop Tiptap's node range selections.

## Implementation Approach

- Register the selection with `Selection.jsonID('nodeRange', NodeRangeSelection)` so `selection.jsonID` resolves to `'nodeRange'` and the selection survives (de)serialization. Guarded against the throw that occurs if the module is evaluated twice (dual ESM/CJS builds).
- Include `depth` in `toJSON`/`fromJSON` so the round-trip is lossless.
- Narrowed the `fromJSON` `json` parameter to its real shape instead of `any`.

## Testing Done

- New unit tests in `packages/extension-node-range/__tests__/NodeRangeSelection.spec.ts` covering: jsonID registration, round-trip through the generic `Selection.fromJSON` dispatcher, depth preservation, and a multi-block selection round-trip.
- Confirmed the new spec fails without the `Selection.jsonID` registration and passes with it (real regression guard).
- `pnpm test:unit` — full suite passes (1167 tests).
- `pnpm --filter @tiptap/extension-node-range build`, `pnpm lint`, `pnpm format` — all clean.
- `fallow audit` — no findings introduced by this changeset.

## Verification Steps

1. Open the same document with two collaborators (real-time Yjs sync) using `@tiptap/extension-drag-handle` + `@tiptap/extension-node-range` + `@tiptap/extension-collaboration`.
2. User A starts dragging one or more blocks via the drag handle.
3. User B makes any edit during the drag (an inline text change is enough).
4. User A drops at a new position.
5. Expected: a single move — the block is removed from its original position and inserted at the drop target, with no empty shell left behind. Verify for both one-block and multi-block drags, and confirm non-collaborative drag is unaffected.

Note: full end-to-end verification also requires the companion `@tiptap/y-tiptap` update.

## Additional Notes

This fix also requires updating `@tiptap/y-tiptap` to a version that includes the matching `nodeRange` restore branch.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude to investigate the root cause, implement the `NodeRangeSelection` JSON-id registration and depth serialization, and write the unit tests.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
