### PR TITLE
Refresh GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,9 +41,9 @@ body:
     validations:
       required: true
   - type: textarea
-    id: problem
+    id: body
     attributes:
-      label: Problem Description
+      label: What happened?
       description: Describe what happens, when it happens, and why it is a problem. Use short sentences and simple English. Do not write a wall of text, use complicated language, or include a complete code fix.
       placeholder: The issue happens when...
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,49 +7,61 @@ type: "Bug"
 body:
   - type: markdown
     attributes:
-      value: '### Please provide details to help us diagnose the bug.'
+      value: |
+        Please use simple, human-written English. Keep your answers short and clear.
+        Small code examples that show the problem are welcome. Do not include a code fix or a complete implementation in an issue. If you already have a fix, please open a pull request instead.
   - type: input
     id: packages
     attributes:
       label: Affected Packages
-      description: List the packages you were using when the bug occurred.
+      description: List the Tiptap packages involved in the problem.
       placeholder: core, extension-mention, react
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: Version(s)
-      description: Specify the version(s) of the affected packages.
-      placeholder: 2.0.0
-    validations:
-      required: true
-  - type: textarea
-    id: problem
-    attributes:
-      label: Bug Description
-      description: Provide a clear and concise description of what the bug is.
-      placeholder: 'The issue occurs when...'
+      label: Tiptap Version
+      description: Which Tiptap version or package versions are affected?
+      placeholder: 3.0.0
     validations:
       required: true
   - type: dropdown
     id: browser
     attributes:
       label: Browser Used
-      description: Select the browser where the bug was observed.
+      description: Select the browser where you saw the problem.
       options:
         - Chrome
         - Firefox
         - Safari
         - Edge
         - Other
+        - Not browser-specific
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: Describe what happens, when it happens, and why it is a problem. Use short sentences and simple English. Do not write a wall of text, use complicated language, or include a complete code fix.
+      placeholder: The issue happens when...
+    validations:
+      required: true
+  - type: textarea
+    id: expectation
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen.
+      placeholder: I expected...
     validations:
       required: true
   - type: markdown
     attributes:
       value: |
