### PR TITLE
Fix drag handle positioning with zero-size widget decorations

### DIFF
--- a/.changeset/fix-drag-handle-zero-size-widget-decorations.md
+++ b/.changeset/fix-drag-handle-zero-size-widget-decorations.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-drag-handle": patch
+---
+
+Fix the drag handle when the editor renders zero-size widget decorations, such as the page chrome injected by the Pages extension. The handle now resolves to the correct block instead of failing to position or aligning to a decoration, and it stays above positioned page chrome so it remains clickable.

--- a/packages/extension-drag-handle/__tests__/drag-handle.spec.ts
+++ b/packages/extension-drag-handle/__tests__/drag-handle.spec.ts
@@ -102,5 +102,16 @@ describe('DragHandle', () => {
     it('should have pointer events set to auto initially', () => {
       expect(dragHandleElement.style.pointerEvents).toBe('auto')
     })
+
+    it('should render the handle wrapper above editor decorations via a z-index', () => {
+      // The wrapper competes in the stacking context with positioned editor
+      // content and decorations (for example the Pages page header/footer chrome
+      // at z-index 2). Without a z-index the handle is painted behind that chrome
+      // and becomes impossible to click, so the wrapper must assert its own.
+      const wrapper = dragHandleElement.parentElement
+
+      expect(wrapper).not.toBeNull()
+      expect(wrapper?.style.zIndex).toBe('10')
+    })
   })
 })

