### PR TITLE
fix(core): deduplicate named extensions to prevent duplicate warnings

### DIFF
--- a/.changeset/fix-duplicate-extension-warning.md
+++ b/.changeset/fix-duplicate-extension-warning.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Deduplicate named extensions during resolution using last-defined precedence. This removes the duplicate extension warning when the same extension is registered more than once (for example `StarterKit` together with `Dropcursor`) and prevents duplicate ProseMirror plugins from being registered.

--- a/packages/core/__tests__/resolveExtensions.spec.ts
+++ b/packages/core/__tests__/resolveExtensions.spec.ts
@@ -1,0 +1,53 @@
+import { Extension, resolveExtensions } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import StarterKit from '@tiptap/starter-kit'
+import { Dropcursor } from '@tiptap/extensions'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('resolveExtensions', () => {
+  it('deduplicates extensions by name and keeps the last defined extension', () => {
+    const customDropcursor = Dropcursor.configure({ color: 'red' })
+
+    const resolved = resolveExtensions([StarterKit, customDropcursor])
+    const dropcursorExtensions = resolved.filter(extension => extension.name === 'dropCursor')
+
+    expect(dropcursorExtensions).toHaveLength(1)
+    expect(dropcursorExtensions[0].options.color).toBe('red')
+  })
+
+  it('does not warn when duplicate extension names are resolved by deduplication', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    resolveExtensions([StarterKit, Dropcursor])
+
+    expect(warn).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+
+  it('does not warn when multiple editors use dropcursor independently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const extensions = [Document, Paragraph, Text, Dropcursor]
+
+    resolveExtensions(extensions)
+    resolveExtensions(extensions)
+
+    expect(warn).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+
+  it('deduplicates custom extensions with the same name', () => {
+    const first = Extension.create({ name: 'custom' })
+    const second = Extension.create({ name: 'custom' }).configure({ foo: 'bar' } as never)
+
+    const resolved = resolveExtensions([first, second])
+    const customExtensions = resolved.filter(extension => extension.name === 'custom')
+
+    expect(customExtensions).toHaveLength(1)
+    expect(customExtensions[0]).toBe(second)
+  })
+})

--- a/packages/core/__tests__/resolveExtensions.spec.ts
+++ b/packages/core/__tests__/resolveExtensions.spec.ts
@@ -50,4 +50,33 @@ describe('resolveExtensions', () => {
     expect(customExtensions).toHaveLength(1)
     expect(customExtensions[0]).toBe(second)
   })
+
+  it('keeps the last defined duplicate before sorting by priority', () => {
+    const highPriority = Extension.create({
+      name: 'custom',
+      priority: 1000,
+      addOptions() {
+        return { variant: 'high' }
+      },
+    })
+    const lowPriority = Extension.create({
+      name: 'custom',
+      priority: 100,
+      addOptions() {
+        return { variant: 'low' }
+      },
+    })
+
+    const resolved = resolveExtensions([highPriority, lowPriority])
+    const customExtensions = resolved.filter(extension => extension.name === 'custom')
+
+    expect(customExtensions).toHaveLength(1)
+    expect(customExtensions[0].options.variant).toBe('low')
+
+    const resolvedReverse = resolveExtensions([lowPriority, highPriority])
+    const customExtensionsReverse = resolvedReverse.filter(extension => extension.name === 'custom')
+
+    expect(customExtensionsReverse).toHaveLength(1)
+    expect(customExtensionsReverse[0].options.variant).toBe('high')
+  })
 })

--- a/packages/core/src/helpers/resolveExtensions.ts
+++ b/packages/core/src/helpers/resolveExtensions.ts
@@ -22,8 +22,10 @@ function deduplicateExtensions(extensions: Extensions): Extensions {
       seen.add(name)
     }
 
-    deduplicated.unshift(extension)
+    deduplicated.push(extension)
   }
+
+  deduplicated.reverse()
 
   return deduplicated
 }
@@ -37,5 +39,5 @@ function deduplicateExtensions(extensions: Extensions): Extensions {
 export function resolveExtensions(extensions: Extensions): Extensions {
   const flattenedExtensions = flattenExtensions(extensions)
 
-  return deduplicateExtensions(sortExtensions(flattenedExtensions))
+  return sortExtensions(deduplicateExtensions(flattenedExtensions))
 }

--- a/packages/core/src/helpers/resolveExtensions.ts
+++ b/packages/core/src/helpers/resolveExtensions.ts
@@ -1,25 +1,41 @@
 import type { Extensions } from '../types.js'
-import { findDuplicates } from '../utilities/findDuplicates.js'
 import { flattenExtensions } from './flattenExtensions.js'
 import { sortExtensions } from './sortExtensions.js'
 
 /**
- * Returns a flattened and sorted extension list while
- * also checking for duplicated extensions and warns the user.
- * @param extensions An array of Tiptap extensions
- * @returns An flattened and sorted array of Tiptap extensions
+ * Removes duplicate extensions by name while keeping the last defined extension.
+ * This matches Tiptap's last-defined precedence for conflicting extension behavior.
  */
-export function resolveExtensions(extensions: Extensions): Extensions {
-  const resolvedExtensions = sortExtensions(flattenExtensions(extensions))
-  const duplicatedNames = findDuplicates(resolvedExtensions.map(extension => extension.name))
+function deduplicateExtensions(extensions: Extensions): Extensions {
+  const seen = new Set<string>()
+  const deduplicated: Extensions = []
 
-  if (duplicatedNames.length) {
-    console.warn(
-      `[tiptap warn]: Duplicate extension names found: [${duplicatedNames
-        .map(item => `'${item}'`)
-        .join(', ')}]. This can lead to issues.`,
-    )
+  for (let index = extensions.length - 1; index >= 0; index -= 1) {
+    const extension = extensions[index]
+    const { name } = extension
+
+    if (name && seen.has(name)) {
+      continue
+    }
+
+    if (name) {
+      seen.add(name)
+    }
+
+    deduplicated.unshift(extension)
   }
 
-  return resolvedExtensions
+  return deduplicated
+}
+
+/**
+ * Returns a flattened, sorted, and de-duplicated extension list.
+ * Duplicate named extensions are resolved using last-defined precedence.
+ * @param extensions An array of Tiptap extensions
+ * @returns A flattened, sorted, and de-duplicated array of Tiptap extensions
+ */
+export function resolveExtensions(extensions: Extensions): Extensions {
+  const flattenedExtensions = flattenExtensions(extensions)
+
+  return deduplicateExtensions(sortExtensions(flattenedExtensions))
 }


### PR DESCRIPTION
## Fixes

Fixes #2890

## Changes and Review

- Deduplicate named extensions in `resolveExtensions` using last-defined precedence.
- This removes the `dropCursor` duplicate warning when `StarterKit` and `Dropcursor` are used together.
- It also stops duplicate ProseMirror plugins from being registered in the same editor.
- Added unit tests in `packages/core/__tests__/resolveExtensions.spec.ts`.

To verify: create an editor with `[StarterKit, Dropcursor]` and confirm there is no duplicate extension warning.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.