### PR TITLE
fix: add bugs metadata to packages/core/package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,5 +65,8 @@
   },
   "peerDependencies": {
     "@tiptap/pm": "workspace:*"
+  },
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
   }
 }


### PR DESCRIPTION
## Summary
The published npm package `@tiptap/core@3.26.1` is missing the `bugs` field in its `package.json` metadata.

The package already has `repository`, `homepage`, and `license` set, but lacks the `bugs` field. This means npm consumers do not get a direct link to the issue tracker from registry clients.

## Fix
Added the following field to `packages/core/package.json`:
```json
"bugs": {
  "url": "https://github.com/ueberdosis/tiptap/issues"
}
```

## Verification
- `npm view @tiptap/core bugs --json` returns nothing
- No dependencies, runtime code, or build configuration affected