### PR TITLE
Heading after list item now terminates the list and gets parsed as headings

### DIFF
--- a/.changeset/fix-ordered-list-heading-lazy-continuation.md
+++ b/.changeset/fix-ordered-list-heading-lazy-continuation.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': patch
+---
+
+Fix a markdown parsing bug where a heading right after an ordered list item (with no blank line in between) got pulled into the list item as plain text, so you'd see a literal `###` inside the list instead of an actual heading. Headings now end the list and get parsed properly, the way other markdown parsers handle it. Indented headings inside a list item are also parsed as real headings now instead of literal text.

--- a/packages/extension-list/src/ordered-list/utils.ts
+++ b/packages/extension-list/src/ordered-list/utils.ts
@@ -40,6 +40,12 @@ export const ORDERED_LIST_LINE_START_REGEX = new RegExp(
 const INDENTED_LINE_REGEX = /^\s/
 
 /**
+ * Matches heading lines (1-6 # characters followed by whitespace or end-of-line)
+ * Heading lines always starts a new block, so they can never be lazy continuation text of a list item
+ */
+const HEADING_LINE_REGEX = /^#{1,6}(?:\s|$)/
+
+/**
  * Represents a parsed ordered list item with indentation information
  */
 export interface OrderedListItem {
@@ -62,6 +68,7 @@ function isBlockContentLine(line: string): boolean {
     // oxlint-disable-next-line prefer-string-starts-ends-with
     /^[-+*]\s+/.test(trimmedLine) ||
     isOrderedListMarkerLine(trimmedLine) ||
+    HEADING_LINE_REGEX.test(trimmedLine) ||
     // oxlint-disable-next-line prefer-string-starts-ends-with
     /^>\s?/.test(trimmedLine) ||
     // oxlint-disable-next-line prefer-string-starts-ends-with
@@ -166,7 +173,7 @@ export function collectOrderedListItems(lines: string[]): [OrderedListItem[], nu
         itemContentLines.push(nextLine.slice(Math.min(leadingWhitespace, contentIndent)))
         nextLineIndex += 1
       } else {
-        if (sawBlankLine) {
+        if (sawBlankLine || HEADING_LINE_REGEX.test(nextLine)) {
           break
         }
 

--- a/packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts
+++ b/packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts
@@ -1,5 +1,7 @@
+import { Bold } from '@tiptap/extension-bold'
 import { Document } from '@tiptap/extension-document'
 import { HardBreak } from '@tiptap/extension-hard-break'
+import { Heading } from '@tiptap/extension-heading'
 import { BulletList, ListItem, OrderedList } from '@tiptap/extension-list'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
@@ -109,6 +111,177 @@ describe('Ordered list lazy continuation parsing', () => {
                 {
                   type: 'paragraph',
                   content: [{ type: 'text', text: 'two' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('stops lazy continuation at a heading line', () => {
+    const markdownManager = new MarkdownManager({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        Bold,
+        Heading,
+        BulletList,
+        OrderedList,
+        ListItem,
+      ],
+    })
+
+    const markdown = ['1. Plain text search', '### **Plain text search**'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Plain text search' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: { level: 3 },
+          content: [{ type: 'text', text: 'Plain text search', marks: [{ type: 'bold' }] }],
+        },
+      ],
+    })
+  })
+
+  it('stops lazy continuation at heading lines of any level, for any item', () => {
+    const markdownManager = new MarkdownManager({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        Heading,
+        BulletList,
+        OrderedList,
+        ListItem,
+      ],
+    })
+
+    const markdown = ['1. one', '2. two', '###### six'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'one' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'two' }] }],
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: { level: 6 },
+          content: [{ type: 'text', text: 'six' }],
+        },
+      ],
+    })
+  })
+
+  it('keeps hashtag-like lines that are not headings as lazy continuation', () => {
+    const markdownManager = new MarkdownManager({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        Heading,
+        BulletList,
+        OrderedList,
+        ListItem,
+      ],
+      markedOptions: {
+        breaks: true,
+      },
+    })
+
+    // "#hashtag" (no space) and "####### seven" (7 hashes) are not headings
+    // per CommonMark, so they must remain lazy continuation text.
+    const markdown = ['1. one', '#hashtag', '####### seven'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'one' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: '#hashtag' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: '####### seven' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('parses indented heading lines as block content inside the list item', () => {
+    const markdownManager = new MarkdownManager({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        HardBreak,
+        Heading,
+        BulletList,
+        OrderedList,
+        ListItem,
+      ],
+    })
+
+    const markdown = ['1. one', '   ### inner heading'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'one' }] },
+                {
+                  type: 'heading',
+                  attrs: { level: 3 },
+                  content: [{ type: 'text', text: 'inner heading' }],
                 },
               ],
             },


### PR DESCRIPTION
BUG: If a heading is placed on the line directly after an ordered list item (with no blank line in between), the heading gets pulled into the list item as literal text (e.g. a visible ###) instead of being parsed as a heading. 
Reference PR: https://github.com/ueberdosis/tiptap/issues/7958

FIX: A heading line now terminates lazy continuation, so the list ends and the heading is parsed properly. This matches how other markdown parsers handle it. 
Also, an indented heading inside a list item is now parsed as a real heading within that item instead of literal text. Lines that aren't valid headings for ex: (#hashtag, 7+ #s) are unaffected and remain continuation text.

Visual reference:
**Before**
<img width="443" height="319" alt="Screenshot 2026-07-04 at 9 46 25 PM" src="https://github.com/user-attachments/assets/a67cf20d-e319-42ad-8ff4-6ccff5184c2e" />

**After**
<img width="389" height="323" alt="Screenshot 2026-07-04 at 7 05 59 PM" src="https://github.com/user-attachments/assets/a5eeb2c9-d6f0-4501-bd86-03a3e7898185" />

## AI Usage
- [x] I have used AI tools (Claude) in creating this PR.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
