### PR TITLE
Fix (extension-list): bullet item nested under task list now no more gets dropped from document

### DIFF
--- a/.changeset/fix-task-list-nested-plain-bullets.md
+++ b/.changeset/fix-task-list-nested-plain-bullets.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': patch
+---
+
+Fix a markdown parsing bug where a plain bullet (`- item`) nested under a task-list parent (`- [ ]`) was silently dropped from the parsed document. The task-list tokenizer's nested parser stopped at the first non-checkbox line and discarded everything after it; that remainder is now lexed and kept as sibling blocks (a bullet list or paragraph inside the parent task item), matching how mixed lists already behave at the top level.

--- a/packages/extension-list/src/task-list/task-list.ts
+++ b/packages/extension-list/src/task-list/task-list.ts
@@ -114,14 +114,20 @@ export const TaskList = Node.create<TaskListOptions>({
         )
 
         if (nestedResult) {
-          // Return as task list token
-          return [
-            {
-              type: 'taskList',
-              raw: nestedResult.raw,
-              items: nestedResult.items,
-            },
-          ]
+          const taskListToken = {
+            type: 'taskList',
+            raw: nestedResult.raw,
+            items: nestedResult.items,
+          }
+
+          // parseIndentedBlocks only consumes checkbox items,
+          // so anything after that (for ex: plain bullets) we parse those and keep as sibling tokens
+          const remainder = content.slice(nestedResult.raw.length)
+          if (remainder.trim()) {
+            return [taskListToken, ...lexer.blockTokens(remainder)]
+          }
+
+          return [taskListToken]
         }
 
         // Fall back to regular markdown parsing if not a task list

--- a/packages/extension-list/src/task-list/task-list.ts
+++ b/packages/extension-list/src/task-list/task-list.ts
@@ -120,8 +120,9 @@ export const TaskList = Node.create<TaskListOptions>({
             items: nestedResult.items,
           }
 
-          // parseIndentedBlocks only consumes checkbox items,
-          // so anything after that (for ex: plain bullets) we parse those and keep as sibling tokens
+          // parseIndentedBlocks only consumes checkbox items.
+          // Parse any remaining indented content, such as plain bullets,
+          // and keep it as sibling tokens.
           const remainder = content.slice(nestedResult.raw.length)
           if (remainder.trim()) {
             return [taskListToken, ...lexer.blockTokens(remainder)]

--- a/packages/markdown/__tests__/task-list-nested-siblings.spec.ts
+++ b/packages/markdown/__tests__/task-list-nested-siblings.spec.ts
@@ -1,0 +1,182 @@
+import { Document } from '@tiptap/extension-document'
+import { BulletList, ListItem, TaskItem, TaskList } from '@tiptap/extension-list'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { describe, expect, it } from 'vitest'
+
+import { MarkdownManager } from '../src/MarkdownManager.js'
+
+const paragraph = (text: string) => ({
+  type: 'paragraph',
+  content: [{ type: 'text', text }],
+})
+
+const listItem = (text: string) => ({
+  type: 'listItem',
+  content: [paragraph(text)],
+})
+
+const taskItem = (text: string, ...nested: object[]) => ({
+  type: 'taskItem',
+  attrs: { checked: false },
+  content: [paragraph(text), ...nested],
+})
+
+describe('Task list with non-checkbox siblings in nested lists', () => {
+  const markdownManager = new MarkdownManager({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      BulletList,
+      ListItem,
+      TaskList,
+      TaskItem.configure({ nested: true }),
+    ],
+  })
+
+  it('keeps a plain bullet that follows a checkbox item in a nested list', () => {
+    const markdown = ['- [ ] parent', '  - [ ] checkbox child', '  - plain child'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            taskItem(
+              'parent',
+              { type: 'taskList', content: [taskItem('checkbox child')] },
+              { type: 'bulletList', content: [listItem('plain child')] },
+            ),
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps multiple trailing plain bullets in one bullet list', () => {
+    const markdown = ['- [ ] parent', '  - [ ] checkbox child', '  - plain 1', '  - plain 2'].join(
+      '\n',
+    )
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            taskItem(
+              'parent',
+              { type: 'taskList', content: [taskItem('checkbox child')] },
+              { type: 'bulletList', content: [listItem('plain 1'), listItem('plain 2')] },
+            ),
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps a plain bullet in a deeply nested task list', () => {
+    const markdown = [
+      '- [ ] parent',
+      '  - [ ] level2',
+      '    - [ ] level3',
+      '    - deep plain',
+    ].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            taskItem('parent', {
+              type: 'taskList',
+              content: [
+                taskItem(
+                  'level2',
+                  { type: 'taskList', content: [taskItem('level3')] },
+                  { type: 'bulletList', content: [listItem('deep plain')] },
+                ),
+              ],
+            }),
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps a trailing paragraph that follows a nested checkbox item', () => {
+    const markdown = ['- [ ] parent', '  - [ ] child', '  trailing paragraph'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            taskItem(
+              'parent',
+              { type: 'taskList', content: [taskItem('child')] },
+              paragraph('trailing paragraph'),
+            ),
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps a plain bullet that precedes a checkbox item in a nested list', () => {
+    const markdown = ['- [ ] parent', '  - plain first', '  - [ ] checkbox after'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            taskItem(
+              'parent',
+              { type: 'bulletList', content: [listItem('plain first')] },
+              { type: 'taskList', content: [taskItem('checkbox after')] },
+            ),
+          ],
+        },
+      ],
+    })
+  })
+
+  it('still parses a purely-checkbox nested list as a single task list', () => {
+    const markdown = ['- [ ] parent', '  - [ ] child 1', '  - [x] child 2'].join('\n')
+
+    expect(markdownManager.parse(markdown)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            taskItem('parent', {
+              type: 'taskList',
+              content: [
+                taskItem('child 1'),
+                {
+                  type: 'taskItem',
+                  attrs: { checked: true },
+                  content: [paragraph('child 2')],
+                },
+              ],
+            }),
+          ],
+        },
+      ],
+    })
+  })
+
+  it('round-trips the mixed nested list back to the original markdown', () => {
+    const markdown = ['- [ ] parent', '  - [ ] checkbox child', '  - plain child'].join('\n')
+
+    const json = markdownManager.parse(markdown)
+    expect(markdownManager.serialize(json).trim()).toBe(markdown)
+  })
+})


### PR DESCRIPTION
Bug: When parsing Markdown, a plain bullet (- item) that is a sibling of task-list items (- [ ]) inside a nested list is silently dropped from the resulting document. 
This PR fixes: https://github.com/ueberdosis/tiptap/issues/8005 (read this issue for a detailed description of the bug)

Fix: Earlier the task-list tokenizer's nested parser stopped at the first non-checkbox line and discarded everything after it.... so now, that remainder is lexed and kept as sibling blocks (a bullet list or paragraph inside the parent task item), matching how mixed lists already behave at the top level.

---
Visual Reference:
**Before**
<img width="905" height="306" alt="Screenshot 2026-07-07 at 12 27 58 PM" src="https://github.com/user-attachments/assets/c0d68400-d8c4-49f6-9621-eca70b8e7a13" />

---
**After**
<img width="888" height="309" alt="Screenshot 2026-07-07 at 12 40 08 PM" src="https://github.com/user-attachments/assets/6c2f687c-0422-4742-baa4-cbdfa1e74052" />

## AI Usage
- [x] I have used AI tools (Claude) in creating this PR.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

