### PR TITLE
fix(drag-handle): respect margins passed via dragImageProperties

### DIFF
--- a/.changeset/drag-handle-image-margin.md
+++ b/.changeset/drag-handle-image-margin.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-drag-handle': patch
+---
+
+Respect margin properties passed via `dragImageProperties` on the drag preview. The clone reset its margin to `0` after copying styles, which discarded any margin the user explicitly requested. The reset now runs only when no margin property is listed in `dragImageProperties`, so the drag image can keep the same spacing as the live block.

--- a/packages/extension-drag-handle/__tests__/cloneElement.spec.ts
+++ b/packages/extension-drag-handle/__tests__/cloneElement.spec.ts
@@ -106,6 +106,22 @@ describe('cloneElement', () => {
       expect(clone.style.cssText).not.toContain('font-size')
     })
 
+    it('trims surrounding whitespace before reading the property', () => {
+      const element = document.createElement('p')
+
+      vi.spyOn(window, 'getComputedStyle').mockImplementation(() => {
+        return {
+          length: 1,
+          0: 'margin-top',
+          getPropertyValue: (property: string) => (property === 'margin-top' ? '24px' : ''),
+        } as unknown as CSSStyleDeclaration
+      })
+
+      const clone = cloneElement(element, [' margin-top '])
+
+      expect(clone.style.cssText).toContain('margin-top: 24px;')
+    })
+
     it('returns an empty cssText when the properties list is empty', () => {
       const element = document.createElement('p')
 

--- a/packages/extension-drag-handle/__tests__/dragHandler.spec.ts
+++ b/packages/extension-drag-handle/__tests__/dragHandler.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getDragImageOffset } from '../src/helpers/dragHandler.js'
+import { getDragImageOffset, shouldResetMargin } from '../src/helpers/dragHandler.js'
 
 describe('getDragImageOffset', () => {
   it('anchors ltr previews to the left edge', () => {
@@ -9,5 +9,28 @@ describe('getDragImageOffset', () => {
 
   it('anchors rtl previews to the right edge', () => {
     expect(getDragImageOffset('rtl', 180)).toBe(180)
+  })
+})
+
+describe('shouldResetMargin', () => {
+  it('resets the margin when no properties are provided', () => {
+    expect(shouldResetMargin(undefined)).toBe(true)
+  })
+
+  it('resets the margin when the properties do not include a margin', () => {
+    expect(shouldResetMargin(['color', 'font-size'])).toBe(true)
+  })
+
+  it('keeps the margin when the shorthand margin is requested', () => {
+    expect(shouldResetMargin(['margin'])).toBe(false)
+  })
+
+  it('keeps the margin for longhand and logical margin properties', () => {
+    expect(shouldResetMargin(['margin-bottom'])).toBe(false)
+    expect(shouldResetMargin(['margin-inline-start'])).toBe(false)
+  })
+
+  it('ignores surrounding whitespace in property names', () => {
+    expect(shouldResetMargin([' margin-top '])).toBe(false)
   })
 })

--- a/packages/extension-drag-handle/src/helpers/cloneElement.ts
+++ b/packages/extension-drag-handle/src/helpers/cloneElement.ts
@@ -3,8 +3,9 @@ function getCSSText(element: Element, properties?: string[]) {
 
   if (properties) {
     return properties
-      .filter(p => p.trim().length > 0)
-      .map(p => `${p}:${style.getPropertyValue(p)};`)
+      .map(property => property.trim())
+      .filter(property => property.length > 0)
+      .map(property => `${property}:${style.getPropertyValue(property)};`)
       .join('')
   }
 

--- a/packages/extension-drag-handle/src/helpers/dragHandler.ts
+++ b/packages/extension-drag-handle/src/helpers/dragHandler.ts
@@ -135,6 +135,8 @@ export function dragHandler(
     slice = selection.content()
   }
 
+  const resetMargin = shouldResetMargin(dragImageProperties)
+
   ranges.forEach(range => {
     const element = getDraggedBlockElement(view, range.$from.pos) as HTMLElement | null
 
@@ -144,7 +146,7 @@ export function dragHandler(
 
     const clonedElement = cloneElement(element, dragImageProperties)
 
-    if (shouldResetMargin(dragImageProperties)) {
+    if (resetMargin) {
       clonedElement.style.margin = '0'
     }
 

--- a/packages/extension-drag-handle/src/helpers/dragHandler.ts
+++ b/packages/extension-drag-handle/src/helpers/dragHandler.ts
@@ -18,6 +18,17 @@ export function getDragImageOffset(direction: string, wrapperWidth: number): num
   return direction === 'rtl' ? wrapperWidth : 0
 }
 
+// The drag preview clone resets its margin so it sits flush against the wrapper
+// origin. Skip the reset when the user explicitly copies a margin property via
+// `dragImageProperties`, otherwise we would discard the value they asked for.
+export function shouldResetMargin(dragImageProperties?: string[]): boolean {
+  if (!dragImageProperties) {
+    return true
+  }
+
+  return !dragImageProperties.some(property => property.trim().startsWith('margin'))
+}
+
 function getDragHandleRanges(
   event: DragEvent,
   editor: Editor,
@@ -130,7 +141,9 @@ export function dragHandler(
 
     const clonedElement = cloneElement(element, dragImageProperties)
 
-    clonedElement.style.margin = '0'
+    if (shouldResetMargin(dragImageProperties)) {
+      clonedElement.style.margin = '0'
+    }
 
     wrapper.append(clonedElement)
   })

--- a/packages/extension-drag-handle/src/helpers/dragHandler.ts
+++ b/packages/extension-drag-handle/src/helpers/dragHandler.ts
@@ -26,7 +26,10 @@ export function shouldResetMargin(dragImageProperties?: string[]): boolean {
     return true
   }
 
-  return !dragImageProperties.some(property => property.trim().startsWith('margin'))
+  return !dragImageProperties.some(property => {
+    const p = property.trim().toLowerCase()
+    return p === 'margin' || p.startsWith('margin-')
+  })
 }
 
 function getDragHandleRanges(


### PR DESCRIPTION
## Changes Overview

The drag preview clone reset its margin to `0` after `cloneElement` copied styles. This overwrote any margin a user passed through `dragImageProperties`, so the drag image looked tighter than the live block.

## Implementation Approach

Added a small pure helper `shouldResetMargin(dragImageProperties)`. The margin reset now runs only when no margin property is listed. Default behavior is unchanged: when `dragImageProperties` is unset, or has no margin entry, the margin is still reset to `0`. Listing any margin property (`margin`, `margin-bottom`, `margin-inline-start`, ...) keeps it on the clone.

## Testing Done

Added unit tests for `shouldResetMargin` covering undefined input, non-margin props, shorthand, longhand, logical properties, and whitespace. All drag-handle unit tests pass (`pnpm test:unit`).

## Verification Steps

1. Configure `DragHandle.configure({ dragImageProperties: ['margin-bottom'] })`.
2. Drag a block that has a `margin-bottom` in CSS.
3. The drag preview keeps the same spacing as the live block instead of collapsing it.

## Additional Notes

When a horizontal margin is kept, the wrapper width used for the RTL drag-image offset includes that margin, so the anchor shifts by that amount. This matches the live block's box. Vertical margins (the reported case) are unaffected.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude to locate the bug, implement the fix, write the unit tests, and draft this PR description.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

TT-651
