### PR TITLE
fix(core): avoid TS literal-overlap error in isAndroid()

### DIFF
--- a/.changeset/2026-07-16-fix-isandroid-type-error.md
+++ b/.changeset/2026-07-16-fix-isandroid-type-error.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix a TypeScript build error in `isAndroid()` where comparing `navigator.platform` against the literal `'Android'` with `===` could fail to compile under some `lib.dom.d.ts` typings ("types have no overlap"). Switched to the same `.includes()` pattern already used by `isiOS()`, which is not affected by this TypeScript narrowing issue. No runtime behavior change.

--- a/packages/core/src/__tests__/isAndroid.test.ts
+++ b/packages/core/src/__tests__/isAndroid.test.ts
@@ -16,6 +16,11 @@ describe('isAndroid', () => {
     expect(isAndroid()).toBe(true)
   })
 
+  it('detects Android via platform', () => {
+    mockNavigator('Android', 'Mozilla/5.0 (X11; Linux x86_64)')
+    expect(isAndroid()).toBe(true)
+  })
+
   it('returns false for non-Android platforms', () => {
     mockNavigator('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
     expect(isAndroid()).toBe(false)

--- a/packages/core/src/__tests__/isAndroid.test.ts
+++ b/packages/core/src/__tests__/isAndroid.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isAndroid } from '../utilities/isAndroid.js'
+
+function mockNavigator(platform: string, userAgent: string) {
+  vi.stubGlobal('navigator', { platform, userAgent })
+}
+
+describe('isAndroid', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('detects Android via userAgent', () => {
+    mockNavigator('Linux armv8l', 'Mozilla/5.0 (Linux; Android 13; Pixel 7)')
+    expect(isAndroid()).toBe(true)
+  })
+
+  it('returns false for non-Android platforms', () => {
+    mockNavigator('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    expect(isAndroid()).toBe(false)
+  })
+})

--- a/packages/core/src/utilities/isAndroid.ts
+++ b/packages/core/src/utilities/isAndroid.ts
@@ -1,3 +1,3 @@
 export function isAndroid(): boolean {
-  return navigator.platform === 'Android' || /android/i.test(navigator.userAgent)
+  return ['Android'].includes(navigator.platform) || /android/i.test(navigator.userAgent)
 }


### PR DESCRIPTION
## What was the bug

`isAndroid()` fails to compile under some `lib.dom.d.ts` typings:

```
Type error: This comparison appears to be unintentional because the types
'"MacIntel" | "Win32" | "Linux x86_64"' and '"Android"' have no overlap.
```

This breaks the build entirely for consumers who hit it.

## Root cause

```ts
export function isAndroid(): boolean {
  return navigator.platform === 'Android' || /android/i.test(navigator.userAgent)
}
```

`navigator.platform === 'Android'` is a direct `===` comparison between two string literal types. When TypeScript's `lib.dom.d.ts` (or a consumer's own narrower typing) narrows `Navigator.platform` to a union that doesn't include `'Android'`, this specific comparison shape is flagged as a literal type with no overlap.

The sibling utility `isiOS()` avoids this entirely by comparing against a plain array with `.includes()` instead of `===`, since `Array<string>.includes()` takes a widened `string` parameter rather than triggering literal-overlap narrowing:

```ts
export function isiOS(): boolean {
  return (
    ['iPad Simulator', 'iPhone Simulator', ...].includes(navigator.platform) || ...
  )
}
```

## What the fix does

Applies the same `.includes()` pattern to `isAndroid()`:

```ts
export function isAndroid(): boolean {
  return ['Android'].includes(navigator.platform) || /android/i.test(navigator.userAgent)
}
```

No runtime behavior change — purely a type-level fix, consistent with the existing convention in this file's sibling utility.

## Testing

Added `packages/core/src/__tests__/isAndroid.test.ts` covering both branches (userAgent-based detection, and a non-Android platform). Ran the full validation checklist:

- `pnpm vitest run packages/core/src/__tests__/isAndroid.test.ts` — pass
- `pnpm -w -F @tiptap/core build` — 74/74 tasks succeed
- `pnpm lint` — clean
- `pnpm fallow:audit` — no issues in changed files

Changeset included.

Fixes #6560