### PR TITLE
Add bugs metadata for @tiptap/markdown

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/markdown"
   },
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/ueberdosis"


### PR DESCRIPTION
## Summary
- Add a bugs.url entry for @tiptap/markdown so npm users can find the public issue tracker from package metadata.
- Leave runtime code, dependencies, exports, and package files unchanged.

## Verification
- node package metadata assertion for packages/markdown/package.json
- git diff --check
- npm pack --dry-run --ignore-scripts --json from packages/markdown

Note: the source checkout does not include built dist artifacts, so the dry-run pack verifies the source manifest/package path available in the checkout and does not rebuild release artifacts.