### PR TITLE
fix(demos): update EnterShortcuts React editor state

### DIFF
--- a/demos/src/Examples/EnterShortcuts/React/index.tsx
+++ b/demos/src/Examples/EnterShortcuts/React/index.tsx
@@ -1,6 +1,6 @@
 import './styles.scss'
 
-import { EditorContent, Extension, useEditor } from '@tiptap/react'
+import { EditorContent, Extension, useEditor, useEditorState } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import React from 'react'
 
@@ -52,6 +52,11 @@ export default () => {
         Hey, try to hit Shift+Enter, Ctrl+Enter or Meta+Enter. The last shortcut hit will be displayed above.
       </p>
     `,
+  })
+
+  useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => currentEditor.state,
   })
 
   if (!editor) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

## Changes and Review
- Subscribe the React EnterShortcuts demo to editor state changes so toolbar state remains current.
- Verify by changing the selection and confirming the active controls update.

## Checklist
- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [ ] I have made sure to test my changes myself.

### Responsibility
- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-601af3a6-eca9-4882-977e-7da65771f9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-601af3a6-eca9-4882-977e-7da65771f9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

