### PR TITLE
fix(extension-blockquote): add @tiptap/pm peer dependency

### DIFF
--- a/.changeset/fix-blockquote-missing-pm-peer-dependency.md
+++ b/.changeset/fix-blockquote-missing-pm-peer-dependency.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-blockquote': patch
+---
+
+Add `@tiptap/pm` as a peer dependency so bundlers resolve ProseMirror packages from the app instead of duplicating `prosemirror-model` inside `@tiptap/extension-blockquote`.

--- a/packages/extension-blockquote/package.json
+++ b/packages/extension-blockquote/package.json
@@ -42,9 +42,11 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@tiptap/core": "workspace:^"
+    "@tiptap/core": "workspace:^",
+    "@tiptap/pm": "workspace:^"
   },
   "peerDependencies": {
-    "@tiptap/core": "workspace:*"
+    "@tiptap/core": "workspace:*",
+    "@tiptap/pm": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,9 @@ importers:
       '@tiptap/core':
         specifier: workspace:^
         version: link:../core
+      '@tiptap/pm':
+        specifier: workspace:^
+        version: link:../pm
 
   packages/extension-bold:
     devDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes Overview

Add `@tiptap/pm` to `@tiptap/extension-blockquote` `devDependencies` and `peerDependencies`.

`handleBackspace` imports `@tiptap/pm/model` and `@tiptap/pm/state`, but the package only declared `@tiptap/core` as a peer. Without `@tiptap/pm` as a peer, bundlers can resolve and ship a duplicate `prosemirror-model` inside `@tiptap/extension-blockquote`.

## Implementation Approach

Match the dependency pattern used by other extensions that import from `@tiptap/pm` (for example `@tiptap/extension-horizontal-rule`):

- add `@tiptap/pm` to `devDependencies` (`workspace:^`)
- add `@tiptap/pm` to `peerDependencies` (`workspace:*`)
- update the lockfile importer entry for `packages/extension-blockquote`

## Testing Done

- Built `@tiptap/extension-blockquote` with `tsup`; build succeeds.
- Confirmed `dist/` output does not contain bundled `prosemirror-*` references.
- Ran `oxlint` successfully.

## Verification Steps

1. Install `@tiptap/extension-blockquote` in an app that already depends on `@tiptap/pm`.
2. Build the app bundle and inspect it for duplicate `prosemirror-model` copies.
3. Confirm only one `prosemirror-model` instance is present after this change.

## Additional Notes

This is a packaging-only fix. No runtime behavior changes.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used AI to investigate issue #8010, compare dependency patterns across extension packages, implement the `package.json` and lockfile update, and draft this PR description.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #8010
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d52966e-836f-42ae-9005-d2b1c6939d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d52966e-836f-42ae-9005-d2b1c6939d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

