### PR TITLE
fix(extensions): fixed scrollIntoView() missing on setHardBreak call

### DIFF
--- a/.changeset/cuddly-coins-melt.md
+++ b/.changeset/cuddly-coins-melt.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-hard-break": patch
+---
+
+Fixed a bug where inserted hard breaks would not scroll the view on insertion via commands.

--- a/packages/extension-hard-break/__tests__/hard-break.spec.ts
+++ b/packages/extension-hard-break/__tests__/hard-break.spec.ts
@@ -3,7 +3,7 @@ import { Document } from '@tiptap/extension-document'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
 import { afterEach, describe, expect, it } from 'vitest'
-import { Transaction } from '@tiptap/pm/state'
+import type { Transaction } from '@tiptap/pm/state'
 
 import { HardBreak } from '../src/hard-break.js'
 
@@ -34,6 +34,34 @@ describe('HardBreak', () => {
 
     expect(lastTr!).toBeDefined()
     expect(lastTr!.scrolledIntoView).toBe(true)
+  })
+
+  it('scrolls the selection into view when pressing Shift+Enter', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, HardBreak],
+      content: '<p>hello</p>',
+    })
+
+    editor.commands.setTextSelection(6)
+
+    let lastTr: Transaction
+    const origDispatch = editor.view.dispatch.bind(editor.view)
+
+    editor.view.dispatch = (tr: Transaction) => {
+      lastTr = tr
+      return origDispatch(tr)
+    }
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      shiftKey: true,
+    })
+    editor.view.dispatchEvent(event)
+
+    expect(lastTr!).toBeDefined()
+    expect(lastTr!.scrolledIntoView).toBe(true)
+    expect(editor.getHTML()).toBe('<p>hello<br></p>')
   })
 
   it('inserts a hardbreak into a document', () => {

--- a/packages/extension-hard-break/__tests__/hard-break.spec.ts
+++ b/packages/extension-hard-break/__tests__/hard-break.spec.ts
@@ -1,0 +1,50 @@
+import { Editor } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Transaction } from '@tiptap/pm/state'
+
+import { HardBreak } from '../src/hard-break.js'
+
+describe('HardBreak', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('scrolls the selection into view when adding a hard break', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, HardBreak],
+      content: '<p>hello</p>',
+    })
+
+    editor.commands.setTextSelection(6)
+
+    let lastTr: Transaction
+    const origDispatch = editor.view.dispatch.bind(editor.view)
+
+    editor.view.dispatch = (tr: Transaction) => {
+      lastTr = tr
+      return origDispatch(tr)
+    }
+
+    editor.commands.setHardBreak()
+
+    expect(lastTr!).toBeDefined()
+    expect(lastTr!.scrolledIntoView).toBe(true)
+  })
+
+  it('inserts a hardbreak into a document', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, HardBreak],
+      content: '<p>hello</p>',
+    })
+
+    editor.commands.setTextSelection(6)
+    editor.commands.setHardBreak()
+
+    expect(editor.getHTML()).toBe('<p>hello<br></p>')
+  })
+})

--- a/packages/extension-hard-break/src/hard-break.ts
+++ b/packages/extension-hard-break/src/hard-break.ts
@@ -104,6 +104,7 @@ export const HardBreak = Node.create<HardBreakOptions>({
 
                     return true
                   })
+                  .scrollIntoView()
                   .run()
               }),
           ])


### PR DESCRIPTION
## Fixes

- Fixes #7125

## Changes and Review

This PR fixes a bug reported in #7125 where inserting a hard break with the `setHardBreak` command would not scroll the newly inserted HardBreak into view.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
