### PR TITLE
fix(extension-file-handler): add consumePasteEvent option to prevent duplicate paste content

### DIFF
--- a/.changeset/add-consume-paste-event-option.md
+++ b/.changeset/add-consume-paste-event-option.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-file-handler": patch
 ---
 
-Add `consumePasteEvent` option to the file-handler extension. When `true`, `handlePaste` returns `true` even when HTML content is present in the clipboard, preventing paste rules from other extensions from creating duplicate content. Default is `false` (backward compatible). See #4944.
+Add `consumePasteEvent` option to the file-handler extension. When `true`, `handlePaste` returns `true` even when HTML content is present in the clipboard, preventing paste rules from other extensions from creating duplicate content. Default is `false`.

--- a/.changeset/add-consume-paste-event-option.md
+++ b/.changeset/add-consume-paste-event-option.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-file-handler": patch
+---
+
+Add `consumePasteEvent` option to the file-handler extension. When `true`, `handlePaste` returns `true` even when HTML content is present in the clipboard, preventing paste rules from other extensions from creating duplicate content. Default is `false` (backward compatible). See #4944.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,16 +33,16 @@ How to work on the Tiptap monorepo. Written for humans and AI coding assistants.
 
 Run from the repo root with `pnpm <script>`:
 
-| Script | What it does |
-|--------|-------------|
-| `dev` | Start demos on port 3000 |
-| `build` | Build all packages via Turborepo |
-| `lint` / `lint:fix` | oxlint checks |
-| `format` / `format:fix` | oxfmt formatting |
-| `test:unit` | Vitest unit tests |
-| `test:e2e` | Playwright e2e (Chromium) |
-| `fallow:audit` | Changed-code audit (run after edits) |
-| `reset` | Full clean + reinstall |
+| Script                  | What it does                         |
+| ----------------------- | ------------------------------------ |
+| `dev`                   | Start demos on port 3000             |
+| `build`                 | Build all packages via Turborepo     |
+| `lint` / `lint:fix`     | oxlint checks                        |
+| `format` / `format:fix` | oxfmt formatting                     |
+| `test:unit`             | Vitest unit tests                    |
+| `test:e2e`              | Playwright e2e (Chromium)            |
+| `fallow:audit`          | Changed-code audit (run after edits) |
+| `reset`                 | Full clean + reinstall               |
 
 Full list: [Scripts](agents/SCRIPTS.md)
 

--- a/agents/CODING.md
+++ b/agents/CODING.md
@@ -8,12 +8,14 @@
 - No decorative comments, no emojis.
 
 Good:
+
 ```
 // We need to check window.DOMParser here because
 // server-side rendering does not have it.
 ```
 
 Bad:
