### PR TITLE
Feat(extension-youtube): allow string width/height for videos

### DIFF
--- a/.changeset/youtube-string-dimensions.md
+++ b/.changeset/youtube-string-dimensions.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-youtube': minor
 ---
 
-Allow string `width` and `height` values like `'100%'` or `'20rem'` in the Youtube extension. Non-numeric values in parsed HTML are now preserved instead of being converted to numbers.
+Allow string `width` and `height` values like `'100%'` or `'20rem'` in the YouTube extension. Non-numeric values in parsed HTML are now preserved instead of being converted to numbers.

--- a/.changeset/youtube-string-dimensions.md
+++ b/.changeset/youtube-string-dimensions.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-youtube': minor
+---
+
+Allow string `width` and `height` values like `'100%'` in the Youtube extension. Percentage values in parsed HTML are now preserved instead of being converted to numbers.

--- a/.changeset/youtube-string-dimensions.md
+++ b/.changeset/youtube-string-dimensions.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-youtube': minor
 ---
 
-Allow string `width` and `height` values like `'100%'` in the Youtube extension. Percentage values in parsed HTML are now preserved instead of being converted to numbers.
+Allow string `width` and `height` values like `'100%'` or `'20rem'` in the Youtube extension. Non-numeric values in parsed HTML are now preserved instead of being converted to numbers.

--- a/packages/extension-youtube/__tests__/youtube.spec.ts
+++ b/packages/extension-youtube/__tests__/youtube.spec.ts
@@ -213,6 +213,121 @@ describe('extension-youtube', () => {
     },
   )
 
