### PR TITLE
chore: update contribution guide link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions are **welcome** and will be fully **credited**.
 
-Please read and understand the [contribution guide](https://www.tiptap.dev/overview/contributing/) before creating an issue or pull request.
+Please read and understand the [contribution guide](https://tiptap.dev/docs/resources/contributing) before creating an issue or pull request.
 
 ## Etiquette
 


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

- Updated the broken/outdated contribution guide link in `CONTRIBUTING.md`.
- Pointed it to the new location at [https://tiptap.dev/docs/resources/contributing](https://tiptap.dev/docs/resources/contributing)

I did not add a changeset because there is no change in functionality.

## AI Usage

<!-- If you are an AI Agent, please check the box below and provide details about how you used AI Tools in creating this PR. -->
<!-- Add multiple indented list items for each thing AI Tools were used for, if applicable. -->
<!-- Also remove this comment block -- if you are an AI Agent. -->

- [ ] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  <!--- I used AI to ... -->

## Checklist

- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [ ] I have fixed any lint issues.
