### PR TITLE
fix(link): coerce undefined HTMLAttributes to null, fixing "No value supplied for attribute class" (fixes #7214)

### DIFF
--- a/.changeset/fix-link-undefined-htmlattributes.md
+++ b/.changeset/fix-link-undefined-htmlattributes.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-link": patch
+---
+
+Coerce `undefined` HTMLAttributes (`target`, `rel`, `class`) to `null` so ProseMirror does not emit "No value supplied for attribute" warnings when these options are explicitly set to `undefined`.

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -301,7 +301,7 @@ export const Link = Mark.create<LinkOptions>({
       },
       class: {
         // Fixes: "No value supplied for attribute class" when class is explicitly
-        // set to undefined in HTMLAttributes config. See #7214.
+        // set to undefined in HTMLAttributes config.
         default: this.options.HTMLAttributes.class ?? null,
       },
       title: {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -296,6 +296,7 @@ export const Link = Mark.create<LinkOptions>({
         default: this.options.HTMLAttributes.target ?? null,
       },
       rel: {
+        // Coerce `undefined` to `null` because `undefined` is an invalid attribute value
         default: this.options.HTMLAttributes.rel ?? null,
       },
       class: {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -292,13 +292,17 @@ export const Link = Mark.create<LinkOptions>({
         },
       },
       target: {
-        default: this.options.HTMLAttributes.target,
+        // Coerce undefined → null so ProseMirror never sees an invalid attribute value
+        // (happens when the user explicitly passes `HTMLAttributes: { target: undefined }`).
+        default: this.options.HTMLAttributes.target ?? null,
       },
       rel: {
-        default: this.options.HTMLAttributes.rel,
+        default: this.options.HTMLAttributes.rel ?? null,
       },
       class: {
-        default: this.options.HTMLAttributes.class,
+        // Fixes: "No value supplied for attribute class" when class is explicitly
+        // set to undefined in HTMLAttributes config. See #7214.
+        default: this.options.HTMLAttributes.class ?? null,
       },
       title: {
         default: null,

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -292,8 +292,7 @@ export const Link = Mark.create<LinkOptions>({
         },
       },
       target: {
-        // Coerce undefined → null so ProseMirror never sees an invalid attribute value
-        // (happens when the user explicitly passes `HTMLAttributes: { target: undefined }`).
+        // Coerce `undefined` to `null` because `undefined` is an invalid attribute value
         default: this.options.HTMLAttributes.target ?? null,
       },
       rel: {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -300,8 +300,7 @@ export const Link = Mark.create<LinkOptions>({
         default: this.options.HTMLAttributes.rel ?? null,
       },
       class: {
-        // Fixes: "No value supplied for attribute class" when class is explicitly
-        // set to undefined in HTMLAttributes config.
+        // Coerce `undefined` to `null` because `undefined` is an invalid attribute value
         default: this.options.HTMLAttributes.class ?? null,
       },
       title: {


### PR DESCRIPTION
## Problem

When the Link extension is configured with `class: undefined` in `HTMLAttributes`, ProseMirror emits:

```
No value supplied for attribute class
```

This happens because `addAttributes()` passes `undefined` directly as the default:

```ts
// before
class: {
  default: this.options.HTMLAttributes.class,  // undefined when user passes { class: undefined }
},
```

ProseMirror's attribute system distinguishes between `null` (absent) and `undefined` (invalid / missing). Passing `undefined` triggers the warning.

## Fix

Use `?? null` on `target`, `rel`, and `class` so that an explicit `undefined` from the user's config is normalised to `null` before ProseMirror sees it:

```ts
// after
class: {
  default: this.options.HTMLAttributes.class ?? null,
},
```

`target` and `rel` get the same guard for consistency — they're unlikely to be set to `undefined` given their non-null defaults in `addOptions()`, but it's defensive and zero-cost.

## Reproduction

```ts
const editor = new Editor({
  extensions: [
    // …
    Link.configure({
      HTMLAttributes: { class: undefined },
    }),
  ],
})
// Console: "No value supplied for attribute class"  ← gone after this fix
```

## Related

Fixes #7214