### PR TITLE
fix(core): remove unreachable navigator.platform check in isAndroid (fixes #6560)

### DIFF
--- a/packages/core/src/utilities/isAndroid.ts
+++ b/packages/core/src/utilities/isAndroid.ts
@@ -1,3 +1,3 @@
 export function isAndroid(): boolean {
-  return navigator.platform === 'Android' || /android/i.test(navigator.userAgent)
+  return typeof navigator !== 'undefined' ? /android/i.test(navigator.userAgent) : false
 }


### PR DESCRIPTION
## Problem

`navigator.platform === "Android"` in `isAndroid.ts` causes a TypeScript build error (TS2367):

```
Type error: This comparison appears to be unintentional because the types
MacIntel