### PR TITLE
test(markdown): guard nested text-style marks serialization (#7499)

### DIFF
--- a/packages/markdown/__tests__/nested-text-style-marks.spec.ts
+++ b/packages/markdown/__tests__/nested-text-style-marks.spec.ts
@@ -6,18 +6,8 @@ import { describe, expect, it } from 'vitest'
 
 import { MarkdownManager } from '../src/MarkdownManager.js'
 
-/**
- * Regression guard for #7499.
- *
- * Adjacent text nodes can share a mark type (here `textStyle`) while carrying
- * different attributes (different colors). The serializer used to treat them as
- * one continuous mark, so `renderMarkdown` ran only once for the whole run and
- * the nested segment lost its own styling.
- *
- * Fixed by #7844 (serialize adjacent marks with different attributes
- * separately). This test keeps that behavior locked in: each distinct
- * attribute set must produce its own rendered mark.
- */
+// Adjacent text nodes sharing a mark type but differing in attributes must each
+// render their own mark, instead of collapsing into one continuous run.
 const TextStyle = Mark.create({
   name: 'textStyle',
 

--- a/packages/markdown/__tests__/nested-text-style-marks.spec.ts
+++ b/packages/markdown/__tests__/nested-text-style-marks.spec.ts
@@ -1,0 +1,83 @@
+import { Mark } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { describe, expect, it } from 'vitest'
+
+import { MarkdownManager } from '../src/MarkdownManager.js'
+
+/**
+ * Regression guard for #7499.
+ *
+ * Adjacent text nodes can share a mark type (here `textStyle`) while carrying
+ * different attributes (different colors). The serializer used to treat them as
+ * one continuous mark, so `renderMarkdown` ran only once for the whole run and
+ * the nested segment lost its own styling.
+ *
+ * Fixed by #7844 (serialize adjacent marks with different attributes
+ * separately). This test keeps that behavior locked in: each distinct
+ * attribute set must produce its own rendered mark.
+ */
+const TextStyle = Mark.create({
+  name: 'textStyle',
+
+  addAttributes() {
+    return {
+      color: { default: null },
+    }
+  },
+
+  renderMarkdown: (node, helpers) => {
+    const content = helpers.renderChildren(node)
+    const color = node.attrs?.color
+    if (!color) {
+      return content
+    }
+    return `<span style="color: ${color}">${content}</span>`
+  },
+})
+
+describe('#7499: nested inline styles in markdown', () => {
+  const markdownManager = new MarkdownManager({
+    extensions: [Document, Paragraph, Text, TextStyle],
+  })
+
+  it('renders each distinct textStyle attribute set instead of collapsing them', () => {
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Test ',
+              marks: [{ type: 'textStyle', attrs: { color: '#9bbb59' } }],
+            },
+            {
+              type: 'text',
+              text: 'nested',
+              marks: [{ type: 'textStyle', attrs: { color: '#ff0000' } }],
+            },
+            {
+              type: 'text',
+              text: ' style',
+              marks: [{ type: 'textStyle', attrs: { color: '#9bbb59' } }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = markdownManager.serialize(json)
+
+    // renderMarkdown must run once per distinct segment: three spans total,
+    // with the middle color present (proving the nested run rendered on its own).
+    const spanCount = (result.match(/<span /g) || []).length
+    expect(spanCount).toBe(3)
+    expect(result).toContain('color: #ff0000')
+    expect(result).toContain('Test')
+    expect(result).toContain('nested')
+    expect(result).toContain('style')
+  })
+})

--- a/packages/markdown/__tests__/nested-text-style-marks.spec.ts
+++ b/packages/markdown/__tests__/nested-text-style-marks.spec.ts
@@ -27,7 +27,7 @@ const TextStyle = Mark.create({
   },
 })
 
-describe('#7499: nested inline styles in markdown', () => {
+describe('serializing adjacent same-type marks with different attributes', () => {
   const markdownManager = new MarkdownManager({
     extensions: [Document, Paragraph, Text, TextStyle],
   })


### PR DESCRIPTION
## What

Adds a regression test for [#7499](https://github.com/ueberdosis/tiptap/issues/7499): adjacent text nodes that share a mark type but differ in attributes (e.g. `textStyle` with different colors) must each render their own markdown via `renderMarkdown`.

## Why

The issue reported that `renderMarkdown` was called only once for a run of same-type marks with different attributes, so nested styling was lost. That behavior was already fixed by #7844 (the serializer now compares mark attributes, not just type). This test locks in that behavior so it can't silently regress.

## Details

- New spec `packages/markdown/__tests__/nested-text-style-marks.spec.ts`.
- Reproduces the exact input from the issue (three `textStyle` spans: green / red / green).
- Asserts three distinct spans are emitted and the nested color renders on its own.
- Test-only change, no product code touched. All 253 markdown package tests pass.

No changeset added since there is no user-facing code change.

_AI assistance was used to write this test._