### PR TITLE
fix(react): bind onMount and onUnmount handlers in useEditor

### DIFF
--- a/.changeset/weak-baboons-occur.md
+++ b/.changeset/weak-baboons-occur.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/react": patch
+---
+
+Bind onMount and onUnmount event handlers when initializing an Editor with useEditor hook.

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -134,6 +134,8 @@ class EditorInstanceManager {
       onDrop: (...args) => this.options.current.onDrop?.(...args),
       onPaste: (...args) => this.options.current.onPaste?.(...args),
       onDelete: (...args) => this.options.current.onDelete?.(...args),
+      onMount: (...args) => this.options.current.onMount?.(...args),
+      onUnmount: (...args) => this.options.current.onUnmount?.(...args),
     }
     const editor = new Editor(optionsToApply)
 


### PR DESCRIPTION
## Fixes

I did not find an existing ticket for this (and since it is so simple I opted not to create one). 

## Changes and Review

The React `useEditor` hook binds handlers for all the editor events except `onMount` and `onUnmount`. This change simply adds bindings for those handlers as well to match how the other handlers.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