+  describe('iframe dimension handling', () => {
+    it('preserves percentage width and height when parsing HTML', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+        content:
+          '<div data-youtube-video><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="100%" height="56.25%"></iframe></div>',
+      })
+
+      const attrs = editor.getJSON().content?.[0]?.attrs ?? {}
+
+      expect(attrs.width).toBe('100%')
+      expect(attrs.height).toBe('56.25%')
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+
+    it('keeps percentage dimensions when content is loaded back from rendered HTML', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'youtube',
+              attrs: {
+                src: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+                width: '100%',
+                height: 480,
+              },
+            },
+          ],
+        },
+      })
+
+      const html = editor.getHTML()
+
+      expect(html).toContain('width="100%"')
+
+      editor.destroy()
+      getEditorEl()?.remove()
+
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+        content: html,
+      })
+
+      const attrs = editor.getJSON().content?.[0]?.attrs ?? {}
+
+      expect(attrs.width).toBe('100%')
+      expect(attrs.height).toBe(480)
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+
+    it('still parses plain numeric dimensions as numbers', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+        content:
+          '<div data-youtube-video><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="720" height="405"></iframe></div>',
+      })
+
+      const attrs = editor.getJSON().content?.[0]?.attrs ?? {}
+
+      expect(attrs.width).toBe(720)
+      expect(attrs.height).toBe(405)
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+
+    it('falls back to the default dimensions for values that are not numeric or percentages', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+        content:
+          '<div data-youtube-video><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="auto" height="auto"></iframe></div>',
+      })
+
+      const attrs = editor.getJSON().content?.[0]?.attrs ?? {}
+
+      expect(attrs.width).toBe(640)
+      expect(attrs.height).toBe(480)
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+
+    it('accepts a percentage width in the setYoutubeVideo command', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+      })
+
+      editor.commands.setYoutubeVideo({
+        src: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        width: '100%',
+        height: 405,
+      })
+
+      const attrs = editor.getJSON().content?.[0]?.attrs ?? {}
+
+      expect(attrs.width).toBe('100%')
+      expect(attrs.height).toBe(405)
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+  })
+
   it('does not persist NaN width or height when parsing iframe dimensions from HTML', () => {
     editor = new Editor({
       element: createEditorEl(),

--- a/packages/extension-youtube/__tests__/youtube.spec.ts
+++ b/packages/extension-youtube/__tests__/youtube.spec.ts
@@ -289,18 +289,38 @@ describe('extension-youtube', () => {
       getEditorEl()?.remove()
     })
 
-    it('falls back to the default dimensions for values that are not numeric or percentages', () => {
+    it.each([
+      ['100px', '200px'],
+      ['20rem', '10em'],
+      ['50vw', '30vh'],
+    ])('preserves unit-based dimensions like %s when parsing HTML', (width, height) => {
       editor = new Editor({
         element: createEditorEl(),
         extensions: [Document, Text, Paragraph, Youtube],
-        content:
-          '<div data-youtube-video><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="auto" height="auto"></iframe></div>',
+        content: `<div data-youtube-video><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="${width}" height="${height}"></iframe></div>`,
       })
 
       const attrs = editor.getJSON().content?.[0]?.attrs ?? {}
 
-      expect(attrs.width).toBe(640)
-      expect(attrs.height).toBe(480)
+      expect(attrs.width).toBe(width)
+      expect(attrs.height).toBe(height)
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+
+    it('preserves non-numeric strings instead of falling back to the default dimensions', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+        content:
+          '<div data-youtube-video><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="not-a-size" height="auto"></iframe></div>',
+      })
+
+      const attrs = editor.getJSON().content?.[0]?.attrs ?? {}
+
+      expect(attrs.width).toBe('not-a-size')
+      expect(attrs.height).toBe('auto')
 
       editor?.destroy()
       getEditorEl()?.remove()

--- a/packages/extension-youtube/src/youtube.ts
+++ b/packages/extension-youtube/src/youtube.ts
@@ -12,7 +12,14 @@ const getParsedDimension = (value: string | null) => {
     return null
   }
 
-  const parsedValue = Number.parseInt(value, 10)
+  const trimmedValue = value.trim()
+
+  // keep percentage values like "100%" as strings
+  if (/^\d+(\.\d+)?%$/.test(trimmedValue)) {
+    return trimmedValue
+  }
+
+  const parsedValue = Number.parseInt(trimmedValue, 10)
 
   return Number.isNaN(parsedValue) ? null : parsedValue
 }
@@ -110,8 +117,9 @@ export interface YoutubeOptions {
    * The height of the youtube video.
    * @default 480
    * @example 720
+   * @example '100%'
    */
-  height: number
+  height: number | string
 
   /**
    * The language of the youtube video.
@@ -187,8 +195,9 @@ export interface YoutubeOptions {
    * The width of the youtube video.
    * @default 640
    * @example 1280
+   * @example '100%'
    */
-  width: number
+  width: number | string
 
   /**
    * Controls if the related youtube videos at the end are from the same channel.
@@ -201,7 +210,12 @@ export interface YoutubeOptions {
 /**
  * The options for setting a youtube video.
  */
-type SetYoutubeVideoOptions = { src: string; width?: number; height?: number; start?: number }
+type SetYoutubeVideoOptions = {
+  src: string
+  width?: number | string
+  height?: number | string
+  start?: number
+}
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {

--- a/packages/extension-youtube/src/youtube.ts
+++ b/packages/extension-youtube/src/youtube.ts
@@ -14,14 +14,13 @@ const getParsedDimension = (value: string | null) => {
 
   const trimmedValue = value.trim()
 
-  // keep percentage values like "100%" as strings
-  if (/^\d+(\.\d+)?%$/.test(trimmedValue)) {
-    return trimmedValue
+  if (trimmedValue === '') {
+    return null
   }
 
-  const parsedValue = Number.parseInt(trimmedValue, 10)
+  const parsedValue = Number(trimmedValue)
 
-  return Number.isNaN(parsedValue) ? null : parsedValue
+  return Number.isNaN(parsedValue) ? trimmedValue : parsedValue
 }
 
 const getParsedYoutubeAttributes = (element: HTMLElement) => {


### PR DESCRIPTION
## Fixes
Implements #7372 

## Changes and Review
Before: width and height for the Youtube extension were typed as number only, so passing something like width: "100%" needed a type cast. On top of that, the HTML parser internally auto converted width="100%" into 100 when content was loaded or pasted. This behaviour feels broken.

Now, plain numeric values are still parsed as numbers, and any non-numeric string like "100%", "100px" or "20rem" is preserved as is.

## Checklist
- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility
- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
