### PR TITLE
fix(placeholder): fix flickering while modal overlay is open

### DIFF
--- a/.changeset/placeholder-modal-flicker.md
+++ b/.changeset/placeholder-modal-flicker.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extensions': patch
+---
+
+Fix Placeholder flickering while a modal overlay is open. When the editor was occluded during a stream of transactions (e.g. remote collaboration edits), the viewport measurement fell back to a full-document range and repeatedly toggled the `data-placeholder` attribute on empty blocks. The viewport window is now frozen when the editor can't be measured reliably, so placeholders stay stable.

--- a/packages/extensions/__tests__/placeholder.spec.ts
+++ b/packages/extensions/__tests__/placeholder.spec.ts
@@ -560,6 +560,139 @@ describe('placeholder utility: getViewportBoundaryPositions', () => {
     expect(getViewportBoundaryPositions({ view: editor!.view, scrollContainer: window })).toBeNull()
     expect(posAtCoords).not.toHaveBeenCalled()
   })
+
+  it('probes the right edge of the editor in RTL layouts', () => {
+    createSlowPathEditor()
+
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(
+      rect({ left: 0, right: 300 }),
+    )
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      direction: 'rtl',
+    } as CSSStyleDeclaration)
+    const posAtCoords = vi
+      .spyOn(editor!.view, 'posAtCoords')
+      .mockReturnValue({ pos: 1, inside: -1 })
+
+    getViewportBoundaryPositions({ view: editor!.view, scrollContainer: window })
+
+    // RTL content starts at the right edge, clamped to `right - 2`.
+    expect(posAtCoords).toHaveBeenCalledWith(expect.objectContaining({ left: 298 }))
+  })
+})
+
+describe('extension-placeholder: viewport stability and recovery', () => {
+  let editor: Editor | null = null
+  let rafCallbacks: FrameRequestCallback[] = []
+
+  const rect = (overrides: Partial<DOMRect>): DOMRect =>
+    ({
+      top: 0,
+      bottom: 500,
+      left: 0,
+      right: 300,
+      width: 300,
+      height: 500,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...overrides,
+    }) as DOMRect
+
+  const flushFrames = () => {
+    const callbacks = rafCallbacks
+    rafCallbacks = []
+    callbacks.forEach(cb => cb(0))
+  }
+
+  const createSlowPathEditor = () => {
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Placeholder.configure({ showOnlyCurrent: false, includeChildren: false }),
+      ],
+      content: '<p></p>'.repeat(20),
+    })
+    // Drain any frame scheduled during construction (under jsdom's zero-size
+    // layout it resolves to null, so nothing is dispatched).
+    flushFrames()
+  }
+
+  beforeEach(() => {
+    rafCallbacks = []
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    // Always jump past the 150ms scroll guard so a flushed frame actually runs.
+    let now = 1_000_000
+    vi.spyOn(performance, 'now').mockImplementation(() => (now += 1000))
+  })
+
+  afterEach(() => {
+    if (editor) {
+      editor.destroy()
+      editor = null
+    }
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not toggle the viewport window while occluded during a stream of edits', () => {
+    createSlowPathEditor()
+
+    // Seed a known narrow window, as if the editor had been measured while visible.
+    editor!.view.dispatch(
+      editor!.view.state.tr.setMeta(PLUGIN_KEY, { positions: { top: 1, bottom: 40 } }),
+    )
+    expect(PLUGIN_KEY.getState(editor!.view.state)).toEqual({ topPos: 1, bottomPos: 40 })
+
+    // The editor is now occluded by a modal: posAtCoords resolves to the overlay → null.
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(rect({}))
+    vi.spyOn(editor!.view, 'posAtCoords').mockReturnValue(null)
+
+    const dispatch = vi.spyOn(editor!.view, 'dispatch')
+
+    // A stream of remote-style edits keeps changing the doc size.
+    for (let i = 0; i < 5; i += 1) {
+      editor!.commands.insertContent('x')
+      flushFrames()
+    }
+
+    // No viewport recompute was dispatched — the window never toggled to a
+    // full-doc scan, so the placeholders did not flicker.
+    const viewportRecomputes = dispatch.mock.calls.filter(
+      ([tr]) => tr.getMeta(PLUGIN_KEY) !== undefined,
+    )
+    expect(viewportRecomputes).toHaveLength(0)
+
+    // The window is still a frozen, defined range (not reset to null/full-doc).
+    const state = PLUGIN_KEY.getState(editor!.view.state)!
+    expect(state.topPos).not.toBeNull()
+    expect(state.bottomPos).not.toBeNull()
+  })
+
+  it('recovers the viewport window when focus returns after the editor becomes measurable', () => {
+    createSlowPathEditor()
+
+    // At mount the editor is not measurable (jsdom has no layout), so the
+    // window starts unset and the slow path falls back to a full-doc scan.
+    expect(PLUGIN_KEY.getState(editor!.view.state)).toEqual({ topPos: null, bottomPos: null })
+
+    // The editor becomes measurable again (e.g. the modal closed).
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(rect({}))
+    vi.spyOn(editor!.view, 'posAtCoords').mockReturnValue({ pos: 12, inside: -1 })
+
+    // Returning focus to the editor triggers a re-measure even though neither
+    // the doc size nor the scroll position changed.
+    editor!.view.dom.dispatchEvent(new Event('focus'))
+    flushFrames()
+
+    expect(PLUGIN_KEY.getState(editor!.view.state)).toEqual({ topPos: 12, bottomPos: 12 })
+  })
 })
 
 describe('placeholder utility: findScrollParent', () => {

--- a/packages/extensions/__tests__/placeholder.spec.ts
+++ b/packages/extensions/__tests__/placeholder.spec.ts
@@ -14,6 +14,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { findScrollParent } from '../src/placeholder/utils/findScrollParent.js'
+import { getViewportBoundaryPositions } from '../src/placeholder/utils/getViewportBoundaryPositions.js'
 import { throttle } from '../src/placeholder/utils/throttle.js'
 
 import { PLUGIN_KEY } from '../src/placeholder/constants.js'
@@ -457,6 +458,82 @@ describe('extension-placeholder — empty editor class', () => {
     const paragraph = editor!.view.dom.querySelector('p') as HTMLElement
     expect(paragraph.classList.contains('paragraph-empty')).toBe(true)
     expect(paragraph.classList.contains('other-empty')).toBe(false)
+  })
+})
+
+describe('placeholder utility: getViewportBoundaryPositions', () => {
+  let editor: Editor | null = null
+
+  const rect = (overrides: Partial<DOMRect>): DOMRect =>
+    ({
+      top: 0,
+      bottom: 500,
+      left: 0,
+      right: 300,
+      width: 300,
+      height: 500,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...overrides,
+    }) as DOMRect
+
+  const createSlowPathEditor = () => {
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Placeholder.configure({ showOnlyCurrent: false, includeChildren: false }),
+      ],
+      content: '<p></p>'.repeat(20),
+    })
+  }
+
+  afterEach(() => {
+    if (editor) {
+      editor.destroy()
+      editor = null
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when the editor is occluded (posAtCoords resolves outside it)', () => {
+    createSlowPathEditor()
+
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(rect({}))
+    // A modal backdrop covering the editor makes posAtCoords resolve to the
+    // overlay rather than editor content → null.
+    vi.spyOn(editor!.view, 'posAtCoords').mockReturnValue(null)
+
+    expect(getViewportBoundaryPositions({ view: editor!.view, scrollContainer: window })).toBeNull()
+  })
+
+  it('returns measured positions when the editor is visible', () => {
+    createSlowPathEditor()
+
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(rect({}))
+    vi.spyOn(editor!.view, 'posAtCoords')
+      .mockReturnValueOnce({ pos: 1, inside: -1 })
+      .mockReturnValueOnce({ pos: 40, inside: -1 })
+
+    expect(getViewportBoundaryPositions({ view: editor!.view, scrollContainer: window })).toEqual({
+      top: 1,
+      bottom: 40,
+    })
+  })
+
+  it('returns null when the editor has no layout', () => {
+    createSlowPathEditor()
+
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(
+      rect({ top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0 }),
+    )
+    const posAtCoords = vi.spyOn(editor!.view, 'posAtCoords')
+
+    expect(getViewportBoundaryPositions({ view: editor!.view, scrollContainer: window })).toBeNull()
+    // Bails out before probing.
+    expect(posAtCoords).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/extensions/__tests__/placeholder.spec.ts
+++ b/packages/extensions/__tests__/placeholder.spec.ts
@@ -535,6 +535,31 @@ describe('placeholder utility: getViewportBoundaryPositions', () => {
     // Bails out before probing.
     expect(posAtCoords).not.toHaveBeenCalled()
   })
+
+  it('returns null when only one dimension is collapsed to zero', () => {
+    createSlowPathEditor()
+
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(
+      rect({ left: 0, right: 0, width: 0 }),
+    )
+    const posAtCoords = vi.spyOn(editor!.view, 'posAtCoords')
+
+    expect(getViewportBoundaryPositions({ view: editor!.view, scrollContainer: window })).toBeNull()
+    expect(posAtCoords).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the editor is too narrow to probe safely', () => {
+    createSlowPathEditor()
+
+    // A 1px-wide box leaves no room for an x-coordinate strictly inside it.
+    vi.spyOn(editor!.view.dom, 'getBoundingClientRect').mockReturnValue(
+      rect({ left: 100, right: 101, width: 1 }),
+    )
+    const posAtCoords = vi.spyOn(editor!.view, 'posAtCoords')
+
+    expect(getViewportBoundaryPositions({ view: editor!.view, scrollContainer: window })).toBeNull()
+    expect(posAtCoords).not.toHaveBeenCalled()
+  })
 })
 
 describe('placeholder utility: findScrollParent', () => {

--- a/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
+++ b/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
@@ -22,8 +22,10 @@ export function getViewportBoundaryPositions({
 }): { top: number; bottom: number } | null {
   const editorRect = view.dom.getBoundingClientRect()
 
-  // No layout yet (detached, `display: none` ancestor, not painted).
-  if (editorRect.width === 0 && editorRect.height === 0) {
+  // No usable layout (detached, `display: none` ancestor, or collapsed to zero
+  // in one dimension during a transition). A zero width or height means we
+  // cannot probe a coordinate inside the box, so treat it as non-measurable.
+  if (editorRect.width <= 0 || editorRect.height <= 0) {
     return null
   }
 
@@ -39,11 +41,20 @@ export function getViewportBoundaryPositions({
     return null
   }
 
-  // Pick the x-coordinate based on text direction. In LTR the content
-  // starts at the left edge; in RTL it starts at the right edge.
-  // Clamp to ensure the coordinate stays inside the editor bounds.
+  // Pick the x-coordinate based on text direction. In LTR the content starts
+  // at the left edge; in RTL it starts at the right edge. Clamp it strictly
+  // inside the editor bounds so a too-narrow box does not push the probe
+  // outside and make `posAtCoords` return null for a non-occlusion reason.
+  const minX = editorRect.left + 1
+  const maxX = editorRect.right - 1
+
+  if (minX > maxX) {
+    return null
+  }
+
   const isRTL = getComputedStyle(view.dom).direction === 'rtl'
-  const x = isRTL ? Math.max(editorRect.right - 2, editorRect.left + 2) : editorRect.left + 2
+  const targetX = isRTL ? editorRect.right - 2 : editorRect.left + 2
+  const x = Math.min(Math.max(targetX, minX), maxX)
 
   // Clamp the probe y-coordinates strictly inside the editor box. The ±200px
   // overscan can push the probe above/below the editor's own content even when

--- a/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
+++ b/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
@@ -70,8 +70,12 @@ export function getViewportBoundaryPositions({
   const topPos = view.posAtCoords({ left: x, top: probeTop })
   const bottomPos = view.posAtCoords({ left: x, top: probeBottom })
 
-  // A null here (after clamping inside the box) means something is covering the
-  // editor — freeze the previous window instead of decorating the whole doc.
+  // A null here (after clamping inside the box) usually means the editor is
+  // occluded, but `posAtCoords` can also return null for benign reasons (a
+  // probe over padding, browser caret-from-point gaps). Either way the result
+  // is unreliable, so freeze the previous window rather than decorating the
+  // whole doc — at worst a node is briefly under-decorated until the next
+  // scroll/resize/focus recompute, which is preferable to flickering.
   if (!topPos || !bottomPos) {
     return null
   }

--- a/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
+++ b/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
@@ -1,4 +1,3 @@
-import type { Node } from '@tiptap/pm/model'
 import type { EditorView } from '@tiptap/pm/view'
 
 import { VIEWPORT_OVERSCAN_PX } from '../constants.js'
@@ -11,16 +10,23 @@ function getContainerRect(container: HTMLElement | Window): { top: number; botto
   return (container as HTMLElement).getBoundingClientRect()
 }
 
+/**
+ * Computes the document positions bounding the currently visible viewport.
+ */
 export function getViewportBoundaryPositions({
-  doc,
   view,
   scrollContainer,
 }: {
-  doc: Node
   view: EditorView
   scrollContainer?: HTMLElement | Window
-}) {
+}): { top: number; bottom: number } | null {
   const editorRect = view.dom.getBoundingClientRect()
+
+  // No layout yet (detached, `display: none` ancestor, not painted).
+  if (editorRect.width === 0 && editorRect.height === 0) {
+    return null
+  }
+
   const containerRect = scrollContainer
     ? getContainerRect(scrollContainer)
     : { top: 0, bottom: window.innerHeight }
@@ -29,8 +35,8 @@ export function getViewportBoundaryPositions({
   const visibleBottom = Math.min(editorRect.bottom, containerRect.bottom) + VIEWPORT_OVERSCAN_PX
 
   if (visibleTop >= visibleBottom) {
-    // Editor is not visible — fall back to full document range
-    return { top: 0, bottom: doc.content.size }
+    // Editor is scrolled fully out of its container so not measurable.
+    return null
   }
 
   // Pick the x-coordinate based on text direction. In LTR the content
@@ -39,11 +45,25 @@ export function getViewportBoundaryPositions({
   const isRTL = getComputedStyle(view.dom).direction === 'rtl'
   const x = isRTL ? Math.max(editorRect.right - 2, editorRect.left + 2) : editorRect.left + 2
 
-  const topPos = view.posAtCoords({ left: x, top: visibleTop + 2 })
-  const bottomPos = view.posAtCoords({ left: x, top: visibleBottom - 2 })
+  // Clamp the probe y-coordinates strictly inside the editor box. The ±200px
+  // overscan can push the probe above/below the editor's own content even when
+  // it is fully visible, which would make `posAtCoords` return null for a
+  // legitimate reason. Clamping means a null result reliably signals occlusion.
+  const probeTop = Math.max(visibleTop + 2, editorRect.top + 1)
+  const probeBottom = Math.min(visibleBottom - 2, editorRect.bottom - 1)
 
-  return {
-    top: topPos ? topPos.pos : 0,
-    bottom: bottomPos ? bottomPos.pos : doc.content.size,
+  if (probeTop > probeBottom) {
+    return null
   }
+
+  const topPos = view.posAtCoords({ left: x, top: probeTop })
+  const bottomPos = view.posAtCoords({ left: x, top: probeBottom })
+
+  // A null here (after clamping inside the box) means something is covering the
+  // editor — freeze the previous window instead of decorating the whole doc.
+  if (!topPos || !bottomPos) {
+    return null
+  }
+
+  return { top: topPos.pos, bottom: bottomPos.pos }
 }

--- a/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
+++ b/packages/extensions/src/placeholder/utils/getViewportBoundaryPositions.ts
@@ -22,9 +22,7 @@ export function getViewportBoundaryPositions({
 }): { top: number; bottom: number } | null {
   const editorRect = view.dom.getBoundingClientRect()
 
-  // No usable layout (detached, `display: none` ancestor, or collapsed to zero
-  // in one dimension during a transition). A zero width or height means we
-  // cannot probe a coordinate inside the box, so treat it as non-measurable.
+  // No usable layout — can't probe a coordinate inside the box.
   if (editorRect.width <= 0 || editorRect.height <= 0) {
     return null
   }
@@ -41,10 +39,8 @@ export function getViewportBoundaryPositions({
     return null
   }
 
-  // Pick the x-coordinate based on text direction. In LTR the content starts
-  // at the left edge; in RTL it starts at the right edge. Clamp it strictly
-  // inside the editor bounds so a too-narrow box does not push the probe
-  // outside and make `posAtCoords` return null for a non-occlusion reason.
+  // Probe the start edge (left in LTR, right in RTL), clamped inside the box
+  // so a too-narrow editor doesn't push the probe out.
   const minX = editorRect.left + 1
   const maxX = editorRect.right - 1
 
@@ -56,10 +52,8 @@ export function getViewportBoundaryPositions({
   const targetX = isRTL ? editorRect.right - 2 : editorRect.left + 2
   const x = Math.min(Math.max(targetX, minX), maxX)
 
-  // Clamp the probe y-coordinates strictly inside the editor box. The ±200px
-  // overscan can push the probe above/below the editor's own content even when
-  // it is fully visible, which would make `posAtCoords` return null for a
-  // legitimate reason. Clamping means a null result reliably signals occlusion.
+  // Clamp the probe y inside the box so the overscan doesn't push it past the
+  // editor's own content (which would make `posAtCoords` null for no reason).
   const probeTop = Math.max(visibleTop + 2, editorRect.top + 1)
   const probeBottom = Math.min(visibleBottom - 2, editorRect.bottom - 1)
 
@@ -70,12 +64,8 @@ export function getViewportBoundaryPositions({
   const topPos = view.posAtCoords({ left: x, top: probeTop })
   const bottomPos = view.posAtCoords({ left: x, top: probeBottom })
 
-  // A null here (after clamping inside the box) usually means the editor is
-  // occluded, but `posAtCoords` can also return null for benign reasons (a
-  // probe over padding, browser caret-from-point gaps). Either way the result
-  // is unreliable, so freeze the previous window rather than decorating the
-  // whole doc — at worst a node is briefly under-decorated until the next
-  // scroll/resize/focus recompute, which is preferable to flickering.
+  // Null usually means occlusion (but can be benign). Either way it's
+  // unreliable, so freeze the previous window instead of decorating the whole doc.
   if (!topPos || !bottomPos) {
     return null
   }

--- a/packages/extensions/src/placeholder/utils/viewportTracking.ts
+++ b/packages/extensions/src/placeholder/utils/viewportTracking.ts
@@ -62,9 +62,13 @@ export function createViewportPluginView(view: EditorView): PluginView {
   const computeAndDispatch = () => {
     const positions = getViewportBoundaryPositions({
       view,
-      doc: view.state.doc,
       scrollContainer,
     })
+
+    // Not measurable, keep the last good window frozen
+    if (positions === null) {
+      return
+    }
 
     const prev = PLUGIN_KEY.getState(view.state)
     if (prev?.topPos === positions.top && prev?.bottomPos === positions.bottom) {

--- a/packages/extensions/src/placeholder/utils/viewportTracking.ts
+++ b/packages/extensions/src/placeholder/utils/viewportTracking.ts
@@ -103,6 +103,21 @@ export function createViewportPluginView(view: EditorView): PluginView {
 
   scrollContainer.addEventListener('scroll', scheduleFrame, { passive: true })
 
+  // When the viewport window is frozen because the editor was not measurable
+  // (e.g. occluded or shifted by a modal), nothing else recomputes once the
+  // editor becomes usable again unless the user scrolls or edits. These
+  // observers and the focus listener re-measure on size/visibility changes and
+  // when focus returns to the editor, so a frozen window recovers.
+  const resizeObserver =
+    typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleFrame) : null
+  resizeObserver?.observe(view.dom)
+
+  const intersectionObserver =
+    typeof IntersectionObserver !== 'undefined' ? new IntersectionObserver(scheduleFrame) : null
+  intersectionObserver?.observe(view.dom)
+
+  view.dom.addEventListener('focus', scheduleFrame)
+
   // Fire once to populate initial viewport
   computeAndDispatch()
 
@@ -117,6 +132,9 @@ export function createViewportPluginView(view: EditorView): PluginView {
         cancelAnimationFrame(frame)
       }
       scrollContainer.removeEventListener('scroll', scheduleFrame)
+      resizeObserver?.disconnect()
+      intersectionObserver?.disconnect()
+      view.dom.removeEventListener('focus', scheduleFrame)
     },
   }
 }

--- a/packages/extensions/src/placeholder/utils/viewportTracking.ts
+++ b/packages/extensions/src/placeholder/utils/viewportTracking.ts
@@ -103,11 +103,8 @@ export function createViewportPluginView(view: EditorView): PluginView {
 
   scrollContainer.addEventListener('scroll', scheduleFrame, { passive: true })
 
-  // When the viewport window is frozen because the editor was not measurable
-  // (e.g. occluded or shifted by a modal), nothing else recomputes once the
-  // editor becomes usable again unless the user scrolls or edits. These
-  // observers and the focus listener re-measure on size/visibility changes and
-  // when focus returns to the editor, so a frozen window recovers.
+  // Recover a frozen window once the editor becomes usable again (e.g. a modal
+  // closes): re-measure on size/visibility changes and when focus returns.
   const resizeObserver =
     typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleFrame) : null
   resizeObserver?.observe(view.dom)


### PR DESCRIPTION
## Changes Overview

Fixes the Placeholder flickering on and off while a modal overlay is open.

## Implementation Approach

When the editor is covered by a modal, the viewport measurement used to pick which empty blocks get a placeholder could not read the editor and fell back to scanning the whole document. During collaboration this flipped the range back and forth on every remote edit, so the `data-placeholder` attribute kept getting added and removed.

Now, when the editor can't be measured reliably (occluded, no layout, scrolled out of view), we keep the last known viewport window instead of falling back to a full-document scan. The window re-measures normally once the modal closes.

## Testing Done

Added unit tests for `getViewportBoundaryPositions`: returns `null` when the editor is occluded or has no layout, and returns the measured positions when visible. All existing placeholder tests still pass.

## Verification Steps

1. Use Placeholder with `showOnlyCurrent: false`.
2. Open a modal with a full-screen backdrop while a second client types.
3. The placeholders on empty blocks should stay stable instead of flickering.

## Additional Notes

Two related items were left out of scope: boundary jitter during collaboration without a modal, and removing the viewport optimisation entirely.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude to find the root cause, write the fix, and add the tests.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

TT-650
