### PR TITLE
fix(react): do not throw when the Tiptap provider editor is null

### DIFF
--- a/.changeset/fix-react-tiptap-null-editor.md
+++ b/.changeset/fix-react-tiptap-null-editor.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Fix `<Tiptap>` throwing `Tiptap: An editor instance is required` when `editor` is `null`. `useEditor()` returns `null` on the first render (and when `immediatelyRender: false` is used), so the canonical `<Tiptap editor={useEditor(...)}>` usage threw. The provider now renders nothing until the editor is ready, matching `EditorProvider` and the optional `editor` prop type. The `editor` and `instance` props are also typed as `Editor | null` to match what `useEditor()` returns. (#7529)

--- a/packages/react/src/Tiptap.spec.ts
+++ b/packages/react/src/Tiptap.spec.ts
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { Tiptap } from './Tiptap.js'
+
+describe('Tiptap provider', () => {
+  // Regression test for https://github.com/ueberdosis/tiptap/issues/7529
+  // `useEditor()` returns `null` on the first render (and with
+  // `immediatelyRender: false`), so the canonical `<Tiptap editor={editor}>`
+  // usage must not throw. It should render nothing until the editor is ready.
+  it('renders nothing instead of throwing when the editor is null', () => {
+    let container: HTMLElement | undefined
+
+    expect(() => {
+      container = render(
+        React.createElement(Tiptap, { editor: null }, React.createElement(Tiptap.Content)),
+      ).container
+    }).not.toThrow()
+
+    expect(container?.firstChild).toBeNull()
+  })
+})

--- a/packages/react/src/Tiptap.tsx
+++ b/packages/react/src/Tiptap.tsx
@@ -99,14 +99,16 @@ export function useTiptapState<TSelectorResult>(
 export type TiptapWrapperProps = {
   /**
    * The editor instance to provide to child components.
-   * Use `useEditor()` to create this instance.
+   * Use `useEditor()` to create this instance. It can be `null` on the first
+   * render (or when `immediatelyRender: false` is used); the provider renders
+   * nothing until the editor is ready.
    */
-  editor?: Editor
+  editor?: Editor | null
 
   /**
    * @deprecated Use `editor` instead. Will be removed in the next major version.
    */
-  instance?: Editor
+  instance?: Editor | null
 
   children: ReactNode
 }
@@ -139,20 +141,24 @@ export type TiptapWrapperProps = {
  * ```
  */
 export function TiptapWrapper({ editor, instance, children }: TiptapWrapperProps) {
-  const resolvedEditor = editor ?? instance
-
-  if (!resolvedEditor) {
-    throw new Error('Tiptap: An editor instance is required. Pass a non-null `editor` prop.')
-  }
+  const resolvedEditor = editor ?? instance ?? null
 
   const tiptapContextValue = useMemo<TiptapContextType>(
-    () => ({ editor: resolvedEditor }),
+    () => ({ editor: resolvedEditor as Editor }),
     [resolvedEditor],
   )
 
   // Provide backwards compatibility with the legacy EditorContext
   // so components using useCurrentEditor() work inside <Tiptap>
   const legacyContextValue = useMemo(() => ({ editor: resolvedEditor }), [resolvedEditor])
+
+  // `useEditor()` returns `null` on the first render (and during SSR with
+  // `immediatelyRender: false`), so the canonical `<Tiptap editor={useEditor(...)}>`
+  // usage would otherwise throw here. Render nothing until the editor is ready,
+  // matching `EditorProvider` and the optional `editor` prop type. (#7529)
+  if (!resolvedEditor) {
+    return null
+  }
 
   return (
     <EditorContext.Provider value={legacyContextValue}>


### PR DESCRIPTION
## Changes Overview

`<Tiptap editor={editor}>` (the `@tiptap/react` provider) threw `Tiptap: An editor instance is required` whenever `editor` was `null`. Because `useEditor()` returns `null` on the first render (and with `immediatelyRender: false`), the canonical `<Tiptap editor={useEditor(...)}>` usage crashed on mount. Regression from v3.18.

This renders nothing until the editor is ready instead of throwing — matching the optional `editor?` type, `EditorProvider`, and `EditorContent`. Fixes #7529.

## Implementation Approach

`TiptapWrapper` threw before its `useMemo` hooks. (1) Move the guard after the hooks and `return null` (Rules of Hooks), mirroring `EditorProvider`. (2) Widen `editor`/`instance` prop types to `Editor | null` to match `useEditor()`.

## Testing Done

- Regression unit test `packages/react/src/Tiptap.spec.ts`: fails on main with the exact error, passes with the fix.
- `pnpm vitest run packages/react` -> 5 passing (no regression)
- `pnpm build` (73 packages) -> success
- lint / format / `fallow:audit` -> clean

## AI Usage

- [x] I have used AI tools in creating this PR.
  - Used Claude to locate the throw, confirm the pattern against `EditorProvider`, write the test, and implement the fix; verified locally.

## Checklist

- [x] Changeset created.
- [x] Changes do not break the library.
- [x] Tests added.
- [x] Followed project guidelines.
- [x] Lint fixed.

## Related Issues

Fixes #7529