### PR TITLE
fix(static-renderer): respect unhandledNode/unhandledMark for unknown types

### DIFF
--- a/.changeset/slimy-onions-beam.md
+++ b/.changeset/slimy-onions-beam.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/static-renderer': patch
+---
+
+Fix the static renderer ignoring `unhandledNode` and `unhandledMark` for node or mark types missing from the schema; such content now falls back to those renderers instead of throwing in `Node.fromJSON`

--- a/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
+++ b/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
@@ -4,7 +4,9 @@ import Document from '@tiptap/extension-document'
 import Heading from '@tiptap/extension-heading'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
+import StarterKit from '@tiptap/starter-kit'
 import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
+import { renderToMarkdown } from '@tiptap/static-renderer/pm/markdown'
 import { renderToReactElement } from '@tiptap/static-renderer/pm/react'
 import React from 'react'
 import { describe, expect, it } from 'vitest'
@@ -114,5 +116,119 @@ describe('static renderer: unhandledNode / unhandledMark for unknown schema type
     })
 
     expect(html).toBe('<h1>x</h1>')
+  })
+})
+
+describe('static renderer: unknown types preserve known nodes (sentinel substitution)', () => {
+  it('hands the original type and attributes to unhandledNode', () => {
+    let seenType: string | undefined
+    let seenVariant: unknown
+
+    render(
+      renderToReactElement({
+        content: docWithUnknownNode,
+        extensions,
+        options: {
+          unhandledNode: ({ node }) => {
+            seenType = node.type.name
+            seenVariant = node.attrs.variant
+            return React.createElement('div')
+          },
+        },
+      }),
+    )
+
+    expect(seenType).toBe('calloutBox')
+    expect(seenVariant).toBe('info')
+  })
+
+  it('hands the original type to unhandledMark', () => {
+    let seenType: string | undefined
+
+    render(
+      renderToReactElement({
+        content: docWithUnknownMark,
+        extensions,
+        options: {
+          unhandledMark: ({ mark, children }) => {
+            seenType = mark.type.name
+            return React.createElement('mark', {}, children)
+          },
+        },
+      }),
+    )
+
+    expect(seenType).toBe('colorMark')
+  })
+
+  it('renders known nodes with their schema attribute defaults alongside an unknown node', () => {
+    // The heading carries no explicit `level`; it must still resolve to its
+    // default (<h1>) rather than losing the attribute and crashing.
+    const view = render(
+      renderToReactElement({
+        content: {
+          type: 'doc',
+          content: [
+            { type: 'heading', content: [{ type: 'text', text: 'title' }] },
+            { type: 'calloutBox', content: [{ type: 'text', text: 'x' }] },
+          ],
+        },
+        extensions,
+        options: { unhandledNode: () => React.createElement('aside') },
+      }),
+    )
+
+    expect(view.container.querySelector('h1')?.textContent).toBe('title')
+    expect(view.container.querySelector('aside')).not.toBeNull()
+  })
+
+  it('keeps markdown output correct for known nodes when an unknown node is present', () => {
+    const markdown = renderToMarkdown({
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'a' }] }],
+              },
+              {
+                type: 'listItem',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'b' }] }],
+              },
+            ],
+          },
+          { type: 'calloutBox', content: [{ type: 'text', text: 'note' }] },
+        ],
+      },
+      extensions: [StarterKit],
+      options: { unhandledNode: ({ children }) => `\n[callout]${children}\n` },
+    })
+
+    expect(markdown).toContain('- a')
+    expect(markdown).toContain('- b')
+    expect(markdown).toContain('[callout]')
+  })
+
+  it('still throws a structural error when an unknown-with-fallback type is also present', () => {
+    // A genuinely malformed known node (text without `text`) must not be masked
+    // just because the document also contains a handled unknown node.
+    expect(() =>
+      render(
+        renderToReactElement({
+          content: {
+            type: 'doc',
+            content: [
+              { type: 'paragraph', content: [{ type: 'text' }] },
+              { type: 'calloutBox', content: [{ type: 'text', text: 'x' }] },
+            ],
+          },
+          extensions,
+          options: { unhandledNode: () => React.createElement('div') },
+        }),
+      ),
+    ).toThrow(/Invalid text node in JSON/)
   })
 })

