### PR TITLE
Feat(extension-link): auto-convert Markdown link syntax into links

### DIFF
--- a/.changeset/link-markdown-syntax-shortcut.md
+++ b/.changeset/link-markdown-syntax-shortcut.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-link': minor
 ---
 
-Typing or pasting Markdown link syntax like `[text](https://url)` or `[text](https://url "title")` can now automatically be converted into a link. The behavior is opt-in, enable it with the new `markdownLinks` option.
+Typing or pasting Markdown link syntax like `[Tiptap](https://tiptap.dev)` or `[Tiptap](https://tiptap.dev "Rich text editor")` can now automatically be converted into a link. The behavior is opt-in, enable it with the new `markdownLinks` option.

--- a/.changeset/link-markdown-syntax-shortcut.md
+++ b/.changeset/link-markdown-syntax-shortcut.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-link': minor
 ---
 
-Typing or pasting the Markdown link syntax, e.g. `[text](https://url)` or `[text](https://url "title")`, now converts it into a link. URLs are validated through the existing `isAllowedUri` option, the Markdown image syntax and code spans are left untouched, and the behavior can be disabled with the new `markdownLinks` option.
+Typing or pasting Markdown link syntax like `[text](https://url)` now converts it into a link. URLs are validated through `isAllowedUri`, and the behavior can be disabled with the new `markdownLinks` option.

--- a/.changeset/link-markdown-syntax-shortcut.md
+++ b/.changeset/link-markdown-syntax-shortcut.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-link': minor
 ---
 
-Typing or pasting Markdown link syntax like `[text](https://url)` can now automatically be converted into a link. The behavior is opt-in, enable it with the new `markdownLinks` option.
+Typing or pasting Markdown link syntax like `[text](https://url)` or `[text](https://url "title")` can now automatically be converted into a link. The behavior is opt-in, enable it with the new `markdownLinks` option.

--- a/.changeset/link-markdown-syntax-shortcut.md
+++ b/.changeset/link-markdown-syntax-shortcut.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-link': minor
+---
+
+Typing or pasting the Markdown link syntax, e.g. `[text](https://url)` or `[text](https://url "title")`, now converts it into a link. URLs are validated through the existing `isAllowedUri` option, the Markdown image syntax and code spans are left untouched, and the behavior can be disabled with the new `markdownLinks` option.

--- a/.changeset/link-markdown-syntax-shortcut.md
+++ b/.changeset/link-markdown-syntax-shortcut.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-link': minor
 ---
 
-Typing or pasting Markdown link syntax like `[text](https://url)` now converts it into a link. The behavior can be disabled with the new `markdownLinks` option.
+Typing or pasting Markdown link syntax like `[text](https://url)` can now automatically be converted into a link. The behavior is opt-in, enable it with the new `markdownLinks` option.

--- a/.changeset/link-markdown-syntax-shortcut.md
+++ b/.changeset/link-markdown-syntax-shortcut.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-link': minor
 ---
 
-Typing or pasting Markdown link syntax like `[text](https://url)` now converts it into a link. URLs are validated through `isAllowedUri`, and the behavior can be disabled with the new `markdownLinks` option.
+Typing or pasting Markdown link syntax like `[text](https://url)` now converts it into a link. The behavior can be disabled with the new `markdownLinks` option.

