### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tiptap/core",
   "version": "3.26.1",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "description": "headless rich text editor",
   "keywords": [
     "headless",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/core/package.json`.