### PR TITLE
fix(extension-blockquote): prevent crash on backspace at document start

### DIFF
--- a/.changeset/fix-blockquote-backspace-doc-start.md
+++ b/.changeset/fix-blockquote-backspace-doc-start.md
@@ -2,4 +2,4 @@
 "@tiptap/extension-blockquote": patch
 ---
 
-Fix a crash when pressing backspace at the very start of the document with a leading image. The blockquote backspace handler dereferenced an undefined parent at the top (doc) level, throwing `TypeError: Cannot read properties of undefined (reading 'type')`. It now bails out so backspace is a no-op at the document start. (#7973)
+Fix a crash when pressing backspace at the very start of the document with a leading image. The blockquote backspace handler dereferenced an undefined parent at the top (doc) level, throwing `TypeError: Cannot read properties of undefined (reading 'type')`. It now bails out so backspace is a no-op at the document start.

--- a/.changeset/fix-blockquote-backspace-doc-start.md
+++ b/.changeset/fix-blockquote-backspace-doc-start.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-blockquote": patch
+---
+
+Fix a crash when pressing backspace at the very start of the document with a leading image. The blockquote backspace handler dereferenced an undefined parent at the top (doc) level, throwing `TypeError: Cannot read properties of undefined (reading 'type')`. It now bails out so backspace is a no-op at the document start. (#7973)

--- a/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
+++ b/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
@@ -1,0 +1,45 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Image from '@tiptap/extension-image'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { GapCursor } from '@tiptap/pm/gapcursor'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { handleBackspace } from '../src/handleBackspace.js'
+import { Blockquote } from '../src/index.js'
+
+describe('Blockquote handleBackspace', () => {
+  let editor: Editor
+
+  beforeEach(() => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    editor = new Editor({
+      element,
+      extensions: [Document, Paragraph, Text, Image, Blockquote],
+      content: '<img src="https://example.com/image.png">',
+    })
+  })
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  // Regression test for https://github.com/ueberdosis/tiptap/issues/7973
+  // With a leading image, pressing backspace at the very start of the document
+  // resolved the caret to the top (doc) level, where `$from.depth` is 0. The
+  // handler then dereferenced `$from.node(-1)` (undefined) and crashed with
+  // `TypeError: can't access property "type", parent is undefined`.
+  it('does not throw when backspacing at the very start of the document', () => {
+    const { state, view } = editor
+    // Before the leading image, the caret resolves to a gap cursor at depth 0.
+    const selection = new GapCursor(state.doc.resolve(0))
+    view.dispatch(state.tr.setSelection(selection))
+
+    const blockquoteType = editor.schema.nodes.blockquote
+
+    expect(() => handleBackspace(editor, blockquoteType)).not.toThrow()
+    expect(handleBackspace(editor, blockquoteType)).toBe(false)
+  })
+})

--- a/packages/extension-blockquote/src/handleBackspace.ts
+++ b/packages/extension-blockquote/src/handleBackspace.ts
@@ -25,6 +25,12 @@ export const handleBackspace = (editor: Editor, type: NodeType): boolean => {
   if ($from.parentOffset !== 0) return false
 
   const parentDepth = $from.depth - 1
+  // At the very start of the document the caret can resolve to the top (doc)
+  // level — for example a gap cursor before a leading image — where there is
+  // no parent block. Bail out so backspace is a no-op instead of dereferencing
+  // an undefined parent at a negative depth. (#7973)
+  if (parentDepth < 0) return false
+
   const parent = $from.node(parentDepth)
   const index = $from.index(parentDepth)
   if (index === 0) return false


### PR DESCRIPTION
## Changes Overview

Pressing <kbd>Backspace</kbd> at the very start of the document with a leading block atom (e.g. an image) crashed the editor with `TypeError: Cannot read properties of undefined (reading 'type')`. This adds a guard so backspace is a no-op at the document start instead of crashing.

## Implementation Approach

The blockquote `handleBackspace` helper assumed the caret sits inside a textblock and read `$from.node($from.depth - 1)`. At the very start of the document the caret resolves to the top (doc) level, where `$from.depth` is `0`, so `parentDepth` is `-1` and `$from.node(-1)` is `undefined`. Added `if (parentDepth < 0) return false`.

## Testing Done

Regression test added; fails on main with the exact TypeError, passes with fix. Build (73 pkgs), blockquote tests, lint, format, fallow audit all green.

## AI Usage

- [x] I have used AI tools in creating this PR.
  - Used Claude to locate the root cause, write the regression test, and implement the guard; verified locally.

## Checklist

- [x] Changeset created.
- [x] Changes do not break the library.
- [x] Tests added.
- [x] Followed project guidelines.
- [x] Lint issues fixed.

## Related Issues

Fixes #7973