### PR TITLE
Fix (extension-list): add paragraph interrupters so that block elements after list doesn't come up as literal text

### DIFF
--- a/.changeset/fix-ordered-list-block-start-lazy-continuation.md
+++ b/.changeset/fix-ordered-list-block-start-lazy-continuation.md
@@ -1,0 +1,11 @@
+---
+'@tiptap/extension-list': patch
+---
+
+Fix markdown parsing bugs where block elements right after an ordered list item (with no blank line in between) were wrongly treated as lazy continuation of the list item, instead of terminating the list the way other markdown parsers do:
+
+- Thematic breaks (`---`, `***`, `___`, `* * *`) were swallowed into the list item as literal paragraph text — along with every line after them. They now terminate the list and become a horizontal rule.
+- Fenced code blocks (```` ``` ```` and `~~~`) were nested inside the list item. They now terminate the list and become a top-level code block.
+- Unindented bullet markers (`- item`) were nested inside the ordered list item. They now terminate the ordered list and start a new top-level bullet list. Indented bullets still nest inside the item as before.
+
+An indented `***`/`___` inside item content is now also parsed as a horizontal rule inside the item instead of literal text. A `---` line directly below item paragraph text keeps its current behavior because it is a setext heading underline per CommonMark, not a thematic break.

--- a/packages/extension-list/src/ordered-list/utils.ts
+++ b/packages/extension-list/src/ordered-list/utils.ts
@@ -40,10 +40,15 @@ export const ORDERED_LIST_LINE_START_REGEX = new RegExp(
 const INDENTED_LINE_REGEX = /^\s/
 
 /**
- * Matches heading lines (1-6 # characters followed by whitespace or end-of-line)
- * Heading lines always starts a new block, so they can never be lazy continuation text of a list item
+ * This are blocks that can interrupt a paragraph, so a line starting with one of
+ * them can never be lazy continuation text of a list item
  */
-const HEADING_LINE_REGEX = /^#{1,6}(?:\s|$)/
+const PARAGRAPH_INTERRUPTERS = {
+  heading: /^#{1,6}(?:\s|$)/,
+  bulletItem: /^[-+*]\s+/,
+  codeFence: /^(?:```|~~~)/,
+  thematicBreak: /^(?:(?:-[ \t]*){3,}|(?:_[ \t]*){3,}|(?:\*[ \t]*){3,})$/,
+}
 
 /**
  * Represents a parsed ordered list item with indentation information
@@ -65,17 +70,20 @@ function isBlockContentLine(line: string): boolean {
   const trimmedLine = line.trimStart()
 
   return (
-    // oxlint-disable-next-line prefer-string-starts-ends-with
-    /^[-+*]\s+/.test(trimmedLine) ||
+    PARAGRAPH_INTERRUPTERS.bulletItem.test(trimmedLine) ||
     isOrderedListMarkerLine(trimmedLine) ||
-    HEADING_LINE_REGEX.test(trimmedLine) ||
+    PARAGRAPH_INTERRUPTERS.heading.test(trimmedLine) ||
+    // dash breaks are excluded: "---" directly below paragraph text is a
+    // setext heading underline, not a thematic break
+    (PARAGRAPH_INTERRUPTERS.thematicBreak.test(trimmedLine) && !trimmedLine.startsWith('-')) ||
     // oxlint-disable-next-line prefer-string-starts-ends-with
     /^>\s?/.test(trimmedLine) ||
-    // oxlint-disable-next-line prefer-string-starts-ends-with
-    /^```/.test(trimmedLine) ||
-    // oxlint-disable-next-line prefer-string-starts-ends-with
-    /^~~~/.test(trimmedLine)
+    PARAGRAPH_INTERRUPTERS.codeFence.test(trimmedLine)
   )
+}
+
+function interruptsLazyContinuation(line: string): boolean {
+  return Object.values(PARAGRAPH_INTERRUPTERS).some(pattern => pattern.test(line))
 }
 
 function splitItemContent(contentLines: string[]): {
@@ -173,7 +181,7 @@ export function collectOrderedListItems(lines: string[]): [OrderedListItem[], nu
         itemContentLines.push(nextLine.slice(Math.min(leadingWhitespace, contentIndent)))
         nextLineIndex += 1
       } else {
-        if (sawBlankLine || HEADING_LINE_REGEX.test(nextLine)) {
+        if (sawBlankLine || interruptsLazyContinuation(nextLine)) {
           break
         }
 

--- a/packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts
+++ b/packages/markdown/__tests__/ordered-list-lazy-continuation.spec.ts
@@ -1,7 +1,10 @@
+import { Blockquote } from '@tiptap/extension-blockquote'
 import { Bold } from '@tiptap/extension-bold'
+import { CodeBlock } from '@tiptap/extension-code-block'
 import { Document } from '@tiptap/extension-document'
 import { HardBreak } from '@tiptap/extension-hard-break'
 import { Heading } from '@tiptap/extension-heading'
+import { HorizontalRule } from '@tiptap/extension-horizontal-rule'
 import { BulletList, ListItem, OrderedList } from '@tiptap/extension-list'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
@@ -282,6 +285,244 @@ describe('Ordered list lazy continuation parsing', () => {
                   type: 'heading',
                   attrs: { level: 3 },
                   content: [{ type: 'text', text: 'inner heading' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  const blockExtensions = [
+    Document,
+    Paragraph,
+    Text,
+    HardBreak,
+    Heading,
+    HorizontalRule,
+    CodeBlock,
+    Blockquote,
+    BulletList,
+    OrderedList,
+    ListItem,
+  ]
+
+  const listWithSingleItem = (text: string) => ({
+    type: 'orderedList',
+    content: [
+      {
+        type: 'listItem',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+      },
+    ],
+  })
+
+  it.each(['---', '***', '___', '* * *', '- - -', '_ _ _'])(
+    'stops lazy continuation at a "%s" thematic break',
+    thematicBreak => {
+      const markdownManager = new MarkdownManager({ extensions: blockExtensions })
+
+      const markdown = ['1. one', thematicBreak, 'Outside paragraph'].join('\n')
+
+      expect(markdownManager.parse(markdown)).toEqual({
+        type: 'doc',
+        content: [
+          listWithSingleItem('one'),
+          { type: 'horizontalRule' },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Outside paragraph' }] },
+        ],
+      })
+    },
+  )
+
+  it.each(['```', '~~~'])('stops lazy continuation at a "%s" code fence', fence => {
+    const markdownManager = new MarkdownManager({ extensions: blockExtensions })
+
+    const markdown = ['1. one', fence, 'const x = 1', fence].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        listWithSingleItem('one'),
+        {
+          type: 'codeBlock',
+          attrs: { language: null },
+          content: [{ type: 'text', text: 'const x = 1' }],
+        },
+      ],
+    })
+  })
+
+  it('stops lazy continuation at an unindented bullet list marker', () => {
+    const markdownManager = new MarkdownManager({ extensions: blockExtensions })
+
+    const markdown = ['1. one', '- bullet'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        listWithSingleItem('one'),
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'bullet' }] }],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('parses indented non-dash thematic breaks as block content inside the list item', () => {
+    const markdownManager = new MarkdownManager({ extensions: blockExtensions })
+
+    const markdown = ['1. one', '   ***'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'one' }] },
+                { type: 'horizontalRule' },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps an indented "---" directly below item text as paragraph text (setext ambiguity)', () => {
+    const markdownManager = new MarkdownManager({
+      extensions: blockExtensions,
+      markedOptions: {
+        breaks: true,
+      },
+    })
+
+    const markdown = ['1. one', '  ---'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'one' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: '---' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps dash-prefixed text that is not a thematic break as lazy continuation', () => {
+    const markdownManager = new MarkdownManager({
+      extensions: blockExtensions,
+      markedOptions: {
+        breaks: true,
+      },
+    })
+
+    const markdown = ['1. one', '---foo'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'one' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: '---foo' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps a setext-style "===" line as lazy continuation text', () => {
+    const markdownManager = new MarkdownManager({
+      extensions: blockExtensions,
+      markedOptions: {
+        breaks: true,
+      },
+    })
+
+    const markdown = ['1. one', '==='].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'one' },
+                    { type: 'hardBreak' },
+                    { type: 'text', text: '===' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps unindented blockquote lines inside the list item (matches marked 17.0.1)', () => {
+    const markdownManager = new MarkdownManager({ extensions: blockExtensions })
+
+    const markdown = ['1. one', '> quoted'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'one' }] },
+                {
+                  type: 'blockquote',
+                  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'quoted' }] }],
                 },
               ],
             },


### PR DESCRIPTION
BUG: If a thematic break (`---`, `***`, `___`), a fenced code block (```` ``` ````/`~~~`), or an unindented bullet (`- item`) is placed on the line directly after an ordered list item (with no blank line in between), it gets pulled into the list item instead of ending the list. 
Thematic breaks are the worst case: they end up as literal text inside the item, and every line after them gets swallowed too. Code fences and bullets get parsed, but nested inside the list item instead of after the list.

This is the same lazy continuation issue as #7997 , which fixed it for headings only.

FIX: Any line that starts a block that can interrupt a paragraph now rightly terminates the lazy continuation. This change is regression free.

---
Visual Reference
**Before**
<img width="1920" height="490" alt="lazy-continuation-before" src="https://github.com/user-attachments/assets/5386a98d-2f2a-426b-8f44-19462660da4b" />

---

**After**
<img width="1920" height="490" alt="lazy-continuation-after" src="https://github.com/user-attachments/assets/7d6c39f7-3e55-4dcf-a1b9-aab52de88f68" />


## AI Usage
- [x] I have used AI tools (Claude) in creating this PR.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
