### PR TITLE
fix(core): delete content across all selection ranges, not just the first

### DIFF
--- a/.changeset/fix-delete-selection-multi-range.md
+++ b/.changeset/fix-delete-selection-multi-range.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix `deleteSelection` to delete content across all selection ranges instead of only the first range. This restores multi-cell table selections and other custom selections with multiple ranges.

--- a/packages/core/src/commands/deleteSelection.ts
+++ b/packages/core/src/commands/deleteSelection.ts
@@ -76,16 +76,25 @@ declare module '@tiptap/core' {
 export const deleteSelection: RawCommands['deleteSelection'] =
   () =>
   ({ state, dispatch }) => {
-    const { $from, $to } = state.selection
     if (state.selection.empty) {
       return false
     }
 
-    const { from, to } = expandSelectionForInlineText($from, $to, state.schema)
-
     if (dispatch) {
-      state.tr.deleteRange(from, to).scrollIntoView()
-      dispatch(state.tr)
+      const tr = state.tr
+      const { ranges } = state.selection
+      const mapFrom = tr.steps.length
+
+      ranges.forEach(range => {
+        const mapping = tr.mapping.slice(mapFrom)
+        const $from = tr.doc.resolve(mapping.map(range.$from.pos))
+        const $to = tr.doc.resolve(mapping.map(range.$to.pos))
+        const { from, to } = expandSelectionForInlineText($from, $to, state.schema)
+        tr.deleteRange(from, to)
+      })
+
+      tr.scrollIntoView()
+      dispatch(tr)
     }
 
     return true

--- a/packages/extension-table/__tests__/deleteSelection.spec.ts
+++ b/packages/extension-table/__tests__/deleteSelection.spec.ts
@@ -1,0 +1,64 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import { TableKit } from '@tiptap/extension-table'
+import Text from '@tiptap/extension-text'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const collectCellPositions = (editor: Editor): number[] => {
+  const positions: number[] = []
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+      positions.push(pos)
+    }
+  })
+  return positions
+}
+
+const getCellContents = (editor: Editor): string[] => {
+  const contents: string[] = []
+  editor.state.doc.descendants(node => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+      contents.push(node.textContent)
+    }
+  })
+  return contents
+}
+
+describe('deleteSelection with CellSelection', () => {
+  let editor: Editor
+
+  beforeEach(() => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    editor = new Editor({
+      element,
+      extensions: [Document, Paragraph, Text, TableKit],
+      content:
+        '<table><tbody><tr><td>A1</td><td>B1</td><td>C1</td></tr><tr><td>A2</td><td>B2</td><td>C2</td></tr></tbody></table>',
+    })
+  })
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  it('clears every selected cell in a multi-cell CellSelection', () => {
+    const cells = collectCellPositions(editor)
+    // Row-major order: A1, B1, C1, A2, B2, C2
+    // Select the 2x2 block A1..B2, leaving C1 and C2 untouched.
+    editor.chain().focus().setCellSelection({ anchorCell: cells[0], headCell: cells[4] }).run()
+
+    const result = editor.commands.deleteSelection()
+
+    expect(result).toBe(true)
+
+    const contents = getCellContents(editor)
+    expect(contents[0]).toBe('') // A1
+    expect(contents[1]).toBe('') // B1
+    expect(contents[2]).toBe('C1')
+    expect(contents[3]).toBe('') // A2
+    expect(contents[4]).toBe('') // B2
+    expect(contents[5]).toBe('C2')
+  })
+})


### PR DESCRIPTION
## Changes Overview

Fix `deleteSelection` command to delete content across all selection ranges instead of only the first range. This restores multi-cell table selections and other custom selections with multiple ranges.

The regression was introduced by PR #7848, which rewrote `deleteSelection` to use `state.selection.$from`/`$to` — these only return the first range, breaking `CellSelection` and other multi-range selections.

## Implementation Approach

Iterate all `state.selection.ranges` with proper position mapping via `tr.mapping.slice(mapFrom)`, re-resolving mapped positions against the mutating document. Preserves the inline-text expansion fix from PR #7848 and the `dispatch` guard for `can()` dry-run support.

## Testing Done

- Unit tests: 1379 tests passed, including a new regression test in `packages/extension-table/__tests__/deleteSelection.spec.ts` that selects a 2×2 block of table cells via `CellSelection` and verifies all selected cells are cleared while non-selected cells remain intact.
- Existing `packages/core/__tests__/delete.spec.ts` (7 tests) all pass, confirming the PR #7848 inline-text expansion fix is preserved.
- Lint, build, and fallow audit all pass cleanly.

## Verification Steps

1. Create a table with multiple cells
2. Select a non-contiguous or multi-cell range (e.g., 2×2 block via shift-click or keyboard)
3. Press Delete/Backspace — all selected cells should be cleared, not just the first one

## Additional Notes

- Position mapping uses `mapFrom = tr.steps.length` set once before the loop, with `tr.mapping.slice(mapFrom)` recomputed each iteration to include prior deletion steps.
- For `CellSelection`, the inline-text expansion is a no-op (block-level parents fail the `isInline` check), so PR #7848 behavior is fully preserved.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #7972