### PR TITLE
fix(core): input rules no longer crash when the match spans an inline atom node

### DIFF
--- a/.changeset/fix-input-rule-inline-atom-range.md
+++ b/.changeset/fix-input-rule-inline-atom-range.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Input rules no longer crash or replace the wrong content when the matched text spans an inline atom node (like a mention). Input rules match against a string where leaf nodes get expanded to placeholders like `%leaf%`, so a match crossing an atom ended up with a range that didn't map back to real document positions, throwing `RangeError: Position -N out of range` or corrupting nearby content. Such matches are now skipped. Rules on plain text, including text after an atom, behave the same as before.

--- a/.changeset/fix-input-rule-inline-atom-range.md
+++ b/.changeset/fix-input-rule-inline-atom-range.md
@@ -2,4 +2,4 @@
 '@tiptap/core': patch
 ---
 
-Input rules no longer crash or replace the wrong content when the matched text spans an inline atom node (like a mention). Input rules match against a string where leaf nodes get expanded to placeholders like `%leaf%`, so a match crossing an atom ended up with a range that didn't map back to real document positions, throwing `RangeError: Position -N out of range` or corrupting nearby content. Such matches are now skipped. Rules on plain text, including text after an atom, behave the same as before.
+Fix input rules crashing when the matched text spans an inline atom node like a mention.

