### PR TITLE
fix(extension-list): stop parsing mid-line number+) as an ordered list

### DIFF
--- a/.changeset/fix-ordered-list-phone-number-split.md
+++ b/.changeset/fix-ordered-list-phone-number-split.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': patch
+---
+
+Fix markdown parsing a line like `(216) 555-1234` as an ordered list. A number followed by `)` mid-line is no longer treated as a list marker.

--- a/packages/extension-list/__tests__/orderedListPhoneNumber.spec.ts
+++ b/packages/extension-list/__tests__/orderedListPhoneNumber.spec.ts
@@ -1,0 +1,66 @@
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { MarkdownManager } from '@tiptap/markdown'
+import { describe, expect, it } from 'vitest'
+
+import { BulletList, ListItem, OrderedList } from '../src/index.js'
+
+describe('phone numbers starting a line', () => {
+  const markdownManager = new MarkdownManager({
+    extensions: [Document, Paragraph, Text, BulletList, OrderedList, ListItem],
+  })
+
+  const paragraph = (text: string) => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  })
+
+  it('keeps "(216) 555-1234" as a single paragraph', () => {
+    // The mid-line "216)" must not split the paragraph into "(" + an ordered
+    // list. A list marker only starts a list at the beginning of a line.
+    const json = markdownManager.parse('(216) 555-1234')
+
+    expect(json).toEqual(paragraph('(216) 555-1234'))
+  })
+
+  it('does not split "Call me at 555) later" mid-line', () => {
+    const json = markdownManager.parse('Call me at 555) later')
+
+    expect(json).toEqual(paragraph('Call me at 555) later'))
+  })
+
+  it('still treats a leading "216) ..." as an ordered list (CommonMark)', () => {
+    const json = markdownManager.parse('216) 555-1234')
+
+    expect(json).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 216 },
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: '555-1234' }] }],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('still splits a paragraph followed by a real ordered list', () => {
+    const json = markdownManager.parse('Intro\n1. First\n2. Second')
+
+    expect(json.content?.[0].type).toBe('paragraph')
+    expect(json.content?.[1].type).toBe('orderedList')
+  })
+
+  it('does not interrupt a paragraph with a non-1 ordered list', () => {
+    const json = markdownManager.parse('Intro\n3. Third\n4. Fourth')
+
+    expect(json.content).toHaveLength(1)
+    expect(json.content?.[0].type).toBe('paragraph')
+  })
+})

--- a/packages/extension-list/src/ordered-list/ordered-list.ts
+++ b/packages/extension-list/src/ordered-list/ordered-list.ts
@@ -233,7 +233,13 @@ export const OrderedList = Node.create<OrderedListOptions>({
     start: (src: string) => {
       const match = src.match(ORDERED_LIST_LINE_START_REGEX)
       const index = match?.index
-      return index !== undefined ? index : -1
+
+      // A marker only starts a list at the start of a line, never mid-line.
+      if (index === undefined || index === 0) {
+        return -1
+      }
+
+      return index
     },
     tokenize: (src: string, _tokens, lexer) => {
       const lines = src.split('\n')

--- a/packages/extension-list/src/ordered-list/ordered-list.ts
+++ b/packages/extension-list/src/ordered-list/ordered-list.ts
@@ -6,7 +6,6 @@ import { mergeAttributes, Node, wrappingInputRule } from '@tiptap/core'
 import {
   buildNestedStructure,
   collectOrderedListItems,
-  ORDERED_LIST_LINE_START_REGEX,
   parseListItems,
   parsePlainTextOrderedListPaste,
 } from './utils.js'
@@ -230,17 +229,12 @@ export const OrderedList = Node.create<OrderedListOptions>({
   markdownTokenizer: {
     name: 'orderedList',
     level: 'block',
-    start: (src: string) => {
-      const match = src.match(ORDERED_LIST_LINE_START_REGEX)
-      const index = match?.index
-
-      // A marker only starts a list at the start of a line, never mid-line.
-      if (index === undefined || index === 0) {
-        return -1
-      }
-
-      return index
-    },
+    // marked already breaks paragraphs before a start-of-line list marker. It
+    // probes this with `src.slice(1)`, so any marker it surfaces here is
+    // mid-line (like the "216)" in "(216) 555-1234") and must not start a list.
+    // We still define the callback so marked does not fall back to probing
+    // `tokenize`, which would re-introduce the mid-line split.
+    start: () => -1,
     tokenize: (src: string, _tokens, lexer) => {
       const lines = src.split('\n')
       const [listItems, consumed] = collectOrderedListItems(lines)

--- a/packages/extension-list/src/ordered-list/utils.ts
+++ b/packages/extension-list/src/ordered-list/utils.ts
@@ -27,13 +27,6 @@ export const ORDERED_LIST_ITEM_REGEX = new RegExp(
 )
 
 /**
- * Matches the start of an ordered list line (used by markdown tokenizer).
- */
-export const ORDERED_LIST_LINE_START_REGEX = new RegExp(
-  `^(\\s*)(${ORDERED_LIST_MARKER_PATTERN})([.)])\\s+`,
-)
-
-/**
  * Matches any line that starts with whitespace (indented content).
  * Used to identify continuation content that belongs to a list item.
  */


### PR DESCRIPTION
## Fixes

Fixes #7968

## Changes and Review

Markdown parsing of phone numbers like `(216) 555-1234` incorrectly split them into a stray `(` paragraph plus an ordered list starting at 216. The ordered-list tokenizer's `start()` function was matching mid-line numeric markers when `marked` probed with `src.slice(1)`.

The fix returns `-1` for matches at index `0`, so a marker only begins a list at the start of a line. A bare `216) 555-1234` (no parentheses) still parses as an ordered list, which is CommonMark-correct and intentionally unchanged.

- New spec: `packages/extension-list/__tests__/orderedListPhoneNumber.spec.ts`
- All `extension-list` and `markdown` tests pass (352 tests)
- `pnpm lint` and `pnpm fallow:audit` clean

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.