### PR TITLE
fix(extension-details): preserve cursor in content at document start

### DIFF
--- a/.changeset/fix-details-content-cursor.md
+++ b/.changeset/fix-details-content-cursor.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-details": patch
+---
+
+Fix the cursor moving to the details summary after typing in content at the start of a document.

--- a/packages/extension-details/__tests__/details.spec.ts
+++ b/packages/extension-details/__tests__/details.spec.ts
@@ -8,9 +8,12 @@ import { Details, DetailsContent, DetailsSummary } from '../src/index.js'
 
 describe('Details', () => {
   let editor: Editor
+  let editorElement: HTMLDivElement | undefined
 
   afterEach(() => {
     editor?.destroy()
+    editorElement?.remove()
+    editorElement = undefined
   })
 
   it('adds a default aria-label to the toggle button', () => {
@@ -149,6 +152,59 @@ describe('Details', () => {
     expect(editor.getHTML()).toBe(
       '<details><summary>Summary</summary><div data-type="detailsContent"><p>Content</p></div></details>',
     )
+  })
+
+  it('keeps the cursor in details content after typing at the start of the document', () => {
+    editorElement = document.createElement('div')
+    document.body.appendChild(editorElement)
+
+    editor = new Editor({
+      element: editorElement,
+      extensions: [Document, Paragraph, Text, Details, DetailsSummary, DetailsContent],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'details',
+            content: [
+              {
+                type: 'detailsSummary',
+                content: [{ type: 'text', text: 'Summary' }],
+              },
+              {
+                type: 'detailsContent',
+                content: [{ type: 'paragraph' }],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    Object.defineProperty(editor.view.dom, 'offsetParent', { value: document.body })
+    const paragraph = editor.view.dom.querySelector('p')
+
+    if (!paragraph) {
+      throw new Error('Expected details content to contain a paragraph')
+    }
+
+    Object.defineProperty(paragraph, 'offsetParent', {
+      value: editor.view.dom,
+    })
+
+    const toggleButton = editor.view.dom.querySelector<HTMLButtonElement>(
+      'div[data-type="details"] > button',
+    )
+    const summary = editor.state.doc.firstChild?.firstChild
+    const contentPosition = 1 + (summary?.nodeSize ?? 0) + 2
+
+    toggleButton?.click()
+    editor.commands.setTextSelection(contentPosition)
+    editor.commands.insertContent('a')
+    editor.commands.setTextSelection(contentPosition + 1)
+
+    expect(editor.state.selection.$from.parent.type).toBe(editor.schema.nodes.paragraph)
+    expect(editor.state.doc.textContent).toBe('Summarya')
   })
 
   it('ignores button attribute mutations triggered by renderToggleButton', async () => {

--- a/packages/extension-details/src/helpers/isNodeVisible.ts
+++ b/packages/extension-details/src/helpers/isNodeVisible.ts
@@ -1,8 +1,16 @@
 import type { Editor } from '@tiptap/core'
 
 export const isNodeVisible = (position: number, editor: Editor): boolean => {
-  const node = editor.view.domAtPos(position).node as HTMLElement
-  const isOpen = node.offsetParent !== null
+  const node = editor.view.domAtPos(position).node
+  // Use the node for elements and its parent for text nodes.
+  const element = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement
+
+  if (!element) {
+    return false
+  }
+
+  // Hidden elements have no offset parent.
+  const isOpen = element.offsetParent !== null
 
   return isOpen
 }


### PR DESCRIPTION
## Fixes

Fixes #7122

## Changes and Review

When ProseMirror resolves the cursor to a text node, the details visibility check now uses its parent element. This prevents visible details content from being mistaken for hidden content and moving the cursor to the summary.

The regression test covers typing in details content when the details block is the first document node.

Validation: affected details tests, package build, formatting, and oxlint pass.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.