### PR TITLE
fix(react): onCreate fired twice under React.StrictMode in useEditor

### DIFF
--- a/.changeset/2026-07-16-fix-useeditor-strictmode-double-oncreate.md
+++ b/.changeset/2026-07-16-fix-useeditor-strictmode-double-oncreate.md
@@ -1,0 +1,9 @@
+---
+'@tiptap/react': patch
+---
+
+Fix `useEditor()` calling `onCreate` twice (with two different `Editor` instances) when mounted under `React.StrictMode`.
+
+The editor instance manager was created via `useState(() => new EditorInstanceManager(...))`. React Strict Mode intentionally invokes `useState` lazy initializer functions twice in development to surface side effects that aren't idempotent — since constructing `EditorInstanceManager` synchronously constructs a real `Editor` (and can trigger its `onCreate` callback), this produced two separate editor instances, each firing `onCreate` once, even though only one instance ultimately became the component's state.
+
+Switched to a guarded `useRef` (`if (instanceManagerRef.current === null) { instanceManagerRef.current = new EditorInstanceManager(...) }`) instead. Unlike a `useState` initializer, a ref's `current` value is not reset between Strict Mode's double invocation, so the guard only ever constructs one instance. No public API change.

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -1,0 +1,58 @@
+import { act, render } from '@testing-library/react'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useEditor } from './useEditor.js'
+
+function TestEditor({ onCreate }: { onCreate: () => void }) {
+  useEditor({
+    extensions: [Document, Paragraph, Text],
+    element: document.createElement('div'),
+    immediatelyRender: true,
+    onCreate,
+  })
+  return null
+}
+
+describe('useEditor', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.useRealTimers()
+  })
+
+  it('calls onCreate exactly once when mounted under React.StrictMode', () => {
+    vi.useFakeTimers()
+    const onCreate = vi.fn()
+
+    act(() => {
+      render(
+        React.createElement(React.StrictMode, null, React.createElement(TestEditor, { onCreate })),
+      )
+    })
+
+    // `create` is emitted via a `setTimeout(0)` inside `Editor.mount()`.
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(onCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('still calls onCreate once outside of React.StrictMode', () => {
+    vi.useFakeTimers()
+    const onCreate = vi.fn()
+
+    act(() => {
+      render(React.createElement(TestEditor, { onCreate }))
+    })
+
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(onCreate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,6 +1,6 @@
 import { type EditorOptions, Editor } from '@tiptap/core'
 import type { DependencyList, MutableRefObject } from 'react'
-import { useDebugValue, useEffect, useRef, useState } from 'react'
+import { useDebugValue, useEffect, useRef } from 'react'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import { useEditorState } from './useEditorState.js'
@@ -340,7 +340,18 @@ export function useEditor(
 
   mostRecentOptions.current = options
 
-  const [instanceManager] = useState(() => new EditorInstanceManager(mostRecentOptions))
+  // Lazily initialized via a guarded ref instead of `useState(() => ...)`.
+  // React Strict Mode intentionally invokes state initializer functions twice
+  // to surface impure logic, which here would construct two separate editor
+  // instances (and fire onCreate twice). A ref guard only ever runs the
+  // constructor once, since `current` is already set on the second invocation.
+  const instanceManagerRef = useRef<EditorInstanceManager | null>(null)
+
+  if (instanceManagerRef.current === null) {
+    instanceManagerRef.current = new EditorInstanceManager(mostRecentOptions)
+  }
+
+  const instanceManager = instanceManagerRef.current
 
   const editor = useSyncExternalStore(
     instanceManager.subscribe,


### PR DESCRIPTION
## What was the bug

When using the `useEditor` hook under `React.StrictMode`, the `onCreate` callback fires twice, each time with a different `Editor` instance, even though the hook correctly returns a single, stable instance to the component.

## Root cause

```ts
const [instanceManager] = useState(() => new EditorInstanceManager(mostRecentOptions))
```

`EditorInstanceManager`'s constructor synchronously builds a real `Editor` instance (`this.setEditor(this.getInitialEditor())`), which — once mounted — schedules its `create` event via `Editor.mount()`'s internal `setTimeout(0)`.

React Strict Mode intentionally invokes `useState`/`useReducer` lazy initializer functions **twice** in development, specifically to surface side effects that aren't idempotent (see [React's docs on fixing bugs found by double-rendering](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-double-rendering-in-development)). Because the initializer here constructs a real `Editor`, this produces two separate `EditorInstanceManager`/`Editor` instances — each independently firing `onCreate` — even though only one of the two instances ultimately becomes the component's actual state. The orphaned instance's `Editor` is eventually destroyed via its own `scheduleDestroy()` timeout, but only *after* `onCreate` has already fired for it.

Confirmed empirically with a regression test: **2** `onCreate` calls under `React.StrictMode` before this fix, **1** after.

## What the fix does

Replaces the `useState` lazy initializer with a guarded `useRef`:

```ts
const instanceManagerRef = useRef<EditorInstanceManager | null>(null)

if (instanceManagerRef.current === null) {
  instanceManagerRef.current = new EditorInstanceManager(mostRecentOptions)
}

const instanceManager = instanceManagerRef.current
```

Unlike a `useState` initializer function, a ref's `current` value is not reset between Strict Mode's double invocation of the render function — it's the same underlying ref object across both calls. So on the second (discarded) invocation, `current` is already set from the first, and the guard prevents constructing a second `EditorInstanceManager`/`Editor` at all. This is the pattern React's own docs recommend for lazy-initializing values that must survive Strict Mode's double-render without side effects re-running.

No public API change — `useEditor` still returns the same `Editor | null` type, and `useSyncExternalStore` wiring is untouched.

## Testing

Added `packages/react/src/useEditor.spec.ts` using `@testing-library/react` (matching the existing pattern in `BubbleMenu.spec.ts`), covering:
- `onCreate` fires exactly once when mounted under `React.StrictMode`
- `onCreate` still fires exactly once outside of `React.StrictMode` (no regression)

Ran the full validation checklist:

- `pnpm vitest run packages/react/src/useEditor.spec.ts` — pass (2/2)
- `pnpm vitest run packages/react/` — full package suite pass (9/9, no regressions)
- `pnpm -w -F @tiptap/react build` — succeeds
- `pnpm lint` — clean
- `pnpm fallow:audit` — no issues in changed files

Changeset included.

Fixes #7091