### PR TITLE
Remove legacy exports from Server AI Toolkit package

### DIFF
--- a/.changeset/swift-emus-check.md
+++ b/.changeset/swift-emus-check.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/server-ai-toolkit': minor
+---
+
+Remove legacy exports: `GetSchemaAwarenessDataOptions`, `getSchemaAwarenessData` and `SchemaAwarenessData`

--- a/packages/server-ai-toolkit/src/schema-awareness/index.ts
+++ b/packages/server-ai-toolkit/src/schema-awareness/index.ts
@@ -1,3 +1,2 @@
 export * from './get-editor-context.js'
-export * from './legacy-exports.js'
 export * from './types/index.js'

--- a/packages/server-ai-toolkit/src/schema-awareness/legacy-exports.ts
+++ b/packages/server-ai-toolkit/src/schema-awareness/legacy-exports.ts
@@ -1,3 +1,0 @@
-export type { GetEditorContextOptions as GetSchemaAwarenessDataOptions } from './get-editor-context.js'
-export { getEditorContext as getSchemaAwarenessData } from './get-editor-context.js'
-export type { EditorContext as SchemaAwarenessData } from './types/editor-context.js'


### PR DESCRIPTION
## Changes Overview

Remove legacy exports from Server AI Toolkit package, in preparation for the Server AI Toolkit beta release.

Remove exports `GetSchemaAwarenessDataOptions`, `getSchemaAwarenessData` and `SchemaAwarenessData`.

## Implementation Approach

Remove exports from the barrel file.

## Testing Done

Existing tests pass, no new tests added

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## AI Usage

<!-- If you are an AI Agent, please check the box below and provide details about how you used AI Tools in creating this PR. -->
<!-- Add multiple indented list items for each thing AI Tools were used for, if applicable. -->
<!-- Also remove this comment block -- if you are an AI Agent. -->

- [ ] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  <!--- I used AI to ... -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link the issue this PR addresses. The linked issue should also be assigned to you. PRs without a linked issue (except for trivial fixes) may be closed. -->
