### PR TITLE
chore(ci): add reusable composite actions

### DIFF
--- a/.github/actions/restore-build/action.yml
+++ b/.github/actions/restore-build/action.yml
@@ -1,0 +1,21 @@
+name: Restore build artifacts
+description: Download and extract build output artifact
+
+inputs:
+  artifact-name:
+    description: Name of the artifact containing build output
+    default: build-output
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: /tmp/build-output
+
+    - name: Restore build output
+      shell: bash
+      run: tar -xzf /tmp/build-output/build-output.tar.gz

--- a/.github/actions/restore-dependencies/action.yml
+++ b/.github/actions/restore-dependencies/action.yml
@@ -1,0 +1,25 @@
+name: Restore dependencies
+description: Download cached pnpm store artifact and restore dependencies offline
+
+inputs:
+  artifact-name:
+    description: Name of the artifact containing the pnpm store
+    default: node-dependencies
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Download dependency artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: /tmp/node-dependencies
+
+    - name: Restore pnpm store
+      shell: bash
+      run: tar -xzf /tmp/node-dependencies/pnpm-store.tar.gz
+
+    - name: Restore dependencies
+      shell: bash
+      run: pnpm install --offline --frozen-lockfile --strict-peer-dependencies

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,42 @@
+name: Setup Node.js and pnpm
+description: Checkout repo, install pnpm, setup Node.js, and optionally configure pnpm store
+
+inputs:
+  node-version:
+    description: Node.js version
+    required: true
+  pnpm-version:
+    description: pnpm version
+    required: true
+  store-dir:
+    description: Relative pnpm store directory within the workspace. Empty uses the default pnpm store.
+    default: ''
+    required: false
+  checkout:
+    description: Whether to checkout the repository
+    default: 'true'
+    required: false
+  cache:
+    description: Whether to use setup-node's pnpm caching (pass literal string `'true'` to enable)
+    default: 'false'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v7
+      if: inputs.checkout == 'true'
+
+    - uses: pnpm/action-setup@v5
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
+
+    - name: Configure pnpm store
+      if: inputs.store-dir != ''
+      shell: bash
+      run: pnpm config set store-dir ${{ github.workspace }}/${{ inputs.store-dir }}

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,5 +1,5 @@
 name: Setup Node.js and pnpm
-description: Checkout repo, install pnpm, setup Node.js, and optionally configure pnpm store
+description: Install pnpm, setup Node.js, and optionally configure pnpm store
 
 inputs:
   node-version:
@@ -12,10 +12,6 @@ inputs:
     description: Relative pnpm store directory within the workspace. Empty uses the default pnpm store.
     default: ''
     required: false
-  checkout:
-    description: Whether to checkout the repository
-    default: 'true'
-    required: false
   cache:
     description: Whether to use setup-node's pnpm caching (pass literal string `'true'` to enable)
     default: 'false'
@@ -24,9 +20,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v7
-      if: inputs.checkout == 'true'
-
     - uses: pnpm/action-setup@v5
       with:
         version: ${{ inputs.pnpm-version }}

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Get Playwright version
       id: playwright-version
       shell: bash
