### PR TITLE
Fix (extension-table): line breaks in table cells no more get lost when serializing to markdown

### DIFF
--- a/.changeset/fix-table-cell-line-breaks-markdown.md
+++ b/.changeset/fix-table-cell-line-breaks-markdown.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Keep line breaks inside table cells when serializing to markdown. Hard breaks and paragraph breaks in a cell are now written as `<br>` instead of being collapsed into a space, so they survive a parse/serialize round trip.

--- a/packages/extension-table/__tests__/tableMarkdown.spec.ts
+++ b/packages/extension-table/__tests__/tableMarkdown.spec.ts
@@ -1,5 +1,6 @@
 import { Code } from '@tiptap/extension-code'
 import Document from '@tiptap/extension-document'
+import HardBreak from '@tiptap/extension-hard-break'
 import Paragraph from '@tiptap/extension-paragraph'
 import { TableKit } from '@tiptap/extension-table'
 import Text from '@tiptap/extension-text'
@@ -170,5 +171,85 @@ describe('table markdown alignment', () => {
 
     expect(serialized).toContain('| left | right | center |')
     expect(serialized).toMatch(/\|\s*:[-]+\s*\|\s*[-]+:\s*\|\s*:[-]+:\s*\|/)
+  })
+})
+
+describe('table markdown line breaks', () => {
+  const markdownManager = new MarkdownManager({
+    extensions: [Document, Paragraph, Text, HardBreak, TableKit],
+  })
+
+  const cell = (content: Record<string, unknown>[]) => ({
+    type: 'tableCell',
+    content,
+  })
+
+  const tableDoc = (cells: ReturnType<typeof cell>[]) => ({
+    type: 'doc',
+    content: [
+      {
+        type: 'table',
+        content: [{ type: 'tableRow', content: cells }],
+      },
+    ],
+  })
+
+  it('keeps hard breaks in cells as <br>', () => {
+    const doc = tableDoc([
+      cell([
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'foo' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'bar' },
+          ],
+        },
+      ]),
+    ])
+
+    const serialized = markdownManager.serialize(doc)
+
+    expect(serialized).toContain('foo<br>bar')
+  })
+
+  it('round trips <br> inside cells', () => {
+    const markdown = `| desc |
+| --- |
+| foo<br>bar |`
+
+    const parsed = markdownManager.parse(markdown)
+    const parsedText = JSON.stringify(parsed)
+
+    expect(parsedText).toContain('"hardBreak"')
+
+    const serialized = markdownManager.serialize(parsed)
+
+    expect(serialized).toContain('foo<br>bar')
+  })
+
+  it('joins multiple paragraphs in a cell with <br>', () => {
+    const doc = tableDoc([
+      cell([
+        { type: 'paragraph', content: [{ type: 'text', text: 'one' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'two' }] },
+      ]),
+    ])
+
+    const serialized = markdownManager.serialize(doc)
+
+    expect(serialized).toContain('one<br>two')
+    expect(serialized).not.toContain('\u001F')
+  })
+
+  it('leaves cells without breaks alone', () => {
+    const doc = tableDoc([
+      cell([{ type: 'paragraph', content: [{ type: 'text', text: 'plain' }] }]),
+    ])
+
+    const serialized = markdownManager.serialize(doc)
+
+    expect(serialized).toContain('| plain |')
+    expect(serialized).not.toContain('<br>')
   })
 })

--- a/packages/extension-table/__tests__/tableMarkdown.spec.ts
+++ b/packages/extension-table/__tests__/tableMarkdown.spec.ts
@@ -213,6 +213,26 @@ describe('table markdown line breaks', () => {
     expect(serialized).toContain('foo<br>bar')
   })
 
+  it('keeps consecutive hard breaks as separate <br> tags', () => {
+    const doc = tableDoc([
+      cell([
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'foo' },
+            { type: 'hardBreak' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'bar' },
+          ],
+        },
+      ]),
+    ])
+
+    const serialized = markdownManager.serialize(doc)
+
+    expect(serialized).toContain('foo<br><br>bar')
+  })
+
   it('round trips <br> inside cells', () => {
     const markdown = `| desc |
 | --- |

--- a/packages/extension-table/src/table/utilities/markdown.ts
+++ b/packages/extension-table/src/table/utilities/markdown.ts
@@ -114,7 +114,14 @@ export function renderTableToMarkdown(
             : ''
         }
 
-        const text = collapseWhitespace(raw)
+        // Cells have to stay on a single line, so line breaks become <br> tags.
+        // The parser already turns <br> back into hard breaks, so this round trips.
+        const text = collapseWhitespace(
+          raw
+            .split(cellSep)
+            .join('\n')
+            .replace(/[ \t]*\n\s*/g, '<br>'),
+        )
         const isHeader = cellNode.type === 'tableHeader'
         const align = normalizeTableCellAlignFromAttributes(cellNode.attrs)
 

--- a/packages/extension-table/src/table/utilities/markdown.ts
+++ b/packages/extension-table/src/table/utilities/markdown.ts
@@ -120,7 +120,7 @@ export function renderTableToMarkdown(
           raw
             .split(cellSep)
             .join('\n')
-            .replace(/[ \t]*\n\s*/g, '<br>'),
+            .replace(/[ \t]*\r?\n[ \t]*/g, '<br>'),
         )
         const isHeader = cellNode.type === 'tableHeader'
         const align = normalizeTableCellAlignFromAttributes(cellNode.attrs)


### PR DESCRIPTION
Bug: A hard break inside a table cell (`first line<br>second line`) is silently turned into a plain space when the document is serialized to markdown. 
Parsing works fine (`<br>` correctly becomes a hardBreak node), so every load -> save cycle permanently loses the user's line breaks.

This PR fixes: https://github.com/ueberdosis/tiptap/issues/7731

I just noticed that there are 2 open PRs trying to solve this same issue but those are not merged yet and looks stale. Those PRs can be closed ig: https://github.com/ueberdosis/tiptap/pull/7738 and https://github.com/ueberdosis/tiptap/pull/7746

Fix: The cell renderer in `renderTableToMarkdown` collapses all whitespace to keep the cell on a single line, which also swallowed the `\n` coming from hardBreak. 
Now line breaks are converted to `<br>` before the whitespace collapse.

This also fixes a second problem in the same function: cells with multiple paragraphs were joined with an internal `\u001F` separator that was never removed and leaked into the output as an invisible control character. Multi-paragraph cells now also join with `<br>`.

---

Visual Reference:
**Before**
<img width="711" height="269" alt="Screenshot 2026-07-08 at 2 10 25 PM" src="https://github.com/user-attachments/assets/7c1ada18-0546-4695-9d07-7dd1dc4f14b7" />

---
**After**
<img width="774" height="260" alt="Screenshot 2026-07-08 at 2 10 41 PM" src="https://github.com/user-attachments/assets/2d89cc54-9d36-44ec-b3d2-b3e6ce324b3f" />

---


## AI Usage
- [x] I have used AI tools (Claude) in creating this PR.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.
