### PR TITLE
fix(character-count): trim excess content from end, not beginning (fixes #7254)

### DIFF
--- a/.changeset/fix-character-count-trim-direction.md
+++ b/.changeset/fix-character-count-trim-direction.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-character-count": patch
+---
+
+Fix autoTrim to trim from the end of the document instead of the beginning. Also fix `findDocPositionAtChar` to account for non-text leaf/atom nodes (images, hard breaks, etc.) that contribute to the character count via `leafText`, and add a safety re-check loop so the document is always trimmed to within the limit even when ProseMirror re-closes nodes after deletion.

--- a/packages/extensions/__tests__/character-count.spec.ts
+++ b/packages/extensions/__tests__/character-count.spec.ts
@@ -15,44 +15,50 @@ describe('extension-character-count', () => {
 
   const createEditor = (content: string, limit: number, autoTrim = true) => {
     editor = new Editor({
-      extensions: [
-        Document,
-        Paragraph,
-        Text,
-        CharacterCount.configure({ limit, autoTrim }),
-      ],
+      extensions: [Document, Paragraph, Text, CharacterCount.configure({ limit, autoTrim })],
       content,
     })
     return editor
   }
 
+  // The `create` lifecycle event (and therefore CharacterCount's onCreate,
+  // which performs the initial autoTrim) is emitted via `window.setTimeout(...,
+  // 0)` inside Editor#mount — it is not synchronous with the constructor.
+  // Tests that assert on initial-content autoTrim must flush that tick first.
+  const flushCreate = () => new Promise(resolve => setTimeout(resolve, 0))
+
   describe('autoTrim', () => {
-    it('trims from the END when initial content exceeds the limit', () => {
+    it('trims from the END when initial content exceeds the limit', async () => {
       // Content is "Hello World" (11 chars), limit is 5.
       // Expected: first 5 characters preserved → "Hello"
       // Bug: previous code deleted from the beginning → "World" (wrong)
       createEditor('<p>Hello World</p>', 5)
+      await flushCreate()
       expect(editor!.getText()).toBe('Hello')
     })
 
-    it('does not modify content that is within the limit', () => {
+    it('does not modify content that is within the limit', async () => {
       createEditor('<p>Hi</p>', 10)
+      await flushCreate()
       expect(editor!.getText()).toBe('Hi')
     })
 
-    it('trims correctly when the document has exactly the limit characters', () => {
+    it('trims correctly when the document has exactly the limit characters', async () => {
       createEditor('<p>Hello</p>', 5)
+      await flushCreate()
       expect(editor!.getText()).toBe('Hello')
     })
 
-    it('preserves an empty document', () => {
+    it('preserves an empty document', async () => {
       createEditor('<p></p>', 5)
+      await flushCreate()
       expect(editor!.getText()).toBe('')
     })
 
-    it('does not trim when autoTrim is false', () => {
+    it('does not trim when autoTrim is false', async () => {
       // When autoTrim is false the content should be left untouched even if over limit.
       createEditor('<p>Hello World</p>', 5, false)
+      await flushCreate()
       expect(editor!.getText()).toBe('Hello World')
     })
   })

--- a/packages/extensions/__tests__/character-count.spec.ts
+++ b/packages/extensions/__tests__/character-count.spec.ts
@@ -1,0 +1,71 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { CharacterCount } from '@tiptap/extensions'
+import { afterEach, describe, expect, it } from 'vitest'
+
+describe('extension-character-count', () => {
+  let editor: Editor | null = null
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+  })
+
+  const createEditor = (content: string, limit: number, autoTrim = true) => {
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        CharacterCount.configure({ limit, autoTrim }),
+      ],
+      content,
+    })
+    return editor
+  }
+
+  describe('autoTrim', () => {
+    it('trims from the END when initial content exceeds the limit', () => {
+      // Content is "Hello World" (11 chars), limit is 5.
+      // Expected: first 5 characters preserved → "Hello"
+      // Bug: previous code deleted from the beginning → "World" (wrong)
+      createEditor('<p>Hello World</p>', 5)
+      expect(editor!.getText()).toBe('Hello')
+    })
+
+    it('does not modify content that is within the limit', () => {
+      createEditor('<p>Hi</p>', 10)
+      expect(editor!.getText()).toBe('Hi')
+    })
+
+    it('trims correctly when the document has exactly the limit characters', () => {
+      createEditor('<p>Hello</p>', 5)
+      expect(editor!.getText()).toBe('Hello')
+    })
+
+    it('preserves an empty document', () => {
+      createEditor('<p></p>', 5)
+      expect(editor!.getText()).toBe('')
+    })
+
+    it('does not trim when autoTrim is false', () => {
+      // When autoTrim is false the content should be left untouched even if over limit.
+      createEditor('<p>Hello World</p>', 5, false)
+      expect(editor!.getText()).toBe('Hello World')
+    })
+  })
+
+  describe('character count', () => {
+    it('counts characters correctly', () => {
+      createEditor('<p>Hello</p>', 100)
+      expect(editor!.storage.characterCount.characters()).toBe(5)
+    })
+
+    it('counts words correctly', () => {
+      createEditor('<p>Hello World</p>', 100)
+      expect(editor!.storage.characterCount.words()).toBe(2)
+    })
+  })
+})

--- a/packages/extensions/__tests__/character-count.spec.ts
+++ b/packages/extensions/__tests__/character-count.spec.ts
@@ -1,5 +1,6 @@
 import { Editor } from '@tiptap/core'
 import Document from '@tiptap/extension-document'
+import HardBreak from '@tiptap/extension-hard-break'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { CharacterCount } from '@tiptap/extensions'
@@ -60,6 +61,33 @@ describe('extension-character-count', () => {
       createEditor('<p>Hello World</p>', 5, false)
       await flushCreate()
       expect(editor!.getText()).toBe('Hello World')
+    })
+
+    it('keeps a leaf node that reaches the limit instead of deleting it', async () => {
+      // "A<br>B" with limit 2: the hard break is the 2nd counted character
+      // (textBetween counts a leaf as a single space), so it reaches the limit
+      // and must be preserved — only "B" should be trimmed. Previously the leaf
+      // was split *before*, dropping the hard break.
+      editor = new Editor({
+        extensions: [
+          Document,
+          Paragraph,
+          Text,
+          HardBreak,
+          CharacterCount.configure({ limit: 2, autoTrim: true }),
+        ],
+        content: '<p>A<br>B</p>',
+      })
+      await flushCreate()
+
+      expect(editor.getJSON()).toMatchObject({
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'A' }, { type: 'hardBreak' }],
+          },
+        ],
+      })
     })
   })
 

--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -175,6 +175,7 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
           const initialContentSize = this.storage.characters({ node: newState.doc })
 
           if (initialContentSize > limit) {
+            // Trim excess content from the END of the document so that the first
             // `limit` characters are preserved
             let from: number
             let to: number

--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -172,70 +172,67 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
     }
   },
 
-  addProseMirrorPlugins() {
-    let initialEvaluationDone = false
+  // Runs once after the initial EditorState (and view) has been created.
+  // Content passed via the `content` constructor option becomes part of that
+  // initial state directly — it is never applied as a dispatched Transaction —
+  // so a ProseMirror `appendTransaction` plugin hook never sees it. Trimming
+  // over-limit initial content therefore has to happen here, by dispatching a
+  // real transaction against the already-created view.
+  onCreate() {
+    const limit = this.options.limit
+    const autoTrim = this.options.autoTrim
 
+    if (limit === null || limit === undefined || limit === 0 || autoTrim === false) {
+      return
+    }
+
+    const initialContentSize = this.storage.characters({ node: this.editor.state.doc })
+
+    if (initialContentSize <= limit) {
+      return
+    }
+
+    const { state, view } = this.editor
+    let tr = state.tr
+
+    const trimOnce = (doc: ProseMirrorNode) => {
+      if (this.options.mode === 'nodeSize') {
+        const currentSize = this.storage.characters({ node: doc, mode: 'nodeSize' })
+        const over = currentSize - limit
+        return { from: doc.content.size - over, to: doc.content.size }
+      }
+
+      return {
+        from: findDocPositionAtChar(doc, limit, this.options.textCounter),
+        to: doc.content.size,
+      }
+    }
+
+    const { from, to } = trimOnce(tr.doc)
+
+    console.warn(
+      `[CharacterCount] Initial content exceeded limit of ${limit} characters. Content was automatically trimmed.`,
+    )
+    tr = tr.deleteRange(from, to)
+
+    // Safety re-check: ProseMirror may close open nodes after deletion,
+    // pushing the count back over the limit (same scenario as the paste
+    // path in filterTransaction below). Keep trimming until within limit.
+    let safetyIterations = 0
+    while (this.storage.characters({ node: tr.doc }) > limit && safetyIterations < 10) {
+      const range = trimOnce(tr.doc)
+      tr = tr.deleteRange(range.from, range.to)
+      safetyIterations++
+    }
+
+    tr.setMeta('addToHistory', false)
+    view.dispatch(tr)
+  },
+
+  addProseMirrorPlugins() {
     return [
       new Plugin({
         key: new PluginKey('characterCount'),
-        appendTransaction: (transactions, oldState, newState) => {
-          if (initialEvaluationDone) {
-            return
-          }
-
-          const limit = this.options.limit
-          const autoTrim = this.options.autoTrim
-
-          if (limit === null || limit === undefined || limit === 0 || autoTrim === false) {
-            initialEvaluationDone = true
-            return
-          }
-
-          const initialContentSize = this.storage.characters({ node: newState.doc })
-
-          if (initialContentSize > limit) {
-            // Trim excess content from the END of the document so that the first
-            // `limit` characters are preserved
-            let from: number
-            let to: number
-
-            if (this.options.mode === 'nodeSize') {
-              const over = initialContentSize - limit
-              from = newState.doc.content.size - over
-              to = newState.doc.content.size
-            } else {
-              // textSize mode: resolve the exact document position after `limit` chars
-              from = findDocPositionAtChar(newState.doc, limit, this.options.textCounter)
-              to = newState.doc.content.size
-            }
-
-            console.warn(
-              `[CharacterCount] Initial content exceeded limit of ${limit} characters. Content was automatically trimmed.`,
-            )
-            const tr = newState.tr.deleteRange(from, to)
-
-            // Safety re-check: ProseMirror may close open nodes after deletion,
-            // pushing the count back over the limit (same scenario as the paste
-            // path in filterTransaction). Keep trimming until within limit.
-            let safetyIterations = 0
-            while (this.storage.characters({ node: tr.doc }) > limit && safetyIterations < 10) {
-              if (this.options.mode === 'nodeSize') {
-                const currentSize = this.storage.characters({ node: tr.doc })
-                const over = currentSize - limit
-                tr.deleteRange(tr.doc.content.size - over, tr.doc.content.size)
-              } else {
-                const newFrom = findDocPositionAtChar(tr.doc, limit, this.options.textCounter)
-                tr.deleteRange(newFrom, tr.doc.content.size)
-              }
-              safetyIterations++
-            }
-
-            initialEvaluationDone = true
-            return tr
-          }
-
-          initialEvaluationDone = true
-        },
         filterTransaction: (transaction, state) => {
           const limit = this.options.limit
 

--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -80,27 +80,46 @@ function findDocPositionAtChar(
 
   doc.descendants((node, pos) => {
     if (accumulated >= limit) return false
-    if (!node.isText || !node.text) return true
 
-    const nodeCharCount = textCounter(node.text)
-    const remaining = limit - accumulated
+    if (node.isText && node.text) {
+      const nodeCharCount = textCounter(node.text)
+      const remaining = limit - accumulated
 
-    if (nodeCharCount >= remaining) {
-      // The trim boundary falls inside (or at the end of) this text node.
-      // For the default counter textCounter === text.length so `remaining` is
-      // the exact UTF-16 offset; for custom counters this is a best-effort
-      // proportional approximation.
-      const charOffset =
-        nodeCharCount === node.text.length
-          ? remaining
-          : Math.round((remaining / nodeCharCount) * node.text.length)
+      if (nodeCharCount >= remaining) {
+        // The trim boundary falls inside (or at the end of) this text node.
+        // For the default counter textCounter === text.length so `remaining` is
+        // the exact UTF-16 offset; for custom counters this is a best-effort
+        // proportional approximation.
+        const charOffset =
+          nodeCharCount === node.text.length
+            ? remaining
+            : Math.round((remaining / nodeCharCount) * node.text.length)
 
-      trimPos = pos + charOffset
-      accumulated = limit
-      return false
+        trimPos = pos + charOffset
+        accumulated = limit
+        return false
+      }
+
+      accumulated += nodeCharCount
+      return true
     }
 
-    accumulated += nodeCharCount
+    // Non-text leaf/atom nodes (e.g. images, hard breaks, inline math) are
+    // counted as a single space by textBetween(..., leafText = ' '), which is
+    // what this.storage.characters() uses to compute initialContentSize. Mirror
+    // that here so the split position stays in sync with the measured count.
+    if (node.isLeaf) {
+      const leafCount = textCounter(' ')
+      const remaining = limit - accumulated
+      if (leafCount >= remaining) {
+        trimPos = pos
+        accumulated = limit
+        return false
+      }
+      accumulated += leafCount
+      return false // leaf nodes have no children to descend into
+    }
+
     return true
   })
 
@@ -194,6 +213,23 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
               `[CharacterCount] Initial content exceeded limit of ${limit} characters. Content was automatically trimmed.`,
             )
             const tr = newState.tr.deleteRange(from, to)
+
+            // Safety re-check: ProseMirror may close open nodes after deletion,
+            // pushing the count back over the limit (same scenario as the paste
+            // path in filterTransaction). Keep trimming until within limit.
+            let safetyIterations = 0
+            while (this.storage.characters({ node: tr.doc }) > limit && safetyIterations < 10) {
+              if (this.options.mode === 'nodeSize') {
+                const currentSize = this.storage.characters({ node: tr.doc })
+                const over = currentSize - limit
+                tr.deleteRange(tr.doc.content.size - over, tr.doc.content.size)
+              } else {
+                const newFrom = findDocPositionAtChar(tr.doc, limit, this.options.textCounter)
+                tr.deleteRange(newFrom, tr.doc.content.size)
+              }
+              safetyIterations++
+            }
+
             initialEvaluationDone = true
             return tr
           }

--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -112,7 +112,10 @@ function findDocPositionAtChar(
       const leafCount = textCounter(' ')
       const remaining = limit - accumulated
       if (leafCount >= remaining) {
-        trimPos = pos
+        // The leaf node contributes the character(s) that reach the limit, so
+        // it belongs to the preserved prefix — split *after* it (like the text
+        // branch splits after the consumed characters), not before it.
+        trimPos = pos + node.nodeSize
         accumulated = limit
         return false
       }

--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -61,6 +61,53 @@ declare module '@tiptap/core' {
 }
 
 /**
+ * Finds the ProseMirror document position at which `limit` text characters
+ * (as counted by `textCounter`) have been consumed, walking from the start of
+ * the document.  Used by autoTrim so that excess content is removed from the
+ * END of the document rather than the beginning.
+ *
+ * For the default counter (`text => text.length`) the position is exact.
+ * For custom counters (e.g. Intl.Segmenter) the per-node approximation is
+ * used: within a node the split point is proportional to the node's length.
+ */
+function findDocPositionAtChar(
+  doc: ProseMirrorNode,
+  limit: number,
+  textCounter: (text: string) => number,
+): number {
+  let accumulated = 0
+  let trimPos = doc.content.size
+
+  doc.descendants((node, pos) => {
+    if (accumulated >= limit) return false
+    if (!node.isText || !node.text) return true
+
+    const nodeCharCount = textCounter(node.text)
+    const remaining = limit - accumulated
+
+    if (nodeCharCount >= remaining) {
+      // The trim boundary falls inside (or at the end of) this text node.
+      // For the default counter textCounter === text.length so `remaining` is
+      // the exact UTF-16 offset; for custom counters this is a best-effort
+      // proportional approximation.
+      const charOffset =
+        nodeCharCount === node.text.length
+          ? remaining
+          : Math.round((remaining / nodeCharCount) * node.text.length)
+
+      trimPos = pos + charOffset
+      accumulated = limit
+      return false
+    }
+
+    accumulated += nodeCharCount
+    return true
+  })
+
+  return trimPos
+}
+
+/**
  * This extension allows you to count the characters and words of your document.
  * @see https://tiptap.dev/api/extensions/character-count
  */
@@ -128,9 +175,21 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
           const initialContentSize = this.storage.characters({ node: newState.doc })
 
           if (initialContentSize > limit) {
-            const over = initialContentSize - limit
-            const from = 0
-            const to = over
+            // Trim excess content from the END of the document so that the first
+            // `limit` characters are preserved (previously the code incorrectly
+            // removed content from the beginning of the document).
+            let from: number
+            let to: number
+
+            if (this.options.mode === 'nodeSize') {
+              const over = initialContentSize - limit
+              from = newState.doc.content.size - over
+              to = newState.doc.content.size
+            } else {
+              // textSize mode: resolve the exact document position after `limit` chars
+              from = findDocPositionAtChar(newState.doc, limit, this.options.textCounter)
+              to = newState.doc.content.size
+            }
 
             console.warn(
               `[CharacterCount] Initial content exceeded limit of ${limit} characters. Content was automatically trimmed.`,
@@ -181,7 +240,7 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
           const from = pos - over
           const to = pos
 
-          // It’s probably a bad idea to mutate transactions within `filterTransaction`
+          // It's probably a bad idea to mutate transactions within `filterTransaction`
           // but for now this is working fine.
           transaction.deleteRange(from, to)
 

--- a/packages/extensions/src/character-count/character-count.ts
+++ b/packages/extensions/src/character-count/character-count.ts
@@ -175,9 +175,7 @@ export const CharacterCount = Extension.create<CharacterCountOptions, CharacterC
           const initialContentSize = this.storage.characters({ node: newState.doc })
 
           if (initialContentSize > limit) {
-            // Trim excess content from the END of the document so that the first
-            // `limit` characters are preserved (previously the code incorrectly
-            // removed content from the beginning of the document).
+            // `limit` characters are preserved
             let from: number
             let to: number
 


### PR DESCRIPTION
## Fixes

Fixes #7254

## Changes and Review

- `autoTrim` was deleting from the start of the document instead of the end. Rewrote the trim-boundary walk to work from the end, including correct handling for leaf/atom nodes.
- Two rounds of maintainer feedback addressed: leaf-node character counting and an off-by-one on the trim boundary.
- Regression tests cover text content and leaf-node edge cases.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