--- a/packages/core/src/InputRule.ts
+++ b/packages/core/src/InputRule.ts
@@ -133,6 +133,25 @@ function run(config: {
       return
     }
 
+    // textBefore expands leaf nodes into placeholders like %leaf% (check getTextContentFromNodes),
+    // so an atom takes up 6 chars in the string but just 1 position in the doc.
+    // if the match crosses a leaf node, the range computed below would land on the wrong
+    // doc positions (can even go negative), so in that case we skip the rule
+    // see: https://github.com/ueberdosis/tiptap/issues/7933
+    const matchedDocLength = match[0].length - text.length
+
+    if (matchedDocLength > 0) {
+      const matchStartOffset = $from.parentOffset - matchedDocLength
+
+      if (
+        matchStartOffset < 0 ||
+        $from.parent.textBetween(matchStartOffset, $from.parentOffset) !==
+          match[0].slice(0, matchedDocLength)
+      ) {
+        return
+      }
+    }
+
     const tr = view.state.tr
     const state = createChainableState({
       state: view.state,

--- a/packages/core/src/InputRule.ts
+++ b/packages/core/src/InputRule.ts
@@ -133,11 +133,8 @@ function run(config: {
       return
     }
 
-    // textBefore expands leaf nodes into placeholders like %leaf% (check getTextContentFromNodes),
-    // so an atom takes up 6 chars in the string but just 1 position in the doc.
-    // if the match crosses a leaf node, the range computed below would land on the wrong
-    // doc positions (can even go negative), so in that case we skip the rule
-    // see: https://github.com/ueberdosis/tiptap/issues/7933
+    // Leaf nodes have a different length in text and the document.
+    // Skip matches across them to avoid wrong document positions.
     const matchedDocLength = match[0].length - text.length
 
     if (matchedDocLength > 0) {

--- a/packages/core/src/__tests__/inputRuleInlineAtoms.test.ts
+++ b/packages/core/src/__tests__/inputRuleInlineAtoms.test.ts
@@ -8,7 +8,6 @@ import { afterEach, describe, expect, it } from 'vitest'
 // minimal stand-in for a mention-like node. inline atoms expand to %leaf% (6 chars)
 // in getTextContentFromNodes but only take up 1 position in the doc,
 // which used to break the input rule range math
-// https://github.com/ueberdosis/tiptap/issues/7933
 const InlineAtom = Node.create({
   name: 'inlineAtom',
   group: 'inline',
@@ -18,9 +17,20 @@ const InlineAtom = Node.create({
   renderHTML: () => ['span', { 'data-atom': '' }],
 })
 
+// same as above, but with a custom text representation instead of the %leaf% fallback
+const InlineAtomWithText = Node.create({
+  name: 'inlineAtomWithText',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  parseHTML: () => [{ tag: 'span[data-atom-text]' }],
+  renderHTML: () => ['span', { 'data-atom-text': '' }],
+  renderText: () => '@mention',
+})
+
 const createEditor = (content: string) =>
   new Editor({
-    extensions: [Document, Paragraph, Text, InlineAtom, Code],
+    extensions: [Document, Paragraph, Text, InlineAtom, InlineAtomWithText, Code],
     content,
   })
 
@@ -69,8 +79,16 @@ describe('input rules with inline atom nodes', () => {
     editor = createEditor('<p>hello world `a<span data-atom></span></p>')
 
     expect(() => typeAtEndOfParagraph(editor, '`')).not.toThrow()
-    expect(editor.getHTML()).not.toContain('<code>')
-    expect(editor.getText()).toContain('hello world')
+    expect(editor.getHTML()).toBe('<p>hello world `a<span data-atom=""></span></p>')
+  })
+
+  it('does not apply the rule when the match spans an atom with a custom text representation', () => {
+    editor = createEditor('<p>hello `a<span data-atom-text></span></p>')
+
+    const handled = typeAtEndOfParagraph(editor, '`')
+
+    expect(handled).toBeFalsy()
+    expect(editor.getHTML()).toBe('<p>hello `a<span data-atom-text=""></span></p>')
   })
 
   it('still applies input rules to plain text', () => {

--- a/packages/core/src/__tests__/inputRuleInlineAtoms.test.ts
+++ b/packages/core/src/__tests__/inputRuleInlineAtoms.test.ts
@@ -1,0 +1,93 @@
+import { Editor, Node } from '@tiptap/core'
+import Code from '@tiptap/extension-code'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// minimal stand-in for a mention-like node. inline atoms expand to %leaf% (6 chars)
+// in getTextContentFromNodes but only take up 1 position in the doc,
+// which used to break the input rule range math
+// https://github.com/ueberdosis/tiptap/issues/7933
+const InlineAtom = Node.create({
+  name: 'inlineAtom',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  parseHTML: () => [{ tag: 'span[data-atom]' }],
+  renderHTML: () => ['span', { 'data-atom': '' }],
+})
+
+const createEditor = (content: string) =>
+  new Editor({
+    extensions: [Document, Paragraph, Text, InlineAtom, Code],
+    content,
+  })
+
+const typeAtEndOfParagraph = (editor: Editor, char: string) => {
+  const pos = editor.state.doc.content.size - 1
+
+  editor.commands.setTextSelection(pos)
+
+  return editor.view.someProp('handleTextInput', f => f(editor.view, pos, pos, char))
+}
+
+describe('input rules with inline atom nodes', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  it('does not crash when the match spans an inline atom (#7933)', () => {
+    editor = createEditor('<p>`a<span data-atom></span></p>')
+
+    expect(() => typeAtEndOfParagraph(editor, '`')).not.toThrow()
+  })
+
+  it('does not apply the rule when the match spans an inline atom', () => {
+    editor = createEditor('<p>`a<span data-atom></span></p>')
+
+    const handled = typeAtEndOfParagraph(editor, '`')
+
+    // someProp returns undefined when the handler declines the input
+    expect(handled).toBeFalsy()
+    expect(editor.getHTML()).not.toContain('<code>')
+  })
+
+  it('does not crash with multiple atoms inside the match', () => {
+    editor = createEditor(
+      '<p>`a<span data-atom></span><span data-atom></span><span data-atom></span></p>',
+    )
+
+    expect(() => typeAtEndOfParagraph(editor, '`')).not.toThrow()
+  })
+
+  it('does not corrupt preceding text when the match spans an atom (#7833)', () => {
+    // with enough text before the backtick the miscalculated range stays positive,
+    // so instead of crashing it used to silently mark/replace the wrong content
+    editor = createEditor('<p>hello world `a<span data-atom></span></p>')
+
+    expect(() => typeAtEndOfParagraph(editor, '`')).not.toThrow()
+    expect(editor.getHTML()).not.toContain('<code>')
+    expect(editor.getText()).toContain('hello world')
+  })
+
+  it('still applies input rules to plain text', () => {
+    editor = createEditor('<p>some `code</p>')
+
+    const handled = typeAtEndOfParagraph(editor, '`')
+
+    expect(handled).toBe(true)
+    expect(editor.getHTML()).toContain('<code>code</code>')
+  })
+
+  it('still applies input rules when an atom precedes the match', () => {
+    editor = createEditor('<p><span data-atom></span>x `code</p>')
+
+    const handled = typeAtEndOfParagraph(editor, '`')
+
+    expect(handled).toBe(true)
+    expect(editor.getHTML()).toContain('<code>code</code>')
+  })
+})


### PR DESCRIPTION
Fixes #7933 and #7833

## Changes and Review

Input rules compute their range from matched text where atoms expand to `%leaf%` (6 chars for 1 doc position), so a match spanning an inline atom produced an invalid range and crashed.
For a detailed description: please refer to the issues linked above. 

Now, the rule checks the matched text against the actual doc content and skips itself when they don't line up, so the typed character just inserts normally. 

To verify: put a backtick + text + mention in a paragraph and type a closing backtick.


## Checklist
- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility
- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
