### PR TITLE
test(e2e): deflake keyboard-shortcut test in Default example

### DIFF
--- a/demos/src/Examples/Default/index.spec.ts
+++ b/demos/src/Examples/Default/index.spec.ts
@@ -45,8 +45,14 @@ test.describe(`${demoPath}/${demoName}`, () => {
         await expect(page.locator('.tiptap h1')).toBeVisible()
 
         const editor = await getEditor(page)
-        await editor.click()
-        await editor.evaluate((el: any) => el.editor.commands.selectAll())
+        // Focus and select programmatically instead of clicking first: a real
+        // mouse click emits an async `selectionchange` that can land after the
+        // programmatic selectAll (or even after the keydown) under CI load,
+        // collapsing the selection before the shortcut applies.
+        await editor.evaluate((el: any) => {
+          el.editor.commands.focus()
+          el.editor.commands.selectAll()
+        })
         await editor.press(process.platform === 'darwin' ? 'Meta+Alt+0' : 'Control+Alt+0')
 
         await expect(page.locator('.tiptap p').first()).toContainText('Example Text')


### PR DESCRIPTION
Fixes #8080

Reproduced the flake locally: 6/30 failures running the Svelte test with 4 parallel workers. Instrumenting each step showed the cause — the test clicks the editor, then programmatically selects all, then presses the shortcut. The mouse click fires an async `selectionchange` that under load lands *after* the programmatic selectAll (sometimes after the keydown), collapsing the selection into the trailing empty paragraph. The shortcut then no-ops on an already-empty paragraph, the h1 survives, and the assertion finds the empty trailing `<p>` — exactly the `""` failure CI reports.

Fix: drop the click and use the same `focus()` + `selectAll()` evaluate that every other shortcut spec already uses. After the change: 150/150 repeats pass under the same parallel load, and the full Default spec passes on chromium + firefox.

I also audited the rest of the suite for the patterns listed in the issue: no `waitForTimeout` sleeps anywhere, and all other keyboard-shortcut specs already use the programmatic focus/select idiom — this test was the one straggler still clicking first.