--- a/packages/extension-drag-handle/__tests__/findNextElementFromCursor.spec.ts
+++ b/packages/extension-drag-handle/__tests__/findNextElementFromCursor.spec.ts
@@ -1,0 +1,138 @@
+import type { EditorView } from '@tiptap/pm/view'
+import { describe, expect, it } from 'vitest'
+
+import {
+  edgeBlockRect,
+  findClosestTopLevelBlock,
+} from '../src/helpers/findNextElementFromCursor.js'
+
+/**
+ * Builds a DOMRect-like object for tests, since jsdom does not run layout and
+ * returns an all-zero rect for every element by default.
+ */
+function rect({
+  width,
+  height,
+  top = 0,
+  left = 0,
+}: {
+  width: number
+  height: number
+  top?: number
+  left?: number
+}): DOMRect {
+  return {
+    width,
+    height,
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+/** Overrides an element's getBoundingClientRect with a fixed rect. */
+function withRect(el: HTMLElement, r: DOMRect): HTMLElement {
+  el.getBoundingClientRect = () => r
+  return el
+}
+
+describe('edgeBlockRect', () => {
+  it('returns the first child that has a real layout box, skipping zero-size widgets', () => {
+    // Mirrors the Pages layout: the first child is a zero-height page-chrome
+    // widget, followed by real content blocks.
+    const container = document.createElement('div')
+    const widget = withRect(document.createElement('div'), rect({ width: 640, height: 0 }))
+    const firstBlock = withRect(
+      document.createElement('p'),
+      rect({ width: 640, height: 24, top: 100 }),
+    )
+    const lastBlock = withRect(
+      document.createElement('p'),
+      rect({ width: 640, height: 24, top: 200 }),
+    )
+    container.append(widget, firstBlock, lastBlock)
+
+    const result = edgeBlockRect(container, 'first')
+
+    expect(result).not.toBeNull()
+    expect(result?.top).toBe(100)
+    expect(result?.height).toBe(24)
+  })
+
+  it('returns the last child that has a real layout box, skipping trailing zero-size widgets', () => {
+    const container = document.createElement('div')
+    const firstBlock = withRect(
+      document.createElement('p'),
+      rect({ width: 640, height: 24, top: 100 }),
+    )
+    const lastBlock = withRect(
+      document.createElement('p'),
+      rect({ width: 640, height: 24, top: 200 }),
+    )
+    const trailingWidget = withRect(
+      document.createElement('div'),
+      rect({ width: 640, height: 0, top: 300 }),
+    )
+    container.append(firstBlock, lastBlock, trailingWidget)
+
+    const result = edgeBlockRect(container, 'last')
+
+    expect(result?.top).toBe(200)
+  })
+
+  it('returns null when no child has a valid box', () => {
+    const container = document.createElement('div')
+    container.append(withRect(document.createElement('div'), rect({ width: 0, height: 0 })))
+
+    expect(edgeBlockRect(container, 'first')).toBeNull()
+  })
+})
+
+describe('findClosestTopLevelBlock', () => {
+  /**
+   * Tags a DOM element with a fake ProseMirror view description. Document nodes
+   * expose a `node`; widget decorations do not.
+   */
+  function tagViewDesc(el: HTMLElement, node: unknown): HTMLElement {
+    ;(el as unknown as { pmViewDesc: { node?: unknown } }).pmViewDesc = { node }
+    return el
+  }
+
+  function makeView(dom: HTMLElement): EditorView {
+    return { dom } as unknown as EditorView
+  }
+
+  it('returns the top-level content block for an element inside it', () => {
+    const editorDom = document.createElement('div')
+    const block = tagViewDesc(document.createElement('p'), { type: { name: 'paragraph' } })
+    const text = document.createElement('span')
+    block.appendChild(text)
+    editorDom.appendChild(block)
+
+    expect(findClosestTopLevelBlock(text, makeView(editorDom))).toBe(block)
+  })
+
+  it('skips widget decorations that have no associated document node', () => {
+    // The Pages page-chrome overlay is a widget decoration: a direct child of
+    // the editor with a view description but no document node. Resolving a hover
+    // to it would align the drag handle to the page header instead of the block.
+    const editorDom = document.createElement('div')
+    const widget = tagViewDesc(document.createElement('div'), undefined)
+    const inner = document.createElement('div')
+    widget.appendChild(inner)
+    editorDom.appendChild(widget)
+
+    expect(findClosestTopLevelBlock(inner, makeView(editorDom))).toBeUndefined()
+  })
+
+  it('returns undefined when the element is not inside the editor', () => {
+    const editorDom = document.createElement('div')
+    const orphan = document.createElement('p')
+
+    expect(findClosestTopLevelBlock(orphan, makeView(editorDom))).toBeUndefined()
+  })
+})

--- a/packages/extension-drag-handle/src/drag-handle-plugin.ts
+++ b/packages/extension-drag-handle/src/drag-handle-plugin.ts
@@ -343,6 +343,9 @@ export const DragHandlePlugin = ({
         wrapper.style.position = 'absolute'
         wrapper.style.top = '0'
         wrapper.style.left = '0'
+        // Keep the handle above positioned editor content/decorations (e.g. the
+        // Pages page header/footer chrome) so it stays visible and clickable.
+        wrapper.style.zIndex = '10'
 
         element.addEventListener('dragstart', onDragStart)
         element.addEventListener('dragend', onDragEnd)

--- a/packages/extension-drag-handle/src/helpers/findNextElementFromCursor.ts
+++ b/packages/extension-drag-handle/src/helpers/findNextElementFromCursor.ts
@@ -14,7 +14,22 @@ export type FindElementNextToCoords = {
 }
 
 /**
- * Finds the draggable block element that is a direct child of view.dom
+ * ProseMirror attaches a `pmViewDesc` to every DOM node it manages. Element view
+ * descriptions for document nodes expose a `node`; widget decorations (such as
+ * the Pages page-chrome overlay, which renders as a zero-height first child of
+ * the editor) have a view description but no associated document node.
+ */
+interface ElementWithViewDesc extends Element {
+  pmViewDesc?: { node?: unknown }
+}
+
+/**
+ * Finds the draggable block element that is a direct child of view.dom.
+ *
+ * Direct children that are widget decorations rather than document content are
+ * skipped — they are not draggable blocks, and treating them as such would
+ * align the drag handle to the decoration (e.g. the page header) instead of the
+ * actual first block on the page.
  */
 export function findClosestTopLevelBlock(
   element: Element,
@@ -26,7 +41,16 @@ export function findClosestTopLevelBlock(
     current = current.parentElement
   }
 
-  return current?.parentElement === view.dom ? (current as HTMLElement) : undefined
+  if (current?.parentElement !== view.dom) {
+    return undefined
+  }
+
+  // Skip widget decorations (no associated document node).
+  if (!(current as ElementWithViewDesc).pmViewDesc?.node) {
+    return undefined
+  }
+
+  return current as HTMLElement
 }
 
 /**
@@ -44,6 +68,33 @@ function isValidRect(rect: DOMRect): boolean {
 }
 
 /**
+ * Returns the bounding rect of the first or last child of `container` that has
+ * a valid (non-zero) layout box.
+ *
+ * Some extensions insert zero-size widget decorations as the first/last child
+ * of the editor — for example the Pages extension anchors its page-chrome
+ * overlay in a zero-height `<div>` as the first child. Reading `firstElementChild`
+ * / `lastElementChild` directly would yield an invalid rect and abort clamping,
+ * so we skip over any edge children without a valid box.
+ */
+export function edgeBlockRect(container: Element, edge: 'first' | 'last'): DOMRect | null {
+  let current: Element | null =
+    edge === 'first' ? container.firstElementChild : container.lastElementChild
+
+  while (current) {
+    const rect = current.getBoundingClientRect()
+
+    if (isValidRect(rect)) {
+      return rect
+    }
+
+    current = edge === 'first' ? current.nextElementSibling : current.previousElementSibling
+  }
+
+  return null
+}
+
+/**
  * Clamps coordinates to content bounds with O(1) layout reads
  */
 function clampToContent(
@@ -58,19 +109,12 @@ function clampToContent(
   }
 
   const container = view.dom
-  const firstBlock = container.firstElementChild
-  const lastBlock = container.lastElementChild
 
-  if (!firstBlock || !lastBlock) {
-    return null
-  }
+  // Clamp Y between the first and last children that actually have a layout box.
+  const topRect = edgeBlockRect(container, 'first')
+  const botRect = edgeBlockRect(container, 'last')
 
-  // Clamp Y between first and last block
-  const topRect = firstBlock.getBoundingClientRect()
-  const botRect = lastBlock.getBoundingClientRect()
-
-  // Validate bounding rects have finite values
-  if (!isValidRect(topRect) || !isValidRect(botRect)) {
+  if (!topRect || !botRect) {
     return null
   }
 


### PR DESCRIPTION
## Why this is needed

The drag handle does not work when the editor renders zero-size widget decorations as the first or last child of the editor. The clearest real world case is the Pages extension, which anchors its page chrome (the page break, header and footer overlay) in a zero-height `div` as the first child of the editor. With Pages active, the drag handle either never appears or, for the first block of every page, shows up far above the actual block and behind the page header where it cannot be clicked. This was reported by a customer using Pages together with the drag handle (Linear TT-304).

This is not strictly a Pages problem. Any extension that injects a zero-size widget decoration at the edge of the document, or any decoration that sits in front of content, runs into the same behavior. The fix lives in the drag handle so every integration benefits.

## What was happening (root cause)

There were three separate issues, all in `@tiptap/extension-drag-handle`.

1. **Block detection bailed out completely.** `clampToContent` in `findNextElementFromCursor.ts` reads `view.dom.firstElementChild` and `view.dom.lastElementChild` and rejects them through `isValidRect` when their box has zero width or height. With Pages, the first child is the zero-height page-chrome widget, so `clampToContent` returned `null`, `findElementNextToCoords` returned no element, and the handle never positioned. It stayed at its initial `0, 0` corner position (or stayed hidden, depending on how the handle element is created).

2. **The first block resolved to the page chrome.** When detection did run near the top of a page, `findClosestTopLevelBlock` walked up to the nearest direct child of `view.dom` and returned it without checking what it was. That direct child was the zero-height widget decoration, so the handle aligned to the decoration (the page header at the top of the page) instead of the first real block below it. This is the "drag handle positioned far above the actual block for the first block of each page" symptom from the report.

3. **The handle was painted behind the page chrome.** The handle wrapper is appended next to the editor with `position: absolute` but no `z-index`. The Pages page break container uses `z-index: 2`, so it painted over the handle and the handle buttons were not clickable, even once positioned correctly.

## The fix

All changes are framework agnostic and contained to the drag handle.

1. **Skip zero-size edge children when clamping.** A new `edgeBlockRect(container, edge)` helper walks inward from the first or last child until it finds one with a valid layout box, and `clampToContent` uses it instead of reading `firstElementChild` / `lastElementChild` directly. Detection now runs normally even when the document starts or ends with a zero-size widget.

2. **Skip widget decorations when resolving the target block.** ProseMirror attaches a `pmViewDesc` to every DOM node it manages. Element view descriptions for document nodes expose a `node`; widget decorations do not. `findClosestTopLevelBlock` now returns `undefined` for a top-level child without an associated document node, so detection falls through to the actual content block instead of the decoration.

3. **Keep the handle above page chrome.** The handle wrapper now sets `z-index: 10`, so it renders above positioned content and decorations (the Pages chrome at `z-index: 2`) and stays clickable. This sits comfortably below overlay editors such as the Pages header and footer editors, which use `z-index: 1000` and above.

## Tests

New and updated unit tests in `packages/extension-drag-handle/__tests__`.

`findNextElementFromCursor.spec.ts` (new):
- `edgeBlockRect` returns the first child with a real layout box and skips a leading zero-height widget.
- `edgeBlockRect` returns the last child with a real layout box and skips a trailing zero-height widget.
- `edgeBlockRect` returns `null` when no child has a valid box.
- `findClosestTopLevelBlock` returns the top-level content block for an element inside it.
- `findClosestTopLevelBlock` skips widget decorations that have no associated document node.
- `findClosestTopLevelBlock` returns `undefined` when the element is not inside the editor.

Because jsdom does not run layout and returns an all-zero rect for every element, the rect-dependent tests override `getBoundingClientRect` per element with fixed values. Each test fails against the previous code and passes with the fix.

`drag-handle.spec.ts` (updated):
- Asserts the handle wrapper receives a `z-index` so it renders above editor decorations.

Full package suite: 138 tests passing across 11 files.

## How it was verified

Beyond the unit tests, the fix was checked end to end in a Pages editor with the drag handle enabled and a multi-page document. Before the fix, the handle stayed at the top-left corner and never aligned to a block. After the fix, hovering any block (including the first block under each page header) positions the handle in the left gutter aligned to that block, and `document.elementFromPoint` at the handle returns the handle rather than the page header, confirming it is no longer occluded.
