### PR TITLE
fix(extension-blockquote): guard backspace at document start

### DIFF
--- a/.changeset/fix-blockquote-backspace-gapcursor.md
+++ b/.changeset/fix-blockquote-backspace-gapcursor.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-blockquote': patch
+---
+
+Fix a crash when pressing Backspace with the caret at the very start of the document, before a leading block node such as an image. The blockquote backspace handler assumed the caret always sat inside a block and threw `TypeError: Cannot read properties of undefined (reading 'type')` for a top-level gap cursor. It now bails out early when there is no enclosing block.

--- a/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
+++ b/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
@@ -1,0 +1,37 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Image from '@tiptap/extension-image'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { TextSelection } from '@tiptap/pm/state'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Blockquote } from '../src/index.js'
+import { handleBackspace } from '../src/handleBackspace.js'
+
+describe('#7973: backspace before a leading block image', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('does not throw when the caret sits at the document start', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Image, Blockquote],
+      content: '<img src="https://example.com/a.png">',
+    })
+
+    // A block image at the start places the caret as a gap cursor at the very
+    // top of the document (position 0, depth 0). A degenerate text selection at
+    // position 0 resolves to the same $from, reproducing that code path without
+    // pulling in the gap-cursor module.
+    const { state, view } = editor
+    view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 0)))
+
+    const blockquoteType = editor.schema.nodes.blockquote
+
+    expect(() => handleBackspace(editor, blockquoteType)).not.toThrow()
+    expect(handleBackspace(editor, blockquoteType)).toBe(false)
+  })
+})

--- a/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
+++ b/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
@@ -31,7 +31,10 @@ describe('blockquote handleBackspace', () => {
 
     const blockquoteType = editor.schema.nodes.blockquote
 
-    expect(() => handleBackspace(editor, blockquoteType)).not.toThrow()
-    expect(handleBackspace(editor, blockquoteType)).toBe(false)
+    let result: boolean | undefined
+    expect(() => {
+      result = handleBackspace(editor, blockquoteType)
+    }).not.toThrow()
+    expect(result).toBe(false)
   })
 })

--- a/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
+++ b/packages/extension-blockquote/__tests__/handleBackspace.spec.ts
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { Blockquote } from '../src/index.js'
 import { handleBackspace } from '../src/handleBackspace.js'
 
-describe('#7973: backspace before a leading block image', () => {
+describe('blockquote handleBackspace', () => {
   let editor: Editor
 
   afterEach(() => {

--- a/packages/extension-blockquote/src/handleBackspace.ts
+++ b/packages/extension-blockquote/src/handleBackspace.ts
@@ -24,6 +24,10 @@ export const handleBackspace = (editor: Editor, type: NodeType): boolean => {
   const { $from } = selection
   if ($from.parentOffset !== 0) return false
 
+  // A caret directly in the document (e.g. a gap cursor before a leading
+  // block node) has no enclosing block to restructure. Nothing to do here.
+  if ($from.depth === 0) return false
+
   const parentDepth = $from.depth - 1
   const parent = $from.node(parentDepth)
   const index = $from.index(parentDepth)


### PR DESCRIPTION
## Changes Overview

Fixes a crash when pressing Backspace with the caret at the very start of the document, before a leading block node such as an image.

`@tiptap/extension-blockquote` binds `Backspace` to its own handler for every keypress. When a block image is the first element, the caret sits as a gap cursor at the top of the document (`$from.depth === 0`). The handler computed `parentDepth = $from.depth - 1 = -1`, so `$from.node(-1)` returned `undefined` and reading `parent.type` threw `TypeError: Cannot read properties of undefined (reading 'type')`.

## Implementation Approach

Add an early return in `handleBackspace` when `$from.depth === 0`. At the top level there is no enclosing block to lift out of or merge into, so blockquote handling does not apply and normal ProseMirror backspace behavior proceeds.

## Testing Done

Added `packages/extension-blockquote/__tests__/handleBackspace.spec.ts`. It positions the caret at document start before a block image and asserts `handleBackspace` does not throw and returns `false`. The test reproduces the exact reported `TypeError` before the fix and passes after it.

The gap-cursor position (`$from` at depth 0) is reproduced with a degenerate `TextSelection` at position 0 rather than importing `@tiptap/pm/gapcursor`. Both resolve `$from` to the same depth-0 position, so the code path is identical.

## Verification Steps

```bash
npx vitest run packages/extension-blockquote
pnpm lint
```

To reproduce the original bug: create an editor with `StarterKit` and `Image`, set content to a single `<img>`, move the caret to the very start, and press Backspace. Before this change it throws; after it, nothing happens.

## Additional Notes

None.

## AI Usage

- [x] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
  - I used Claude Code to investigate the stack trace, write the failing regression test, and implement the fix.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #7973