--- a/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
+++ b/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
@@ -1,0 +1,118 @@
+import { render } from '@testing-library/react'
+import Bold from '@tiptap/extension-bold'
+import Document from '@tiptap/extension-document'
+import Heading from '@tiptap/extension-heading'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
+import { renderToReactElement } from '@tiptap/static-renderer/pm/react'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+const extensions = [Document, Paragraph, Text, Bold, Heading]
+
+// `calloutBox` is not in the schema above.
+const docWithUnknownNode = {
+  type: 'doc',
+  content: [
+    { type: 'calloutBox', attrs: { variant: 'info' }, content: [{ type: 'text', text: 'hi' }] },
+  ],
+}
+
+// `colorMark` is not in the schema above.
+const docWithUnknownMark = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'hi', marks: [{ type: 'colorMark', attrs: {} }] }],
+    },
+  ],
+}
+
+describe('static renderer: unhandledNode / unhandledMark for unknown schema types', () => {
+  it('react: routes an unknown node to unhandledNode instead of throwing', () => {
+    const view = render(
+      renderToReactElement({
+        content: docWithUnknownNode,
+        extensions,
+        options: {
+          unhandledNode: () => React.createElement('div', { 'data-unhandled-node': 'true' }),
+        },
+      }),
+    )
+
+    expect(view.container.querySelector('[data-unhandled-node]')).not.toBeNull()
+  })
+
+  it('react: routes an unknown mark to unhandledMark instead of throwing', () => {
+    const view = render(
+      renderToReactElement({
+        content: docWithUnknownMark,
+        extensions,
+        options: {
+          unhandledMark: ({ children }) => React.createElement('mark', {}, children),
+        },
+      }),
+    )
+
+    expect(view.container.querySelector('mark')?.textContent).toBe('hi')
+  })
+
+  it('react: still throws for an unknown node when no fallback is provided', () => {
+    expect(() => renderToReactElement({ content: docWithUnknownNode, extensions })).toThrow(
+      /Unknown node type: calloutBox/,
+    )
+  })
+
+  it('react: re-throws the original error when the unknown node has no matching fallback', () => {
+    // Only `unhandledMark` is provided, but the unknown type is a node — the
+    // clear "Unknown node type" error must still surface instead of falling back.
+    expect(() =>
+      renderToReactElement({
+        content: docWithUnknownNode,
+        extensions,
+        options: { unhandledMark: ({ children }) => React.createElement('mark', {}, children) },
+      }),
+    ).toThrow(/Unknown node type: calloutBox/)
+  })
+
+  it('does not mask non-unknown-type schema errors even when a fallback is set', () => {
+    const malformed = {
+      type: 'doc',
+      // text node without a `text` string — all types are known, so this is a
+      // structural error, not an unknown-type one. It must still throw.
+      content: [{ type: 'paragraph', content: [{ type: 'text' }] }],
+    }
+
+    expect(() =>
+      renderToReactElement({
+        content: malformed,
+        extensions,
+        options: { unhandledNode: () => React.createElement('div') },
+      }),
+    ).toThrow(/Invalid text node in JSON/)
+  })
+
+  it('html-string: routes an unknown node to unhandledNode instead of throwing', () => {
+    const html = renderToHTMLString({
+      content: docWithUnknownNode,
+      extensions,
+      options: { unhandledNode: () => '<div data-unhandled-node></div>' },
+    })
+
+    expect(html).toContain('data-unhandled-node')
+  })
+
+  it('preserves the happy path for fully-known content', () => {
+    const html = renderToHTMLString({
+      content: {
+        type: 'doc',
+        content: [{ type: 'heading', content: [{ type: 'text', text: 'x' }] }],
+      },
+      extensions,
+    })
+
+    expect(html).toBe('<h1>x</h1>')
+  })
+})

--- a/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
+++ b/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import type { JSONContent } from '@tiptap/core'
 import Bold from '@tiptap/extension-bold'
 import Document from '@tiptap/extension-document'
 import Heading from '@tiptap/extension-heading'
@@ -230,5 +231,47 @@ describe('static renderer: unknown types preserve known nodes (sentinel substitu
         }),
       ),
     ).toThrow(/Invalid text node in JSON/)
