### PR TITLE
fix(core): convert between list types with different item schemas

### DIFF
--- a/.changeset/fix-cross-type-list-toggle.md
+++ b/.changeset/fix-cross-type-list-toggle.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix list toggling between list types that use different item nodes. Nested lists are recursively converted when the target item schema supports nesting, and flattened into sibling items when it does not.

--- a/demos/src/Examples/Default/React/MenuBar.tsx
+++ b/demos/src/Examples/Default/React/MenuBar.tsx
@@ -102,6 +102,12 @@ export const MenuBar = ({ editor }: { editor: Editor | null }) => {
           Ordered list
         </button>
         <button
+          onClick={() => editor.chain().focus().toggleTaskList().run()}
+          className={editorState.isTaskList ? 'is-active' : ''}
+        >
+          Task list
+        </button>
+        <button
           onClick={() => editor.chain().focus().toggleCodeBlock().run()}
           className={editorState.isCodeBlock ? 'is-active' : ''}
         >

--- a/demos/src/Examples/Default/React/index.tsx
+++ b/demos/src/Examples/Default/React/index.tsx
@@ -1,5 +1,6 @@
 import './styles.scss'
 
+import { TaskItem, TaskList } from '@tiptap/extension-list'
 import { TextStyleKit } from '@tiptap/extension-text-style'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -7,7 +8,7 @@ import React from 'react'
 
 import { MenuBar } from './MenuBar.jsx'
 
-const extensions = [TextStyleKit, StarterKit]
+const extensions = [TextStyleKit, StarterKit, TaskItem.configure({ nested: true }), TaskList]
 
 export default () => {
   const editor = useEditor({

--- a/demos/src/Examples/Default/React/menuBarState.ts
+++ b/demos/src/Examples/Default/React/menuBarState.ts
@@ -30,6 +30,7 @@ export function menuBarStateSelector(ctx: EditorStateSnapshot<Editor>) {
     // Lists and blocks
     isBulletList: ctx.editor.isActive('bulletList') ?? false,
     isOrderedList: ctx.editor.isActive('orderedList') ?? false,
+    isTaskList: ctx.editor.isActive('taskList') ?? false,
     isCodeBlock: ctx.editor.isActive('codeBlock') ?? false,
     isBlockquote: ctx.editor.isActive('blockquote') ?? false,
 

--- a/demos/src/Examples/Default/Svelte/index.svelte
+++ b/demos/src/Examples/Default/Svelte/index.svelte
@@ -2,7 +2,7 @@
   import "./styles.scss";
 
   import { Color } from '@tiptap/extension-text-style'
-  import { ListItem } from '@tiptap/extension-list'
+  import { ListItem, TaskItem, TaskList } from '@tiptap/extension-list'
   import { TextStyle } from '@tiptap/extension-text-style'
   import StarterKit from "@tiptap/starter-kit";
   import { Editor } from "@tiptap/core";
@@ -19,6 +19,8 @@
         Color.configure({ types: [TextStyle.name, ListItem.name] }),
         TextStyle.configure({ types: [ListItem.name] }),
         StarterKit,
+        TaskItem.configure({ nested: true }),
+        TaskList,
       ],
       content: `
             <h2>
@@ -145,6 +147,12 @@
         class={editor.isActive("orderedList") ? "is-active" : ""}
       >
         Ordered list
+      </button>
+      <button
+        on:click={() => editor.chain().focus().toggleTaskList().run()}
+        class={editor.isActive("taskList") ? "is-active" : ""}
+      >
+        Task list
       </button>
       <button
         on:click={() => editor.chain().focus().toggleCodeBlock().run()}

--- a/demos/src/Examples/Default/Vue/index.vue
+++ b/demos/src/Examples/Default/Vue/index.vue
@@ -87,6 +87,12 @@
           Ordered list
         </button>
         <button
+          @click="editor.chain().focus().toggleTaskList().run()"
+          :class="{ 'is-active': editor.isActive('taskList') }"
+        >
+          Task list
+        </button>
+        <button
           @click="editor.chain().focus().toggleCodeBlock().run()"
           :class="{ 'is-active': editor.isActive('codeBlock') }"
         >
@@ -125,7 +131,7 @@
 </template>
 
 <script>
-import { ListItem } from '@tiptap/extension-list'
+import { ListItem, TaskItem, TaskList } from '@tiptap/extension-list'
 import { Color, TextStyle } from '@tiptap/extension-text-style'
 import StarterKit from '@tiptap/starter-kit'
 import { Editor, EditorContent } from '@tiptap/vue-3'
@@ -147,6 +153,8 @@ export default {
         Color.configure({ types: [TextStyle.name, ListItem.name] }),
         TextStyle.configure({ types: [ListItem.name] }),
         StarterKit,
+        TaskItem.configure({ nested: true }),
+        TaskList,
       ],
       content: `
         <h2>

--- a/demos/src/Examples/Default/index.spec.ts
+++ b/demos/src/Examples/Default/index.spec.ts
@@ -21,6 +21,7 @@ const buttonNodes = [
   { label: 'H6', tag: 'h6' },
   { label: 'Bullet list', tag: 'ul' },
   { label: 'Ordered list', tag: 'ol' },
+  { label: 'Task list', tag: 'ul[data-type="taskList"]' },
   { label: 'Code block', tag: 'pre code' },
   { label: 'Blockquote', tag: 'blockquote' },
 ]

--- a/packages/core/src/commands/toggleList.ts
+++ b/packages/core/src/commands/toggleList.ts
@@ -1,4 +1,5 @@
-import type { NodeType } from '@tiptap/pm/model'
+import { Fragment } from '@tiptap/pm/model'
+import type { Node as ProseMirrorNode, NodeType } from '@tiptap/pm/model'
 import type { Transaction } from '@tiptap/pm/state'
 import { TextSelection } from '@tiptap/pm/state'
 import { canJoin } from '@tiptap/pm/transform'
@@ -7,6 +8,8 @@ import { findParentNode } from '../helpers/findParentNode.js'
 import { getNodeType } from '../helpers/getNodeType.js'
 import { isList } from '../helpers/isList.js'
 import type { RawCommands } from '../types.js'
+import { convertListItems } from './utils/convertListItems.js'
+import { findNodePosition } from './utils/findNodePosition.js'
 
 /**
  * Normalise a list type attribute for comparison.
@@ -117,16 +120,14 @@ function createInnerSelectionForWholeDocList(tr: Transaction) {
     return null
   }
 
-  // Place the selection inside the list node so that ProseMirror's
-  // liftListItem command can operate. AllSelection sits at the doc root.
-  // Use TextSelection.between to resolve positions into valid inline
-  // content positions, so the selection survives position mapping after
-  // liftListItem removes list/item wrappers.
+  // Move the root AllSelection into the list so liftListItem can operate
+  // while preserving a valid text selection.
   const $start = doc.resolve(1)
   const $end = doc.resolve(list.nodeSize - 1)
 
   return TextSelection.between($start, $end)
 }
+
 export const toggleList: RawCommands['toggleList'] =
   (listTypeOrName, itemTypeOrName, keepMarks, attributes = {}) =>
   ({ editor, tr, state, dispatch, chain, commands, can }) => {
@@ -145,12 +146,8 @@ export const toggleList: RawCommands['toggleList'] =
 
     const parentList = findParentNode(node => isList(node.type.name, extensions))(selection)
 
-    // When the user presses Ctrl/Cmd+A, ProseMirror creates an `AllSelection`
-    // covering the entire document (0..doc.content.size). In that case
-    // `findParentNode` cannot detect the surrounding list because the
-    // selection sits at the document root. If the document consists of a
-    // single top-level list node, treat that list as the active list so the
-    // toggle logic can correctly lift or change it.
+    // Treat a sole top-level list selected with Ctrl/Cmd+A as the active list,
+    // since findParentNode cannot detect it from the document root.
     const isAllSelection = selection.from === 0 && selection.to === state.doc.content.size
     const topLevelNodes = state.doc.content.content
     const soleTopLevelNode = topLevelNodes.length === 1 ? topLevelNodes[0] : null
@@ -175,10 +172,7 @@ export const toggleList: RawCommands['toggleList'] =
         if (isAllSelection && hasWholeDocSelectedList) {
           return chain()
             .command(({ tr: trx, dispatch: disp }) => {
-              // Ctrl/Cmd+A creates an AllSelection at the document root.
-              // When the whole document is a single top-level list, normalize the
-              // selection into that list before lifting, since liftListItem expects
-              // a selection inside a list item.
+              // Move the root AllSelection into the list before lifting it.
               const nextSelection = createInnerSelectionForWholeDocList(trx)
 
               if (!nextSelection) {
@@ -200,7 +194,7 @@ export const toggleList: RawCommands['toggleList'] =
         return commands.liftListItem(itemType)
       }
 
-      // change list type
+      // change list type: same item type (e.g., bulletList to orderedList)
       if (
         isList(currentList.node.type.name, extensions) &&
         listType.validContent(currentList.node.content)
@@ -214,6 +208,62 @@ export const toggleList: RawCommands['toggleList'] =
           .command(() => joinListBackwards(tr, listType))
           .command(() => joinListForwards(tr, listType))
           .run()
+      }
+
+      // change list type: cross-item-type conversion
+      // Handles cases like bulletList(listItem) to taskList(taskItem)
+      // where the list item type differs between source and target lists.
+      if (isList(currentList.node.type.name, extensions)) {
+        const currentItemType = currentList.node.firstChild?.type
+
+        if (currentItemType && currentItemType !== itemType) {
+          const convertedItems = convertListItems(currentList.node, {
+            listType,
+            itemType,
+            isListNode: node => isList(node.type.name, extensions),
+          })
+
+          const convertedContent = convertedItems ? Fragment.from(convertedItems) : null
+
+          if (!convertedContent || !listType.validContent(convertedContent)) {
+            return false
+          }
+
+          return chain()
+            .command(() => {
+              const { $anchor, $head } = tr.selection
+              const anchorParent = $anchor.parent
+              const headParent = $head.parent
+              const anchorOffset = $anchor.parentOffset
+              const headOffset = $head.parentOffset
+              let newList: ProseMirrorNode
+
+              try {
+                newList = listType.create(attributes, convertedContent)
+              } catch {
+                return false
+              }
+
+              tr.replaceWith(currentList.pos, currentList.pos + currentList.node.nodeSize, newList)
+
+              if (anchorParent.inlineContent && headParent.inlineContent) {
+                const anchorParentPos = findNodePosition(newList, anchorParent)
+                const headParentPos = findNodePosition(newList, headParent)
+
+                if (anchorParentPos !== null && headParentPos !== null) {
+                  const anchor = currentList.pos + anchorParentPos + 2 + anchorOffset
+                  const head = currentList.pos + headParentPos + 2 + headOffset
+
+                  tr.setSelection(TextSelection.create(tr.doc, anchor, head))
+                }
+              }
+
+              return true
+            })
+            .command(() => joinListBackwards(tr, listType))
+            .command(() => joinListForwards(tr, listType))
+            .run()
+        }
       }
     }
 

--- a/packages/core/src/commands/utils/appendContentNode.ts
+++ b/packages/core/src/commands/utils/appendContentNode.ts
@@ -1,0 +1,25 @@
+import { Fragment } from '@tiptap/pm/model'
+import type { Node as ProseMirrorNode, NodeType } from '@tiptap/pm/model'
+
+import { flushPendingContent } from './flushPendingContent.js'
+import type { ListItemConversionState } from './listConversionTypes.js'
+
+/** Appends a content node to the current item or starts a new item when needed. */
+export function appendContentNode(
+  node: ProseMirrorNode,
+  state: ListItemConversionState,
+  itemType: NodeType,
+): boolean {
+  if (itemType.validContent(Fragment.from([...state.pendingContent, node]))) {
+    state.pendingContent.push(node)
+    return true
+  }
+
+  if (!flushPendingContent(state, itemType) || !itemType.validContent(Fragment.from(node))) {
+    return false
+  }
+
+  state.pendingContent.push(node)
+
+  return true
+}

--- a/packages/core/src/commands/utils/appendNestedList.ts
+++ b/packages/core/src/commands/utils/appendNestedList.ts
@@ -1,0 +1,43 @@
+import { Fragment } from '@tiptap/pm/model'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+import { createNode } from './createNode.js'
+import { flushPendingContent } from './flushPendingContent.js'
+import type {
+  ConvertListItems,
+  ListConversionContext,
+  ListItemConversionState,
+} from './listConversionTypes.js'
+
+/** Preserves a nested list when supported or flattens its converted items. */
+export function appendNestedList(
+  sourceList: ProseMirrorNode,
+  state: ListItemConversionState,
+  context: ListConversionContext,
+  convertListItems: ConvertListItems,
+): boolean {
+  const nestedItems = convertListItems(sourceList, context)
+
+  if (!nestedItems) {
+    return false
+  }
+
+  const nestedList = createNode(context.listType, Fragment.from(nestedItems))
+
+  if (!nestedList) {
+    return false
+  }
+
+  if (context.itemType.validContent(Fragment.from([...state.pendingContent, nestedList]))) {
+    state.pendingContent.push(nestedList)
+    return true
+  }
+
+  if (!flushPendingContent(state, context.itemType)) {
+    return false
+  }
+
+  state.items.push(...nestedItems)
+
+  return true
+}

--- a/packages/core/src/commands/utils/convertListItem.ts
+++ b/packages/core/src/commands/utils/convertListItem.ts
@@ -1,0 +1,32 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+import { appendContentNode } from './appendContentNode.js'
+import { appendNestedList } from './appendNestedList.js'
+import { flushPendingContent } from './flushPendingContent.js'
+import type {
+  ConvertListItems,
+  ListConversionContext,
+  ListItemConversionState,
+} from './listConversionTypes.js'
+
+/** Converts one source list item into one or more target list items. */
+export function convertListItem(
+  sourceItem: ProseMirrorNode,
+  context: ListConversionContext,
+  convertListItems: ConvertListItems,
+): ProseMirrorNode[] | null {
+  const state: ListItemConversionState = { items: [], pendingContent: [] }
+
+  for (let index = 0; index < sourceItem.childCount; index += 1) {
+    const child = sourceItem.child(index)
+    const appended = context.isListNode(child)
+      ? appendNestedList(child, state, context, convertListItems)
+      : appendContentNode(child, state, context.itemType)
+
+    if (!appended) {
+      return null
+    }
+  }
+
+  return flushPendingContent(state, context.itemType) ? state.items : null
+}

--- a/packages/core/src/commands/utils/convertListItems.ts
+++ b/packages/core/src/commands/utils/convertListItems.ts
@@ -1,0 +1,24 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+import { convertListItem } from './convertListItem.js'
+import type { ListConversionContext } from './listConversionTypes.js'
+
+/** Recursively converts all items in a source list to the target list schema. */
+export function convertListItems(
+  sourceList: ProseMirrorNode,
+  context: ListConversionContext,
+): ProseMirrorNode[] | null {
+  const convertedItems: ProseMirrorNode[] = []
+
+  for (let index = 0; index < sourceList.childCount; index += 1) {
+    const items = convertListItem(sourceList.child(index), context, convertListItems)
+
+    if (!items) {
+      return null
+    }
+
+    convertedItems.push(...items)
+  }
+
+  return convertedItems
+}

--- a/packages/core/src/commands/utils/createNode.ts
+++ b/packages/core/src/commands/utils/createNode.ts
@@ -1,0 +1,14 @@
+import type { Fragment, Node as ProseMirrorNode, NodeType } from '@tiptap/pm/model'
+
+/** Creates a node when its content and required attributes are valid. */
+export function createNode(type: NodeType, content: Fragment): ProseMirrorNode | null {
+  if (!type.validContent(content)) {
+    return null
+  }
+
+  try {
+    return type.create(null, content)
+  } catch {
+    return null
+  }
+}

--- a/packages/core/src/commands/utils/findNodePosition.ts
+++ b/packages/core/src/commands/utils/findNodePosition.ts
@@ -1,0 +1,18 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+/** Finds a descendant node's position relative to its root node. */
+export function findNodePosition(root: ProseMirrorNode, target: ProseMirrorNode): number | null {
+  let targetPos: number | null = null
+
+  root.descendants((node, pos) => {
+    if (node !== target) {
+      return true
+    }
+
+    targetPos = pos
+
+    return false
+  })
+
+  return targetPos
+}

--- a/packages/core/src/commands/utils/flushPendingContent.ts
+++ b/packages/core/src/commands/utils/flushPendingContent.ts
@@ -1,0 +1,23 @@
+import { Fragment } from '@tiptap/pm/model'
+import type { NodeType } from '@tiptap/pm/model'
+
+import { createNode } from './createNode.js'
+import type { ListItemConversionState } from './listConversionTypes.js'
+
+/** Converts and appends the content accumulated for the current list item. */
+export function flushPendingContent(state: ListItemConversionState, itemType: NodeType): boolean {
+  if (state.pendingContent.length === 0) {
+    return true
+  }
+
+  const item = createNode(itemType, Fragment.from(state.pendingContent))
+
+  if (!item) {
+    return false
+  }
+
+  state.items.push(item)
+  state.pendingContent = []
+
+  return true
+}

--- a/packages/core/src/commands/utils/listConversionTypes.ts
+++ b/packages/core/src/commands/utils/listConversionTypes.ts
@@ -1,0 +1,17 @@
+import type { Node as ProseMirrorNode, NodeType } from '@tiptap/pm/model'
+
+export interface ListConversionContext {
+  listType: NodeType
+  itemType: NodeType
+  isListNode: (node: ProseMirrorNode) => boolean
+}
+
+export interface ListItemConversionState {
+  items: ProseMirrorNode[]
+  pendingContent: ProseMirrorNode[]
+}
+
+export type ConvertListItems = (
+  sourceList: ProseMirrorNode,
+  context: ListConversionContext,
+) => ProseMirrorNode[] | null

--- a/packages/extension-list/__tests__/taskItem.spec.ts
+++ b/packages/extension-list/__tests__/taskItem.spec.ts
@@ -663,4 +663,359 @@ describe('TaskItem', () => {
     expect(from).toBe(1)
     expect(to).toBe(14)
   })
+
+  it('converts a simple bullet list to a task list', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, TaskItem, BulletList, TaskList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Item 1' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.toggleTaskList()
+
+    expect(editor.getJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            {
+              type: 'taskItem',
+              attrs: { checked: false },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item 1' }] }],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('converts a task list to a bullet list', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, TaskItem, BulletList, TaskList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'taskList',
+            content: [
+              {
+                type: 'taskItem',
+                attrs: { checked: true },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Done item' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.toggleBulletList()
+
+    expect(editor.getJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Done item' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('converts a bullet list with multiple items to a task list', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, TaskItem, BulletList, TaskList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Alpha' }],
+                  },
+                ],
+              },
+              {
+                type: 'listItem',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Beta' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.toggleTaskList()
+
+    const json = editor.getJSON()
+
+    expect(json.content[0].type).toBe('taskList')
+    expect(json.content[0].content).toHaveLength(2)
+    expect(json.content[0].content[0].type).toBe('taskItem')
+    expect(json.content[0].content[1].type).toBe('taskItem')
+    expect(json.content[0].content[0].content[0].content[0].text).toBe('Alpha')
+    expect(json.content[0].content[1].content[0].content[0].text).toBe('Beta')
+  })
+
+  it('converts an ordered list to a task list', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, TaskItem, OrderedList, TaskList],
+      content: '<ol><li><p>A</p></li><li><p>B</p></li></ol>',
+    })
+
+    editor.commands.toggleTaskList()
+
+    const json = editor.getJSON()
+
+    expect(json.content[0].type).toBe('taskList')
+    expect(json.content[0].content).toHaveLength(2)
+    expect(json.content[0].content[0].type).toBe('taskItem')
+    expect(json.content[0].content[1].type).toBe('taskItem')
+  })
+
+  it('converts a task list to an ordered list', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, TaskItem, OrderedList, TaskList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'taskList',
+            content: [
+              {
+                type: 'taskItem',
+                attrs: { checked: false },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'One' }],
+                  },
+                ],
+              },
+              {
+                type: 'taskItem',
+                attrs: { checked: true },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Two' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.toggleOrderedList()
+
+    const json = editor.getJSON()
+
+    expect(json.content[0].type).toBe('orderedList')
+    expect(json.content[0].content).toHaveLength(2)
+    expect(json.content[0].content[0].type).toBe('listItem')
+    expect(json.content[0].content[1].type).toBe('listItem')
+  })
+
+  it('flattens nested lists when converting to non-nested task items', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, TaskItem, BulletList, TaskList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  { type: 'paragraph', content: [{ type: 'text', text: 'Parent' }] },
+                  {
+                    type: 'bulletList',
+                    content: [
+                      {
+                        type: 'listItem',
+                        content: [
+                          { type: 'paragraph', content: [{ type: 'text', text: 'Child' }] },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'listItem',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item 2' }] }],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const result = editor.commands.toggleTaskList()
+
+    expect(result).toBe(true)
+    expect(editor.getJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            {
+              type: 'taskItem',
+              attrs: { checked: false },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Parent' }] }],
+            },
+            {
+              type: 'taskItem',
+              attrs: { checked: false },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Child' }] }],
+            },
+            {
+              type: 'taskItem',
+              attrs: { checked: false },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item 2' }] }],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('preserves a text selection when flattening nested lists', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, TaskItem, BulletList, TaskList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  { type: 'paragraph', content: [{ type: 'text', text: 'Parent' }] },
+                  {
+                    type: 'bulletList',
+                    content: [
+                      {
+                        type: 'listItem',
+                        content: [
+                          { type: 'paragraph', content: [{ type: 'text', text: 'Child' }] },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    let childPosition = 0
+
+    editor.state.doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'Child') {
+        childPosition = pos
+      }
+    })
+
+    editor.commands.setTextSelection({ from: childPosition, to: childPosition + 5 })
+    editor.commands.toggleTaskList()
+
+    const { from, to } = editor.state.selection
+
+    expect(editor.state.doc.textBetween(from, to)).toBe('Child')
+  })
+
+  it('converts a nested bullet list with nested task item configured', () => {
+    const NestedTaskItem = TaskItem.configure({ nested: true })
+
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, NestedTaskItem, BulletList, TaskList],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  { type: 'paragraph', content: [{ type: 'text', text: 'Parent' }] },
+                  {
+                    type: 'bulletList',
+                    content: [
+                      {
+                        type: 'listItem',
+                        content: [
+                          { type: 'paragraph', content: [{ type: 'text', text: 'Child' }] },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.toggleTaskList()
+
+    const json = editor.getJSON()
+
+    expect(json.content[0].type).toBe('taskList')
+    expect(json.content[0].content[0].type).toBe('taskItem')
+    expect(json.content[0].content[0].content[1].type).toBe('taskList')
+    expect(json.content[0].content[0].content[1].content[0].type).toBe('taskItem')
+  })
 })


### PR DESCRIPTION
What: toggleList now converts items when the list type changes (e.g. bulletList -> taskList). Nested lists are recursively converted when the target item schema supports nesting, and flattened into sibling items when it does not.

Why: Toggling between list types with different item nodes (listItem vs taskItem) either did nothing or produced a broken document.

Closes #2492