### PR TITLE
fix(extension-list): keep first char of under-indented ordered list continuation lines

### DIFF
--- a/.changeset/ordered-list-continuation-char-drop.md
+++ b/.changeset/ordered-list-continuation-char-drop.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': patch
+---
+
+Fix the ordered list markdown parser dropping the first character of an under-indented continuation line. When a list item's continuation line was indented by fewer columns than the marker width (e.g. a single leading space), the tokenizer sliced a fixed number of characters off the line and removed real content along with the indentation. It now strips only the leading whitespace that is actually present, capped at the marker's content indent, so the first character is preserved.

--- a/.changeset/ordered-list-continuation-char-drop.md
+++ b/.changeset/ordered-list-continuation-char-drop.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-list': patch
 ---
 
-Fix the ordered list markdown parser dropping the first character of an under-indented continuation line. When a list item's continuation line was indented by fewer columns than the marker width (e.g. a single leading space), the tokenizer sliced a fixed number of characters off the line and removed real content along with the indentation. It now strips only the leading whitespace that is actually present, capped at the marker's content indent, so the first character is preserved.
+Fix ordered list parsing so under-indented continuation lines preserve their first character.

--- a/packages/extension-list/__tests__/orderedListType.spec.ts
+++ b/packages/extension-list/__tests__/orderedListType.spec.ts
@@ -228,6 +228,39 @@ describe('OrderedList type attribute', () => {
       expect(json.content[0].attrs?.type).toBeUndefined()
     })
 
+    it('keeps the first character of an under-indented continuation line', () => {
+      const markdownManager = new MarkdownManager({
+        extensions: [Document, Paragraph, Text, ListItem, OrderedList],
+      })
+
+      // The continuation line is indented by a single space, fewer columns than the
+      // marker width. The leading indentation must be stripped without eating the
+      // first real character of the line.
+      const json = markdownManager.parse('1. Item one\n continued text')
+
+      const collectText = (node: JSONContent): string =>
+        (node.text ?? '') + (node.content ?? []).map(collectText).join('')
+
+      const text = collectText(json.content[0].content[0])
+
+      expect(text).toBe('Item one\ncontinued text')
+    })
+
+    it('keeps the first character of an under-indented continuation line for wider markers', () => {
+      const markdownManager = new MarkdownManager({
+        extensions: [Document, Paragraph, Text, ListItem, OrderedList],
+      })
+
+      const collectText = (node: JSONContent): string =>
+        (node.text ?? '') + (node.content ?? []).map(collectText).join('')
+
+      const numeric = markdownManager.parse('10. Item ten\n continued text')
+      expect(collectText(numeric.content[0].content[0])).toBe('Item ten\ncontinued text')
+
+      const roman = markdownManager.parse('iv. Item four\n continued text')
+      expect(collectText(roman.content[0].content[0])).toBe('Item four\ncontinued text')
+    })
+
     it('serializes an ordered list with type="a" to lowercase alpha markers', () => {
       const markdownManager = new MarkdownManager({
         extensions: [Document, Paragraph, Text, ListItem, OrderedList],

--- a/packages/extension-list/src/ordered-list/utils.ts
+++ b/packages/extension-list/src/ordered-list/utils.ts
@@ -157,9 +157,13 @@ export function collectOrderedListItems(lines: string[]): [OrderedListItem[], nu
         sawBlankLine = true
         nextLineIndex += 1
       } else if (nextLine.match(INDENTED_LINE_REGEX)) {
-        // Indented content - part of this item (but not a list item)
+        // Indented content - part of this item (but not a list item).
+        // Strip the indentation only up to the whitespace that is actually present,
+        // so an under-indented line (e.g. a single leading space) keeps its first character.
+        const leadingWhitespace = nextLine.length - nextLine.trimStart().length
+        const contentIndent = indentLevel + marker.length + 1
         itemLines.push(nextLine)
-        itemContentLines.push(nextLine.slice(indentLevel + 2))
+        itemContentLines.push(nextLine.slice(Math.min(leadingWhitespace, contentIndent)))
         nextLineIndex += 1
       } else {
         if (sawBlankLine) {


### PR DESCRIPTION
## Problem

When parsing Markdown, an ordered list item whose continuation line is indented by fewer columns than the marker width loses the **first character** of that line.

```ts
import { MarkdownManager } from '@tiptap/markdown'
// ...
markdownManager.parse('1. Item one\n continued text')
// continuation line parsed as "ontinued text"  ← leading "c" dropped
```

A single leading space is enough to trigger it, so it shows up with real-world Markdown such as LLM-generated documents where list bodies are indented by one space:

```md
1. **Funding purpose**
 1,000M loan amount ...
```

renders as `,000M loan amount ...`.

Bullet lists and vanilla `marked` are unaffected — only the ordered-list custom tokenizer is.

## Root cause

`collectOrderedListItems` in `packages/extension-list/src/ordered-list/utils.ts` stripped a fixed number of characters from continuation lines:

```ts
itemContentLines.push(nextLine.slice(indentLevel + 2))
```

When the line has fewer leading whitespace characters than `indentLevel + 2`, `slice` cuts into the actual content. The hardcoded `+ 2` is also wrong for multi-character markers (`10.`, `iii.`).

## Fix

Strip only the leading whitespace that is actually present, capped at the marker's content indent (`indentLevel + marker.length + 1`):

```ts
const leadingWhitespace = nextLine.length - nextLine.trimStart().length
const contentIndent = indentLevel + marker.length + 1
itemContentLines.push(nextLine.slice(Math.min(leadingWhitespace, contentIndent)))
```

For well-formed input this is identical to the previous behaviour; it only stops over-slicing under-indented lines, and additionally handles multi-character markers.

## Tests / changeset

- Added a regression test in `__tests__/orderedListType.spec.ts` (markdown round-trip): `1. Item one\n continued text` → `Item one\ncontinued text`.
- `pnpm vitest run packages/extension-list` → 93 passed.
- Added a changeset (`@tiptap/extension-list` patch).

## AI usage disclosure

Root-cause investigation, the fix, and the test were drafted with assistance from an AI coding tool (Claude) and reviewed/verified by me before submitting.