+  })
+
+  it('restores the original JSON when a fallback calls node.toJSON()', () => {
+    let dumped: JSONContent | undefined
+
+    render(
+      renderToReactElement({
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'calloutBox',
+              attrs: { variant: 'info' },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'deep', marks: [{ type: 'colorMark', attrs: { c: 1 } }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        extensions,
+        options: {
+          unhandledNode: ({ node }) => {
+            dumped = node.toJSON()
+            return React.createElement('div')
+          },
+          unhandledMark: ({ children }) => React.createElement('mark', {}, children),
+        },
+      }),
+    )
+
+    // The unknown node serializes back to its original type/attrs, with no
+    // placeholder leakage — including a nested unknown mark deeper in the tree.
+    expect(dumped?.type).toBe('calloutBox')
+    expect(dumped?.attrs).toEqual({ variant: 'info' })
+    const text = dumped?.content?.[0]?.content?.[0]
+    expect(text?.text).toBe('deep')
+    expect(text?.marks?.[0]).toEqual({ type: 'colorMark', attrs: { c: 1 } })
   })
 })

--- a/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
+++ b/packages/static-renderer/__tests__/pm-unhandled-types.spec.ts
@@ -213,6 +213,32 @@ describe('static renderer: unknown types preserve known nodes (sentinel substitu
     expect(markdown).toContain('[callout]')
   })
 
