### PR TITLE
fix(core): re-check canSplit after deleteSelection to prevent cross-boundary crash

### DIFF
--- a/packages/core/__tests__/splitBlock.spec.ts
+++ b/packages/core/__tests__/splitBlock.spec.ts
@@ -1,0 +1,61 @@
+import { Editor } from '@tiptap/core'
+import BulletList from '@tiptap/extension-bullet-list'
+import Document from '@tiptap/extension-document'
+import ListItem from '@tiptap/extension-list-item'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+describe('splitBlock', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('does not throw when splitting across list item boundaries (cross-boundary selection)', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, BulletList, ListItem],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'first item' }] }],
+              },
+              {
+                type: 'listItem',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'second item' }] }],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    // Select from inside first list item to inside second list item (cross-boundary)
+    const { doc } = editor.state
+    const firstTextPos = 3 // inside "first item"
+    const secondTextPos = doc.content.size - 4 // inside "second item"
+
+    editor.commands.setTextSelection({ from: firstTextPos, to: secondTextPos })
+
+    // This should not throw "TransformError: Inserted content deeper than insertion position"
+    expect(() => editor.commands.splitBlock()).not.toThrow()
+  })
+
+  it('splits a normal paragraph without error', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>hello world</p>',
+    })
+
+    editor.commands.setTextSelection(5)
+
+    expect(() => editor.commands.splitBlock()).not.toThrow()
+    expect(editor.state.doc.childCount).toBe(2)
+  })
+})

--- a/packages/core/src/commands/splitBlock.ts
+++ b/packages/core/src/commands/splitBlock.ts
@@ -99,12 +99,27 @@ export const splitBlock: RawCommands['splitBlock'] =
     }
 
     if (dispatch) {
-      if (can) {
-        if (selection instanceof TextSelection) {
-          tr.deleteSelection()
-        }
+      if (selection instanceof TextSelection) {
+        tr.deleteSelection()
+      }
 
-        tr.split(tr.mapping.map($from.pos), 1, types)
+      // Re-check canSplit after deletion: deleteSelection may merge or remove nodes,
+      // making the pre-deletion position invalid for split. This restores the v2.5.0
+      // ordering where both checks operated on the same document state.
+      const mappedPos = tr.mapping.map($from.pos)
+      let canAfterDelete = canSplit(tr.doc, mappedPos, 1, types)
+
+      if (
+        !types &&
+        !canAfterDelete &&
+        canSplit(tr.doc, mappedPos, 1, deflt ? [{ type: deflt }] : undefined)
+      ) {
+        canAfterDelete = true
+        types = deflt ? [{ type: deflt, attrs: newAttributes }] : undefined
+      }
+
+      if (canAfterDelete) {
+        tr.split(mappedPos, 1, types)
 
         if (deflt && !atEnd && !$from.parentOffset && $from.parent.type !== deflt) {
           const first = tr.mapping.map($from.before())


### PR DESCRIPTION
## Fixes

Fixes #7734

## Changes and Review

- `splitBlock` re-checks `canSplit` after `deleteSelection` mutates the document — the original check ran against now-stale positions, letting an invalid split through on cross-boundary selections.
- Added a regression test reproducing the crash; it fails with the fix reverted.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
