### PR TITLE
fix(core): avoid TS2367 in isAndroid by matching isiOS.ts's includes(…

### DIFF
--- a/.changeset/orange-apricots-hug.md
+++ b/.changeset/orange-apricots-hug.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+fix(core): avoid TS2367 in isAndroid by matching isiOS.ts's includes() pattern

--- a/packages/core/src/utilities/isAndroid.ts
+++ b/packages/core/src/utilities/isAndroid.ts
@@ -1,3 +1,3 @@
 export function isAndroid(): boolean {
-  return navigator.platform === 'Android' || /android/i.test(navigator.userAgent)
+  return ['Android'].includes(navigator.platform) || /android/i.test(navigator.userAgent)
 }


### PR DESCRIPTION
Fixes #6560

## Fixes
Fixes #6560

## Changes and Review
`isAndroid()` compared `navigator.platform` directly against the literal `'Android'` with `===`. In TypeScript setups where `navigator.platform`'s type gets narrowed to a literal union (e.g. `"MacIntel" | "Win32" | "Linux x86_64"`), this direct comparison has no overlap and fails the build with `TS2367`.

- Changed the comparison to `['Android'].includes(navigator.platform)`, matching the existing pattern already used by `isiOS.ts` in the same file -  no behavior change, since `.includes()` produces the same boolean result but doesn't trigger the literal-overlap check.

## Checklist
- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility
- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.