### PR TITLE
fix(extension-emoji): fix arrow key navigation past emoji nodes in Firefox

### DIFF
--- a/.changeset/2026-06-27-fix-emoji-arrow-key-navigation-firefox.md
+++ b/.changeset/2026-06-27-fix-emoji-arrow-key-navigation-firefox.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-emoji': patch
+---
+
+Fix arrow key navigation past emoji nodes in Firefox. Previously, pressing ArrowLeft with the cursor adjacent to an inline non-selectable emoji node at a paragraph boundary would not move the cursor in Firefox. The cursor now correctly skips over emoji nodes in both directions.

--- a/demos/src/Nodes/Emoji/index.spec.ts
+++ b/demos/src/Nodes/Emoji/index.spec.ts
@@ -27,6 +27,54 @@ test.describe(`${demoPath}/${demoName}`, () => {
         await page.getByRole('button', { name: 'Insert ⚡' }).click()
         await expect(page.locator('.tiptap [data-type="emoji"][data-name="zap"]')).toHaveCount(1)
       })
+
+      test('arrow left navigates past emoji at start of paragraph', async ({ page }) => {
+        // Set content with an emoji at the start followed by text
+        await setEditorContent(
+          page,
+          '<p><span data-type="emoji" data-name="smile">😄</span>hello</p>',
+        )
+        const editor = await getEditor(page)
+
+        // Place cursor right after the emoji (before "hello")
+        await editor.click()
+        await page.keyboard.press('Home')
+        await page.keyboard.press('ArrowRight')
+
+        // Now press ArrowLeft — cursor should move before the emoji (position 0)
+        await page.keyboard.press('ArrowLeft')
+
+        // Type a character to verify cursor is at position 0 (before emoji)
+        await page.keyboard.type('X')
+
+        // The "X" should appear before the emoji
+        const html = await editor.evaluate((el: any) => el.editor.getHTML())
+        expect(html).toMatch(/X.*data-type="emoji"/)
+      })
+
+      test('arrow right navigates past emoji node', async ({ page }) => {
+        // Set content with text followed by an emoji
+        await setEditorContent(
+          page,
+          '<p>hi<span data-type="emoji" data-name="zap">⚡</span>there</p>',
+        )
+        const editor = await getEditor(page)
+
+        // Place cursor at start and move right past "hi" to be just before the emoji
+        await editor.click()
+        await page.keyboard.press('Home')
+        await page.keyboard.press('ArrowRight')
+        await page.keyboard.press('ArrowRight')
+
+        // Now press ArrowRight — cursor should skip over the emoji
+        await page.keyboard.press('ArrowRight')
+
+        // Type a character to verify cursor is after the emoji (before "there")
+        await page.keyboard.type('Y')
+
+        const html = await editor.evaluate((el: any) => el.editor.getHTML())
+        expect(html).toMatch(/data-type="emoji".*Y.*there/)
+      })
     })
   })
 })

--- a/packages/extension-emoji/src/emoji.ts
+++ b/packages/extension-emoji/src/emoji.ts
@@ -4,13 +4,14 @@ import {
   findChildrenInRange,
   getChangedRanges,
   InputRule,
+  isFirefox,
   mergeAttributes,
   Node,
   nodeInputRule,
   PasteRule,
 } from '@tiptap/core'
 import type { Transaction } from '@tiptap/pm/state'
-import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
 import type { SuggestionOptions } from '@tiptap/suggestion'
 import { Suggestion } from '@tiptap/suggestion'
 import emojiRegex from 'emoji-regex'