-      run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      run: echo "version=$(node -p 'require("@playwright/test/package.json").version')" >> "$GITHUB_OUTPUT"
 
     - name: Cache Playwright browsers
       id: playwright-cache

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,27 @@
+name: Setup Playwright
+description: Cache and install Playwright browsers with system dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: Get Playwright version
+      id: playwright-version
+      shell: bash
+      run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+    - name: Install Playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm exec playwright install --with-deps chromium
+
+    - name: Install Playwright system deps
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: pnpm exec playwright install-deps chromium

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,72 +28,24 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Configure pnpm store
-        run: pnpm config set store-dir ${{ github.workspace }}/${{ env.PNPM_STORE_DIR }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          store-dir: ${{ env.PNPM_STORE_DIR }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --strict-peer-dependencies
 
       - name: Pack dependency artifacts
-        run: |
-          tar -czf /tmp/pnpm-store.tar.gz ${{ env.PNPM_STORE_DIR }}
+        run: tar -czf /tmp/pnpm-store.tar.gz ${{ env.PNPM_STORE_DIR }}
 
       - name: Upload dependency artifacts
         uses: actions/upload-artifact@v7
         with:
           name: node-dependencies
-          path: |
-            /tmp/pnpm-store.tar.gz
+          path: /tmp/pnpm-store.tar.gz
           retention-days: 1
-
-  check-linting-formatting:
-    name: Check linting & formatting
-    runs-on: ubuntu-latest
-    needs: build-packages
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Configure pnpm store
-        run: pnpm config set store-dir ${{ github.workspace }}/${{ env.PNPM_STORE_DIR }}
-
-      - name: Download dependency artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: node-dependencies
-          path: /tmp/node-dependencies
-
-      - name: Restore pnpm store
-        run: tar -xzf /tmp/node-dependencies/pnpm-store.tar.gz
-
-      - name: Restore dependencies
-        run: pnpm install --offline --frozen-lockfile --strict-peer-dependencies
-
-      - name: Run linting and formatting checks
-        run: pnpm run lint
 
   build-packages:
     name: Build packages
@@ -102,32 +54,13 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          store-dir: ${{ env.PNPM_STORE_DIR }}
 
-      - name: Configure pnpm store
-        run: pnpm config set store-dir ${{ github.workspace }}/${{ env.PNPM_STORE_DIR }}
-
-      - name: Download dependency artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: node-dependencies
-          path: /tmp/node-dependencies
-
-      - name: Restore pnpm store
-        run: tar -xzf /tmp/node-dependencies/pnpm-store.tar.gz
-
-      - name: Restore dependencies
-        run: pnpm install --offline --frozen-lockfile --strict-peer-dependencies
+      - uses: ./.github/actions/restore-dependencies
 
       - name: Build packages
         run: pnpm run build && pnpm run build:demos
@@ -142,6 +75,24 @@ jobs:
           path: /tmp/build-output.tar.gz
           retention-days: 1
 
+  check-linting-formatting:
+    name: Check linting & formatting
+    runs-on: ubuntu-latest
+    needs: build-packages
+    timeout-minutes: 15
+
+    steps:
+      - uses: ./.github/actions/setup-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          store-dir: ${{ env.PNPM_STORE_DIR }}
+
+      - uses: ./.github/actions/restore-dependencies
+
+      - name: Run linting and formatting checks
+        run: pnpm run lint
+
   run-unit-tests:
     name: Run unit tests
     runs-on: ubuntu-latest
@@ -149,41 +100,15 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          store-dir: ${{ env.PNPM_STORE_DIR }}
 
-      - name: Configure pnpm store
-        run: pnpm config set store-dir ${{ github.workspace }}/${{ env.PNPM_STORE_DIR }}
+      - uses: ./.github/actions/restore-dependencies
 
-      - name: Download dependency artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: node-dependencies
-          path: /tmp/node-dependencies
-
-      - name: Restore pnpm store
-        run: tar -xzf /tmp/node-dependencies/pnpm-store.tar.gz
-
-      - name: Restore dependencies
-        run: pnpm install --offline --frozen-lockfile --strict-peer-dependencies
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: build-output
-          path: /tmp/build-output
-
-      - name: Restore build output
-        run: tar -xzf /tmp/build-output/build-output.tar.gz
+      - uses: ./.github/actions/restore-build
 
       - name: Run unit tests
         run: pnpm run test:unit
@@ -200,60 +125,17 @@ jobs:
         total: [4]
 
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          store-dir: ${{ env.PNPM_STORE_DIR }}
 
-      - name: Configure pnpm store
-        run: pnpm config set store-dir ${{ github.workspace }}/${{ env.PNPM_STORE_DIR }}
+      - uses: ./.github/actions/restore-dependencies
 
-      - name: Download dependency artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: node-dependencies
-          path: /tmp/node-dependencies
+      - uses: ./.github/actions/restore-build
 
-      - name: Restore pnpm store
-        run: tar -xzf /tmp/node-dependencies/pnpm-store.tar.gz
-
-      - name: Restore dependencies
-        run: pnpm install --offline --frozen-lockfile --strict-peer-dependencies
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: build-output
-          path: /tmp/build-output
-
-      - name: Restore build output
-        run: tar -xzf /tmp/build-output/build-output.tar.gz
-
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Install Playwright system deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
+      - uses: ./.github/actions/setup-playwright
 
       - name: Run Playwright tests
         run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shard }}/${{ matrix.total }}
@@ -274,32 +156,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          store-dir: ${{ env.PNPM_STORE_DIR }}
 
-      - name: Configure pnpm store
-        run: pnpm config set store-dir ${{ github.workspace }}/${{ env.PNPM_STORE_DIR }}
-
-      - name: Download dependency artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: node-dependencies
-          path: /tmp/node-dependencies
-
-      - name: Restore pnpm store
-        run: tar -xzf /tmp/node-dependencies/pnpm-store.tar.gz
-
-      - name: Restore dependencies
-        run: pnpm install --offline --frozen-lockfile --strict-peer-dependencies
+      - uses: ./.github/actions/restore-dependencies
 
       - name: Download blob reports
         uses: actions/download-artifact@v8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -54,6 +56,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -82,6 +86,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -100,6 +106,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -125,6 +133,8 @@ jobs:
         total: [4]
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -156,6 +166,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-
       - v2
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,23 +44,21 @@ jobs:
     needs: resolve-config
     if: needs.resolve-config.outputs.configured == 'true'
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v7
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          cache: 'true'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --strict-peer-dependencies
+
       - name: Run build
         run: pnpm run build && pnpm run build:demos
+
       - name: Archive package dist artifacts
         run: tar -cf package-dist-artifacts.tar packages/*/dist packages-deprecated/*/dist
+
       - name: Upload package dist artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -82,30 +80,30 @@ jobs:
       label: ${{ needs.resolve-config.outputs.label }}
       published: ${{ steps.changesets.outputs.published }}
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v7
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          cache: 'true'
+
       - name: Update npm for trusted publishing
         run: npm install -g npm@11.6.2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --strict-peer-dependencies
+
       - name: Download package dist artifacts
         uses: actions/download-artifact@v8
         with:
           name: package-dist-artifacts
           path: .
+
       - name: Restore package dist artifacts
         run: tar -xf package-dist-artifacts.tar
+
       - name: Verify package dist artifacts
         run: bash ./scripts/check-package-dists.sh
+
       - name: Run changesets release flow
         id: changesets
         uses: changesets/action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,8 @@ jobs:
     needs: resolve-config
     if: needs.resolve-config.outputs.configured == 'true'
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -80,6 +82,8 @@ jobs:
       label: ${{ needs.resolve-config.outputs.label }}
       published: ${{ steps.changesets.outputs.published }}
     steps:
+      - uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
Create setup-env, restore-dependencies, restore-build, and setup-playwright actions to reduce duplication across jobs. Update build.yml and publish.yml to use them.

## Fixes

- No issue, this is a stacked PR for #8027 

## Changes and Review

Extracted four composite actions (setup-env, restore-dependencies, restore-build, setup-playwright) to consolidate repeated setup and restore logic across build.yml and publish.yml.

## Checklist

- [ ] I have added a changeset if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