+  it('routes an unknown mark to unhandledMark in markdown output', () => {
+    let seenMark: string | undefined
+
+    const markdown = renderToMarkdown({
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'hi', marks: [{ type: 'colorMark', attrs: {} }] }],
+          },
+        ],
+      },
+      extensions: [StarterKit],
+      options: {
+        unhandledMark: ({ mark, children }) => {
+          seenMark = mark.type.name
+          return `[[${children}]]`
+        },
+      },
+    })
+
+    expect(markdown).toContain('[[hi]]')
+    expect(seenMark).toBe('colorMark')
+  })
+
   it('still throws a structural error when an unknown-with-fallback type is also present', () => {
     // A genuinely malformed known node (text without `text`) must not be masked
     // just because the document also contains a handled unknown node.

--- a/packages/static-renderer/src/json/renderer.ts
+++ b/packages/static-renderer/src/json/renderer.ts
@@ -121,11 +121,23 @@ export type TiptapStaticRendererOptions<
    */
   markMapping: Record<string, NoInfer<TMarkRender>>
   /**
-   * Component to render if a node type is not handled
+   * Component to render if a node type is not handled.
+   *
+   * With the ProseMirror renderers, a type missing from the schema is passed here
+   * as a lightweight stand-in: `node.type` is only `{ name }` (no real `NodeType`
+   * exists for a type absent from the schema), while `node.attrs` and
+   * `node.toJSON()` reflect the original. Do not rely on `type.spec`,
+   * `type.schema`, `isInline`, etc.
    */
   unhandledNode?: NoInfer<TNodeRender>
   /**
-   * Component to render if a mark type is not handled
+   * Component to render if a mark type is not handled.
+   *
+   * With the ProseMirror renderers, a type missing from the schema is passed here
+   * as a lightweight stand-in: `mark.type` is only `{ name }` (no real `MarkType`
+   * exists for a type absent from the schema), while `mark.attrs` and
+   * `mark.toJSON()` reflect the original. Do not rely on `type.spec`,
+   * `type.schema`, etc.
    */
   unhandledMark?: NoInfer<TMarkRender>
 }

--- a/packages/static-renderer/src/pm/extensionRenderer.ts
+++ b/packages/static-renderer/src/pm/extensionRenderer.ts
@@ -18,7 +18,7 @@ import {
   resolveExtensions,
   splitExtensions,
 } from '@tiptap/core'
-import type { DOMOutputSpec, Mark } from '@tiptap/pm/model'
+import type { DOMOutputSpec, Mark, Schema } from '@tiptap/pm/model'
 import { Node } from '@tiptap/pm/model'
 
 import { getHTMLAttributes } from '../helpers.js'
@@ -183,6 +183,75 @@ export function mapMarkExtensionToReactNode<T>(
 }
 
 /**
+ * Walks `content` and reports whether it can be rendered through the unknown-type
+ * fallbacks: returns true only when it contains at least one node/mark type absent
+ * from `schema` AND every such kind has its matching `unhandledNode` /
+ * `unhandledMark` fallback. Returns false when there are no unknown types, or when
+ * an unknown type has no matching fallback. Pure; does no I/O.
+ */
+function unknownTypesAllHaveFallback(
+  content: JSONContent,
+  schema: Schema,
+  options?: { unhandledNode?: unknown; unhandledMark?: unknown },
+): boolean {
+  const hasNodeFallback = Boolean(options?.unhandledNode)
+  const hasMarkFallback = Boolean(options?.unhandledMark)
+  let sawUnknownType = false
+  let unhandled = false
+
+  const visit = (node: JSONContent): void => {
+    if (node.type && !(node.type in schema.nodes)) {
+      sawUnknownType = true
+      if (!hasNodeFallback) {
+        unhandled = true
+      }
+    }
+    node.marks?.forEach(mark => {
+      if (mark.type && !(mark.type in schema.marks)) {
+        sawUnknownType = true
+        if (!hasMarkFallback) {
+          unhandled = true
+        }
+      }
+    })
+    node.content?.forEach(visit)
+  }
+
+  visit(content)
+
+  return sawUnknownType && !unhandled
+}
+
+/**
+ * Resolves render input to a ProseMirror `Node`. A `Node` is returned as-is; JSON
+ * is converted via `Node.fromJSON`. If that conversion fails only because the
+ * document contains unknown types the caller has fallbacks for, the original JSON
+ * is returned unchanged so the renderer can route them to the fallbacks. Any other
+ * failure is re-thrown unchanged.
+ */
+function resolveRenderContent(
+  content: Node | JSONContent,
+  extensions: Extensions,
+  options?: { unhandledNode?: unknown; unhandledMark?: unknown },
+): Node | JSONContent {
+  if (content instanceof Node) {
+    return content
+  }
+
+  const schema = getSchemaByResolvedExtensions(extensions)
+
+  try {
+    return Node.fromJSON(schema, content)
+  } catch (error) {
+    if (unknownTypesAllHaveFallback(content, schema, options)) {
+      return content
+    }
+
+    throw error
+  }
+}
+
+/**
  * This function will statically render a Prosemirror Node to a target element type using the given extensions
  * @param renderer The renderer to use to render the Prosemirror Node to the target element type
  * @param domOutputSpecToElement A function that takes a Prosemirror DOMOutputSpec and returns a function that takes children and returns the target element type
@@ -215,9 +284,7 @@ export function renderToElement<T>({
   const extensionAttributes = getAttributesFromExtensions(extensions)
   const { nodeExtensions, markExtensions } = splitExtensions(extensions)
 
-  if (!(content instanceof Node)) {
-    content = Node.fromJSON(getSchemaByResolvedExtensions(extensions), content)
-  }
+  content = resolveRenderContent(content, extensions, options)
 
   return renderer({
     ...options,
@@ -268,5 +335,7 @@ export function renderToElement<T>({
       ),
       ...options?.markMapping,
     },
-  })({ content })
+    // `resolveRenderContent` yields a PM Node on the happy path, or the original
+    // JSON in the unknown-type fallback path; the renderer accepts both at runtime.
+  })({ content: content as Node })
 }

--- a/packages/static-renderer/src/pm/extensionRenderer.ts
+++ b/packages/static-renderer/src/pm/extensionRenderer.ts
@@ -198,7 +198,6 @@ const placeholderAttrs = {
 
 /**
  * Returns true if `content` references any node or mark type absent from `schema`.
- * Pure; does no I/O.
  */
 function hasUnknownType(content: JSONContent, schema: Schema): boolean {
   let found = false
@@ -228,7 +227,7 @@ function hasUnknownType(content: JSONContent, schema: Schema): boolean {
  * `schema` AND covered by a matching fallback in `options` is replaced by a
  * placeholder type carrying the original type/attrs. Unknown types without a
  * matching fallback are left untouched so `Node.fromJSON` still surfaces its clear
- * error for them. Pure; does no I/O.
+ * error for them.
  */
 function substituteUnknownTypes(
   content: JSONContent,
@@ -310,7 +309,7 @@ function resolveRenderContent(
 
 /**
  * Swaps a placeholder node/mark JSON back to its original type and attributes.
- * Leaves non-placeholder JSON untouched. Pure.
+ * Leaves non-placeholder JSON untouched.
  */
 function unwrapPlaceholderJSON(json: JSONContent): JSONContent {
   return json.type === UNHANDLED_NODE_TYPE || json.type === UNHANDLED_MARK_TYPE
@@ -320,7 +319,7 @@ function unwrapPlaceholderJSON(json: JSONContent): JSONContent {
 
 /**
  * Recursively restores the original JSON of a (possibly nested) placeholder
- * subtree, including placeholder marks. Pure; does no I/O.
+ * subtree, including placeholder marks.
  */
 function restoreOriginalJSON(json: JSONContent): JSONContent {
   const node = unwrapPlaceholderJSON(json)
@@ -338,6 +337,10 @@ function restoreOriginalJSON(json: JSONContent): JSONContent {
  * Presents a placeholder node/mark to a fallback renderer under its original type
  * name and attributes — including a `toJSON()` that returns the restored original
  * JSON — while keeping the live ProseMirror children/methods intact.
+ *
+ * `type` is exposed as a minimal `{ name }` rather than a real `NodeType`/`MarkType`:
+ * the original type is absent from the schema so no real one exists, and surfacing
+ * the placeholder's own type would leak misleading `spec`/`schema`/`isInline` values.
  */
 function withOriginalIdentity<T extends { attrs: Record<string, any>; toJSON: () => JSONContent }>(
   target: T,

--- a/packages/static-renderer/src/pm/extensionRenderer.ts
+++ b/packages/static-renderer/src/pm/extensionRenderer.ts
@@ -18,8 +18,8 @@ import {
   resolveExtensions,
   splitExtensions,
 } from '@tiptap/core'
-import type { DOMOutputSpec, Mark, Schema } from '@tiptap/pm/model'
-import { Node } from '@tiptap/pm/model'
+import type { DOMOutputSpec, Mark } from '@tiptap/pm/model'
+import { Node, Schema } from '@tiptap/pm/model'
 
 import { getHTMLAttributes } from '../helpers.js'
 import type { MarkProps, NodeProps, TiptapStaticRendererOptions } from '../json/renderer.js'
@@ -182,36 +182,37 @@ export function mapMarkExtensionToReactNode<T>(
   ]
 }
 
+// Placeholder node/mark types injected into a copy of the schema so JSON that
+// references types missing from the user's schema can still be converted by
+// `Node.fromJSON`. The original type/attrs are carried on the placeholder and
+// restored when it reaches `unhandledNode`/`unhandledMark`.
+const UNHANDLED_NODE_TYPE = '__tiptapUnhandledNode__'
+const UNHANDLED_MARK_TYPE = '__tiptapUnhandledMark__'
+const ORIGINAL_TYPE_ATTR = '__originalType'
+const ORIGINAL_ATTRS_ATTR = '__originalAttrs'
+
+const placeholderAttrs = {
+  [ORIGINAL_TYPE_ATTR]: { default: '' },
+  [ORIGINAL_ATTRS_ATTR]: { default: {} },
+}
+
 /**
- * Walks `content` and reports whether it can be rendered through the unknown-type
- * fallbacks: returns true only when it contains at least one node/mark type absent
- * from `schema` AND every such kind has its matching `unhandledNode` /
- * `unhandledMark` fallback. Returns false when there are no unknown types, or when
- * an unknown type has no matching fallback. Pure; does no I/O.
+ * Returns true if `content` references any node or mark type absent from `schema`.
+ * Pure; does no I/O.
  */
-function unknownTypesAllHaveFallback(
-  content: JSONContent,
-  schema: Schema,
-  options?: { unhandledNode?: unknown; unhandledMark?: unknown },
-): boolean {
-  const hasNodeFallback = Boolean(options?.unhandledNode)
-  const hasMarkFallback = Boolean(options?.unhandledMark)
-  let sawUnknownType = false
-  let unhandled = false
+function hasUnknownType(content: JSONContent, schema: Schema): boolean {
+  let found = false
 
   const visit = (node: JSONContent): void => {
+    if (found) {
+      return
+    }
     if (node.type && !(node.type in schema.nodes)) {
-      sawUnknownType = true
-      if (!hasNodeFallback) {
-        unhandled = true
-      }
+      found = true
     }
     node.marks?.forEach(mark => {
       if (mark.type && !(mark.type in schema.marks)) {
-        sawUnknownType = true
-        if (!hasMarkFallback) {
-          unhandled = true
-        }
+        found = true
       }
     })
     node.content?.forEach(visit)
@@ -219,36 +220,125 @@ function unknownTypesAllHaveFallback(
 
   visit(content)
 
-  return sawUnknownType && !unhandled
+  return found
 }
 
 /**
- * Resolves render input to a ProseMirror `Node`. A `Node` is returned as-is; JSON
- * is converted via `Node.fromJSON`. If that conversion fails only because the
- * document contains unknown types the caller has fallbacks for, the original JSON
- * is returned unchanged so the renderer can route them to the fallbacks. Any other
- * failure is re-thrown unchanged.
+ * Returns a deep copy of `content` in which every node/mark type absent from
+ * `schema` AND covered by a matching fallback in `options` is replaced by a
+ * placeholder type carrying the original type/attrs. Unknown types without a
+ * matching fallback are left untouched so `Node.fromJSON` still surfaces its clear
+ * error for them. Pure; does no I/O.
+ */
+function substituteUnknownTypes(
+  content: JSONContent,
+  schema: Schema,
+  options?: { unhandledNode?: unknown; unhandledMark?: unknown },
+): JSONContent {
+  const canSubstituteNode = Boolean(options?.unhandledNode)
+  const canSubstituteMark = Boolean(options?.unhandledMark)
+
+  const substituteMark = (mark: NonNullable<JSONContent['marks']>[number]) =>
+    canSubstituteMark && !(mark.type in schema.marks)
+      ? {
+          type: UNHANDLED_MARK_TYPE,
+          attrs: { [ORIGINAL_TYPE_ATTR]: mark.type, [ORIGINAL_ATTRS_ATTR]: mark.attrs ?? {} },
+        }
+      : mark
+
+  const isUnknownNode = (node: JSONContent) =>
+    canSubstituteNode && node.type != null && !(node.type in schema.nodes)
+
+  const toPlaceholder = (node: JSONContent, rewritten: JSONContent): JSONContent => ({
+    ...rewritten,
+    type: UNHANDLED_NODE_TYPE,
+    attrs: { [ORIGINAL_TYPE_ATTR]: node.type, [ORIGINAL_ATTRS_ATTR]: node.attrs ?? {} },
+  })
+
+  const substituteNode = (node: JSONContent): JSONContent => {
+    const rewritten = {
+      ...node,
+      marks: node.marks?.map(substituteMark),
+      content: node.content?.map(substituteNode),
+    }
+    return isUnknownNode(node) ? toPlaceholder(node, rewritten) : rewritten
+  }
+
+  return substituteNode(content)
+}
+
+/**
+ * Builds a copy of `schema` with the placeholder node/mark types added, so a
+ * document produced by `substituteUnknownTypes` converts cleanly.
+ */
+function withPlaceholderTypes(schema: Schema): Schema {
+  return new Schema({
+    topNode: schema.spec.topNode,
+    nodes: schema.spec.nodes.addToEnd(UNHANDLED_NODE_TYPE, { attrs: placeholderAttrs }),
+    marks: schema.spec.marks.addToEnd(UNHANDLED_MARK_TYPE, { attrs: placeholderAttrs }),
+  })
+}
+
+/**
+ * Resolves render input to a ProseMirror `Node`. A `Node` is returned as-is. JSON
+ * with only known types converts directly. JSON containing types missing from the
+ * schema has those types — when a matching `unhandledNode`/`unhandledMark` fallback
+ * exists — swapped for placeholders before conversion, so known nodes keep their
+ * materialized attributes and only the unknown ones route to the fallbacks. Unknown
+ * types without a fallback, and genuinely malformed content, still throw.
  */
 function resolveRenderContent(
   content: Node | JSONContent,
   extensions: Extensions,
   options?: { unhandledNode?: unknown; unhandledMark?: unknown },
-): Node | JSONContent {
+): Node {
   if (content instanceof Node) {
     return content
   }
 
   const schema = getSchemaByResolvedExtensions(extensions)
 
-  try {
+  if (!hasUnknownType(content, schema)) {
     return Node.fromJSON(schema, content)
-  } catch (error) {
-    if (unknownTypesAllHaveFallback(content, schema, options)) {
-      return content
-    }
-
-    throw error
   }
+
+  return Node.fromJSON(
+    withPlaceholderTypes(schema),
+    substituteUnknownTypes(content, schema, options),
+  )
+}
+
+/**
+ * Presents a placeholder node/mark to a fallback renderer under its original type
+ * name and attributes, while keeping the live ProseMirror children/methods intact.
+ */
+function withOriginalIdentity<T extends { attrs: Record<string, any> }>(target: T): T {
+  return new Proxy(target, {
+    get(node, prop) {
+      if (prop === 'type') {
+        return { name: node.attrs[ORIGINAL_TYPE_ATTR] }
+      }
+      if (prop === 'attrs') {
+        return node.attrs[ORIGINAL_ATTRS_ATTR]
+      }
+      const value = (node as Record<string | symbol, unknown>)[prop]
+      return typeof value === 'function' ? value.bind(node) : value
+    },
+  })
+}
+
+/** Maps the placeholder node type to the caller's `unhandledNode`, restoring identity. */
+function placeholderNodeRenderer<T>(
+  unhandledNode: (props: NodeProps<Node, T | T[]>) => T,
+): (props: NodeProps<Node, T | T[]>) => T {
+  return props => unhandledNode({ ...props, node: withOriginalIdentity(props.node) })
+}
+
+/** Maps the placeholder mark type to the caller's `unhandledMark`, restoring identity. */
+function placeholderMarkRenderer<T>(
+  unhandledMark: (props: MarkProps<Mark, T | T[], Node>) => T,
+): (props: MarkProps<Mark, T | T[], Node>) => T {
+  return props => unhandledMark({ ...props, mark: withOriginalIdentity(props.mark) })
 }
 
 /**
@@ -283,6 +373,12 @@ export function renderToElement<T>({
   extensions = resolveExtensions(extensions)
   const extensionAttributes = getAttributesFromExtensions(extensions)
   const { nodeExtensions, markExtensions } = splitExtensions(extensions)
+  const {
+    unhandledNode,
+    unhandledMark,
+    nodeMapping: userNodeMapping,
+    markMapping: userMarkMapping,
+  } = options ?? {}
 
   content = resolveRenderContent(content, extensions, options)
 
@@ -297,8 +393,8 @@ export function renderToElement<T>({
               return false
             }
             // No need to generate mappings for nodes that are already mapped
-            if (options?.nodeMapping) {
-              return !(e.name in options.nodeMapping)
+            if (userNodeMapping) {
+              return !(e.name in userNodeMapping)
             }
             return true
           })
@@ -312,15 +408,19 @@ export function renderToElement<T>({
           ),
       ),
       ...mapDefinedTypes,
-      ...options?.nodeMapping,
+      ...userNodeMapping,
+      // Route substituted unknown nodes to the caller's fallback (see resolveRenderContent).
+      ...(unhandledNode
+        ? { [UNHANDLED_NODE_TYPE]: placeholderNodeRenderer<T>(unhandledNode) }
+        : {}),
     },
     markMapping: {
       ...Object.fromEntries(
         markExtensions
           .filter(e => {
             // No need to generate mappings for marks that are already mapped
-            if (options?.markMapping) {
-              return !(e.name in options.markMapping)
+            if (userMarkMapping) {
+              return !(e.name in userMarkMapping)
             }
             return true
           })
@@ -333,9 +433,11 @@ export function renderToElement<T>({
             ),
           ),
       ),
-      ...options?.markMapping,
+      ...userMarkMapping,
+      // Route substituted unknown marks to the caller's fallback (see resolveRenderContent).
+      ...(unhandledMark
+        ? { [UNHANDLED_MARK_TYPE]: placeholderMarkRenderer<T>(unhandledMark) }
+        : {}),
     },
-    // `resolveRenderContent` yields a PM Node on the happy path, or the original
-    // JSON in the unknown-type fallback path; the renderer accepts both at runtime.
-  })({ content: content as Node })
+  })({ content })
 }

--- a/packages/static-renderer/src/pm/extensionRenderer.ts
+++ b/packages/static-renderer/src/pm/extensionRenderer.ts
@@ -309,17 +309,50 @@ function resolveRenderContent(
 }
 
 /**
- * Presents a placeholder node/mark to a fallback renderer under its original type
- * name and attributes, while keeping the live ProseMirror children/methods intact.
+ * Swaps a placeholder node/mark JSON back to its original type and attributes.
+ * Leaves non-placeholder JSON untouched. Pure.
  */
-function withOriginalIdentity<T extends { attrs: Record<string, any> }>(target: T): T {
+function unwrapPlaceholderJSON(json: JSONContent): JSONContent {
+  return json.type === UNHANDLED_NODE_TYPE || json.type === UNHANDLED_MARK_TYPE
+    ? { ...json, type: json.attrs![ORIGINAL_TYPE_ATTR], attrs: json.attrs![ORIGINAL_ATTRS_ATTR] }
+    : json
+}
+
+/**
+ * Recursively restores the original JSON of a (possibly nested) placeholder
+ * subtree, including placeholder marks. Pure; does no I/O.
+ */
+function restoreOriginalJSON(json: JSONContent): JSONContent {
+  const node = unwrapPlaceholderJSON(json)
+
+  return {
+    ...node,
+    marks: node.marks?.map(
+      mark => unwrapPlaceholderJSON(mark) as NonNullable<JSONContent['marks']>[number],
+    ),
+    content: node.content?.map(restoreOriginalJSON),
+  }
+}
+
+/**
+ * Presents a placeholder node/mark to a fallback renderer under its original type
+ * name and attributes — including a `toJSON()` that returns the restored original
+ * JSON — while keeping the live ProseMirror children/methods intact.
+ */
+function withOriginalIdentity<T extends { attrs: Record<string, any>; toJSON: () => JSONContent }>(
+  target: T,
+): T {
+  const overrides: Record<string | symbol, unknown> = Object.assign(Object.create(null), {
+    type: { name: target.attrs[ORIGINAL_TYPE_ATTR] },
+    attrs: target.attrs[ORIGINAL_ATTRS_ATTR],
+    toJSON: () => restoreOriginalJSON(target.toJSON()),
+  })
+
   return new Proxy(target, {
     get(node, prop) {
-      if (prop === 'type') {
-        return { name: node.attrs[ORIGINAL_TYPE_ATTR] }
-      }
-      if (prop === 'attrs') {
-        return node.attrs[ORIGINAL_ATTRS_ATTR]
+      const override = overrides[prop]
+      if (override !== undefined) {
+        return override
       }
       const value = (node as Record<string | symbol, unknown>)[prop]
       return typeof value === 'function' ? value.bind(node) : value


### PR DESCRIPTION
## Changes Overview

Fix `renderToReactElement`, `renderToHTMLString`, and `renderToMarkdown` ignoring the `unhandledNode` / `unhandledMark` options when the content contains node or mark types missing from the schema.

## Implementation Approach

`renderToElement` now attempts `Node.fromJSON` and, only when it fails because of unknown types that have matching fallbacks, renders the original JSON so the renderer routes those types to the fallbacks; structural/schema errors and unknown types without a matching fallback are re-thrown unchanged.

## Testing Done

Added `packages/static-renderer/__tests__/pm-unhandled-types.spec.ts` covering the fallback path, the preserved throw behaviour (no fallback, and a node-only unknown with only `unhandledMark`), and that structural errors are not masked; `test:unit`, `lint`, `build`, and `fallow:audit` all pass.

## Verification Steps

Call `renderToReactElement` (or `renderToHTMLString`) with JSON containing a node/mark type absent from the provided extensions plus `unhandledNode`/`unhandledMark` options — it now renders the fallbacks instead of throwing a `RangeError`.

## Additional Notes

In the fallback path the document is rendered from raw JSON, so schema attribute defaults are not materialised; this only affects documents that previously threw outright.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude to reproduce the issue, design the fix approach, implement it, write the regression tests, and draft this description.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #6866
