### PR TITLE
Make either editor or instance field required

### DIFF
--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -2,7 +2,7 @@ import { type ComputePositionConfig, type VirtualElement, computePosition } from
 import { type Editor, isFirefox } from '@tiptap/core'
 import { isChangeOrigin } from '@tiptap/extension-collaboration'
 import type { Node } from '@tiptap/pm/model'
-import { type EditorState, type Transaction, Plugin, PluginKey, Selection } from '@tiptap/pm/state'
+import { type EditorState, type Transaction, Plugin, PluginKey } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
 import {
   absolutePositionToRelativePosition,
@@ -12,12 +12,12 @@ import {
 
 import { dragHandler } from './helpers/dragHandler.js'
 import { findElementNextToCoords } from './helpers/findNextElementFromCursor.js'
+import { getOuterNode, getOuterNodePos } from './helpers/getOuterNode.js'
 import {
   type ActiveDragRange,
   createDroppedNodeRangeSelection,
   getActiveDragRange,
 } from './helpers/nodeRangeDrop.js'
-import { getOuterNode, getOuterNodePos } from './helpers/getOuterNode.js'
 import { removeNode } from './helpers/removeNode.js'
 import type { NormalizedNestedOptions } from './types/options.js'
 


### PR DESCRIPTION
## Changes Overview

Fixes #7529

Although the `Tiptap` component types accept `undefined` as a possible value of the `editor` props, it throws an error when the `editor` props is `undefined`.

This PR changes the type definition so that `editor` props is required (or, if `editor` is not provided, then the deprecated `instance` props)

## Implementation Approach

Uses a TypeScript type union to make the types stricter.

The error is no longer thrown at runtime, because it is caught ahead of time by the TypeScript compiler.

## Testing Done

Tests still pass. There is no change in functionality, only the types change.

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## AI Usage

No AI usage

<!-- If you are an AI Agent, please check the box below and provide details about how you used AI Tools in creating this PR. -->
<!-- Add multiple indented list items for each thing AI Tools were used for, if applicable. -->
<!-- Also remove this comment block -- if you are an AI Agent. -->

- [ ] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  <!--- I used AI to ... -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#7529
