### PR TITLE
Fix(core): Pos returning child node instead of the containing node

### DIFF
--- a/.changeset/fix-pos-atom-only.md
+++ b/.changeset/fix-pos-atom-only.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix `editor.$pos()` returning the wrong node inside container nodes, for example the list item instead of the list.

--- a/packages/core/__tests__/nodePos.spec.ts
+++ b/packages/core/__tests__/nodePos.spec.ts
@@ -2,8 +2,12 @@ import { Editor, Node } from '@tiptap/core'
 import Blockquote from '@tiptap/extension-blockquote'
 import BulletList from '@tiptap/extension-bullet-list'
 import Document from '@tiptap/extension-document'
+import HardBreak from '@tiptap/extension-hard-break'
+import HorizontalRule from '@tiptap/extension-horizontal-rule'
 import ListItem from '@tiptap/extension-list-item'
+import OrderedList from '@tiptap/extension-ordered-list'
 import Paragraph from '@tiptap/extension-paragraph'
+import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
 import Text from '@tiptap/extension-text'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -575,6 +579,105 @@ describe('NodePos', () => {
 
       expect(nodeAtPos.node.type.name).toBe('customBlockAtom')
       expect(nodeAtPos.node.type.name).not.toBe('doc')
+    })
+
+    it('should return the containing node for positions inside containers, not the child after them', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, OrderedList, ListItem, Blockquote],
+        content: '<ol><li><p>Hello</p></li></ol><blockquote><p>World</p></blockquote>',
+      })
+
+      // pos 1 sits before the list item, pos 12 before the inner paragraph
+      expect(editor.$pos(1).node.type.name).toBe('orderedList')
+      expect(editor.$pos(12).node.type.name).toBe('blockquote')
+    })
+
+    it('should still resolve text positions to the containing node', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text],
+        content: '<p>Hello</p>',
+      })
+
+      expect(editor.$pos(3).node.type.name).toBe('paragraph')
+    })
+
+    it('should return the list for the boundary between two list items', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, OrderedList, ListItem],
+        content: '<ol><li><p>a</p></li><li><p>b</p></li></ol>',
+      })
+
+      expect(editor.$pos(6).node.type.name).toBe('orderedList')
+    })
+
+    it('should resolve positions in nested lists to the containing node', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, BulletList, OrderedList, ListItem],
+        content: '<ul><li><p>a</p><ol><li><p>b</p></li></ol></li></ul>',
+      })
+
+      expect(editor.$pos(5).node.type.name).toBe('listItem')
+      expect(editor.$pos(6).node.type.name).toBe('orderedList')
+      expect(editor.$pos(7).node.type.name).toBe('listItem')
+    })
+
+    it('should resolve positions in tables to the containing node', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, Table, TableRow, TableCell, TableHeader],
+        content: '<table><tr><td><p>a</p></td><td><p>b</p></td></tr></table>',
+      })
+
+      expect(editor.$pos(1).node.type.name).toBe('table')
+      expect(editor.$pos(2).node.type.name).toBe('tableRow')
+      expect(editor.$pos(3).node.type.name).toBe('tableCell')
+    })
+
+    it('should return leaf nodes like hard breaks when pointing directly at them', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, HardBreak],
+        content: '<p>Hello<br>World</p>',
+      })
+
+      expect(editor.$pos(6).node.type.name).toBe('hardBreak')
+      expect(editor.$pos(3).node.type.name).toBe('paragraph')
+    })
+
+    it('should return leaf nodes like horizontal rules when pointing directly at them', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, HorizontalRule],
+        content: '<p>a</p><hr><p>b</p>',
+      })
+
+      expect(editor.$pos(3).node.type.name).toBe('horizontalRule')
+      expect(editor.$pos(4).node.type.name).toBe('doc')
+    })
+
+    it('should return the doc for the position at the very end of the document', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text],
+        content: '<p>Hi</p>',
+      })
+
+      expect(editor.$pos(editor.state.doc.content.size).node.type.name).toBe('doc')
+    })
+
+    it('should return the following atom for the boundary between two block atoms', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, CustomBlockAtomNode],
+        content:
+          '<p>a</p><div data-type="custom-block-atom"></div><div data-type="custom-block-atom"></div>',
+      })
+
+      expect(editor.$pos(4).node.type.name).toBe('customBlockAtom')
+    })
+
+    it('should return inline atoms nested inside list items', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, BulletList, ListItem, CustomInlineNode],
+        content: '<ul><li><p>x<span data-type="custom-inline"></span></p></li></ul>',
+      })
+
+      expect(editor.$pos(4).node.type.name).toBe('customInline')
     })
   })
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -816,13 +816,13 @@ export class Editor extends EventEmitter<EditorEvents> {
 
   public $pos(pos: number) {
     const $pos = this.state.doc.resolve(pos)
-    // When the position sits directly before a non-text node (e.g. an image or
-    // other atom), nodeAfter is that node but resolvedPos.node() would return
-    // the parent (often the doc at depth 0). Pass nodeAfter as the explicit node
-    // so NodePos.node returns the expected node instead of the parent.
-    // Keep $pos(0) returning the doc node; for other positions, prefer nodeAfter
-    // when it points at a non-text node.
-    const node = pos > 0 && $pos.nodeAfter && !$pos.nodeAfter.isText ? $pos.nodeAfter : null
+    // For positions directly before a non-text atom, resolvedPos.node() returns
+    // the parent, so pass the atom explicitly. Container nodes and $pos(0) keep
+    // resolving to the parent.
+    const node =
+      pos > 0 && $pos.nodeAfter && !$pos.nodeAfter.isText && $pos.nodeAfter.isAtom
+        ? $pos.nodeAfter
+        : null
 
     return new NodePos($pos, this, false, node)
   }


### PR DESCRIPTION
Fixes #8082 

## Changes and Review

`$pos()` was returning the child node after the position (like a list item) instead of the containing node.
This was because the nodeAfter preference applied to all non-text nodes. So, now it is narrowed down to atoms only, so that container positions resolve to the parent again.

## Checklist
- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility
- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