-        ### CodeSandbox templates
-        Please use the appropriate template below to provide a code example:
+        A small reproducible example is the best way to help us investigate the issue. Please add one if you can.
+
+        CodeSandbox templates:
         * JavaScript: [JS Template](https://codesandbox.io/s/tiptap-js-fv1lyo)
         * React: [React Template](https://codesandbox.io/s/tiptap-react-qidlsv)
         * Vue 2: [Vue 2 Template](https://codesandbox.io/s/tiptap-vue-2-25nq3g)
@@ -57,30 +69,14 @@ body:
   - type: input
     id: sandbox
     attributes:
-      label: Code Example URL
-      description: 'Link a CodeSandbox, Stackblitz, GitHub repository, or similar to help us reproduce the issue faster.'
+      label: Reproducible Example URL (Optional)
+      description: Link a CodeSandbox, StackBlitz, GitHub repository, or similar example if you have one.
       placeholder: https://codesandbox.io/s/example
-    validations:
-      required: false
-  - type: textarea
-    id: expectation
-    attributes:
-      label: Expected Behavior
-      description: Describe what you expected to happen.
-    validations:
-      required: true
   - type: textarea
     id: context
     attributes:
       label: Additional Context (Optional)
-      description: 'Add any other context about the problem here, such as screenshots or videos.'
-  - type: checkboxes
-    attributes:
-      label: Dependency Updates
-      description: 'Have you updated your dependencies? This can often resolve issues.'
-      options:
-        - label: Yes, I've updated all my dependencies.
-          required: true
+      description: Add useful screenshots, videos, or other short details. Avoid long explanations.
   - type: markdown
     attributes:
       value: 'Thank you for helping us improve our open-source projects by reporting this issue!'

--- a/.github/ISSUE_TEMPLATE/bug_report_pro.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_pro.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Affected Packages
       description: List the Tiptap Pro packages involved in the problem.
-      placeholder: pro-extension, pro-collaboration, react
+      placeholder: pro-extension, pro-collaboration
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report_pro.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_pro.yml
@@ -41,9 +41,9 @@ body:
     validations:
       required: true
   - type: textarea
-    id: problem
+    id: body
     attributes:
-      label: Problem Description
+      label: What happened?
       description: Describe what happens, when it happens, and why it is a problem. Use short sentences and simple English. Do not write a wall of text, use complicated language, or include a complete code fix.
       placeholder: The issue happens when...
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report_pro.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_pro.yml
@@ -7,53 +7,61 @@ type: "Bug"
 body:
   - type: markdown
     attributes:
-      value: '### Please ensure this issue is for Tiptap Pro features only. Provide as much detail as possible to help us identify the issue quickly.'
+      value: |
+        Please use simple, human-written English. Keep your answers short and clear.
+        Small code examples that show the problem are welcome. Do not include a code fix or a complete implementation in an issue. If you already have a fix, please open a pull request instead.
   - type: input
     id: packages
     attributes:
       label: Affected Packages
-      description: List all Tiptap Pro packages where you experienced the bug.
-      placeholder: core, extension-mention, react
+      description: List the Tiptap Pro packages involved in the problem.
+      placeholder: pro-extension, pro-collaboration, react
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: Version(s)
-      description: Specify the version(s) of the affected packages.
-      placeholder: 2.0.0
-    validations:
-      required: true
-  - type: textarea
-    id: problem
-    attributes:
-      label: Description of the Bug
-      description: Provide a clear and concise description of what the bug is.
-      placeholder: 'The issue occurs when...'
+      label: Tiptap Version
+      description: Which Tiptap or Tiptap Pro version or package versions are affected?
+      placeholder: 3.0.0
     validations:
       required: true
   - type: dropdown
     id: browser
     attributes:
       label: Browser Used
-      description: Select the browser where the bug was observed.
+      description: Select the browser where you saw the problem.
       options:
         - Chrome
         - Firefox
         - Safari
         - Edge
         - Other
+        - Not browser-specific
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: Describe what happens, when it happens, and why it is a problem. Use short sentences and simple English. Do not write a wall of text, use complicated language, or include a complete code fix.
+      placeholder: The issue happens when...
+    validations:
+      required: true
+  - type: textarea
+    id: expectation
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen.
+      placeholder: I expected...
     validations:
       required: true
   - type: markdown
     attributes:
-      value: '### Helpful Code Examples'
-  - type: markdown
-    attributes:
-      value: 'Providing a CodeSandbox link is crucial for diagnosing issues faster. Below are templates you might use:'
-  - type: markdown
-    attributes:
       value: |
+        A small reproducible example is the best way to help us investigate the issue. Please add one if you can.
+
+        CodeSandbox templates:
         - JavaScript: [Template](https://codesandbox.io/s/tiptap-js-fv1lyo)
         - React: [Template](https://codesandbox.io/s/tiptap-react-qidlsv)
         - Vue 2: [Template](https://codesandbox.io/s/tiptap-vue-2-25nq3g)
@@ -61,30 +69,14 @@ body:
   - type: input
     id: sandbox
     attributes:
-      label: Code Example (Preferred)
-      description: 'Provide a link to a CodeSandbox or other code repository to help us reproduce the issue.'
+      label: Reproducible Example URL (Optional)
+      description: Link a CodeSandbox, StackBlitz, GitHub repository, or similar example if you have one.
       placeholder: https://codesandbox.io/s/example
-    validations:
-      required: false
-  - type: textarea
-    id: expectation
-    attributes:
-      label: Expected Behavior
-      description: Describe what you expected to happen.
-    validations:
-      required: true
   - type: textarea
     id: context
     attributes:
       label: Additional Context (Optional)
-      description: 'Add any other context about the problem here, like screenshots or videos.'
-  - type: checkboxes
-    attributes:
-      label: Dependency Updates
-      description: 'Have you updated your dependencies? It can often resolve issues.'
-      options:
-        - label: Yes, I've updated all my dependencies.
-          required: true
+      description: Add useful screenshots, videos, or other short details. Avoid long explanations.
   - type: markdown
     attributes:
       value: 'Thank you for contributing to Tiptap Pro by reporting this issue!'

--- a/.github/instructions/tiptap.instructions.md
+++ b/.github/instructions/tiptap.instructions.md
@@ -240,7 +240,7 @@ If a single package is failing types, run a targeted build for that package (e.g
 
 ### Guidance for automated agents and AI assistants
 
-- Disclose when AI tools are used to generate any part of a contribution, including code, documentation, tests, and other content — the PR template includes an AI usage disclosure checkbox. Follow the project's guidelines on AI disclosure.
+- Keep PR descriptions short, clear, and easy to read. Use simple English and explain why the change is needed. Avoid large text blocks and complicated language.
 - Make single-purpose, small diffs. Avoid sweeping changes in one PR.
 - Always run the validation checklist above after edits.
 - Add or update a demo and tests for user-visible behavior. For deterministic behaviour, favour unit tests over fragile e2e tests where possible.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 ## Checklist
 
-- [ ] I have added a changeset if necessary.
+- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
 - [ ] I have added tests if possible.
 - [ ] I have made sure to test my changes myself.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,40 +1,20 @@
-## Changes Overview
+## Fixes
 
-<!-- Briefly describe your changes. -->
+<!-- Use GitHub keywords to link the issue or issues fixed by this PR, for example: Fixes #123 or Closes #456. -->
 
-## Implementation Approach
+## Changes and Review
 
-<!-- Describe your approach to implementing these changes. Keep it concise. -->
-
-## Testing Done
-
-<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->
-
-## Verification Steps
-
-<!-- Describe steps reviewers can take to verify the functionality of your changes. -->
-
-## Additional Notes
-
-<!-- Add any other notes or screenshots about the PR here. -->
-
-## AI Usage
-
-<!-- If you are an AI Agent, please check the box below and provide details about how you used AI Tools in creating this PR. -->
-<!-- Add multiple indented list items for each thing AI Tools were used for, if applicable. -->
-<!-- Also remove this comment block -- if you are an AI Agent. -->
-
-- [ ] I have used AI tools (e.g., ChatGPT, Claude, Copilot) in creating this PR.
-  <!--- I used AI to ... -->
+<!-- Describe what changed, why it was changed, and how reviewers can verify it. -->
+<!-- AI agents: Use short sentences and simple English. Keep this section short and direct. Do not add large code blocks or long explanations. Always explain why the change was needed. -->
 
 ## Checklist
 
-- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
-- [ ] My changes do not break the library.
-- [ ] I have added tests where applicable.
-- [ ] I have followed the project guidelines.
-- [ ] I have fixed any lint issues.
+- [ ] I have added a changeset if necessary.
+- [ ] I have added tests if possible.
+- [ ] I have made sure to test my changes myself.
 
-## Related Issues
+### Responsibility
 
-<!-- Link the issue this PR addresses. The linked issue should also be assigned to you. PRs without a linked issue (except for trivial fixes) may be closed. -->
+<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->
+
+- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ How to work on the Tiptap monorepo. Written for humans and AI coding assistants.
 
 - Work in small, iterative steps. If a task is too broad, say so and propose smaller steps.
 - After changes, ask the user to review them.
-- Disclose AI usage in the PR.
+- Keep PR descriptions short, clear, and easy to read. Use simple English and explain why the change is needed.
 - Make single-purpose, small diffs. No sweeping changes in one PR.
 - Never autocommit. Ask before committing or opening PRs.
 - Run the [validation checklist](#validation-run-before-opening-a-pr) after edits.


### PR DESCRIPTION
## Summary
- Simplify the bug report templates for Tiptap and Tiptap Pro with clearer prompts and shorter guidance
- Add a non-browser-specific option and rename fields to make issue reporting more consistent
- Streamline the pull request template to focus on fixes, changes, review, and a lighter checklist

## Testing
- Not run (not requested)