### PR TITLE
fix: Allow custom content DOM element tag in VueNodeViewRenderer

### DIFF
--- a/.changeset/fix-vuenodeview-contentdom-custom-tag.md‎
+++ b/.changeset/fix-vuenodeview-contentdom-custom-tag.md‎
@@ -1,0 +1,6 @@
+---
+'@tiptap/vue-3': patch
+'@tiptap/vue-2': patch
+---
+
+Fix `VueNodeViewRenderer`, using the contentDOMElementTag option. Keep it the same logic with react.

--- a/packages/vue-2/src/VueNodeViewRenderer.ts
+++ b/packages/vue-2/src/VueNodeViewRenderer.ts
@@ -132,7 +132,11 @@ class VueNodeView extends NodeView<Vue | VueConstructor, Editor, VueNodeViewRend
     this.currentPos = this.getPos()
 
     if (!this.node.isLeaf) {
-      this.contentDOMElement = document.createElement(this.node.isInline ? 'span' : 'div')
+      if (this.options.contentDOMElementTag) {
+        this.contentDOMElement = document.createElement(this.options.contentDOMElementTag)
+      } else {
+        this.contentDOMElement = document.createElement(this.node.isInline ? 'span' : 'div')
+      }
       this.contentDOMElement.style.whiteSpace = 'inherit'
       // Use a distinct attribute to avoid clashing with the user's
       // <node-view-content> element (which carries data-node-view-content).

--- a/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
+++ b/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
@@ -7,7 +7,11 @@ import { defineComponent } from 'vue'
 
 import { NodeViewContent } from '../src/NodeViewContent.js'
 import { NodeViewWrapper } from '../src/NodeViewWrapper.js'
-import { nodeViewProps, VueNodeViewRenderer } from '../src/VueNodeViewRenderer.js'
+import {
+  nodeViewProps,
+  VueNodeViewRenderer,
+  type VueNodeViewRendererOptions,
+} from '../src/VueNodeViewRenderer.js'
 import { Editor as VueEditor } from '../src/Editor.js'
 
 const ComponentWithoutContent = defineComponent({
@@ -34,14 +38,17 @@ const LeafComponent = defineComponent({
   components: { NodeViewWrapper },
 })
 
-function createBlockNode(component: ReturnType<typeof defineComponent>) {
+function createBlockNode(
+  component: ReturnType<typeof defineComponent>,
+  options?: Partial<VueNodeViewRendererOptions>,
+) {
   return Node.create({
     name: 'customBlock',
     group: 'block',
     content: 'inline*',
     parseHTML: () => [{ tag: 'custom-block' }],
     renderHTML: ({ HTMLAttributes }) => ['custom-block', mergeAttributes(HTMLAttributes), 0],
-    addNodeView: () => VueNodeViewRenderer(component),
+    addNodeView: () => VueNodeViewRenderer(component, options),
   })
 }
 
@@ -77,6 +84,7 @@ describe('VueNodeViewRenderer contentDOM', () => {
     content: string,
     component: ReturnType<typeof defineComponent>,
     leaf = false,
+    options?: Partial<VueNodeViewRendererOptions>,
   ) {
     editor = createVueEditor({
       element: el!,
@@ -84,7 +92,7 @@ describe('VueNodeViewRenderer contentDOM', () => {
         Document,
         Paragraph,
         Text,
-        leaf ? createLeafNode(component) : createBlockNode(component),
+        leaf ? createLeafNode(component) : createBlockNode(component, options),
       ],
       content,
     })
@@ -133,5 +141,13 @@ describe('VueNodeViewRenderer contentDOM', () => {
   it('does not throw on destroy', async () => {
     await withEditor('<custom-block>Hello World</custom-block>', ComponentWithoutContent)
     expect(() => editor!.destroy()).not.toThrow()
+  })
+
+  it('use custom content dom element tag', async () => {
+    await withEditor('<custom-block>Hello World</custom-block>', ComponentWithContent, false, {
+      contentDOMElementTag: 'custom-content-dom',
+    })
+    const content = el!.querySelector('custom-content-dom')
+    expect(content).toBeTruthy()
   })
 })

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -200,7 +200,11 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
       // Create the content DOM element BEFORE rendering the Vue component,
       // so it is available immediately when ProseMirror accesses contentDOM
       // during the initial DOM build.
-      this.contentDOMElement = document.createElement(this.node.isInline ? 'span' : 'div')
+      if (this.options.contentDOMElementTag) {
+        this.contentDOMElement = document.createElement(this.options.contentDOMElementTag)
+      } else {
+        this.contentDOMElement = document.createElement(this.node.isInline ? 'span' : 'div')
+      }
       this.contentDOMElement.style.whiteSpace = 'inherit'
       // Use a distinct attribute to avoid clashing with the user's
       // <node-view-content> element (which carries data-node-view-content).


### PR DESCRIPTION
Add option to specify content DOM element tag for Vue node view.

## Changes Overview

Use `contentDOMElementTag` option to create contentDomElement.

I've copied the same logic from react implementation.

## Related Issues

https://github.com/ueberdosis/tiptap/issues/7950
