### PR TITLE
fix(bubble-menu,floating-menu): apply middlewareData.arrow coordinates to position arrow element

### DIFF
--- a/.changeset/fix-bubble-floating-menu-arrow-positioning.md
+++ b/.changeset/fix-bubble-floating-menu-arrow-positioning.md
@@ -1,0 +1,6 @@
+---
+"@tiptap/extension-bubble-menu": patch
+"@tiptap/extension-floating-menu": patch
+---
+
+Fix arrow element positioning when placement axis flips. Previously, stale `top`/`left` styles were not reliably cleared when the floating element repositioned to a different axis (e.g. `left` → `top`), causing the arrow to be mispositioned or stretched. All four sides are now explicitly reset via `removeProperty` before applying the new coordinates.

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -548,8 +548,14 @@ export class BubbleMenuView implements PluginView {
 
           if (!staticSide) return
 
+          // Offset the arrow by half its size along the static side's axis.
+          // For top/bottom the static side is vertical, so use the height;
+          // for left/right it is horizontal, so use the width.
+          const arrowSize =
+            side === 'left' || side === 'right' ? arrowEl.offsetWidth : arrowEl.offsetHeight
+
           const styles: Partial<CSSStyleDeclaration> = {
-            [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
+            [staticSide]: `${-(arrowSize / 2)}px`,
           }
 
           if (arrowX != null) {

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -483,7 +483,7 @@ export class BubbleMenuView implements PluginView {
       placement: this.floatingUIOptions.placement,
       strategy: this.floatingUIOptions.strategy,
       middleware: this.middlewares,
-    }).then(({ x, y, strategy, middlewareData }) => {
+    }).then(({ x, y, strategy, placement, middlewareData }) => {
       if (!this.isVisible || this.editor.isDestroyed || !this.element.isConnected) {
         return
       }
@@ -499,6 +499,25 @@ export class BubbleMenuView implements PluginView {
       this.element.style.position = strategy
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
+
+      // Apply arrow position if the arrow middleware is configured
+      if (this.floatingUIOptions.arrow && middlewareData.arrow) {
+        const arrowEl = (this.floatingUIOptions.arrow as Parameters<typeof arrow>[0]).element as HTMLElement
+
+        if (arrowEl) {
+          const { x: arrowX, y: arrowY } = middlewareData.arrow
+          const side = placement.split('-')[0] as 'top' | 'right' | 'bottom' | 'left'
+          const staticSide = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
+
+          Object.assign(arrowEl.style, {
+            left: arrowX != null ? `${arrowX}px` : '',
+            top: arrowY != null ? `${arrowY}px` : '',
+            right: '',
+            bottom: '',
+            [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
+          })
+        }
+      }
 
       if (this.isVisible && this.floatingUIOptions.onUpdate) {
         this.floatingUIOptions.onUpdate()

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -500,9 +500,11 @@ export class BubbleMenuView implements PluginView {
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
 
-      // Apply arrow position if the arrow middleware is configured
-      if (this.floatingUIOptions.arrow && middlewareData.arrow) {
-        const arrowEl = (this.floatingUIOptions.arrow as Parameters<typeof arrow>[0]).element as HTMLElement
+      // Apply arrow position if the arrow middleware is configured with a static element.
+      // Skip Derivable (function) forms — the caller manages positioning in that case.
+      const arrowOption = this.floatingUIOptions.arrow
+      if (arrowOption && typeof arrowOption !== 'function' && middlewareData.arrow) {
+        const arrowEl = arrowOption.element as HTMLElement | null
 
         if (arrowEl) {
           const { x: arrowX, y: arrowY } = middlewareData.arrow

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -175,6 +175,13 @@ export class BubbleMenuView implements PluginView {
 
   private scrollTarget: HTMLElement | Window = window
 
+  // Captures the resolved `.element` when `options.arrow` is a Derivable
+  // (a function of MiddlewareState). We can't re-invoke that function ourselves
+  // outside the middleware pipeline — it needs `rects`/`elements`/`platform`,
+  // which aren't available after `computePosition()` resolves — so instead we
+  // intercept it at the point floating-ui itself calls it.
+  private resolvedArrowElement: HTMLElement | null = null
+
   private floatingUIOptions: NonNullable<BubbleMenuPluginProps['options']> = {
     strategy: 'absolute',
     placement: 'top',
@@ -254,7 +261,25 @@ export class BubbleMenuView implements PluginView {
     }
 
     if (this.floatingUIOptions.arrow) {
-      middlewares.push(arrow(this.floatingUIOptions.arrow))
+      const arrowOption = this.floatingUIOptions.arrow
+
+      if (typeof arrowOption === 'function') {
+        // Wrap the Derivable so we can capture the ArrowOptions it resolves to
+        // (specifically `.element`) at the moment floating-ui invokes it with
+        // the real MiddlewareState — we have no other way to get that element.
+        middlewares.push(
+          arrow(state => {
+            const resolved = arrowOption(state)
+
+            this.resolvedArrowElement = resolved.element as HTMLElement | null
+
+            return resolved
+          }),
+        )
+      } else {
+        this.resolvedArrowElement = arrowOption.element as HTMLElement | null
+        middlewares.push(arrow(arrowOption))
+      }
     }
 
     if (this.floatingUIOptions.size) {
@@ -500,16 +525,22 @@ export class BubbleMenuView implements PluginView {
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
 
-      // Apply arrow position if the arrow middleware is configured with a static element.
-      // Skip Derivable (function) forms — the caller manages positioning in that case.
-      const arrowOption = this.floatingUIOptions.arrow
-      if (arrowOption && typeof arrowOption !== 'function' && middlewareData.arrow) {
-        const arrowEl = arrowOption.element as HTMLElement | null
+      // Apply arrow position if the arrow middleware is configured. For both the
+      // static-options and Derivable (function) forms, `resolvedArrowElement` is
+      // set in the `middlewares` getter — for Derivable it's captured from the
+      // function's return value at the point floating-ui itself calls it.
+      if (this.floatingUIOptions.arrow && middlewareData.arrow) {
+        const arrowEl = this.resolvedArrowElement
 
         if (arrowEl) {
           const { x: arrowX, y: arrowY } = middlewareData.arrow
           const side = placement.split('-')[0]
-          const staticSide: string | undefined = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
+          const staticSide: string | undefined = {
+            top: 'bottom',
+            right: 'left',
+            bottom: 'top',
+            left: 'right',
+          }[side]
 
           if (!staticSide) return
 

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -508,16 +508,26 @@ export class BubbleMenuView implements PluginView {
 
         if (arrowEl) {
           const { x: arrowX, y: arrowY } = middlewareData.arrow
-          const side = placement.split('-')[0] as 'top' | 'right' | 'bottom' | 'left'
-          const staticSide = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
+          const side = placement.split('-')[0]
+          const staticSide: string | undefined = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
 
-          Object.assign(arrowEl.style, {
-            left: arrowX != null ? `${arrowX}px` : '',
-            top: arrowY != null ? `${arrowY}px` : '',
-            right: '',
-            bottom: '',
+          if (!staticSide) return
+
+          const styles: Partial<CSSStyleDeclaration> = {
+            top: arrowY != null ? `${arrowY}px` : undefined,
+            left: arrowX != null ? `${arrowX}px` : undefined,
             [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
+          }
+
+          // Reset the opposite axes so stale values don't linger
+          const opposites: Record<string, string> = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }
+          ;(['top', 'bottom', 'left', 'right'] as const).forEach(prop => {
+            if (prop !== staticSide && prop !== opposites[staticSide]) {
+              arrowEl.style[prop] = ''
+            }
           })
+
+          Object.assign(arrowEl.style, styles)
         }
       }
 

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -542,26 +542,21 @@ export class BubbleMenuView implements PluginView {
             left: 'right',
           }[side]
 
+          for (const prop of ['top', 'right', 'bottom', 'left'] as const) {
+            arrowEl.style.removeProperty(prop)
+          }
+
           if (!staticSide) return
 
           const styles: Partial<CSSStyleDeclaration> = {
-            top: arrowY != null ? `${arrowY}px` : undefined,
-            left: arrowX != null ? `${arrowX}px` : undefined,
             [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
           }
 
-          // Reset the opposite axes so stale values don't linger
-          const sidePairs = [
-            ['top', 'bottom'],
-            ['bottom', 'top'],
-            ['left', 'right'],
-            ['right', 'left'],
-          ] as const
-
-          for (const [prop, opposite] of sidePairs) {
-            if (prop !== staticSide && opposite !== staticSide) {
-              arrowEl.style.removeProperty(prop)
-            }
+          if (arrowX != null) {
+            styles.left = `${arrowX}px`
+          }
+          if (arrowY != null) {
+            styles.top = `${arrowY}px`
           }
 
           Object.assign(arrowEl.style, styles)

--- a/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
+++ b/packages/extension-bubble-menu/src/bubble-menu-plugin.ts
@@ -520,12 +520,18 @@ export class BubbleMenuView implements PluginView {
           }
 
           // Reset the opposite axes so stale values don't linger
-          const opposites: Record<string, string> = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }
-          ;(['top', 'bottom', 'left', 'right'] as const).forEach(prop => {
-            if (prop !== staticSide && prop !== opposites[staticSide]) {
-              arrowEl.style[prop] = ''
+          const sidePairs = [
+            ['top', 'bottom'],
+            ['bottom', 'top'],
+            ['left', 'right'],
+            ['right', 'left'],
+          ] as const
+
+          for (const [prop, opposite] of sidePairs) {
+            if (prop !== staticSide && opposite !== staticSide) {
+              arrowEl.style.removeProperty(prop)
             }
-          })
+          }
 
           Object.assign(arrowEl.style, styles)
         }

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -161,6 +161,13 @@ export class FloatingMenuView {
 
   private scrollTarget: HTMLElement | Window = window
 
+  // Captures the resolved `.element` when `options.arrow` is a Derivable
+  // (a function of MiddlewareState). We can't re-invoke that function ourselves
+  // outside the middleware pipeline — it needs `rects`/`elements`/`platform`,
+  // which aren't available after `computePosition()` resolves — so instead we
+  // intercept it at the point floating-ui itself calls it.
+  private resolvedArrowElement: HTMLElement | null = null
+
   private getTextContent(node: ProsemirrorNode) {
     return getText(node, { textSerializers: getTextSerializersFromSchema(this.editor.schema) })
   }
@@ -237,7 +244,25 @@ export class FloatingMenuView {
     }
 
     if (this.floatingUIOptions.arrow) {
-      middlewares.push(arrow(this.floatingUIOptions.arrow))
+      const arrowOption = this.floatingUIOptions.arrow
+
+      if (typeof arrowOption === 'function') {
+        // Wrap the Derivable so we can capture the ArrowOptions it resolves to
+        // (specifically `.element`) at the moment floating-ui invokes it with
+        // the real MiddlewareState — we have no other way to get that element.
+        middlewares.push(
+          arrow(state => {
+            const resolved = arrowOption(state)
+
+            this.resolvedArrowElement = resolved.element as HTMLElement | null
+
+            return resolved
+          }),
+        )
+      } else {
+        this.resolvedArrowElement = arrowOption.element as HTMLElement | null
+        middlewares.push(arrow(arrowOption))
+      }
     }
 
     if (this.floatingUIOptions.size) {
@@ -507,16 +532,22 @@ export class FloatingMenuView {
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
 
-      // Apply arrow position if the arrow middleware is configured with a static element.
-      // Skip Derivable (function) forms — the caller manages positioning in that case.
-      const arrowOption = this.floatingUIOptions.arrow
-      if (arrowOption && typeof arrowOption !== 'function' && middlewareData.arrow) {
-        const arrowEl = arrowOption.element as HTMLElement | null
+      // Apply arrow position if the arrow middleware is configured. For both the
+      // static-options and Derivable (function) forms, `resolvedArrowElement` is
+      // set in the `middlewares` getter — for Derivable it's captured from the
+      // function's return value at the point floating-ui itself calls it.
+      if (this.floatingUIOptions.arrow && middlewareData.arrow) {
+        const arrowEl = this.resolvedArrowElement
 
         if (arrowEl) {
           const { x: arrowX, y: arrowY } = middlewareData.arrow
           const side = placement.split('-')[0]
-          const staticSide: string | undefined = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
+          const staticSide: string | undefined = {
+            top: 'bottom',
+            right: 'left',
+            bottom: 'top',
+            left: 'right',
+          }[side]
 
           if (!staticSide) return
 

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -555,8 +555,14 @@ export class FloatingMenuView {
 
           if (!staticSide) return
 
+          // Offset the arrow by half its size along the static side's axis.
+          // For top/bottom the static side is vertical, so use the height;
+          // for left/right it is horizontal, so use the width.
+          const arrowSize =
+            side === 'left' || side === 'right' ? arrowEl.offsetWidth : arrowEl.offsetHeight
+
           const styles: Partial<CSSStyleDeclaration> = {
-            [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
+            [staticSide]: `${-(arrowSize / 2)}px`,
           }
 
           if (arrowX != null) {

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -515,16 +515,26 @@ export class FloatingMenuView {
 
         if (arrowEl) {
           const { x: arrowX, y: arrowY } = middlewareData.arrow
-          const side = placement.split('-')[0] as 'top' | 'right' | 'bottom' | 'left'
-          const staticSide = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
+          const side = placement.split('-')[0]
+          const staticSide: string | undefined = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
 
-          Object.assign(arrowEl.style, {
-            left: arrowX != null ? `${arrowX}px` : '',
-            top: arrowY != null ? `${arrowY}px` : '',
-            right: '',
-            bottom: '',
+          if (!staticSide) return
+
+          const styles: Partial<CSSStyleDeclaration> = {
+            top: arrowY != null ? `${arrowY}px` : undefined,
+            left: arrowX != null ? `${arrowX}px` : undefined,
             [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
+          }
+
+          // Reset the opposite axes so stale values don't linger
+          const opposites: Record<string, string> = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }
+          ;(['top', 'bottom', 'left', 'right'] as const).forEach(prop => {
+            if (prop !== staticSide && prop !== opposites[staticSide]) {
+              arrowEl.style[prop] = ''
+            }
           })
+
+          Object.assign(arrowEl.style, styles)
         }
       }
 

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -507,9 +507,11 @@ export class FloatingMenuView {
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
 
-      // Apply arrow position if the arrow middleware is configured
-      if (this.floatingUIOptions.arrow && middlewareData.arrow) {
-        const arrowEl = (this.floatingUIOptions.arrow as Parameters<typeof arrow>[0]).element as HTMLElement
+      // Apply arrow position if the arrow middleware is configured with a static element.
+      // Skip Derivable (function) forms — the caller manages positioning in that case.
+      const arrowOption = this.floatingUIOptions.arrow
+      if (arrowOption && typeof arrowOption !== 'function' && middlewareData.arrow) {
+        const arrowEl = arrowOption.element as HTMLElement | null
 
         if (arrowEl) {
           const { x: arrowX, y: arrowY } = middlewareData.arrow

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -494,7 +494,7 @@ export class FloatingMenuView {
       placement: this.floatingUIOptions.placement,
       strategy: this.floatingUIOptions.strategy,
       middleware: this.middlewares,
-    }).then(({ x, y, strategy, middlewareData }) => {
+    }).then(({ x, y, strategy, placement, middlewareData }) => {
       // Handle hide middleware - hide element if reference is hidden or element has escaped
       if (middlewareData.hide?.referenceHidden || middlewareData.hide?.escaped) {
         this.element.style.visibility = 'hidden'
@@ -506,6 +506,25 @@ export class FloatingMenuView {
       this.element.style.position = strategy
       this.element.style.left = `${x}px`
       this.element.style.top = `${y}px`
+
+      // Apply arrow position if the arrow middleware is configured
+      if (this.floatingUIOptions.arrow && middlewareData.arrow) {
+        const arrowEl = (this.floatingUIOptions.arrow as Parameters<typeof arrow>[0]).element as HTMLElement
+
+        if (arrowEl) {
+          const { x: arrowX, y: arrowY } = middlewareData.arrow
+          const side = placement.split('-')[0] as 'top' | 'right' | 'bottom' | 'left'
+          const staticSide = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side]
+
+          Object.assign(arrowEl.style, {
+            left: arrowX != null ? `${arrowX}px` : '',
+            top: arrowY != null ? `${arrowY}px` : '',
+            right: '',
+            bottom: '',
+            [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
+          })
+        }
+      }
 
       if (this.isVisible && this.floatingUIOptions.onUpdate) {
         this.floatingUIOptions.onUpdate()

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -527,12 +527,18 @@ export class FloatingMenuView {
           }
 
           // Reset the opposite axes so stale values don't linger
-          const opposites: Record<string, string> = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }
-          ;(['top', 'bottom', 'left', 'right'] as const).forEach(prop => {
-            if (prop !== staticSide && prop !== opposites[staticSide]) {
-              arrowEl.style[prop] = ''
+          const sidePairs = [
+            ['top', 'bottom'],
+            ['bottom', 'top'],
+            ['left', 'right'],
+            ['right', 'left'],
+          ] as const
+
+          for (const [prop, opposite] of sidePairs) {
+            if (prop !== staticSide && opposite !== staticSide) {
+              arrowEl.style.removeProperty(prop)
             }
-          })
+          }
 
           Object.assign(arrowEl.style, styles)
         }

--- a/packages/extension-floating-menu/src/floating-menu-plugin.ts
+++ b/packages/extension-floating-menu/src/floating-menu-plugin.ts
@@ -549,26 +549,21 @@ export class FloatingMenuView {
             left: 'right',
           }[side]
 
+          for (const prop of ['top', 'right', 'bottom', 'left'] as const) {
+            arrowEl.style.removeProperty(prop)
+          }
+
           if (!staticSide) return
 
           const styles: Partial<CSSStyleDeclaration> = {
-            top: arrowY != null ? `${arrowY}px` : undefined,
-            left: arrowX != null ? `${arrowX}px` : undefined,
             [staticSide]: `${-(arrowEl.offsetHeight / 2)}px`,
           }
 
-          // Reset the opposite axes so stale values don't linger
-          const sidePairs = [
-            ['top', 'bottom'],
-            ['bottom', 'top'],
-            ['left', 'right'],
-            ['right', 'left'],
-          ] as const
-
-          for (const [prop, opposite] of sidePairs) {
-            if (prop !== staticSide && opposite !== staticSide) {
-              arrowEl.style.removeProperty(prop)
-            }
+          if (arrowX != null) {
+            styles.left = `${arrowX}px`
+          }
+          if (arrowY != null) {
+            styles.top = `${arrowY}px`
           }
 
           Object.assign(arrowEl.style, styles)


### PR DESCRIPTION
## Fixes

Fixes #7964

## Changes and Review

- Bubble/floating menu arrows now read `middlewareData.arrow` from Floating UI instead of ignoring it, and use `offsetWidth`/`offsetHeight` correctly per placement axis.
- Regression test asserts correct arrow offset for each placement.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