--- a/demos/src/Marks/Link/React/index.jsx
+++ b/demos/src/Marks/Link/React/index.jsx
@@ -19,6 +19,7 @@ export default () => {
       Link.configure({
         openOnClick: false,
         autolink: true,
+        markdownLinks: true,
         defaultProtocol: 'https',
         protocols: ['http', 'https'],
         isAllowedUri: (url, ctx) => {

--- a/demos/src/Marks/Link/Vue/index.vue
+++ b/demos/src/Marks/Link/Vue/index.vue
@@ -43,6 +43,7 @@ export default {
         Code,
         Link.configure({
           openOnClick: false,
+          markdownLinks: true,
           defaultProtocol: 'https',
         }),
       ],

--- a/demos/src/Marks/Link/index.spec.ts
+++ b/demos/src/Marks/Link/index.spec.ts
@@ -128,6 +128,36 @@ test.describe(`${demoPath}/${demoName}`, () => {
         )
       })
 
+      test('converts typed Markdown link syntax into a link', async ({ page }) => {
+        const editor = await getEditor(page)
+        await editor.evaluate((el: any) => el.editor.commands.clearContent())
+        await editor.click()
+        await page.keyboard.type('[Tiptap](https://example.com)')
+        await expect(page.locator('.tiptap a')).toContainText('Tiptap')
+        await expect(page.locator('.tiptap a')).toHaveAttribute('href', 'https://example.com')
+        await expect(page.locator('.tiptap')).not.toContainText('[')
+      })
+
+      test('converts typed Markdown link syntax with a title into a link', async ({ page }) => {
+        const editor = await getEditor(page)
+        await editor.evaluate((el: any) => el.editor.commands.clearContent())
+        await editor.click()
+        await page.keyboard.type('[Tiptap](https://example.com "Rich text editor")')
+        await expect(page.locator('.tiptap a')).toContainText('Tiptap')
+        await expect(page.locator('.tiptap a')).toHaveAttribute('href', 'https://example.com')
+        await expect(page.locator('.tiptap a')).toHaveAttribute('title', 'Rich text editor')
+      })
+
+      test('converts a pasted Markdown link within text', async ({ page }) => {
+        const editor = await getEditor(page)
+        await editor.evaluate((el: any) => el.editor.commands.clearContent())
+        await editor.click()
+        await paste(editor, 'Check out [Tiptap](https://example.com) today')
+        await expect(page.locator('.tiptap a')).toContainText('Tiptap')
+        await expect(page.locator('.tiptap a')).toHaveAttribute('href', 'https://example.com')
+        await expect(page.locator('.tiptap')).toContainText('Check out Tiptap today')
+      })
+
       if (frameworkPath === 'React') {
         test('disallows links with disallowed protocols', async ({ page }) => {
           const editor = await getEditor(page)

--- a/packages/extension-link/__tests__/markdownLink.spec.ts
+++ b/packages/extension-link/__tests__/markdownLink.spec.ts
@@ -35,7 +35,7 @@ describe('markdown links', () => {
   const createEditor = (options: Partial<ConstructorParameters<typeof Editor>[0]> = {}) => {
     editor = new Editor({
       element: createEditorEl(),
-      extensions: [Document, Text, Paragraph, Link],
+      extensions: [Document, Text, Paragraph, Link.configure({ markdownLinks: true })],
       ...options,
     })
 
@@ -270,7 +270,7 @@ describe('markdown links', () => {
 
     it('does not convert inside code marks', () => {
       createEditor({
-        extensions: [Document, Text, Paragraph, Code, Link],
+        extensions: [Document, Text, Paragraph, Code, Link.configure({ markdownLinks: true })],
         content: '<p><code>[Tiptap](https://tiptap.dev</code></p>',
       })
 
@@ -280,9 +280,9 @@ describe('markdown links', () => {
       expect(editor!.getHTML()).not.toContain('<a')
     })
 
-    it('can be disabled with the markdownLinks option', () => {
+    it('does not convert unless the markdownLinks option is enabled', () => {
       createEditor({
-        extensions: [Document, Text, Paragraph, Link.configure({ markdownLinks: false })],
+        extensions: [Document, Text, Paragraph, Link],
         content: '<p>[Tiptap](https://tiptap.dev</p>',
       })
 
@@ -294,7 +294,12 @@ describe('markdown links', () => {
 
     it('respects a custom isAllowedUri option', () => {
       createEditor({
-        extensions: [Document, Text, Paragraph, Link.configure({ isAllowedUri: () => false })],
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          Link.configure({ markdownLinks: true, isAllowedUri: () => false }),
+        ],
         content: '<p>[Tiptap](https://tiptap.dev</p>',
       })
 
@@ -442,9 +447,9 @@ describe('markdown links', () => {
       expect(editor!.state.doc.textContent).toBe('![alt](https://example.com/image.png)')
     })
 
-    it('can be disabled with the markdownLinks option', () => {
+    it('does not convert unless the markdownLinks option is enabled', () => {
       createEditor({
-        extensions: [Document, Text, Paragraph, Link.configure({ markdownLinks: false })],
+        extensions: [Document, Text, Paragraph, Link],
       })
 
       editor!.view.pasteText('[Tiptap](https://tiptap.dev)')

--- a/packages/extension-link/__tests__/markdownLink.spec.ts
+++ b/packages/extension-link/__tests__/markdownLink.spec.ts
@@ -241,6 +241,24 @@ describe('markdown links', () => {
       expect(editor!.getHTML()).not.toContain('<a')
     })
 
+    it('converts after an escaped backtick', () => {
+      createEditor({ content: '<p>\\`[Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+    })
+
+    it('closes a code span on a backtick preceded by a backslash', () => {
+      createEditor({ content: '<p>`code\\` [Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+    })
+
     it('converts after a closed double-backtick span containing a backtick', () => {
       createEditor({ content: '<p>`` ` `` [Tiptap](https://tiptap.dev</p>' })
 
@@ -385,6 +403,15 @@ describe('markdown links', () => {
 
       expect(editor!.getHTML()).not.toContain('>Tiptap</a>')
       expect(editor!.state.doc.textContent).toBe('``some code [Tiptap](https://tiptap.dev)')
+    })
+
+    it('converts a Markdown link pasted after an escaped backtick', () => {
+      createEditor()
+
+      editor!.view.pasteText('\\`not code [Tiptap](https://tiptap.dev)')
+
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+      expect(editor!.state.doc.textContent).toBe('\\`not code Tiptap')
     })
 
     it('converts a Markdown link pasted after a closed double-backtick span', () => {

--- a/packages/extension-link/__tests__/markdownLink.spec.ts
+++ b/packages/extension-link/__tests__/markdownLink.spec.ts
@@ -1,0 +1,308 @@
+import { Editor, Mark } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Link from '@tiptap/extension-link'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const Code = Mark.create({
+  name: 'code',
+  excludes: '_',
+  code: true,
+
+  parseHTML() {
+    return [{ tag: 'code' }]
+  },
+
+  renderHTML() {
+    return ['code', 0]
+  },
+})
+
+describe('markdown links', () => {
+  const editorElClass = 'tiptap'
+  let editor: Editor | null = null
+
+  const createEditorEl = () => {
+    const editorEl = document.createElement('div')
+
+    editorEl.classList.add(editorElClass)
+    document.body.appendChild(editorEl)
+    return editorEl
+  }
+  const getEditorEl = () => document.querySelector(`.${editorElClass}`)
+
+  const createEditor = (options: Partial<ConstructorParameters<typeof Editor>[0]> = {}) => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Text, Paragraph, Link],
+      ...options,
+    })
+
+    return editor
+  }
+
+  // Simulates typing a character at the end of the document,
+  // the way the input rules plugin receives real keystrokes.
+  // Returns whether a rule handled it.
+  const typeAtEnd = (currentEditor: Editor, character: string) => {
+    currentEditor.commands.setTextSelection(currentEditor.state.doc.nodeSize)
+
+    return currentEditor.view.someProp('handleTextInput', f =>
+      f(
+        currentEditor.view,
+        currentEditor.state.selection.from,
+        currentEditor.state.selection.from,
+        character,
+      ),
+    )
+  }
+
+  afterEach(() => {
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
+  describe('input rule', () => {
+    it('converts the typed Markdown link syntax into a link', () => {
+      createEditor({ content: '<p>Check out [Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+      expect(editor!.getHTML()).toContain('>Tiptap</a>')
+      expect(editor!.getHTML()).not.toContain('[')
+      expect(editor!.state.doc.textContent).toBe('Check out Tiptap')
+    })
+
+    it('supports titles in straight quotes', () => {
+      createEditor({ content: '<p>[Tiptap](https://tiptap.dev "Rich text editor"</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+      expect(editor!.getHTML()).toContain('title="Rich text editor"')
+      expect(editor!.state.doc.textContent).toBe('Tiptap')
+    })
+
+    it('treats an empty title as no title, as in CommonMark', () => {
+      createEditor({ content: '<p>[Tiptap](https://tiptap.dev ""</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+      expect(editor!.getHTML()).not.toContain('title=')
+      expect(editor!.state.doc.textContent).toBe('Tiptap')
+    })
+
+    it('supports titles in curly quotes, as replaced by the Typography extension', () => {
+      createEditor({ content: '<p>[Tiptap](https://tiptap.dev “Rich text editor”</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('title="Rich text editor"')
+    })
+
+    it('converts URLs containing balanced parentheses', () => {
+      createEditor({ content: '<p>[Wiki](https://en.wikipedia.org/wiki/Node_(disambiguation)</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain(
+        'href="https://en.wikipedia.org/wiki/Node_(disambiguation)"',
+      )
+      expect(editor!.state.doc.textContent).toBe('Wiki')
+    })
+
+    it('does not fire on the closing parenthesis of a URL containing parentheses', () => {
+      createEditor({ content: '<p>[Wiki](https://en.wikipedia.org/wiki/Node_(disambiguation</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('converts only the trailing link when another link precedes it', () => {
+      createEditor({
+        content: '<p>[alpha](https://alpha.example.com)[beta](https://beta.example.com</p>',
+      })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://beta.example.com"')
+      expect(editor!.getHTML()).not.toContain('href="https://alpha.example.com"')
+      expect(editor!.state.doc.textContent).toBe('[alpha](https://alpha.example.com)beta')
+    })
+
+    it('converts non-http protocols allowed by default', () => {
+      createEditor({ content: '<p>[Email](mailto:info@example.com</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="mailto:info@example.com"')
+    })
+
+    it('converts relative URLs', () => {
+      createEditor({ content: '<p>[Docs](/docs/introduction</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="/docs/introduction"')
+    })
+
+    it('does not convert disallowed protocols', () => {
+      // oxlint-disable-next-line no-script-url
+      createEditor({ content: '<p>[click](javascript:alert(window.origin</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('does not convert the Markdown image syntax', () => {
+      createEditor({ content: '<p>![alt](https://example.com/image.png</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('does not convert escaped brackets', () => {
+      createEditor({ content: '<p>\\[Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('does not convert whitespace-only link text', () => {
+      createEditor({ content: '<p>[ ](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('does not convert inside code marks', () => {
+      createEditor({
+        extensions: [Document, Text, Paragraph, Code, Link],
+        content: '<p><code>[Tiptap](https://tiptap.dev</code></p>',
+      })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('can be disabled with the markdownLinks option', () => {
+      createEditor({
+        extensions: [Document, Text, Paragraph, Link.configure({ markdownLinks: false })],
+        content: '<p>[Tiptap](https://tiptap.dev</p>',
+      })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('respects a custom isAllowedUri option', () => {
+      createEditor({
+        extensions: [Document, Text, Paragraph, Link.configure({ isAllowedUri: () => false })],
+        content: '<p>[Tiptap](https://tiptap.dev</p>',
+      })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+  })
+
+  describe('paste rule', () => {
+    it('converts pasted Markdown links', () => {
+      createEditor()
+
+      editor!.view.pasteText('Check out [Tiptap](https://tiptap.dev) today')
+
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+      expect(editor!.getHTML()).toContain('>Tiptap</a>')
+      expect(editor!.state.doc.textContent).toBe('Check out Tiptap today')
+    })
+
+    it('converts multiple pasted Markdown links', () => {
+      createEditor()
+
+      editor!.view.pasteText(
+        'See [alpha](https://alpha.example.com) and [beta](https://beta.example.com)',
+      )
+
+      expect(editor!.getHTML()).toContain('href="https://alpha.example.com"')
+      expect(editor!.getHTML()).toContain('href="https://beta.example.com"')
+      expect(editor!.state.doc.textContent).toBe('See alpha and beta')
+    })
+
+    it('converts adjacent Markdown links', () => {
+      createEditor()
+
+      editor!.view.pasteText('[alpha](https://alpha.example.com)[beta](https://beta.example.com)')
+
+      expect(editor!.getHTML()).toContain('href="https://alpha.example.com"')
+      expect(editor!.getHTML()).toContain('href="https://beta.example.com"')
+      expect(editor!.state.doc.textContent).toBe('alphabeta')
+    })
+
+    it('converts pasted Markdown links with titles', () => {
+      createEditor()
+
+      editor!.view.pasteText('[Tiptap](https://tiptap.dev "Rich text editor")')
+
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+      expect(editor!.getHTML()).toContain('title="Rich text editor"')
+      expect(editor!.state.doc.textContent).toBe('Tiptap')
+    })
+
+    it('does not convert disallowed protocols', () => {
+      createEditor()
+
+      // oxlint-disable-next-line no-script-url
+      editor!.view.pasteText('[click](javascript:alert(window.origin))')
+
+      expect(editor!.getHTML()).not.toContain('<a')
+      expect(editor!.state.doc.textContent).toContain('[click](')
+    })
+
+    it('keeps the Markdown image syntax as plain text', () => {
+      createEditor()
+
+      editor!.view.pasteText('![alt](https://example.com/image.png)')
+
+      // the bare URL inside may still get autolinked, we only care that the brackets survive
+      expect(editor!.state.doc.textContent).toBe('![alt](https://example.com/image.png)')
+    })
+
+    it('can be disabled with the markdownLinks option', () => {
+      createEditor({
+        extensions: [Document, Text, Paragraph, Link.configure({ markdownLinks: false })],
+      })
+
+      editor!.view.pasteText('[Tiptap](https://tiptap.dev)')
+
+      expect(editor!.state.doc.textContent).toBe('[Tiptap](https://tiptap.dev)')
+    })
+  })
+})

--- a/packages/extension-link/__tests__/markdownLink.spec.ts
+++ b/packages/extension-link/__tests__/markdownLink.spec.ts
@@ -223,6 +223,33 @@ describe('markdown links', () => {
       expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
     })
 
+    it('does not convert inside an unclosed double-backtick code span', () => {
+      createEditor({ content: '<p>``some code [Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('treats a single backtick inside a double-backtick span as literal', () => {
+      createEditor({ content: '<p>``some ` code [Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('converts after a closed double-backtick span containing a backtick', () => {
+      createEditor({ content: '<p>`` ` `` [Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+    })
+
     it('does not convert inside code marks', () => {
       createEditor({
         extensions: [Document, Text, Paragraph, Code, Link],
@@ -349,6 +376,34 @@ describe('markdown links', () => {
 
       expect(editor!.getHTML()).toContain('href="https://tiptap.dev/docs"')
       expect(editor!.state.doc.textContent).toBe('see `some code` then read the docs')
+    })
+
+    it('keeps a Markdown link inside an unclosed double-backtick span as plain text', () => {
+      createEditor()
+
+      editor!.view.pasteText('``some code [Tiptap](https://tiptap.dev)')
+
+      expect(editor!.getHTML()).not.toContain('>Tiptap</a>')
+      expect(editor!.state.doc.textContent).toBe('``some code [Tiptap](https://tiptap.dev)')
+    })
+
+    it('converts a Markdown link pasted after a closed double-backtick span', () => {
+      createEditor()
+
+      editor!.view.pasteText('`` ` `` then read [the docs](https://tiptap.dev/docs)')
+
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev/docs"')
+      expect(editor!.state.doc.textContent).toBe('`` ` `` then read the docs')
+    })
+
+    it('updates the href when a bare URL is pasted inside an existing link', () => {
+      createEditor({ content: '<p><a href="https://old.example.com">click here</a></p>' })
+
+      editor!.commands.setTextSelection(6)
+      editor!.view.pasteText('https://new.example.com')
+
+      expect(editor!.getHTML()).toContain('href="https://new.example.com"')
+      expect(editor!.getHTML()).toContain('href="https://old.example.com"')
     })
 
     it('keeps the Markdown image syntax as plain text', () => {

--- a/packages/extension-link/__tests__/markdownLink.spec.ts
+++ b/packages/extension-link/__tests__/markdownLink.spec.ts
@@ -107,6 +107,42 @@ describe('markdown links', () => {
       expect(editor!.getHTML()).toContain('title="Rich text editor"')
     })
 
+    it('supports titles in curly single quotes', () => {
+      createEditor({ content: '<p>[Tiptap](https://tiptap.dev ‘Rich text editor’</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('title="Rich text editor"')
+    })
+
+    it('supports titles containing the other quote character', () => {
+      createEditor({ content: `<p>[Tiptap](https://tiptap.dev "editor's title"</p>` })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain(`title="editor's title"`)
+    })
+
+    it('does not convert a title with mismatched quotes', () => {
+      createEditor({ content: `<p>[Tiptap](https://tiptap.dev “Rich text editor'</p>` })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('does not convert a title closed by a different straight quote', () => {
+      createEditor({ content: `<p>[Tiptap](https://tiptap.dev "Rich text editor'</p>` })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
     it('converts URLs containing balanced parentheses', () => {
       createEditor({ content: '<p>[Wiki](https://en.wikipedia.org/wiki/Node_(disambiguation)</p>' })
 
@@ -351,6 +387,16 @@ describe('markdown links', () => {
       expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
       expect(editor!.getHTML()).toContain('title="Rich text editor"')
       expect(editor!.state.doc.textContent).toBe('Tiptap')
+    })
+
+    it('keeps a pasted link with a mismatched title quote as plain text', () => {
+      createEditor()
+
+      editor!.view.pasteText(`[Tiptap](https://tiptap.dev “Rich text editor')`)
+
+      // the bare URL inside may still get autolinked, we only care that the syntax survives
+      expect(editor!.getHTML()).not.toContain('>Tiptap</a>')
+      expect(editor!.state.doc.textContent).toBe(`[Tiptap](https://tiptap.dev “Rich text editor')`)
     })
 
     it('keeps the Markdown href when the link text looks like a URL', () => {

--- a/packages/extension-link/__tests__/markdownLink.spec.ts
+++ b/packages/extension-link/__tests__/markdownLink.spec.ts
@@ -276,6 +276,26 @@ describe('markdown links', () => {
       expect(editor!.state.doc.textContent).toBe('Tiptap')
     })
 
+    it('keeps the Markdown href when the link text looks like a URL', () => {
+      createEditor()
+
+      editor!.view.pasteText('Read [tiptap.dev](https://tiptap.dev/docs) now')
+
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev/docs"')
+      expect(editor!.getHTML()).not.toContain('href="http://tiptap.dev"')
+      expect(editor!.state.doc.textContent).toBe('Read tiptap.dev now')
+    })
+
+    it('still links bare URLs pasted outside of Markdown syntax', () => {
+      createEditor()
+
+      editor!.view.pasteText('visit https://example.com and [Tiptap](https://tiptap.dev)')
+
+      expect(editor!.getHTML()).toContain('href="https://example.com"')
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+      expect(editor!.state.doc.textContent).toBe('visit https://example.com and Tiptap')
+    })
+
     it('does not convert disallowed protocols', () => {
       createEditor()
 

--- a/packages/extension-link/__tests__/markdownLink.spec.ts
+++ b/packages/extension-link/__tests__/markdownLink.spec.ts
@@ -196,6 +196,33 @@ describe('markdown links', () => {
       expect(editor!.getHTML()).not.toContain('<a')
     })
 
+    it('does not convert after an unclosed backtick', () => {
+      createEditor({ content: '<p>`[Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('does not convert inside a code span still being typed', () => {
+      createEditor({ content: '<p>`some code [Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBeFalsy()
+      expect(editor!.getHTML()).not.toContain('<a')
+    })
+
+    it('converts after a closed pair of backticks', () => {
+      createEditor({ content: '<p>`some code` [Tiptap](https://tiptap.dev</p>' })
+
+      const handled = typeAtEnd(editor!, ')')
+
+      expect(handled).toBe(true)
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev"')
+    })
+
     it('does not convert inside code marks', () => {
       createEditor({
         extensions: [Document, Text, Paragraph, Code, Link],
@@ -304,6 +331,24 @@ describe('markdown links', () => {
 
       expect(editor!.getHTML()).not.toContain('<a')
       expect(editor!.state.doc.textContent).toContain('[click](')
+    })
+
+    it('keeps a Markdown link inside a pasted code span as plain text', () => {
+      createEditor()
+
+      editor!.view.pasteText('`[Tiptap](https://tiptap.dev)` renders a link')
+
+      expect(editor!.getHTML()).not.toContain('>Tiptap</a>')
+      expect(editor!.state.doc.textContent).toBe('`[Tiptap](https://tiptap.dev)` renders a link')
+    })
+
+    it('converts a Markdown link pasted after a closed code span', () => {
+      createEditor()
+
+      editor!.view.pasteText('see `some code` then read [the docs](https://tiptap.dev/docs)')
+
+      expect(editor!.getHTML()).toContain('href="https://tiptap.dev/docs"')
+      expect(editor!.state.doc.textContent).toBe('see `some code` then read the docs')
     })
 
     it('keeps the Markdown image syntax as plain text', () => {

--- a/packages/extension-link/src/helpers/markdownLink.ts
+++ b/packages/extension-link/src/helpers/markdownLink.ts
@@ -34,6 +34,16 @@ export interface MarkdownLinkPasteRuleConfig extends MarkdownLinkRuleConfig {
   findPlainUrls?: (text: string) => PasteRuleMatch[]
 }
 
+function isEscaped(text: string, index: number): boolean {
+  let backslashes = 0
+
+  for (let position = index - 1; position >= 0 && text[position] === '\\'; position -= 1) {
+    backslashes += 1
+  }
+
+  return backslashes % 2 === 1
+}
+
 /**
  * Pairs the backtick runs before the match by length, as CommonMark does.
  * A run left open means the match sits in an unfinished code span.
@@ -44,6 +54,12 @@ function isInsideCodeSpan(text: string, matchIndex: number): boolean {
 
   while (index < matchIndex) {
     if (text[index] !== '`') {
+      index += 1
+      continue
+    }
+
+    // escapes only apply outside code spans
+    if (openRunLength === 0 && isEscaped(text, index)) {
       index += 1
       continue
     }

--- a/packages/extension-link/src/helpers/markdownLink.ts
+++ b/packages/extension-link/src/helpers/markdownLink.ts
@@ -26,20 +26,43 @@ export interface MarkdownLinkRuleConfig {
   isAllowedHref: (href: string) => boolean
 }
 
+export interface MarkdownLinkPasteRuleConfig extends MarkdownLinkRuleConfig {
+  /**
+   * Finds plain URLs to link in the same pass. Matches overlapping a
+   * converted Markdown link are dropped so its href is kept.
+   */
+  findPlainUrls?: (text: string) => PasteRuleMatch[]
+}
+
 /**
- * An odd number of backticks before the match means it sits in an unclosed
- * code span, either one still being typed or one from pasted text.
+ * Pairs the backtick runs before the match by length, as CommonMark does.
+ * A run left open means the match sits in an unfinished code span.
  */
 function isInsideCodeSpan(text: string, matchIndex: number): boolean {
-  let backticks = 0
+  let openRunLength = 0
+  let index = 0
 
-  for (let index = 0; index < matchIndex; index += 1) {
-    if (text[index] === '`') {
-      backticks += 1
+  while (index < matchIndex) {
+    if (text[index] !== '`') {
+      index += 1
+      continue
+    }
+
+    let runLength = 0
+
+    while (index < matchIndex && text[index] === '`') {
+      runLength += 1
+      index += 1
+    }
+
+    if (openRunLength === 0) {
+      openRunLength = runLength
+    } else if (runLength === openRunLength) {
+      openRunLength = 0
     }
   }
 
-  return backticks % 2 === 1
+  return openRunLength > 0
 }
 
 function isConvertibleLink(
@@ -73,8 +96,13 @@ function toRuleMatch(match: RegExpMatchArray): InputRuleMatch & PasteRuleMatch {
       href,
       // an empty title ("") counts as no title, as in CommonMark
       title: title || null,
+      markdown: true,
     },
   }
+}
+
+function matchesOverlap(a: PasteRuleMatch, b: PasteRuleMatch): boolean {
+  return a.index < b.index + b.text.length && b.index < a.index + a.text.length
 }
 
 function getMarkdownLinkAttributes(match: { data?: Record<string, any> }) {
@@ -118,20 +146,25 @@ export function markdownLinkInputRule(config: MarkdownLinkRuleConfig): InputRule
 }
 
 /**
- * Same for pasting, converts every Markdown link found in the pasted text.
+ * Same for pasting, converts every Markdown link found in the pasted text
+ * and links the plain URLs from `findPlainUrls`.
  */
-export function markdownLinkPasteRule(config: MarkdownLinkRuleConfig): PasteRule {
+export function markdownLinkPasteRule(config: MarkdownLinkPasteRuleConfig): PasteRule {
   const rule = markPasteRule({
     find: text => {
-      const matches: PasteRuleMatch[] = []
+      const markdownMatches: PasteRuleMatch[] = []
 
       for (const match of text.matchAll(MARKDOWN_LINK_PASTE_REGEX)) {
         if (isConvertibleLink(text, match, config.isAllowedHref)) {
-          matches.push(toRuleMatch(match))
+          markdownMatches.push(toRuleMatch(match))
         }
       }
 
-      return matches
+      const plainUrlMatches = (config.findPlainUrls?.(text) ?? []).filter(
+        urlMatch => !markdownMatches.some(markdownMatch => matchesOverlap(markdownMatch, urlMatch)),
+      )
+
+      return [...markdownMatches, ...plainUrlMatches]
     },
     type: config.type,
     getAttributes: getMarkdownLinkAttributes,
@@ -142,7 +175,8 @@ export function markdownLinkPasteRule(config: MarkdownLinkRuleConfig): PasteRule
     handler: props => {
       const result = rule.handler(props)
 
-      if (result !== null && props.state.tr.steps.length) {
+      // only Markdown conversions suppress autolink
+      if (result !== null && props.state.tr.steps.length && props.match.data?.markdown) {
         props.state.tr.setMeta('preventAutolink', true)
       }
 

--- a/packages/extension-link/src/helpers/markdownLink.ts
+++ b/packages/extension-link/src/helpers/markdownLink.ts
@@ -1,0 +1,132 @@
+import type { InputRuleMatch, PasteRuleMatch } from '@tiptap/core'
+import { InputRule, markInputRule, markPasteRule, PasteRule } from '@tiptap/core'
+import type { MarkType } from '@tiptap/pm/model'
+
+/**
+ * Matches a Markdown link with an optional quoted title.
+ * for ex: [Tiptap](https://tiptap.dev) or [Tiptap](https://tiptap.dev "some title")
+ * the URL may also contain one level of balanced parentheses, as in CommonMark
+ * (titles accept curly quotes too, the Typography extension swaps them in while typing)
+ */
+const MARKDOWN_LINK_INPUT_REGEX =
+  /\[([^[\]]+)\]\(((?:[^\s()]|\([^\s()]*\))+)(?:\s+["'“‘](.*?)["'”’])?\)$/
+
+/**
+ * Same as the input regex but global, to find every Markdown link in pasted text.
+ */
+const MARKDOWN_LINK_PASTE_REGEX =
+  /\[([^[\]]+)\]\(((?:[^\s()]|\([^\s()]*\))+)(?:\s+["'“‘](.*?)["'”’])?\)/g
+
+export interface MarkdownLinkRuleConfig {
+  type: MarkType
+
+  /**
+   * Return `false` to leave the Markdown syntax untouched.
+   */
+  isAllowedHref: (href: string) => boolean
+}
+
+function isConvertibleLink(
+  text: string,
+  match: RegExpMatchArray,
+  isAllowedHref: MarkdownLinkRuleConfig['isAllowedHref'],
+): boolean {
+  const [, linkText, href] = match
+  const characterBefore = match.index ? text[match.index - 1] : undefined
+
+  // `!` is the Markdown image syntax, `\` an escaped bracket
+  if (characterBefore === '!' || characterBefore === '\\') {
+    return false
+  }
+
+  return !!linkText.trim() && isAllowedHref(href)
+}
+
+function toRuleMatch(match: RegExpMatchArray): InputRuleMatch & PasteRuleMatch {
+  const [linkSyntax, linkText, href, title] = match
+
+  return {
+    index: match.index ?? 0,
+    text: linkSyntax,
+    replaceWith: linkText,
+    data: {
+      href,
+      // an empty title ("") counts as no title, as in CommonMark
+      title: title || null,
+    },
+  }
+}
+
+function getMarkdownLinkAttributes(match: { data?: Record<string, any> }) {
+  return {
+    href: match.data?.href,
+    title: match.data?.title ?? null,
+  }
+}
+
+/**
+ * Turns typed Markdown link syntax into a link mark as soon as the closing `)` comes in.
+ * The transaction gets flagged so autolink doesn't touch the converted text again.
+ */
+export function markdownLinkInputRule(config: MarkdownLinkRuleConfig): InputRule {
+  const rule = markInputRule({
+    find: text => {
+      const match = MARKDOWN_LINK_INPUT_REGEX.exec(text)
+
+      if (!match || !isConvertibleLink(text, match, config.isAllowedHref)) {
+        return null
+      }
+
+      return toRuleMatch(match)
+    },
+    type: config.type,
+    getAttributes: getMarkdownLinkAttributes,
+  })
+
+  return new InputRule({
+    find: rule.find,
+    handler: props => {
+      const result = rule.handler(props)
+
+      if (result !== null && props.state.tr.steps.length) {
+        props.state.tr.setMeta('preventAutolink', true)
+      }
+
+      return result
+    },
+  })
+}
+
+/**
+ * Same for pasting, converts every Markdown link found in the pasted text.
+ */
+export function markdownLinkPasteRule(config: MarkdownLinkRuleConfig): PasteRule {
+  const rule = markPasteRule({
+    find: text => {
+      const matches: PasteRuleMatch[] = []
+
+      for (const match of text.matchAll(MARKDOWN_LINK_PASTE_REGEX)) {
+        if (isConvertibleLink(text, match, config.isAllowedHref)) {
+          matches.push(toRuleMatch(match))
+        }
+      }
+
+      return matches
+    },
+    type: config.type,
+    getAttributes: getMarkdownLinkAttributes,
+  })
+
+  return new PasteRule({
+    find: rule.find,
+    handler: props => {
+      const result = rule.handler(props)
+
+      if (result !== null && props.state.tr.steps.length) {
+        props.state.tr.setMeta('preventAutolink', true)
+      }
+
+      return result
+    },
+  })
+}

--- a/packages/extension-link/src/helpers/markdownLink.ts
+++ b/packages/extension-link/src/helpers/markdownLink.ts
@@ -89,8 +89,8 @@ function isConvertibleLink(
   const [, linkText, href] = match
   const characterBefore = match.index ? text[match.index - 1] : undefined
 
-  // `!` is the Markdown image syntax, `\` an escaped bracket
-  if (characterBefore === '!' || characterBefore === '\\') {
+  // `!` is the Markdown image syntax, `\` may escape the opening bracket
+  if (characterBefore === '!' || isEscaped(text, match.index ?? 0)) {
     return false
   }
 

--- a/packages/extension-link/src/helpers/markdownLink.ts
+++ b/packages/extension-link/src/helpers/markdownLink.ts
@@ -26,6 +26,22 @@ export interface MarkdownLinkRuleConfig {
   isAllowedHref: (href: string) => boolean
 }
 
+/**
+ * An odd number of backticks before the match means it sits in an unclosed
+ * code span, either one still being typed or one from pasted text.
+ */
+function isInsideCodeSpan(text: string, matchIndex: number): boolean {
+  let backticks = 0
+
+  for (let index = 0; index < matchIndex; index += 1) {
+    if (text[index] === '`') {
+      backticks += 1
+    }
+  }
+
+  return backticks % 2 === 1
+}
+
 function isConvertibleLink(
   text: string,
   match: RegExpMatchArray,
@@ -36,6 +52,10 @@ function isConvertibleLink(
 
   // `!` is the Markdown image syntax, `\` an escaped bracket
   if (characterBefore === '!' || characterBefore === '\\') {
+    return false
+  }
+
+  if (isInsideCodeSpan(text, match.index ?? 0)) {
     return false
   }
 

--- a/packages/extension-link/src/helpers/markdownLink.ts
+++ b/packages/extension-link/src/helpers/markdownLink.ts
@@ -7,15 +7,16 @@ import type { MarkType } from '@tiptap/pm/model'
  * for ex: [Tiptap](https://tiptap.dev) or [Tiptap](https://tiptap.dev "some title")
  * the URL may also contain one level of balanced parentheses, as in CommonMark
  * (titles accept curly quotes too, the Typography extension swaps them in while typing)
+ * the title delimiters must come in matching pairs
  */
 const MARKDOWN_LINK_INPUT_REGEX =
-  /\[([^[\]]+)\]\(((?:[^\s()]|\([^\s()]*\))+)(?:\s+["'“‘](.*?)["'”’])?\)$/
+  /\[([^[\]]+)\]\(((?:[^\s()]|\([^\s()]*\))+)(?:\s+(?:(["'])(.*?)\3|“(.*?)”|‘(.*?)’))?\)$/
 
 /**
  * Same as the input regex but global, to find every Markdown link in pasted text.
  */
 const MARKDOWN_LINK_PASTE_REGEX =
-  /\[([^[\]]+)\]\(((?:[^\s()]|\([^\s()]*\))+)(?:\s+["'“‘](.*?)["'”’])?\)/g
+  /\[([^[\]]+)\]\(((?:[^\s()]|\([^\s()]*\))+)(?:\s+(?:(["'])(.*?)\3|“(.*?)”|‘(.*?)’))?\)/g
 
 export interface MarkdownLinkRuleConfig {
   type: MarkType
@@ -102,7 +103,9 @@ function isConvertibleLink(
 }
 
 function toRuleMatch(match: RegExpMatchArray): InputRuleMatch & PasteRuleMatch {
-  const [linkSyntax, linkText, href, title] = match
+  const [linkSyntax, linkText, href, , straightQuotedTitle, curlyDoubleTitle, curlySingleTitle] =
+    match
+  const title = straightQuotedTitle ?? curlyDoubleTitle ?? curlySingleTitle
 
   return {
     index: match.index ?? 0,

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -1,5 +1,5 @@
-import type { PasteRule, PasteRuleMatch } from '@tiptap/core'
-import { Mark, markPasteRule, mergeAttributes } from '@tiptap/core'
+import type { PasteRuleMatch } from '@tiptap/core'
+import { Mark, markPasteRule, mergeAttributes, PasteRule } from '@tiptap/core'
 import type { Plugin } from '@tiptap/pm/state'
 import { find, registerCustomProtocol, reset } from 'linkifyjs'
 
@@ -464,47 +464,60 @@ export const Link = Mark.create<LinkOptions>({
       )
     }
 
-    rules.push(
-      markPasteRule({
-        find: text => {
-          const foundLinks: PasteRuleMatch[] = []
+    const urlPasteRule = markPasteRule({
+      find: text => {
+        const foundLinks: PasteRuleMatch[] = []
 
-          if (text) {
-            const { protocols, defaultProtocol } = this.options
-            const links = find(text).filter(
-              item =>
-                item.isLink &&
-                this.options.isAllowedUri(item.value, {
-                  defaultValidate: href => !!isAllowedUri(href, protocols),
-                  protocols,
-                  defaultProtocol,
-                }),
-            )
+        if (text) {
+          const { protocols, defaultProtocol } = this.options
+          const links = find(text).filter(
+            item =>
+              item.isLink &&
+              this.options.isAllowedUri(item.value, {
+                defaultValidate: href => !!isAllowedUri(href, protocols),
+                protocols,
+                defaultProtocol,
+              }),
+          )
 
-            if (links.length) {
-              links.forEach(link => {
-                if (!this.options.shouldAutoLink(link.value)) {
-                  return
-                }
+          if (links.length) {
+            links.forEach(link => {
+              if (!this.options.shouldAutoLink(link.value)) {
+                return
+              }
 
-                foundLinks.push({
-                  text: link.value,
-                  data: {
-                    href: link.href,
-                  },
-                  index: link.start,
-                })
+              foundLinks.push({
+                text: link.value,
+                data: {
+                  href: link.href,
+                },
+                index: link.start,
               })
-            }
+            })
+          }
+        }
+
+        return foundLinks
+      },
+      type: this.type,
+      getAttributes: match => {
+        return {
+          href: match.data?.href,
+        }
+      },
+    })
+
+    rules.push(
+      new PasteRule({
+        find: urlPasteRule.find,
+        handler: props => {
+          // the Markdown paste rule above may have already linked this range,
+          // re-marking it here would replace its href
+          if (props.state.doc.rangeHasMark(props.range.from, props.range.to, this.type)) {
+            return
           }
 
-          return foundLinks
-        },
-        type: this.type,
-        getAttributes: match => {
-          return {
-            href: match.data?.href,
-          }
+          return urlPasteRule.handler(props)
         },
       }),
     )

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -76,8 +76,8 @@ export interface LinkOptions {
   /**
    * If enabled, typing or pasting the Markdown link syntax, e.g. `[Tiptap](https://tiptap.dev)`
    * or `[Tiptap](https://tiptap.dev "Rich text editor")`, converts it into a link.
-   * @default true
-   * @example false
+   * @default false
+   * @example true
    */
   markdownLinks: boolean
 
@@ -256,7 +256,7 @@ export const Link = Mark.create<LinkOptions>({
       openOnClick: true,
       enableClickSelection: false,
       linkOnPaste: true,
-      markdownLinks: true,
+      markdownLinks: false, // TODO (major) - default to true on next major version
       autolink: true,
       protocols: [],
       defaultProtocol: 'http',

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -1,5 +1,5 @@
 import type { PasteRuleMatch } from '@tiptap/core'
-import { Mark, markPasteRule, mergeAttributes, PasteRule } from '@tiptap/core'
+import { Mark, markPasteRule, mergeAttributes } from '@tiptap/core'
 import type { Plugin } from '@tiptap/pm/state'
 import { find, registerCustomProtocol, reset } from 'linkifyjs'
 
@@ -448,10 +448,41 @@ export const Link = Mark.create<LinkOptions>({
   },
 
   addPasteRules() {
-    const rules: PasteRule[] = []
+    const findPlainUrls = (text: string): PasteRuleMatch[] => {
+      const foundLinks: PasteRuleMatch[] = []
+
+      if (text) {
+        const { protocols, defaultProtocol } = this.options
+        const links = find(text).filter(
+          item =>
+            item.isLink &&
+            this.options.isAllowedUri(item.value, {
+              defaultValidate: href => !!isAllowedUri(href, protocols),
+              protocols,
+              defaultProtocol,
+            }),
+        )
+
+        links.forEach(link => {
+          if (!this.options.shouldAutoLink(link.value)) {
+            return
+          }
+
+          foundLinks.push({
+            text: link.value,
+            data: {
+              href: link.href,
+            },
+            index: link.start,
+          })
+        })
+      }
+
+      return foundLinks
+    }
 
     if (this.options.markdownLinks) {
-      rules.push(
+      return [
         markdownLinkPasteRule({
           type: this.type,
           isAllowedHref: href =>
@@ -460,69 +491,22 @@ export const Link = Mark.create<LinkOptions>({
               protocols: this.options.protocols,
               defaultProtocol: this.options.defaultProtocol,
             }),
+          findPlainUrls,
         }),
-      )
+      ]
     }
 
-    const urlPasteRule = markPasteRule({
-      find: text => {
-        const foundLinks: PasteRuleMatch[] = []
-
-        if (text) {
-          const { protocols, defaultProtocol } = this.options
-          const links = find(text).filter(
-            item =>
-              item.isLink &&
-              this.options.isAllowedUri(item.value, {
-                defaultValidate: href => !!isAllowedUri(href, protocols),
-                protocols,
-                defaultProtocol,
-              }),
-          )
-
-          if (links.length) {
-            links.forEach(link => {
-              if (!this.options.shouldAutoLink(link.value)) {
-                return
-              }
-
-              foundLinks.push({
-                text: link.value,
-                data: {
-                  href: link.href,
-                },
-                index: link.start,
-              })
-            })
+    return [
+      markPasteRule({
+        find: findPlainUrls,
+        type: this.type,
+        getAttributes: match => {
+          return {
+            href: match.data?.href,
           }
-        }
-
-        return foundLinks
-      },
-      type: this.type,
-      getAttributes: match => {
-        return {
-          href: match.data?.href,
-        }
-      },
-    })
-
-    rules.push(
-      new PasteRule({
-        find: urlPasteRule.find,
-        handler: props => {
-          // the Markdown paste rule above may have already linked this range,
-          // re-marking it here would replace its href
-          if (props.state.doc.rangeHasMark(props.range.from, props.range.to, this.type)) {
-            return
-          }
-
-          return urlPasteRule.handler(props)
         },
       }),
-    )
-
-    return rules
+    ]
   },
 
   addProseMirrorPlugins() {

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -1,10 +1,11 @@
-import type { PasteRuleMatch } from '@tiptap/core'
+import type { PasteRule, PasteRuleMatch } from '@tiptap/core'
 import { Mark, markPasteRule, mergeAttributes } from '@tiptap/core'
 import type { Plugin } from '@tiptap/pm/state'
 import { find, registerCustomProtocol, reset } from 'linkifyjs'
 
 import { autolink } from './helpers/autolink.js'
 import { clickHandler } from './helpers/clickHandler.js'
+import { markdownLinkInputRule, markdownLinkPasteRule } from './helpers/markdownLink.js'
 import { pasteHandler } from './helpers/pasteHandler.js'
 import { UNICODE_WHITESPACE_REGEX_GLOBAL } from './helpers/whitespace.js'
 
@@ -71,6 +72,14 @@ export interface LinkOptions {
    * @example false
    */
   linkOnPaste: boolean
+
+  /**
+   * If enabled, typing or pasting the Markdown link syntax, e.g. `[Tiptap](https://tiptap.dev)`
+   * or `[Tiptap](https://tiptap.dev "Rich text editor")`, converts it into a link.
+   * @default true
+   * @example false
+   */
+  markdownLinks: boolean
 
   /**
    * HTML attributes to add to the link element.
@@ -247,6 +256,7 @@ export const Link = Mark.create<LinkOptions>({
       openOnClick: true,
       enableClickSelection: false,
       linkOnPaste: true,
+      markdownLinks: true,
       autolink: true,
       protocols: [],
       defaultProtocol: 'http',
@@ -419,8 +429,42 @@ export const Link = Mark.create<LinkOptions>({
     }
   },
 
-  addPasteRules() {
+  addInputRules() {
+    if (!this.options.markdownLinks) {
+      return []
+    }
+
     return [
+      markdownLinkInputRule({
+        type: this.type,
+        isAllowedHref: href =>
+          this.options.isAllowedUri(href, {
+            defaultValidate: url => !!isAllowedUri(url, this.options.protocols),
+            protocols: this.options.protocols,
+            defaultProtocol: this.options.defaultProtocol,
+          }),
+      }),
+    ]
+  },
+
+  addPasteRules() {
+    const rules: PasteRule[] = []
+
+    if (this.options.markdownLinks) {
+      rules.push(
+        markdownLinkPasteRule({
+          type: this.type,
+          isAllowedHref: href =>
+            this.options.isAllowedUri(href, {
+              defaultValidate: url => !!isAllowedUri(url, this.options.protocols),
+              protocols: this.options.protocols,
+              defaultProtocol: this.options.defaultProtocol,
+            }),
+        }),
+      )
+    }
+
+    rules.push(
       markPasteRule({
         find: text => {
           const foundLinks: PasteRuleMatch[] = []
@@ -463,7 +507,9 @@ export const Link = Mark.create<LinkOptions>({
           }
         },
       }),
-    ]
+    )
+
+    return rules
   },
 
   addProseMirrorPlugins() {


### PR DESCRIPTION
Typing or pasting text containing Markdown links now automatically converts them into link marks. For example, typing `[Tiptap](https://tiptap.dev)` converts to a link as soon as the closing ) is typed.

Please read this discussion thread for more details: #6140 

Some things to note: 
1. Image syntax, escaped brackets and code spans are untouched.
2. URLs are validated using the existing `isAllowedUri`, so disallowed protocols such as `javascript:` stay as plain text.
3. This feature can be turned off via the newly added `markdownLinks` option. Disabled for now by default, in the next major release, need to set it to enabled.

**Visual Reference**

https://github.com/user-attachments/assets/92ad85f3-912e-47fd-b595-fa2273b3d19c



## Checklist
- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility
- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.