+
 ```
 // This function returns the editor state for the given editor instance.
 function getState(editor) {

--- a/packages-deprecated/extension-character-count/package.json
+++ b/packages-deprecated/extension-character-count/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages-deprecated/extension-character-count"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-dropcursor/package.json
+++ b/packages-deprecated/extension-dropcursor/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages-deprecated/extension-dropcursor"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-focus/package.json
+++ b/packages-deprecated/extension-focus/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages-deprecated/extension-focus"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-gapcursor/package.json
+++ b/packages-deprecated/extension-gapcursor/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages-deprecated/extension-gapcursor"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-history/package.json
+++ b/packages-deprecated/extension-history/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages-deprecated/extension-history"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-list-item/package.json
+++ b/packages-deprecated/extension-list-item/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-list-item"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-list-keymap/package.json
+++ b/packages-deprecated/extension-list-keymap/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-list-keymap"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-placeholder/package.json
+++ b/packages-deprecated/extension-placeholder/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages-deprecated/extension-placeholder"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-table-cell/package.json
+++ b/packages-deprecated/extension-table-cell/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-table-cell"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-table-header/package.json
+++ b/packages-deprecated/extension-table-header/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-table-header"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-table-row/package.json
+++ b/packages-deprecated/extension-table-row/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-table-row"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-task-item/package.json
+++ b/packages-deprecated/extension-task-item/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-task-item"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages-deprecated/extension-task-list/package.json
+++ b/packages-deprecated/extension-task-list/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-task-list"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,14 +10,14 @@
     "wysiwyg"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/core"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/core/src/__tests__/rewriteUnknownContent.test.ts
+++ b/packages/core/src/__tests__/rewriteUnknownContent.test.ts
@@ -38,7 +38,9 @@ describe('rewriteUnknownContent', () => {
   it('still keeps valid marks and content', () => {
     const json = {
       type: 'doc',
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi', marks: [{ type: 'bold' }] }] }],
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'hi', marks: [{ type: 'bold' }] }] },
+      ],
     }
 
     const result = rewriteUnknownContent(json as any, schema)

--- a/packages/extension-audio/package.json
+++ b/packages/extension-audio/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-audio"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-blockquote/package.json
+++ b/packages/extension-blockquote/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-blockquote"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-bold/package.json
+++ b/packages/extension-bold/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-bold"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-bubble-menu/package.json
+++ b/packages/extension-bubble-menu/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-bubble-menu"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-bullet-list/package.json
+++ b/packages/extension-bullet-list/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-bullet-list"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-code-block-lowlight"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-code-block/package.json
+++ b/packages/extension-code-block/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-code-block"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-code/package.json
+++ b/packages/extension-code/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-code"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-collaboration-caret/package.json
+++ b/packages/extension-collaboration-caret/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-collaboration-caret"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-collaboration/package.json
+++ b/packages/extension-collaboration/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-collaboration"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-color/package.json
+++ b/packages/extension-color/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-color"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/api/nodes/details",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-details"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-document/package.json
+++ b/packages/extension-document/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-document"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-drag-handle-react/package.json
+++ b/packages/extension-drag-handle-react/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-drag-handle-react"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-drag-handle-vue-2/package.json
+++ b/packages/extension-drag-handle-vue-2/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-drag-handle-vue-2"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-drag-handle-vue-3/package.json
+++ b/packages/extension-drag-handle-vue-3/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-drag-handle-vue-3"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-drag-handle/package.json
+++ b/packages/extension-drag-handle/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/docs/editor/extensions/functionality/drag-handle",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-drag-handle"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/api/nodes/emoji",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-emoji"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-file-handler/__tests__/fileHandler.spec.ts
+++ b/packages/extension-file-handler/__tests__/fileHandler.spec.ts
@@ -1,0 +1,407 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { FileHandler } from '@tiptap/extension-file-handler'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const createMockEvent = (files: File[], htmlContent?: string) => {
+  return {
+    clipboardData: {
+      files,
+      getData(type: string) {
+        if (type === 'text/html') {
+          return htmlContent || ''
+        }
+        return ''
+      },
+    },
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as ClipboardEvent
+}
+
+const getFile = (name = 'test.png', type = 'image/png') => {
+  return new File(['dummy content'], name, { type })
+}
+
+describe('extension-file-handler', () => {
+  const editorElClass = 'tiptap'
+  let editor: Editor | null = null
+
+  const createEditorEl = () => {
+    const editorEl = document.createElement('div')
+
+    editorEl.classList.add(editorElClass)
+    document.body.appendChild(editorEl)
+    return editorEl
+  }
+
+  const getEditorEl = () => document.querySelector(`.${editorElClass}`)
+
+  const getHandlePaste = () => {
+    // Find the file handler plugin's handlePaste prop
+    const plugins = editor!.view.state.plugins
+
+    for (const plugin of plugins) {
+      if (plugin.props.handlePaste) {
+        return plugin.props.handlePaste
+      }
+    }
+
+    return null
+  }
+
+  afterEach(() => {
+    editor?.destroy()
+    getEditorEl()?.remove()
+    editor = null
+  })
+
+  describe('current behavior (regression)', () => {
+    it('returns false when no onPaste callback is provided', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, FileHandler],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile()])
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when clipboard has no files', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const clipboardData = new DataTransfer()
+
+      clipboardData.setData('text/plain', 'just text')
+
+      const event = createMockEvent([])
+
+      // Override clipboardData to return empty files
+      Object.defineProperty(event, 'clipboardData', {
+        value: {
+          files: [],
+          getData: () => '',
+        },
+      })
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      expect(result).toBe(false)
+      expect(onPasteSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns false when all files are filtered out by allowedMimeTypes', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+            allowedMimeTypes: ['application/pdf'],
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile('image.png', 'image/png')])
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      expect(result).toBe(false)
+      expect(onPasteSpy).not.toHaveBeenCalled()
+    })
+
+    it('calls onPaste and returns true when files are pasted without HTML', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile()])
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      expect(result).toBe(true)
+      expect(onPasteSpy).toHaveBeenCalledOnce()
+      expect(onPasteSpy).toHaveBeenCalledWith(editor, expect.any(Array), '')
+    })
+
+    it('calls onPaste and returns false when files are pasted with HTML', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile()], '<img src="test.png">')
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      // When HTML is present and consumePasteEvent is false, returns false
+      expect(result).toBe(false)
+      expect(onPasteSpy).toHaveBeenCalledOnce()
+    })
+
+    it('receives htmlContent in onPaste callback when HTML is present', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const htmlContent = '<img src="test.png">'
+      const event = createMockEvent([getFile()], htmlContent)
+
+      handlePaste!(editor!.view, event, {} as any)
+
+      expect(onPasteSpy).toHaveBeenCalledWith(editor, expect.any(Array), htmlContent)
+    })
+  })
+
+  describe('consumePasteEvent option', () => {
+    it('defaults to false (backward compatible)', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile()], '<img src="test.png">')
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      // Default: onPaste is called but event is not consumed (returns false)
+      expect(result).toBe(false)
+      expect(onPasteSpy).toHaveBeenCalledOnce()
+    })
+
+    it('returns true when files are pasted with HTML and consumePasteEvent is true', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+            consumePasteEvent: true,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile()], '<img src="test.png">')
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      // With consumePasteEvent: true, returns true even with HTML
+      expect(result).toBe(true)
+      expect(onPasteSpy).toHaveBeenCalledOnce()
+    })
+
+    it('returns true when files are pasted without HTML and consumePasteEvent is true', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+            consumePasteEvent: true,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile()])
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      expect(result).toBe(true)
+      expect(onPasteSpy).toHaveBeenCalledOnce()
+    })
+
+    it('still receives htmlContent in onPaste callback when consumePasteEvent is true', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+            consumePasteEvent: true,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const htmlContent = '<img src="test.png">'
+      const event = createMockEvent([getFile()], htmlContent)
+
+      handlePaste!(editor!.view, event, {} as any)
+
+      expect(onPasteSpy).toHaveBeenCalledWith(editor, expect.any(Array), htmlContent)
+    })
+
+    it('receives correct files array in onPaste callback when consumePasteEvent is true', () => {
+      let receivedFiles: File[] = []
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: (_editor, files) => {
+              receivedFiles = files
+            },
+            consumePasteEvent: true,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const file1 = getFile('image1.png', 'image/png')
+      const file2 = getFile('image2.png', 'image/png')
+      const event = createMockEvent([file1, file2], '<img src="test.png">')
+
+      handlePaste!(editor!.view, event, {} as any)
+
+      // Check files array has correct length and types
+      expect(receivedFiles).toHaveLength(2)
+      expect(receivedFiles[0].type).toBe('image/png')
+      expect(receivedFiles[1].type).toBe('image/png')
+    })
+
+    it('calls preventDefault and stopPropagation when files are present', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: vi.fn(),
+            consumePasteEvent: true,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile()])
+
+      handlePaste!(editor!.view, event, {} as any)
+
+      expect(event.preventDefault).toHaveBeenCalledOnce()
+      expect(event.stopPropagation).toHaveBeenCalledOnce()
+    })
+
+    it('does not call onPaste when files are filtered out by allowedMimeTypes', () => {
+      const onPasteSpy = vi.fn()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FileHandler.configure({
+            onPaste: onPasteSpy,
+            allowedMimeTypes: ['application/pdf'],
+            consumePasteEvent: true,
+          }),
+        ],
+        content: '<p>test</p>',
+      })
+
+      const handlePaste = getHandlePaste()
+      const event = createMockEvent([getFile('image.png', 'image/png')])
+
+      const result = handlePaste!(editor!.view, event, {} as any)
+
+      expect(result).toBe(false)
+      expect(onPasteSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/extension-file-handler/__tests__/fileHandler.spec.ts
+++ b/packages/extension-file-handler/__tests__/fileHandler.spec.ts
@@ -91,10 +91,6 @@ describe('extension-file-handler', () => {
       })
 
       const handlePaste = getHandlePaste()
-      const clipboardData = new DataTransfer()
-
-      clipboardData.setData('text/plain', 'just text')
-
       const event = createMockEvent([])
 
       // Override clipboardData to return empty files

--- a/packages/extension-file-handler/__tests__/fileHandler.spec.ts
+++ b/packages/extension-file-handler/__tests__/fileHandler.spec.ts
@@ -40,11 +40,11 @@ describe('extension-file-handler', () => {
   const getEditorEl = () => document.querySelector(`.${editorElClass}`)
 
   const getHandlePaste = () => {
-    // Find the file handler plugin's handlePaste prop
+    // Find the file handler plugin's handlePaste prop by its key name
     const plugins = editor!.view.state.plugins
 
     for (const plugin of plugins) {
-      if (plugin.props.handlePaste) {
+      if (plugin.key.includes('fileHandler') && plugin.props.handlePaste) {
         return plugin.props.handlePaste
       }
     }

--- a/packages/extension-file-handler/package.json
+++ b/packages/extension-file-handler/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/docs/editor/extensions/functionality/filehandler",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-file-handler"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-file-handler/src/FileHandlePlugin.ts
+++ b/packages/extension-file-handler/src/FileHandlePlugin.ts
@@ -8,6 +8,7 @@ export const FileHandlePlugin = ({
   onPaste,
   onDrop,
   allowedMimeTypes,
+  consumePasteEvent,
 }: FileHandlePluginOptions) => {
   return new Plugin({
     key: key || new PluginKey('fileHandler'),
@@ -77,12 +78,10 @@ export const FileHandlePlugin = ({
 
         onPaste(editor, filesArray, htmlContent)
 
-        // if there is also file data inside the clipboard html,
-        // we won't use the files array and instead get the file url from the html
-        // this mostly happens for gifs or webms as they are not copied correctly as a file
-        // and will always be transformed into a PNG
-        // in this case we will let other extensions handle the incoming html via their inputRules
-        if (htmlContent.length > 0) {
+        // When HTML content is present alongside files (e.g. animated GIFs
+        // copied as PNG), and consumePasteEvent is not set, let other
+        // extensions handle the HTML content via their parseHTML/paste rules.
+        if (htmlContent.length > 0 && !consumePasteEvent) {
           return false
         }
 

--- a/packages/extension-file-handler/src/fileHandler.ts
+++ b/packages/extension-file-handler/src/fileHandler.ts
@@ -12,6 +12,7 @@ export const FileHandler = Extension.create<FileHandlerOptions>({
       onPaste: undefined,
       onDrop: undefined,
       allowedMimeTypes: undefined,
+      consumePasteEvent: false,
     }
   },
 
@@ -23,6 +24,7 @@ export const FileHandler = Extension.create<FileHandlerOptions>({
         allowedMimeTypes: this.options.allowedMimeTypes,
         onDrop: this.options.onDrop,
         onPaste: this.options.onPaste,
+        consumePasteEvent: this.options.consumePasteEvent,
       }),
     ]
   },

--- a/packages/extension-file-handler/src/types.ts
+++ b/packages/extension-file-handler/src/types.ts
@@ -30,6 +30,19 @@ export type FileHandlePluginOptions = {
   onPaste?: (editor: Editor, files: File[], pasteContent?: string) => void
 
   /**
+   * When true, the paste event is fully consumed when files are present,
+   * even if HTML content exists in the clipboard. This prevents paste
+   * rules from other extensions from running on the same paste event
+   * and creating duplicate content.
+   *
+   * Set this to true when your onPaste callback handles file insertion
+   * and you want to prevent other extensions from processing the same paste.
+   *
+   * @default false
+   */
+  consumePasteEvent?: boolean
+
+  /**
    * The onDrop callback that is called when a file is dropped.
    * @param editor the editor instance
    * @param files the File array including File objects

--- a/packages/extension-floating-menu/package.json
+++ b/packages/extension-floating-menu/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-floating-menu"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-font-family/package.json
+++ b/packages/extension-font-family/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-font-family"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-hard-break/package.json
+++ b/packages/extension-hard-break/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-hard-break"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-heading/package.json
+++ b/packages/extension-heading/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-heading"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-highlight/package.json
+++ b/packages/extension-highlight/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-highlight"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-horizontal-rule/package.json
+++ b/packages/extension-horizontal-rule/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-horizontal-rule"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-image"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-invisible-characters/package.json
+++ b/packages/extension-invisible-characters/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/docs/editor/extensions/functionality/invisiblecharacters",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-invisible-characters"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-italic/package.json
+++ b/packages/extension-italic/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-italic"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-link/package.json
+++ b/packages/extension-link/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-link"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-list/package.json
+++ b/packages/extension-list/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-list"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-mathematics/package.json
+++ b/packages/extension-mathematics/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/api/extensions/mathematics",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-mathematics"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-mention"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-node-range/package.json
+++ b/packages/extension-node-range/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-node-range"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-ordered-list/package.json
+++ b/packages/extension-ordered-list/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-ordered-list"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-paragraph/package.json
+++ b/packages/extension-paragraph/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-paragraph"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-strike/package.json
+++ b/packages/extension-strike/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-strike"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-subscript/package.json
+++ b/packages/extension-subscript/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-subscript"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-superscript/package.json
+++ b/packages/extension-superscript/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-superscript"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-table-of-contents/package.json
+++ b/packages/extension-table-of-contents/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/docs/editor/extensions/functionality/table-of-contents",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-table-of-contents"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-table"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-text-align/package.json
+++ b/packages/extension-text-align/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-text-align"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-text-style/package.json
+++ b/packages/extension-text-style/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-text-style"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-text/package.json
+++ b/packages/extension-text/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-text"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-twitch/package.json
+++ b/packages/extension-twitch/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-twitch"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-typography/package.json
+++ b/packages/extension-typography/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-typography"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-underline/package.json
+++ b/packages/extension-underline/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-underline"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-unique-id/package.json
+++ b/packages/extension-unique-id/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev/api/extensions/unique-id",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-unique-id"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extension-youtube/package.json
+++ b/packages/extension-youtube/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension-youtube"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -7,14 +7,14 @@
     "tiptap extension"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/extension"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -7,14 +7,14 @@
     "tiptap utility"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/html"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -7,14 +7,14 @@
     "tiptap utility"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/markdown"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -7,14 +7,14 @@
     "tiptap"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/pm"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,14 +7,14 @@
     "tiptap react components"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/react"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/server-ai-toolkit/package.json
+++ b/packages/server-ai-toolkit/package.json
@@ -10,14 +10,14 @@
     "tiptap ai"
   ],
   "homepage": "https://tiptap.dev/docs/editor/extensions/functionality/server-ai-toolkit",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/server-ai-toolkit"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/starter-kit/package.json
+++ b/packages/starter-kit/package.json
@@ -7,14 +7,14 @@
     "tiptap starter kit"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/starter-kit"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/static-renderer/package.json
+++ b/packages/static-renderer/package.json
@@ -8,14 +8,14 @@
     "tiptap static renderer"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/static-renderer"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/suggestion/package.json
+++ b/packages/suggestion/package.json
@@ -7,14 +7,14 @@
     "tiptap utility"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/suggestion"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/vue-2/package.json
+++ b/packages/vue-2/package.json
@@ -7,14 +7,14 @@
     "tiptap vue components"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/vue-2"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -7,14 +7,14 @@
     "tiptap vue components"
   ],
   "homepage": "https://tiptap.dev",
+  "bugs": {
+    "url": "https://github.com/ueberdosis/tiptap/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ueberdosis/tiptap",
     "directory": "packages/vue-3"
-  },
-  "bugs": {
-    "url": "https://github.com/ueberdosis/tiptap/issues"
   },
   "funding": {
     "type": "github",


### PR DESCRIPTION
## Changes Overview

Add a `consumePasteEvent` option to the file-handler extension that, when `true`, causes `handlePaste` to return `true` even when HTML content is present in the clipboard. This prevents paste rules from other extensions from firing on the same paste event and creating duplicate content.

## Implementation Approach

- Added `consumePasteEvent?: boolean` option to `FileHandlePluginOptions` and `FileHandlerOptions` (default `false`)
- Modified the `handlePaste` return logic: `if (htmlContent.length > 0 && !consumePasteEvent)` - when `consumePasteEvent` is `true`, always returns `true` when files are present
- The `onPaste` callback continues to receive `htmlContent` regardless of the option value

## Testing Done

Added 13 Vitest tests in `packages/extension-file-handler/__tests__/fileHandler.spec.ts`:

**Current behavior regression tests:**
- Returns `false` when no `onPaste` callback is provided
- Returns `false` when clipboard has no files
- Returns `false` when all files filtered out by `allowedMimeTypes`
- Calls `onPaste` and returns `true` when files pasted without HTML
- Calls `onPaste` and returns `false` when files pasted with HTML
- Receives `htmlContent` in callback when HTML is present

**New behavior tests:**
- Defaults to `false` (backward compatible)
- Returns `true` when files pasted with HTML and `consumePasteEvent: true`
- Returns `true` when files pasted without HTML and `consumePasteEvent: true`
- Still receives `htmlContent` in callback when `consumePasteEvent: true`
- Receives correct files array when `consumePasteEvent: true`
- Calls `preventDefault`/`stopPropagation` when files present
- Does not call `onPaste` when files filtered by `allowedMimeTypes`

All 1336 unit tests pass.

## Verification Steps

1. Configure file-handler with `consumePasteEvent: true` and an `onPaste` callback
2. Paste content that contains both files and HTML (e.g. copying an image from a website)
3. Verify the `onPaste` callback receives both files and `htmlContent`
4. Verify no duplicate content is inserted by paste rules from other extensions

## Related Issues

Closes #4944