### PR TITLE
fix(core): merge task-item wrapped continuation lines instead of dropping them

### DIFF
--- a/.changeset/fix-task-item-wrapped-continuation.md
+++ b/.changeset/fix-task-item-wrapped-continuation.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fix markdown parsing dropping task-item continuation lines that are aligned under the marker's text column. A soft-wrapped line following a task item (e.g. indented six columns to line up under `- [ ] `, a common authoring style that LLMs also emit) was treated as nested content, dedented by a fixed amount that left it with four or more residual leading spaces, and then parsed by `marked` as an indented code block — which cannot interrupt a paragraph, so the line was silently dropped. `parseIndentedBlocks` now peels leading lazy paragraph-continuation lines into the item's main content so they merge into its paragraph (matching CommonMark renderers), and dedents any genuinely-nested content by its common indentation rather than a fixed amount. Genuinely-nested list items, blockquotes, code blocks, headings, and thematic breaks are still parsed as nested blocks.

--- a/packages/core/src/utilities/markdown/parseIndentedBlocks.ts
+++ b/packages/core/src/utilities/markdown/parseIndentedBlocks.ts
@@ -6,6 +6,28 @@
  * for lists, task lists, and other indented block types.
  */
 
+/**
+ * Whether a (leading-whitespace-trimmed) line begins a new markdown block —
+ * a list item (bullet, ordered, or task), blockquote, fenced code block, ATX
+ * heading, or thematic break. Such a line is not a lazy paragraph continuation
+ * and must not be merged into a preceding paragraph.
+ */
+function isBlockStart(trimmedLine: string): boolean {
+  return (
+    // oxlint-disable-next-line prefer-string-starts-ends-with
+    /^[-+*](\s|$)/.test(trimmedLine) || // bullet / task-item marker
+    // oxlint-disable-next-line prefer-string-starts-ends-with
+    /^\d+[.)](\s|$)/.test(trimmedLine) || // ordered list marker
+    // oxlint-disable-next-line prefer-string-starts-ends-with
+    /^>/.test(trimmedLine) || // blockquote
+    // oxlint-disable-next-line prefer-string-starts-ends-with
+    /^(```|~~~)/.test(trimmedLine) || // fenced code block
+    // oxlint-disable-next-line prefer-string-starts-ends-with
+    /^#{1,6}(\s|$)/.test(trimmedLine) || // ATX heading
+    /^(-{3,}|\*{3,}|_{3,})$/.test(trimmedLine) // thematic break
+  )
+}
+
 export interface ParsedBlock {
   type: string
   raw: string
@@ -160,12 +182,51 @@ export function parseIndentedBlocks(
 
     // Parse nested content if present
     let nestedTokens: any[] | undefined
-    const nestedContent = itemContent.slice(1)
+    let nestedContent = itemContent.slice(1)
+
+    // Peel off leading lazy paragraph-continuation lines into the item's main
+    // content. A soft-wrapped line that directly follows the item's text — no
+    // blank line separating it, and not itself the start of a new block — is a
+    // continuation of the item's paragraph in CommonMark, not new nested
+    // content. Authors (and LLMs) commonly align such wrapped lines under the
+    // marker's *text* column (e.g. six columns for `- [ ] `). Previously these
+    // were treated as nested content, dedented by a fixed amount that left >= 4
+    // residual spaces, and parsed by `marked` as an indented code block — which
+    // cannot interrupt a paragraph, so the line was silently dropped. Merging
+    // them into `mainContent` (which is tokenized inline by the caller) yields a
+    // single paragraph, matching CommonMark renderers.
+    let continuationCount = 0
+    for (const nestedLine of nestedContent) {
+      const trimmed = nestedLine.trim()
+      if (trimmed === '' || isBlockStart(trimmed)) {
+        break
+      }
+      continuationCount += 1
+    }
+
+    if (continuationCount > 0) {
+      const continuationText = nestedContent
+        .slice(0, continuationCount)
+        .map(nestedLine => nestedLine.trim())
+        .join(' ')
+      itemData.mainContent = `${itemData.mainContent} ${continuationText}`.trimEnd()
+      nestedContent = nestedContent.slice(continuationCount)
+    }
 
     if (nestedContent.length > 0) {
-      // Remove the base indentation from nested content
+      // Dedent by the smallest leading indentation shared by the non-blank
+      // nested lines rather than a fixed `indentLevel + baseIndentSize`, so a
+      // genuinely-nested block indented past `indentLevel + baseIndentSize` is
+      // not left with residual leading whitespace (which `marked` would parse
+      // as an indented code block). Deeper content keeps its relative
+      // indentation.
+      const nonBlankIndents = nestedContent
+        .filter(nestedLine => nestedLine.trim() !== '')
+        .map(nestedLine => nestedLine.length - nestedLine.trimStart().length)
+      const dedentAmount =
+        nonBlankIndents.length > 0 ? Math.min(...nonBlankIndents) : indentLevel + baseIndentSize
       const dedentedNested = nestedContent
-        .map(nestedLine => nestedLine.slice(indentLevel + baseIndentSize)) // Remove base indent + 2 spaces
+        .map(nestedLine => nestedLine.slice(dedentAmount))
         .join('\n')
 
       if (dedentedNested.trim()) {

--- a/packages/markdown/__tests__/task-item-wrapped-continuation.spec.ts
+++ b/packages/markdown/__tests__/task-item-wrapped-continuation.spec.ts
@@ -1,0 +1,77 @@
+import { Document } from '@tiptap/extension-document'
+import { BulletList, ListItem, OrderedList, TaskItem, TaskList } from '@tiptap/extension-list'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { describe, expect, it } from 'vitest'
+
+import { MarkdownManager } from '../src/MarkdownManager.js'
+
+/**
+ * Regression tests for #7909.
+ *
+ * A task-item continuation line aligned under the marker's text column (e.g.
+ * six spaces for `- [ ] `) was dedented by a fixed amount that left >= 4
+ * residual spaces, so `marked` parsed it as an indented code block — which
+ * cannot interrupt a paragraph, silently dropping the line. Such soft-wrapped
+ * lines should merge into the item's paragraph, matching CommonMark renderers.
+ */
+describe('Task item wrapped continuation parsing (#7909)', () => {
+  const mm = new MarkdownManager({
+    extensions: [Document, Paragraph, Text, BulletList, OrderedList, ListItem, TaskList, TaskItem],
+  })
+
+  it('merges a continuation aligned under the checkbox text column into one paragraph', () => {
+    const input =
+      '- [ ] Agent tab renders the composer in all states (no session\n' +
+      '      empty transcript + composer).'
+
+    expect(mm.parse(input)).toMatchObject({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            {
+              type: 'taskItem',
+              attrs: { checked: false },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Agent tab renders the composer in all states (no session empty transcript + composer).',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('merges multiple wrapped continuation lines into one paragraph', () => {
+    const input = '- [ ] first line\n      second line\n      third line'
+    const json = mm.parse(input)
+    const item = json.content![0].content![0]
+    expect(item.content).toHaveLength(1)
+    expect(item.content![0]).toMatchObject({
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'first line second line third line' }],
+    })
+  })
+
+  it('still keeps a genuinely nested task item as a nested list, not a continuation', () => {
+    const input = '- [ ] parent\n  - [ ] child'
+    const parent = mm.parse(input).content![0].content![0]
+    // parent paragraph + a nested taskList (not merged into the paragraph text)
+    expect(parent.content![0]).toMatchObject({
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'parent' }],
+    })
+    expect(parent.content![1].type).toBe('taskList')
+    expect(parent.content![1].content![0].content![0].content![0].text).toBe('child')
+  })
+})


### PR DESCRIPTION
## Fixes

Fixes #7909

## Changes and Review

- Task-item continuation lines indented under `- [ ] ` were dedented incorrectly, leaving 4+ leading spaces — which CommonMark parses as an indented code block and silently drops.
- Continuation lines now merge into the item's paragraph instead of being treated as nested content.
- Regression tests added; they fail with the fix reverted.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