@@ -385,8 +386,75 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
       new Plugin({
         key: new PluginKey('emoji'),
         props: {
-          // double click to select emoji doesn’t work by default
-          // that’s why we simulate this behavior
+          // Firefox cannot move the cursor past emoji nodes at paragraph
+          // boundaries using arrow keys. We intercept plain (unmodified)
+          // ArrowLeft/ArrowRight and manually resolve the correct position.
+          // Only handles emoji nodes — other inline non-selectable nodes
+          // (mentions, hard breaks) are out of scope for this extension.
+          // See: https://github.com/ProseMirror/prosemirror/issues/1220
+          handleKeyDown: (view, event) => {
+            if (!isFirefox()) {
+              return false
+            }
+
+            const isLeft = event.key === 'ArrowLeft'
+            const isRight = event.key === 'ArrowRight'
+
+            if (!isLeft && !isRight) {
+              return false
+            }
+
+            // Don't interfere with selection extension (Shift), word
+            // navigation (Ctrl/Alt), or OS shortcuts (Meta).
+            if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+              return false
+            }
+
+            const { state } = view
+            const { selection } = state
+
+            if (!selection.empty || !(selection instanceof TextSelection)) {
+              return false
+            }
+
+            const $pos = selection.$from
+            const emojiType = this.type
+
+            if (isLeft) {
+              const nodeBefore = $pos.nodeBefore
+
+              if (!nodeBefore || nodeBefore.type !== emojiType) {
+                return false
+              }
+
+              // Cursor is right after an emoji node. Move past it to the left.
+              const newPos = $pos.pos - nodeBefore.nodeSize
+
+              if (newPos >= $pos.start()) {
+                view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, newPos)))
+                return true
+              }
+            } else {
+              const nodeAfter = $pos.nodeAfter
+
+              if (!nodeAfter || nodeAfter.type !== emojiType) {
+                return false
+              }
+
+              // Cursor is right before an emoji node. Skip over it to the right.
+              const newPos = $pos.pos + nodeAfter.nodeSize
+
+              if (newPos <= $pos.end()) {
+                view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, newPos)))
+                return true
+              }
+            }
+
+            return false
+          },
+
+          // double click to select emoji doesn't work by default
+          // that's why we simulate this behavior
           handleDoubleClickOn: (view, pos, node) => {
             if (node.type !== this.type) {
               return false


### PR DESCRIPTION
## Changes Overview

Fix arrow key navigation past inline non-selectable emoji nodes in Firefox. Added a `handleKeyDown` plugin prop that intercepts ArrowLeft/ArrowRight and manually resolves the correct cursor position when adjacent to an emoji node.

## Implementation Approach

Added a Firefox-only `handleKeyDown` handler to the existing emoji ProseMirror plugin. When the cursor is adjacent to a non-selectable inline node and the user presses an arrow key, the handler computes the correct `TextSelection` and dispatches it manually — bypassing Firefox's broken native cursor movement. Uses the existing `isFirefox()` utility from `@tiptap/core`. Bounds-checked with `$pos.start()` and `$pos.end()` to avoid jumping outside the parent paragraph.

## Testing Done

- Unit tests pass (`pnpm vitest run packages/extension-emoji/__tests__` — 6/6 passing)
- Added 2 e2e tests in `demos/src/Nodes/Emoji/index.spec.ts` for arrow left/right navigation
- Manually verified in Firefox on the emoji demo at `localhost:3000/preview/Nodes/Emoji`
- Chrome behavior unchanged (handler early-returns via `isFirefox()`)

## Verification Steps

1. Run `pnpm dev` and open http://localhost:3000/preview/Nodes/Emoji/React/ in Firefox
2. Insert an emoji at the start of a paragraph (type `:smile:`)
3. Place cursor right after the emoji
4. Press ArrowLeft — cursor should now move to position 0 (before the emoji)
5. Also test with adjacent emojis — arrow keys should navigate between them one at a time

## Additional Notes

This is a known browser-level issue with Firefox's handling of `contenteditable` and inline non-editable elements. ProseMirror acknowledged it in [issue #1220](https://github.com/ProseMirror/prosemirror/issues/1220) as a browser bug they cannot fix at their level. This fix handles it at the Tiptap extension level.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used AI to research the root cause across ProseMirror issues and forums
  - I used AI to assist with implementation of the handleKeyDown fix
  - I used AI to draft the e2e test cases

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7980
