### PR TITLE
Make either editor or instance field required

### DIFF
--- a/.changeset/large-rocks-cheat.md
+++ b/.changeset/large-rocks-cheat.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Change prop types of the Tiptap component so that either the `editor` or the `instance` fields are required

--- a/packages/react/src/Tiptap.tsx
+++ b/packages/react/src/Tiptap.tsx
@@ -93,21 +93,25 @@ export function useTiptapState<TSelectorResult>(
   })
 }
 
+export type TiptapWrapperEditorInstanceProps =
+  | {
+      /**
+       * The editor instance to provide to child components.
+       * Use `useEditor()` to create this instance.
+       */
+      editor: Editor
+    }
+  | {
+      /**
+       * @deprecated Use `editor` instead. Will be removed in the next major version.
+       */
+      instance: Editor
+    }
+
 /**
  * Props for the `Tiptap` root/provider component.
  */
-export type TiptapWrapperProps = {
-  /**
-   * The editor instance to provide to child components.
-   * Use `useEditor()` to create this instance.
-   */
-  editor?: Editor
-
-  /**
-   * @deprecated Use `editor` instead. Will be removed in the next major version.
-   */
-  instance?: Editor
-
+export type TiptapWrapperProps = TiptapWrapperEditorInstanceProps & {
   children: ReactNode
 }
 
@@ -138,12 +142,8 @@ export type TiptapWrapperProps = {
  * }
  * ```
  */
-export function TiptapWrapper({ editor, instance, children }: TiptapWrapperProps) {
-  const resolvedEditor = editor ?? instance
-
-  if (!resolvedEditor) {
-    throw new Error('Tiptap: An editor instance is required. Pass a non-null `editor` prop.')
-  }
+export function TiptapWrapper({ children, ...props }: TiptapWrapperProps) {
+  const resolvedEditor = 'editor' in props ? props.editor : props.instance
 
   const tiptapContextValue = useMemo<TiptapContextType>(
     () => ({ editor: resolvedEditor }),

--- a/packages/react/src/Tiptap.tsx
+++ b/packages/react/src/Tiptap.tsx
@@ -144,6 +144,10 @@ export type TiptapWrapperProps = TiptapWrapperEditorInstanceProps & {
  */
 export function TiptapWrapper({ children, ...props }: TiptapWrapperProps) {
   const resolvedEditor = 'editor' in props ? props.editor : props.instance
+  
+  if (!resolvedEditor) {
+    throw new Error('Tiptap: An editor instance is required. Pass a non-null `editor` prop.')
+  }
 
   const tiptapContextValue = useMemo<TiptapContextType>(
     () => ({ editor: resolvedEditor }),


### PR DESCRIPTION
## Changes Overview

Fixes #7529

Although the `Tiptap` component types accept `undefined` as a possible value of the `editor` props, it throws an error when the `editor` props is `undefined`.

Currently, this is like this because there are two fields that allow you to pass the editor: the `editor` field an the deprecated `instance` field. Developers are expected to pass the editor instance through either one field or the other. 

This PR changes the type definition so that either the `editor` field or the deprecated `instance` field are required.

## Implementation Approach

Uses a TypeScript type union to make the types stricter.

The error is no longer thrown at runtime, because it is caught ahead of time by the TypeScript compiler.

## Testing Done

Tests still pass. There is no change in functionality, only the types change.

## AI Usage

No AI assistance used

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

#7529
