### PR TITLE
fix(static-renderer): correct markdown table rendering for merged cells

### DIFF
--- a/.changeset/kind-tigers-turn.md
+++ b/.changeset/kind-tigers-turn.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/static-renderer": patch
+---
+
+Fix Markdown table serialization for merged cells by preserving the correct column layout for rowspan and colspan.

--- a/packages/static-renderer/__tests__/md-string.spec.ts
+++ b/packages/static-renderer/__tests__/md-string.spec.ts
@@ -259,6 +259,48 @@ describe('static render json to string (no prosemirror)', () => {
     )
   })
 
+  it('should render a table with merged cells (rowspan) without breaking the grid', () => {
+    const cell = (text: string, attrs: { colspan?: number; rowspan?: number } = {}) => ({
+      type: 'tableCell',
+      attrs: { colspan: 1, rowspan: 1, colwidth: null, ...attrs },
+      content: text
+        ? [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+        : [{ type: 'paragraph', content: [] }],
+    })
+
+    const json = {
+      type: 'doc',
+      content: [
+        {
+          type: 'table',
+          content: [
+            {
+              // Row 0: "3" spans down into row 1, so row 0 has 3 real cells
+              type: 'tableRow',
+              content: [cell('1'), cell('3', { rowspan: 2 }), cell('-')],
+            },
+            {
+              // Row 1: only 2 real cells exist here, the 3rd column is covered by row 0's rowspan
+              type: 'tableRow',
+              content: [cell('2'), cell('4')],
+            },
+            {
+              // Row 2: back to 3 real (empty) cells
+              type: 'tableRow',
+              content: [cell(''), cell(''), cell('')],
+            },
+          ],
+        },
+      ],
+    }
+
+    const md = renderToMarkdown({ content: json, extensions: [StarterKit, TableKit] })
+
+    // Every row must keep the same number of columns as the header separator row,
+    // with a blank placeholder standing in for the rowspan-covered slot.
+    expect(md).toBe('\n| 1 | 3 | - |\n| --- | --- | --- |\n| 2 |  | 4 |\n|  |  |  |\n\n')
+  })
+
   it('should render a blockquote with trailing newline before a paragraph', () => {
     const json = {
       type: 'doc',

--- a/packages/static-renderer/src/pm/markdown/markdown.ts
+++ b/packages/static-renderer/src/pm/markdown/markdown.ts
@@ -1,5 +1,6 @@
 import type { Extensions, JSONContent } from '@tiptap/core'
 import type { Mark, Node } from '@tiptap/pm/model'
+import { TableMap } from '@tiptap/pm/tables'
 
 import type { TiptapStaticRendererOptions } from '../../json/renderer.js'
 import type { StaticEditorOptions } from '../extensionRenderer.js'
@@ -88,14 +89,49 @@ export function renderToMarkdown({
             return `\n${serializeChildrenToHTMLString(children)}\n`
           }
 
-          const columnCount = node.children[0].childCount
+          // Use the table's real column count (accounting for row/colspan) rather than
+          // assuming the first row spans every column.
+          const columnCount = TableMap.get(node).width
           return `\n${serializeChildrenToHTMLString(children[0])}| ${Array.from<string>({ length: columnCount }).fill('---').join(' | ')} |\n${serializeChildrenToHTMLString(children.slice(1))}\n`
         },
-        tableRow({ children }) {
-          if (Array.isArray(children)) {
+        tableRow({ node, children, parent }) {
+          if (!Array.isArray(children) || !parent) {
+            return `${serializeChildrenToHTMLString(children)}\n`
+          }
+
+          const map = TableMap.get(parent)
+
+          let rowIndex = -1
+          parent.forEach((rowNode, _offset, index) => {
+            if (rowNode === node) {
+              rowIndex = index
+            }
+          })
+
+          if (rowIndex === -1) {
+            // Should not happen, but fall back to the previous (naive) behavior rather than throwing.
             return `| ${children.join(' | ')} |\n`
           }
-          return `${serializeChildrenToHTMLString(children)}\n`
+
+          const cells: string[] = []
+          let cellIndex = 0
+
+          for (let col = 0; col < map.width; col += 1) {
+            const cellPos = map.map[rowIndex * map.width + col]
+            const rect = map.findCell(cellPos)
+
+            // Only the cell's top-left slot corresponds to an actual rendered child of this row.
+            // Every other slot it covers (via rowspan/colspan) needs a blank placeholder so the
+            // markdown grid stays rectangular.
+            if (rect.top === rowIndex && rect.left === col) {
+              cells.push(children[cellIndex] ?? '')
+              cellIndex += 1
+            } else {
+              cells.push('')
+            }
+          }
+
+          return `| ${cells.join(' | ')} |\n`
         },
         tableHeader({ children }) {
           return serializeChildrenToHTMLString(children).trim()


### PR DESCRIPTION
Fixes #7237

## Fixes
Fixes #7237

## Changes and Review
The markdown table serializer (`table`/`tableRow` in `packages/static-renderer/src/pm/markdown/markdown.ts`) assumed every row has one cell per column and joined cells naively. This broke tables with merged cells (rowspan/colspan), since a row spanned-into by a cell above has fewer real child nodes than the table's column count - producing a misaligned markdown grid.

- `table()` now derives column count from `TableMap.get(node).width` instead of `node.children[0].childCount`.
- `tableRow()` now walks the row using `TableMap` and inserts a blank placeholder for any slot covered by a rowspan/colspan from elsewhere, keeping every row the same width.
- Added a regression test in `md-string.spec.ts` reproducing the exact rowspan scenario from the issue.

## Checklist
- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility
- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.