### PR TITLE
fix(core): allow markdown attribute IDs that start with a number

### DIFF
--- a/.changeset/parse-attributes-numeric-id.md
+++ b/.changeset/parse-attributes-numeric-id.md
@@ -1,0 +1,7 @@
+---
+'@tiptap/core': patch
+---
+
+Fix `parseAttributes` stripping Pandoc-style IDs that start with a number.
+
+IDs such as `#2123` or `#5hello` were silently dropped because the ID matcher required a leading letter. The first character is now matched against `\w`, so numeric-leading IDs (valid in HTML5) are preserved. Example: `parseAttributes('#2123 .foo')` now returns `{ id: '2123', class: 'foo' }`. Class parsing is unchanged.

--- a/packages/core/__tests__/attributeUtils.spec.ts
+++ b/packages/core/__tests__/attributeUtils.spec.ts
@@ -1,0 +1,50 @@
+import { parseAttributes, serializeAttributes } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+
+describe('parseAttributes', () => {
+  it('parses a class', () => {
+    expect(parseAttributes('.foo')).toEqual({ class: 'foo' })
+  })
+
+  it('parses an id', () => {
+    expect(parseAttributes('#hello .foo')).toEqual({ id: 'hello', class: 'foo' })
+  })
+
+  it('parses an id that starts with a number', () => {
+    expect(parseAttributes('#2123 .foo')).toEqual({ id: '2123', class: 'foo' })
+  })
+
+  it('parses an id that starts with a number followed by letters', () => {
+    expect(parseAttributes('#5hello .foo')).toEqual({ id: '5hello', class: 'foo' })
+  })
+
+  it('parses an id without a class', () => {
+    expect(parseAttributes('#2123')).toEqual({ id: '2123' })
+  })
+
+  it('does not treat a numeric-leading id as a boolean attribute', () => {
+    // Regression: the id text must be consumed, not left behind as a boolean attr.
+    const result = parseAttributes('#5hello')
+    expect(result).toEqual({ id: '5hello' })
+    expect(result['5hello']).toBeUndefined()
+  })
+
+  it('keeps class parsing intact alongside ids and key-value pairs', () => {
+    expect(parseAttributes('.btn #submit disabled type="button"')).toEqual({
+      class: 'btn',
+      id: 'submit',
+      disabled: true,
+      type: 'button',
+    })
+  })
+
+  it('still ignores invalid class names that start with a number', () => {
+    // Classes intentionally require a leading letter; this should not become a class.
+    expect(parseAttributes('.2foo')).toEqual({})
+  })
+
+  it('round-trips a numeric-leading id through serialize/parse', () => {
+    const attrs = { id: '2123', class: 'foo' }
+    expect(parseAttributes(serializeAttributes(attrs))).toEqual(attrs)
+  })
+})

--- a/packages/core/src/utilities/markdown/attributeUtils.ts
+++ b/packages/core/src/utilities/markdown/attributeUtils.ts
@@ -44,8 +44,10 @@ export function parseAttributes(attrString: string): Record<string, any> {
     attributes.class = classes.join(' ')
   }
 
-  // Parse IDs (#myId) - only outside of quoted strings
-  const idMatch = tempString.match(/(?:^|\s)#([a-zA-Z][\w-]*)/)
+  // Parse IDs (#myId) - only outside of quoted strings.
+  // HTML5 ids may start with a digit (e.g. `#2123`, `#5hello`), so the first
+  // character is matched with `\w` rather than a letter-only class.
+  const idMatch = tempString.match(/(?:^|\s)#(\w[\w-]*)/)
   if (idMatch) {
     attributes.id = idMatch[1]
   }
@@ -65,7 +67,7 @@ export function parseAttributes(attrString: string): Record<string, any> {
   // Parse boolean attributes (standalone words that aren't classes/IDs)
   const cleanString = tempString
     .replace(/(?:^|\s)\.([a-zA-Z][\w-]*)/g, '') // Remove classes
-    .replace(/(?:^|\s)#([a-zA-Z][\w-]*)/g, '') // Remove IDs
+    .replace(/(?:^|\s)#(\w[\w-]*)/g, '') // Remove IDs
     .replace(/([a-zA-Z][\w-]*)\s*=\s*__QUOTED_\d+__/g, '') // Remove key-value pairs
     .trim()
 


### PR DESCRIPTION
## Problem

`parseAttributes` dropped Pandoc-style IDs beginning with a digit, such as `#2123` or `#5hello`, because the ID matcher required the first character to be a letter.

HTML5 allows IDs that start with a number, so these attributes should be preserved.

Before:

```ts
parseAttributes('#2123 .foo')
// => { class: 'foo' }

parseAttributes('#5hello .foo')
// => { class: 'foo' }
```

After:

```ts
parseAttributes('#2123 .foo')
// => { id: '2123', class: 'foo' }

parseAttributes('#5hello .foo')
// => { id: '5hello', class: 'foo' }
```

## Fix

This updates the ID parsing regex to allow a numeric-leading ID by matching the first ID character with `\w` instead of `[a-zA-Z]`.

The same update is applied to the cleanup regex used before boolean-attribute parsing, so numeric-leading IDs are consumed as IDs rather than left behind.

This is intentionally scoped to IDs only:

- class parsing is unchanged
- key-value attribute names are unchanged
- boolean attribute names are unchanged

So `.2foo` still is not treated as a class.

## Tests

Added focused coverage for:

- IDs that start with a number
- IDs that start with a number followed by letters
- numeric-leading IDs without classes
- the boolean-attribute regression case
- existing class/id/key-value behavior
- preserving the existing behavior for invalid numeric-leading class names
- serialize/parse round-trip for numeric-leading IDs

Verification run:

```sh
pnpm exec vitest run packages/core/__tests__/attributeUtils.spec.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       9 passed (9)
```

Closes #7345
