### PR TITLE
fix(react): add use client directive for React Server Components

### DIFF
--- a/.changeset/react-use-client-directive.md
+++ b/.changeset/react-use-client-directive.md
@@ -2,4 +2,4 @@
 "@tiptap/react": patch
 ---
 
-Add a `use client` directive to the package entry so `@tiptap/react` can be imported from a React Server Component without crashing. Previously any import (for example `ReactNodeViewRenderer`) threw `Class extends value undefined is not a constructor or null` during the server render pass, because the client-only class components were evaluated in the server graph. The directive marks the package as a client boundary, which every RSC bundler honors, while staying inert in normal client and SSR setups. Note that core symbols re-exported through `@tiptap/react` now also cross that boundary, so import them from `@tiptap/core` directly in server code.
+Add a `use client` directive so `@tiptap/react` can be imported from React Server Components without crashing. Core symbols re-exported through `@tiptap/react` now cross the client boundary too, so import them from `@tiptap/core` directly in server code.

--- a/.changeset/react-use-client-directive.md
+++ b/.changeset/react-use-client-directive.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Add a `use client` directive to the package entry so `@tiptap/react` can be imported from a React Server Component without crashing. Previously any import (for example `ReactNodeViewRenderer`) threw `Class extends value undefined is not a constructor or null` during the server render pass, because the client-only class components were evaluated in the server graph. The directive marks the package as a client boundary, which every RSC bundler honors, while staying inert in normal client and SSR setups. Note that core symbols re-exported through `@tiptap/react` now also cross that boundary, so import them from `@tiptap/core` directly in server code.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,5 @@
+'use client'
+
 export * from './Context.js'
 export * from './EditorContent.js'
 export * from './NodeViewContent.js'

--- a/packages/react/src/menus/index.ts
+++ b/packages/react/src/menus/index.ts
@@ -1,2 +1,4 @@
+'use client'
+
 export * from './BubbleMenu.js'
 export * from './FloatingMenu.js'

--- a/packages/react/src/use-client.spec.ts
+++ b/packages/react/src/use-client.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment node
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+// The package boundary must stay a client module so it can be imported from
+// React Server Components without evaluating the class components inside.
+const entries = ['./index.ts', './menus/index.ts']
+
+describe('use client boundary', () => {
+  it.each(entries)('%s starts with the "use client" directive', entry => {
+    const path = fileURLToPath(new URL(entry, import.meta.url))
+    const firstLine = readFileSync(path, 'utf8').trimStart().split('\n')[0].trim()
+
+    expect(firstLine).toMatch(/^(['"])use client\1;?$/)
+  })
+})

--- a/packages/react/src/use-client.spec.ts
+++ b/packages/react/src/use-client.spec.ts
@@ -13,7 +13,13 @@ const entries = ['./index.ts', './menus/index.ts']
 describe('use client boundary', () => {
   it.each(entries)('%s starts with the "use client" directive', entry => {
     const path = fileURLToPath(new URL(entry, import.meta.url))
-    const firstLine = readFileSync(path, 'utf8').trimStart().split('\n')[0].trim()
+
+    // The directive must be the very first statement (only a BOM may precede
+    // it), otherwise some RSC tooling ignores it. Do not trim leading blanks.
+    const firstLine = readFileSync(path, 'utf8')
+      .replace(/^\uFEFF/, '')
+      .split('\n')[0]
+      .trimEnd()
 
     expect(firstLine).toMatch(/^(['"])use client\1;?$/)
   })


### PR DESCRIPTION
## Fixes

- Fixes #6328

## Changes and Review

Add `"use client"` to the `@tiptap/react` entry points so React Server Components can import the package without crashing at module load.

Review by checking the generated files and loading `ReactNodeViewRenderer` from a Server Component. The existing client behavior must continue to work.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [ ] I have tested my changes myself. (Local SSR demo not available.)

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR.