### PR TITLE
fix(react): batch node view portal notifications

### DIFF
--- a/.changeset/fix-react-nodeview-portal-notifications.md
+++ b/.changeset/fix-react-nodeview-portal-notifications.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Batch React node view portal store notifications that happen in the same microtask to avoid nested update depth warnings when many node views mount together.

--- a/packages/react/src/EditorContent.spec.ts
+++ b/packages/react/src/EditorContent.spec.ts
@@ -1,0 +1,39 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createContentComponent } from './EditorContent.js'
+import type { ReactRenderer } from './ReactRenderer.js'
+
+const createRenderer = (id: string) =>
+  ({
+    reactElement: React.createElement('span', null, id),
+    element: document.createElement('div'),
+  }) as ReactRenderer
+
+describe('createContentComponent', () => {
+  it('batches synchronous renderer change notifications', async () => {
+    const contentComponent = createContentComponent()
+    const subscriber = vi.fn()
+
+    contentComponent.subscribe(subscriber)
+
+    contentComponent.setRenderer('first', createRenderer('first'))
+    contentComponent.setRenderer('second', createRenderer('second'))
+
+    expect(Object.keys(contentComponent.getSnapshot())).toEqual(['first', 'second'])
+    expect(subscriber).not.toHaveBeenCalled()
+
+    await Promise.resolve()
+
+    expect(subscriber).toHaveBeenCalledTimes(1)
+
+    contentComponent.removeRenderer('first')
+    contentComponent.removeRenderer('second')
+
+    expect(Object.keys(contentComponent.getSnapshot())).toEqual([])
+
+    await Promise.resolve()
+
+    expect(subscriber).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/react/src/EditorContent.tsx
+++ b/packages/react/src/EditorContent.tsx
@@ -41,9 +41,23 @@ export interface EditorContentProps extends HTMLProps<HTMLDivElement> {
   innerRef?: ForwardedRef<HTMLDivElement | null>
 }
 
-function getInstance(): ContentComponent {
+export function createContentComponent(): ContentComponent {
   const subscribers = new Set<() => void>()
   let renderers: Record<string, React.ReactPortal> = {}
+  let isNotificationQueued = false
+
+  const notifySubscribers = () => {
+    if (isNotificationQueued || !subscribers.size) {
+      return
+    }
+
+    isNotificationQueued = true
+
+    queueMicrotask(() => {
+      isNotificationQueued = false
+      subscribers.forEach(subscriber => subscriber())
+    })
+  }
 
   return {
     /**
@@ -70,7 +84,7 @@ function getInstance(): ContentComponent {
         [id]: ReactDOM.createPortal(renderer.reactElement, renderer.element, id),
       }
 
-      subscribers.forEach(subscriber => subscriber())
+      notifySubscribers()
     },
     /**
      * Removes a NodeView Renderer from the editor.
@@ -80,7 +94,7 @@ function getInstance(): ContentComponent {
 
       delete nextRenderers[id]
       renderers = nextRenderers
-      subscribers.forEach(subscriber => subscriber())
+      notifySubscribers()
     },
   }
 }
@@ -120,7 +134,7 @@ export class PureEditorContent extends React.Component<
         element,
       })
 
-      editor.contentComponent = getInstance()
+      editor.contentComponent = createContentComponent()
 
       editor.createNodeViews()
 


### PR DESCRIPTION
Fixes #8000.

React node views register their portals through the content component store. When many renderers are added or removed in the same synchronous pass, the store currently notifies subscribers for each individual change, which can repeatedly re-enter React updates while the editor is mounting.

This keeps the renderer snapshot update synchronous, but batches subscriber notifications into a microtask. A burst of portal changes now produces one external-store notification while `getSnapshot()` still returns the latest renderer map immediately.

Verification:

- red check: the new `EditorContent.spec.ts` test fails with the old synchronous notification path
- `./node_modules/.bin/vitest run packages/react/src/EditorContent.spec.ts`
- `./node_modules/.bin/oxfmt --check packages/react/src/EditorContent.tsx packages/react/src/EditorContent.spec.ts .changeset/fix-react-nodeview-portal-notifications.md`
- `./node_modules/.bin/oxlint packages/react/src/EditorContent.tsx packages/react/src/EditorContent.spec.ts`
- `git diff --check`
- `pnpm -F @tiptap/react build`
