### PR TITLE
fix(extension-list): use item's own indent as base for ordered-list markdown nesting

### DIFF
--- a/.changeset/fix-ordered-list-indented-inline-parsing.md
+++ b/.changeset/fix-ordered-list-indented-inline-parsing.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-list": patch
+---
+
+Fix indented ordered list items (e.g. one leading space before the marker, as happens when a top-level ordered list is itself nested inside another list) losing inline formatting during markdown parsing. The custom ordered-list markdown tokenizer built its nested structure with a hardcoded base indentation of 0, so an item whose actual indentation was non-zero never matched, causing the tokenizer to silently produce zero items and bail out — falling back to a path that left the item's content as literal, unparsed text instead of running it through inline tokenization (bold, italic, etc. were lost). The base indentation is now taken from the first collected item instead of being hardcoded.

--- a/packages/extension-list/__tests__/orderedListType.spec.ts
+++ b/packages/extension-list/__tests__/orderedListType.spec.ts
@@ -1,5 +1,6 @@
 import type { JSONContent } from '@tiptap/core'
 import { Editor } from '@tiptap/core'
+import Bold from '@tiptap/extension-bold'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
@@ -399,6 +400,25 @@ describe('OrderedList type attribute', () => {
 
       const md = markdownManager.serialize(json)
       expect(md).toBe(original)
+    })
+
+    it('parses inline formatting inside an indented ordered list item', () => {
+      // A single leading space before the marker (e.g. a top-level ordered
+      // list nested one level inside another list) previously made the
+      // custom ordered-list tokenizer bail out silently, falling back to a
+      // path that left the item's content as literal, unparsed text.
+      const markdownManager = new MarkdownManager({
+        extensions: [Document, Paragraph, Text, Bold, ListItem, OrderedList],
+      })
+
+      const noIndent = markdownManager.parse('1. **bold** item')
+      const indented = markdownManager.parse(' 1. **bold** item')
+
+      expect(indented.content).toEqual(noIndent.content)
+
+      const textNode = indented.content[0].content[0].content[0].content[0]
+      expect(textNode.text).toBe('bold')
+      expect(textNode.marks?.[0]?.type).toBe('bold')
     })
   })
 

--- a/packages/extension-list/src/ordered-list/ordered-list.ts
+++ b/packages/extension-list/src/ordered-list/ordered-list.ts
@@ -243,7 +243,14 @@ export const OrderedList = Node.create<OrderedListOptions>({
         return undefined
       }
 
-      const items = buildNestedStructure(listItems, 0, lexer)
+      // The first collected item defines the indentation level of this list.
+      // Using a hardcoded 0 here meant an indented top-level list (e.g. one
+      // space before the marker, as can happen when nested inside another
+      // list) never matched its own indent in buildNestedStructure, silently
+      // produced zero items, and made this tokenizer bail out — falling back
+      // to marked's default list handling, which does not run this list's
+      // items back through this extension's inline tokenizer.
+      const items = buildNestedStructure(listItems, listItems[0].indent, lexer)
 
       if (items.length === 0) {
         return undefined

--- a/packages/extension-list/src/ordered-list/ordered-list.ts
+++ b/packages/extension-list/src/ordered-list/ordered-list.ts
@@ -243,13 +243,11 @@ export const OrderedList = Node.create<OrderedListOptions>({
         return undefined
       }
 
-      // The first collected item defines the indentation level of this list.
-      // Using a hardcoded 0 here meant an indented top-level list (e.g. one
-      // space before the marker, as can happen when nested inside another
-      // list) never matched its own indent in buildNestedStructure, silently
-      // produced zero items, and made this tokenizer bail out — falling back
-      // to marked's default list handling, which does not run this list's
-      // items back through this extension's inline tokenizer.
+      // buildNestedStructure() only includes an item when item.indent matches
+      // the base indent it's given, so the base must be this list's own
+      // indentation level (that of its first collected item, e.g. 1 for a
+      // line with a single leading space) rather than always 0 — a nested
+      // list is not necessarily flush with the start of the line.
       const items = buildNestedStructure(listItems, listItems[0].indent, lexer)
 
       if (items.length === 0) {


### PR DESCRIPTION
Fixes #7966.

Indented ordered list items lose inline formatting when parsed as markdown. Minimal repro from the issue:

manager.parse('1. **bold** item')   -- correct: "bold" gets a bold mark
manager.parse(' 1. **bold** item')  -- broken: literal text "**bold** item", no mark

The only difference is a single leading space before the marker (the case that occurs when a top-level ordered list is itself nested inside another list).

Root cause: OrderedList's custom markdown tokenizer (packages/extension-list/src/ordered-list/ordered-list.ts) calls buildNestedStructure(listItems, 0, lexer) with a hardcoded baseIndent of 0. collectOrderedListItems() correctly records each item's actual indentation (indent: 1 for a line with one leading space), but buildNestedStructure() only includes an item if item.indent === baseIndent. With the hardcoded 0, an indented top-level item never matches its own list's base indent, so buildNestedStructure() silently returns zero items and the tokenizer bails out. That fallback path skips this extension's inline tokenizer, so bold/italic markup ends up as literal text.

I confirmed this by logging the intermediate arrays: for ' 1. **bold** item', listItems[0].indent is 1, buildNestedStructure(listItems, 0, lexer) returns [], and the tokenizer falls back -- reproducing the exact broken output from the issue.

Fix: derive baseIndent from the first collected item's own indent instead of hardcoding it to 0.

Tests: added a test to packages/extension-list/__tests__/orderedListType.spec.ts asserting that the indented and non-indented inputs parse to identical JSON, both with the bold mark applied. Verified the test actually catches the bug by reverting only the one-line fix (keeping the test) and confirming it fails with the exact broken output described in the issue, then restoring the fix and confirming it passes. Full monorepo suite (1365 tests) passes with no regressions.

Added a patch-level changeset for @tiptap/extension-list.