### PR TITLE
fix(core): stop rewriteUnknownContent crashing on null array entries

### DIFF
--- a/.changeset/smooth-pets-march.md
+++ b/.changeset/smooth-pets-march.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fix a edge-case in `rewriteUnknownContent` to not fail on null-ish values inside marks or nodes.

--- a/packages/core/src/__tests__/rewriteUnknownContent.test.ts
+++ b/packages/core/src/__tests__/rewriteUnknownContent.test.ts
@@ -1,0 +1,49 @@
+import { Schema } from '@tiptap/pm/model'
+import { describe, expect, it } from 'vitest'
+
+import { rewriteUnknownContent } from '../helpers/rewriteUnknownContent.js'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    text: { group: 'inline' },
+  },
+  marks: { bold: {} },
+})
+
+describe('rewriteUnknownContent', () => {
+  it('drops nullish entries in a marks array without throwing', () => {
+    const json = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi', marks: [null] }] }],
+    }
+
+    const result = rewriteUnknownContent(json as any, schema)
+
+    expect(result.json).toEqual({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi', marks: [] }] }],
+    })
+  })
+
+  it('drops nullish entries in a content array without throwing', () => {
+    const json = { type: 'doc', content: [null] }
+
+    const result = rewriteUnknownContent(json as any, schema)
+
+    expect(result.json).toEqual({ type: 'doc', content: [] })
+  })
+
+  it('still keeps valid marks and content', () => {
+    const json = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi', marks: [{ type: 'bold' }] }] }],
+    }
+
+    const result = rewriteUnknownContent(json as any, schema)
+
+    expect(result.json).toEqual(json)
+    expect(result.rewrittenContent).toHaveLength(0)
+  })
+})

--- a/packages/core/src/helpers/rewriteUnknownContent.ts
+++ b/packages/core/src/helpers/rewriteUnknownContent.ts
@@ -48,6 +48,11 @@ function rewriteUnknownContentInner({
 } {
   if (json.marks && Array.isArray(json.marks)) {
     json.marks = json.marks.filter(mark => {
+      if (mark === null || mark === undefined) {
+        // Drop malformed (nullish) mark entries instead of crashing
+        return false
+      }
+
       const name = typeof mark === 'string' ? mark : mark.type
 
       if (validMarks.has(name)) {
@@ -65,16 +70,20 @@ function rewriteUnknownContentInner({
 
   if (json.content && Array.isArray(json.content)) {
     json.content = json.content
-      .map(
-        value =>
-          rewriteUnknownContentInner({
-            json: value,
-            validMarks,
-            validNodes,
-            options,
-            rewrittenContent,
-          }).json,
-      )
+      .map(value => {
+        if (value === null || value === undefined) {
+          // Drop malformed (nullish) content entries instead of crashing
+          return null
+        }
+
+        return rewriteUnknownContentInner({
+          json: value,
+          validMarks,
+          validNodes,
+          options,
+          rewrittenContent,
+        }).json
+      })
       .filter(a => a !== null && a !== undefined)
   }
 


### PR DESCRIPTION
## What's broken

`rewriteUnknownContent` — the helper that sanitizes untrusted/old-schema JSON before loading it into the editor — throws a `TypeError` when a node's `marks` or `content` array contains a `null` (or `undefined`) entry, instead of cleaning it out:

- a `null` in `marks` → `typeof mark === 'string' ? mark : mark.type` reads `null.type`;
- a `null` in `content` → the entry is recursed into and `.marks` is read off `null`.

```
marks: [null]            => TypeError: Cannot read properties of null (reading 'type')
content has null child   => TypeError: Cannot read properties of null (reading 'marks')
```

## Why it happens

Both iteration sites assume every array entry is an object; there's no nullish guard before dereferencing. The function already tolerates other malformed shapes (a mark missing `type`, a string mark), so nullish entries are a gap in an otherwise defensive routine.

## Fix

Drop nullish entries from `marks` and `content` (the existing `.filter` then removes the emptied content slots) instead of dereferencing them.

## Test

Added `rewriteUnknownContent` cases for `null` in `marks`, `null` in `content`, and a valid-input baseline; the two malformed cases throw before and pass after, valid input is unchanged.
