### PR TITLE
fix(extension-blockquote): fix backspace getting blocked after merging

### DIFF
--- a/.changeset/serious-books-kneel.md
+++ b/.changeset/serious-books-kneel.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-blockquote': patch
+---
+
+Fix Backspace key getting blocked after merging a paragraph into a blockquote by using the correct TextSelection import and replacing the block boundary atomically.

--- a/.changeset/serious-books-kneel.md
+++ b/.changeset/serious-books-kneel.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-blockquote': patch
 ---
 
-Fix Backspace key getting blocked after merging a paragraph into a blockquote by using the correct TextSelection import and replacing the block boundary atomically.
+Fix Backspace freezing after merging a paragraph into a blockquote by avoiding bundled duplicate ProseMirror classes (via an @tiptap/pm peer dependency) and performing the merge atomically with a single replace step.

--- a/.changeset/serious-books-kneel.md
+++ b/.changeset/serious-books-kneel.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-blockquote': patch
 ---
 
-Fix Backspace freezing after merging a paragraph into a blockquote by avoiding bundled duplicate ProseMirror classes (via an @tiptap/pm peer dependency) and performing the merge atomically with a single replace step.
+Fixed Backspace freezing after merging a paragraph into a blockquote.

--- a/demos/src/Nodes/Blockquote/index.spec.ts
+++ b/demos/src/Nodes/Blockquote/index.spec.ts
@@ -144,6 +144,17 @@ test.describe(`${demoPath}/${demoName}`, () => {
         const html = await editor.evaluate((el: any) => el.editor.getHTML())
         expect(html).toBe('<blockquote><p>AB</p></blockquote>')
       })
+
+      test('backspace after merge: should continue to delete text inside the blockquote', async ({
+        page,
+      }) => {
+        const editor = await getEditor(page)
+        await placeCaretBefore(editor, '<blockquote><p>A</p></blockquote><p>B</p>', 'B')
+        await editor.press('Backspace') // merges B into A -> "AB"
+        await editor.press('Backspace') // deletes 'B' -> "A"
+        const html = await editor.evaluate((el: any) => el.editor.getHTML())
+        expect(html).toBe('<blockquote><p>A</p></blockquote>')
+      })
     })
   })
 })

--- a/packages/extension-blockquote/src/handleBackspace.ts
+++ b/packages/extension-blockquote/src/handleBackspace.ts
@@ -1,5 +1,5 @@
 import type { Editor } from '@tiptap/core'
-import type { NodeType } from '@tiptap/pm/model'
+import { Slice, type NodeType } from '@tiptap/pm/model'
 import { TextSelection } from '@tiptap/pm/state'
 
 /**
@@ -17,7 +17,7 @@ import { TextSelection } from '@tiptap/pm/state'
  * Returns true when the backspace was consumed.
  */
 export const handleBackspace = (editor: Editor, type: NodeType): boolean => {
-  const { state, view } = editor
+  const { state } = editor
   const { selection } = state
   if (!selection.empty) return false
 
@@ -56,9 +56,15 @@ export const handleBackspace = (editor: Editor, type: NodeType): boolean => {
   // child at the end of its inline content.
   const insideBlockquoteEnd = blockStart - 1
   const targetPos = insideBlockquoteEnd - 1
-  const { tr } = state
-  tr.delete(blockStart, $from.after()).insert(targetPos, $from.parent.content)
-  tr.setSelection(TextSelection.create(tr.doc, targetPos))
-  view.dispatch(tr.scrollIntoView())
-  return true
+
+  return editor.commands.command(({ tr, dispatch }) => {
+    const content = $from.parent.content
+    const slice = content.size ? new Slice(content, 0, 0) : Slice.empty
+
+    tr.replace(targetPos, $from.after(), slice)
+    tr.setSelection(TextSelection.create(tr.doc, targetPos))
+    tr.scrollIntoView()
+    if (dispatch) dispatch(tr)
+    return true
+  })
 }

--- a/packages/extension-blockquote/src/handleBackspace.ts
+++ b/packages/extension-blockquote/src/handleBackspace.ts
@@ -66,8 +66,9 @@ export const handleBackspace = (editor: Editor, type: NodeType): boolean => {
     const slice = content.size ? new Slice(content, 0, 0) : Slice.empty
 
     tr.replace(targetPos, $from.after(), slice)
-    tr.setSelection(TextSelection.create(tr.doc, targetPos))
+    tr.setSelection(TextSelection.create(tr.doc, targetPos + content.size))
     tr.scrollIntoView()
+    dispatch(tr)
 
     return true
   })

--- a/packages/extension-blockquote/src/handleBackspace.ts
+++ b/packages/extension-blockquote/src/handleBackspace.ts
@@ -58,13 +58,17 @@ export const handleBackspace = (editor: Editor, type: NodeType): boolean => {
   const targetPos = insideBlockquoteEnd - 1
 
   return editor.commands.command(({ tr, dispatch }) => {
+    if (!dispatch) {
+      return true
+    }
+
     const content = $from.parent.content
     const slice = content.size ? new Slice(content, 0, 0) : Slice.empty
 
     tr.replace(targetPos, $from.after(), slice)
     tr.setSelection(TextSelection.create(tr.doc, targetPos))
     tr.scrollIntoView()
-    if (dispatch) dispatch(tr)
+
     return true
   })
 }

--- a/packages/extension-blockquote/src/handleBackspace.ts
+++ b/packages/extension-blockquote/src/handleBackspace.ts
@@ -63,7 +63,7 @@ export const handleBackspace = (editor: Editor, type: NodeType): boolean => {
     }
 
     const content = $from.parent.content
-    const slice = content.size ? new Slice(content, 0, 0) : Slice.empty
+    const slice = new Slice(content, 0, 0)
 
     tr.replace(targetPos, $from.after(), slice)
     tr.setSelection(TextSelection.create(tr.doc, targetPos + content.size))


### PR DESCRIPTION
## Changes Overview

Fixes a bug where the Backspace key stops working/freezes after merging a paragraph into a blockquote. This was a regression introduced in PR #7891 

## Implementation Approach

This PR resolves the issue in two ways:
1. **Peer Dependency Fix:** Adds `@tiptap/pm` to the `peerDependencies` of `@tiptap/extension-blockquote`. Previously, this package was bundling `prosemirror-state` inline, causing `instanceof TextSelection` checks in `prosemirror-view` to fail due to duplicate runtime classes.
2. **Atomic Merge:** Refactors the merge logic in `handleBackspace.ts` to use a single, atomic `tr.replace()` step inside the standard `editor.commands.command` wrapper, avoiding desyncs and maintaining collaborative editing/history compatibility.

## Testing Done

- Ran `pnpm test:unit` and verified all unit tests pass.

## Verification Steps

1. Create the following editor content:
   hello
   > quote hello
2. Place the cursor at the end of `hello`.
3. Press and hold Backspace until the paragraph is deleted and merged into the blockquote.
4. Try pressing Backspace again, verify that it successfully deletes characters from `quote` instead of freezing.

## Additional Notes

Traced back to selection desyncs in the backspace handler introduced in PR #7891.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
- Used Claude to debug the `prosemirror-view` selection mismatch, refactor the merge logic to use `tr.replace`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7971 
