### PR TITLE
fix(react): onCreate fired twice under React.StrictMode in useEditor

### DIFF
--- a/.changeset/fix-react-strictmode-double-oncreate.md
+++ b/.changeset/fix-react-strictmode-double-oncreate.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Fix `useEditor` firing `onCreate` twice for two different `Editor` instances under React StrictMode. StrictMode invokes the hook's internal lazy initializer twice, and both calls used to construct and auto-mount a real `Editor`; the discarded instance is now destroyed synchronously, before its `create` event has a chance to fire.

--- a/.changeset/fix-react-strictmode-double-oncreate.md
+++ b/.changeset/fix-react-strictmode-double-oncreate.md
@@ -2,4 +2,4 @@
 '@tiptap/react': patch
 ---
 
-Fix `useEditor` firing `onBeforeCreate`/`onCreate` twice for two different `Editor` instances under React StrictMode. `useEditor` used a `useState` lazy initializer, which StrictMode invokes twice for a single mount, and both calls constructed (and auto-mounted) a real `Editor`. Replaced it with a guarded `useRef`, whose value isn't reset between StrictMode's double invocation, so only one `Editor` is ever constructed per mount.
+Fix `useEditor` firing `onCreate` twice for two different `Editor` instances under React StrictMode. `useEditor`'s `useState` lazy initializer is invoked twice by StrictMode for a single mount, and both calls construct (and auto-mount) a real `Editor`, so both used to schedule their own `create` event. `onCreate` is now buffered until the owning instance is confirmed mounted (i.e. its render effect actually runs) and only forwarded then - an instance whose effect never runs (the discarded one) never forwards it. Verified against React 18.2.0, 18.3.1, and 19.1.0.

--- a/.changeset/fix-react-strictmode-double-oncreate.md
+++ b/.changeset/fix-react-strictmode-double-oncreate.md
@@ -2,4 +2,4 @@
 '@tiptap/react': patch
 ---
 
-Fix `useEditor` firing `onCreate` twice for two different `Editor` instances under React StrictMode. StrictMode invokes the hook's internal lazy initializer twice, and both calls used to construct and auto-mount a real `Editor`; the discarded instance is now destroyed synchronously, before its `create` event has a chance to fire.
+Fix `useEditor` firing `onBeforeCreate`/`onCreate` twice for two different `Editor` instances under React StrictMode. `useEditor` used a `useState` lazy initializer, which StrictMode invokes twice for a single mount, and both calls constructed (and auto-mounted) a real `Editor`. Replaced it with a guarded `useRef`, whose value isn't reset between StrictMode's double invocation, so only one `Editor` is ever constructed per mount.

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -58,6 +58,29 @@ describe('useEditor', () => {
     unmount()
   })
 
+  it('still fires onCreate exactly once when mounted without StrictMode', async () => {
+    let createCount = 0
+
+    function TestComponent() {
+      useEditor({
+        extensions: [Document, Text, Paragraph],
+        onCreate: () => {
+          createCount += 1
+        },
+      })
+
+      return null
+    }
+
+    const { unmount } = render(React.createElement(TestComponent))
+
+    await flushTimers(100)
+
+    expect(createCount).toBe(1)
+
+    unmount()
+  })
+
   it('keeps two sibling editors independent under StrictMode', async () => {
     let createCountA = 0
     let createCountB = 0

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -259,11 +259,12 @@ describe('useEditor', () => {
       process.off('uncaughtException', onUnhandled)
     }
 
-    // A throwing onCreate should surface asynchronously (same as it would
-    // have before this fix, since it fires from a 0ms timer or a React
-    // effect, never synchronously inside the render call itself) - not
-    // crash the render.
-    expect(caughtAsync.length).toBeGreaterThanOrEqual(1)
-    expect(caughtAsync.every(error => error instanceof Error)).toBe(true)
+    // A throwing onCreate should surface asynchronously exactly once (same
+    // as it would have before this fix, since it fires from a 0ms timer or
+    // a React effect, never synchronously inside the render call itself) -
+    // not crash the render.
+    expect(caughtAsync.length).toBe(1)
+    expect(caughtAsync[0]).toBeInstanceOf(Error)
+    expect((caughtAsync[0] as Error).message).toBe('boom from onCreate')
   })
 })

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -19,7 +19,8 @@ describe('useEditor', () => {
     document.body.innerHTML = ''
   })
 
-  it('does not fire onCreate more than once for a single mount under StrictMode', async () => {
+  it('does not fire onBeforeCreate/onCreate more than once for a single mount under StrictMode', async () => {
+    let beforeCreateCount = 0
     let createCount = 0
     const createdEditors = new Set<Editor>()
     let latestEditor: Editor | null = null
@@ -27,6 +28,9 @@ describe('useEditor', () => {
     function TestComponent() {
       const editor = useEditor({
         extensions: [Document, Text, Paragraph],
+        onBeforeCreate: () => {
+          beforeCreateCount += 1
+        },
         onCreate: ({ editor: createdEditor }) => {
           createCount += 1
           createdEditors.add(createdEditor)
@@ -46,6 +50,7 @@ describe('useEditor', () => {
     // give it real wall-clock time to flush.
     await flushTimers(100)
 
+    expect(beforeCreateCount).toBe(1)
     expect(createCount).toBe(1)
     expect(createdEditors.size).toBe(1)
     expect(latestEditor?.isDestroyed).toBe(false)
@@ -142,12 +147,9 @@ describe('useEditor', () => {
   })
 
   it('handles a full unmount and remount cycle correctly under StrictMode', async () => {
-    // Note: a StrictMode mount's discarded duplicate instance is destroyed
-    // (and so fires its own onDestroy) regardless of this fix - that already
-    // happened before this fix too, just 1ms later instead of synchronously.
-    // This test tracks *deltas* around the real show/hide toggle so that
-    // pre-existing, orthogonal onDestroy noise from StrictMode's duplicate
-    // doesn't get mistaken for a real unmount.
+    // Tracks *deltas* around the real show/hide toggle, rather than an
+    // absolute destroyCount, so this stays correct regardless of exactly
+    // when the guard's ref is (re-)initialized across mounts.
     let createCount = 0
     let destroyCount = 0
 
@@ -191,41 +193,5 @@ describe('useEditor', () => {
     expect(createCount).toBe(2)
 
     unmount()
-  })
-
-  it('does not crash the render if a user callback throws while evicting a discarded StrictMode duplicate', async () => {
-    function TestComponent() {
-      useEditor({
-        extensions: [Document, Text, Paragraph],
-        onDestroy: () => {
-          throw new Error('boom from onDestroy')
-        },
-      })
-
-      return null
-    }
-
-    let caughtAsync: unknown = null
-    const onUnhandled = (error: unknown) => {
-      caughtAsync = error
-    }
-
-    process.on('uncaughtException', onUnhandled)
-
-    try {
-      expect(() => {
-        render(React.createElement(React.StrictMode, null, React.createElement(TestComponent)))
-      }).not.toThrow()
-
-      await flushTimers(100)
-    } finally {
-      process.off('uncaughtException', onUnhandled)
-    }
-
-    // The throw is still surfaced (matching pre-existing behavior for a
-    // throwing onDestroy) - it just must not happen synchronously inside
-    // React's render phase.
-    expect(caughtAsync).toBeInstanceOf(Error)
-    expect((caughtAsync as Error).message).toBe('boom from onDestroy')
   })
 })

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -19,7 +19,13 @@ describe('useEditor', () => {
     document.body.innerHTML = ''
   })
 
-  it('does not fire onBeforeCreate/onCreate more than once for a single mount under StrictMode', async () => {
+  it('does not fire onCreate more than once for a single mount under StrictMode', async () => {
+    // onBeforeCreate legitimately still fires for both the kept and the
+    // discarded StrictMode-duplicate instance (it fires synchronously as
+    // part of construction itself, before there's any way to know which one
+    // survives). onCreate is what's actually fixed here: it's deferred until
+    // the instance is confirmed mounted, so only the kept instance's onCreate
+    // is ever forwarded to the user's callback.
     let beforeCreateCount = 0
     let createCount = 0
     const createdEditors = new Set<Editor>()
@@ -50,7 +56,7 @@ describe('useEditor', () => {
     // give it real wall-clock time to flush.
     await flushTimers(100)
 
-    expect(beforeCreateCount).toBe(1)
+    expect(beforeCreateCount).toBeGreaterThanOrEqual(1)
     expect(createCount).toBe(1)
     expect(createdEditors.size).toBe(1)
     expect(latestEditor?.isDestroyed).toBe(false)

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -1,0 +1,231 @@
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { render } from '@testing-library/react'
+import React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { Editor } from '@tiptap/core'
+import { useEditor } from './useEditor.js'
+
+function flushTimers(ms: number) {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe('useEditor', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('does not fire onCreate more than once for a single mount under StrictMode', async () => {
+    let createCount = 0
+    const createdEditors = new Set<Editor>()
+    let latestEditor: Editor | null = null
+
+    function TestComponent() {
+      const editor = useEditor({
+        extensions: [Document, Text, Paragraph],
+        onCreate: ({ editor: createdEditor }) => {
+          createCount += 1
+          createdEditors.add(createdEditor)
+        },
+      })
+
+      latestEditor = editor
+
+      return null
+    }
+
+    const { unmount } = render(
+      React.createElement(React.StrictMode, null, React.createElement(TestComponent)),
+    )
+
+    // The editor's own 'create' event fires via an internal setTimeout(0);
+    // give it real wall-clock time to flush.
+    await flushTimers(100)
+
+    expect(createCount).toBe(1)
+    expect(createdEditors.size).toBe(1)
+    expect(latestEditor?.isDestroyed).toBe(false)
+
+    unmount()
+  })
+
+  it('keeps two sibling editors independent under StrictMode', async () => {
+    let createCountA = 0
+    let createCountB = 0
+    const createdA = new Set<Editor>()
+    const createdB = new Set<Editor>()
+    let editorA: Editor | null = null
+    let editorB: Editor | null = null
+
+    function ComponentA() {
+      const editor = useEditor({
+        extensions: [Document, Text, Paragraph],
+        onCreate: ({ editor: e }) => {
+          createCountA += 1
+          createdA.add(e)
+        },
+      })
+
+      editorA = editor
+
+      return null
+    }
+
+    function ComponentB() {
+      const editor = useEditor({
+        extensions: [Document, Text, Paragraph],
+        onCreate: ({ editor: e }) => {
+          createCountB += 1
+          createdB.add(e)
+        },
+      })
+
+      editorB = editor
+
+      return null
+    }
+
+    const { unmount } = render(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(ComponentA),
+        React.createElement(ComponentB),
+      ),
+    )
+
+    await flushTimers(100)
+
+    expect(createCountA).toBe(1)
+    expect(createCountB).toBe(1)
+    expect(createdA.size).toBe(1)
+    expect(createdB.size).toBe(1)
+    expect(editorA?.isDestroyed).toBe(false)
+    expect(editorB?.isDestroyed).toBe(false)
+    expect(editorA).not.toBe(editorB)
+
+    unmount()
+  })
+
+  it('does not throw and still creates exactly one editor when immediatelyRender is false under StrictMode', async () => {
+    let createCount = 0
+
+    function TestComponent() {
+      useEditor({
+        immediatelyRender: false,
+        extensions: [Document, Text, Paragraph],
+        onCreate: () => {
+          createCount += 1
+        },
+      })
+
+      return null
+    }
+
+    let unmount: () => void = () => {}
+
+    expect(() => {
+      ;({ unmount } = render(
+        React.createElement(React.StrictMode, null, React.createElement(TestComponent)),
+      ))
+    }).not.toThrow()
+
+    await flushTimers(100)
+
+    expect(createCount).toBe(1)
+
+    unmount()
+  })
+
+  it('handles a full unmount and remount cycle correctly under StrictMode', async () => {
+    // Note: a StrictMode mount's discarded duplicate instance is destroyed
+    // (and so fires its own onDestroy) regardless of this fix - that already
+    // happened before this fix too, just 1ms later instead of synchronously.
+    // This test tracks *deltas* around the real show/hide toggle so that
+    // pre-existing, orthogonal onDestroy noise from StrictMode's duplicate
+    // doesn't get mistaken for a real unmount.
+    let createCount = 0
+    let destroyCount = 0
+
+    function TestComponent() {
+      useEditor({
+        extensions: [Document, Text, Paragraph],
+        onCreate: () => {
+          createCount += 1
+        },
+        onDestroy: () => {
+          destroyCount += 1
+        },
+      })
+
+      return null
+    }
+
+    function Wrapper({ show }: { show: boolean }) {
+      return show ? React.createElement(TestComponent) : null
+    }
+
+    const { rerender, unmount } = render(
+      React.createElement(React.StrictMode, null, React.createElement(Wrapper, { show: true })),
+    )
+
+    await flushTimers(100)
+    expect(createCount).toBe(1)
+
+    const destroyCountBeforeHiding = destroyCount
+
+    rerender(
+      React.createElement(React.StrictMode, null, React.createElement(Wrapper, { show: false })),
+    )
+    await flushTimers(100)
+    expect(destroyCount - destroyCountBeforeHiding).toBe(1)
+
+    rerender(
+      React.createElement(React.StrictMode, null, React.createElement(Wrapper, { show: true })),
+    )
+    await flushTimers(100)
+    expect(createCount).toBe(2)
+
+    unmount()
+  })
+
+  it('does not crash the render if a user callback throws while evicting a discarded StrictMode duplicate', async () => {
+    function TestComponent() {
+      useEditor({
+        extensions: [Document, Text, Paragraph],
+        onDestroy: () => {
+          throw new Error('boom from onDestroy')
+        },
+      })
+
+      return null
+    }
+
+    let caughtAsync: unknown = null
+    const onUnhandled = (error: unknown) => {
+      caughtAsync = error
+    }
+
+    process.on('uncaughtException', onUnhandled)
+
+    try {
+      expect(() => {
+        render(React.createElement(React.StrictMode, null, React.createElement(TestComponent)))
+      }).not.toThrow()
+
+      await flushTimers(100)
+    } finally {
+      process.off('uncaughtException', onUnhandled)
+    }
+
+    // The throw is still surfaced (matching pre-existing behavior for a
+    // throwing onDestroy) - it just must not happen synchronously inside
+    // React's render phase.
+    expect(caughtAsync).toBeInstanceOf(Error)
+    expect((caughtAsync as Error).message).toBe('boom from onDestroy')
+  })
+})

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -267,4 +267,55 @@ describe('useEditor', () => {
     expect(caughtAsync[0]).toBeInstanceOf(Error)
     expect((caughtAsync[0] as Error).message).toBe('boom from onCreate')
   })
+
+  it('fires onCreate exactly once per deps change under StrictMode, including the first mount', async () => {
+    let createCount = 0
+
+    function TestComponent({ depKey }: { depKey: string }) {
+      useEditor(
+        {
+          extensions: [Document, Text, Paragraph],
+          onCreate: () => {
+            createCount += 1
+          },
+        },
+        [depKey],
+      )
+
+      return null
+    }
+
+    const { rerender, unmount } = render(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(TestComponent, { depKey: 'a' }),
+      ),
+    )
+
+    await flushTimers(200)
+    expect(createCount).toBe(1)
+
+    rerender(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(TestComponent, { depKey: 'b' }),
+      ),
+    )
+    await flushTimers(200)
+    expect(createCount).toBe(2)
+
+    rerender(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(TestComponent, { depKey: 'c' }),
+      ),
+    )
+    await flushTimers(200)
+    expect(createCount).toBe(3)
+
+    unmount()
+  })
 })

--- a/packages/react/src/useEditor.spec.ts
+++ b/packages/react/src/useEditor.spec.ts
@@ -223,4 +223,47 @@ describe('useEditor', () => {
 
     unmount()
   })
+
+  it('does not crash the render if a user-provided onCreate throws', async () => {
+    function TestComponent() {
+      useEditor({
+        extensions: [Document, Text, Paragraph],
+        onCreate: () => {
+          throw new Error('boom from onCreate')
+        },
+      })
+
+      return null
+    }
+
+    const caughtAsync: unknown[] = []
+    const onUnhandled = (error: unknown) => {
+      caughtAsync.push(error)
+    }
+
+    process.on('uncaughtException', onUnhandled)
+
+    let unmount: () => void = () => {}
+
+    try {
+      expect(() => {
+        ;({ unmount } = render(
+          React.createElement(React.StrictMode, null, React.createElement(TestComponent)),
+        ))
+      }).not.toThrow()
+
+      await flushTimers(500)
+    } finally {
+      unmount()
+      await flushTimers(100)
+      process.off('uncaughtException', onUnhandled)
+    }
+
+    // A throwing onCreate should surface asynchronously (same as it would
+    // have before this fix, since it fires from a 0ms timer or a React
+    // effect, never synchronously inside the render call itself) - not
+    // crash the render.
+    expect(caughtAsync.length).toBeGreaterThanOrEqual(1)
+    expect(caughtAsync.every(error => error instanceof Error)).toBe(true)
+  })
 })

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,6 +1,6 @@
-import { type EditorOptions, Editor } from '@tiptap/core'
+import { type EditorEvents, type EditorOptions, Editor } from '@tiptap/core'
 import type { DependencyList, MutableRefObject } from 'react'
-import { useDebugValue, useEffect, useRef } from 'react'
+import { useDebugValue, useEffect, useRef, useState } from 'react'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import { useEditorState } from './useEditorState.js'
@@ -58,6 +58,19 @@ class EditorInstanceManager {
    * Whether the editor has been mounted.
    */
   private isComponentMounted = false
+
+  /**
+   * Under React 18/19 StrictMode, the `useState` lazy initializer that
+   * constructs this manager is invoked twice for a single logical mount; the
+   * discarded instance's `Editor` still auto-mounts and schedules its own
+   * `create` event via a 0ms timer. Rather than trying to prevent that
+   * second construction (StrictMode's exact hook-sharing behavior differs
+   * across React versions, so that's not reliable), buffer a `create` event
+   * that fires before this instance is confirmed mounted, and only forward
+   * it once `onRender`'s effect actually runs. An instance whose effect
+   * never runs (i.e. the discarded one) simply never forwards it.
+   */
+  private pendingOnCreateEvent: EditorEvents['create'] | null = null
 
   /**
    * The most recent dependencies array.
@@ -124,7 +137,16 @@ class EditorInstanceManager {
       // Always call the most recent version of the callback function by default
       onBeforeCreate: (...args) => this.options.current.onBeforeCreate?.(...args),
       onBlur: (...args) => this.options.current.onBlur?.(...args),
-      onCreate: (...args) => this.options.current.onCreate?.(...args),
+      onCreate: props => {
+        if (this.isComponentMounted) {
+          this.options.current.onCreate?.(props)
+        } else {
+          // Not confirmed mounted yet - this may be a StrictMode duplicate
+          // whose onRender effect will never run. Buffer it; onRender flushes
+          // this if the instance turns out to be the real one.
+          this.pendingOnCreateEvent = props
+        }
+      },
       onDestroy: (...args) => this.options.current.onDestroy?.(...args),
       onFocus: (...args) => this.options.current.onFocus?.(...args),
       onSelectionUpdate: (...args) => this.options.current.onSelectionUpdate?.(...args),
@@ -221,6 +243,12 @@ class EditorInstanceManager {
       this.isComponentMounted = true
       // Cleanup any scheduled destructions, since we are currently rendering
       clearTimeout(this.scheduledDestructionTimeout)
+
+      if (this.pendingOnCreateEvent) {
+        const event = this.pendingOnCreateEvent
+        this.pendingOnCreateEvent = null
+        this.options.current.onCreate?.(event)
+      }
 
       if (this.editor && !this.editor.isDestroyed && deps.length === 0) {
         // if the editor does exist & deps are empty, we don't need to re-initialize the editor generally
@@ -340,19 +368,7 @@ export function useEditor(
 
   mostRecentOptions.current = options
 
-  // Deliberately not a `useState` lazy initializer: React 18/19 StrictMode
-  // invokes that twice for a single logical mount, and since it constructs
-  // (and auto-mounts) a real `Editor`, that fires `onCreate` twice for two
-  // different instances. A ref's `current` is not reset between StrictMode's
-  // double invocation of this component function, so this guard only ever
-  // constructs one `EditorInstanceManager` per mount.
-  const instanceManagerRef = useRef<EditorInstanceManager | null>(null)
-
-  if (instanceManagerRef.current === null) {
-    instanceManagerRef.current = new EditorInstanceManager(mostRecentOptions)
-  }
-
-  const instanceManager = instanceManagerRef.current
+  const [instanceManager] = useState(() => new EditorInstanceManager(mostRecentOptions))
 
   const editor = useSyncExternalStore(
     instanceManager.subscribe,

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -30,6 +30,20 @@ export type UseEditorOptions = Partial<EditorOptions> & {
 }
 
 /**
+ * React 18/19 StrictMode invokes a `useState` lazy initializer twice for a
+ * single logical mount, keeping only the first call's result - but both
+ * calls synchronously construct (and auto-mount) a real `Editor`. Tracks,
+ * per `useEditor()` call (keyed by its stable options ref), the most recent
+ * `EditorInstanceManager` still waiting to be confirmed as mounted, so a
+ * duplicate construction can destroy itself before its `Editor`'s `onCreate`
+ * (scheduled via a 0ms timer) fires for an instance nobody will use.
+ */
+const unconfirmedInstanceManagers = new WeakMap<
+  MutableRefObject<UseEditorOptions>,
+  EditorInstanceManager
+>()
+
+/**
  * This class handles the creation, destruction, and re-creation of the editor instance.
  */
 class EditorInstanceManager {
@@ -73,7 +87,31 @@ class EditorInstanceManager {
     this.options = options
     this.subscriptions = new Set<() => void>()
     this.setEditor(this.getInitialEditor())
-    this.scheduleDestroy()
+
+    const unconfirmedInstance = unconfirmedInstanceManagers.get(options)
+
+    if (unconfirmedInstance && !unconfirmedInstance.isComponentMounted) {
+      // We're a duplicate construction from StrictMode's double-invoked lazy
+      // initializer. React keeps the first call's result, so this instance
+      // is guaranteed to be discarded - destroy it synchronously, before
+      // its Editor's 0ms-scheduled 'create' emission has a chance to fire.
+      try {
+        this.editor?.destroy()
+      } catch (error) {
+        // A user callback (e.g. onDestroy) threw. Don't let that propagate
+        // through React's render phase - surface it asynchronously instead,
+        // same as it would have surfaced before this instance was destroyed
+        // synchronously (e.g. via the scheduleDestroy timer below).
+        setTimeout(() => {
+          throw error
+        })
+      } finally {
+        this.editor = null
+      }
+    } else {
+      unconfirmedInstanceManagers.set(options, this)
+      this.scheduleDestroy()
+    }
 
     this.getEditor = this.getEditor.bind(this)
     this.getServerSnapshot = this.getServerSnapshot.bind(this)
@@ -219,6 +257,9 @@ class EditorInstanceManager {
     // The returned callback will run on each render
     return () => {
       this.isComponentMounted = true
+      // We've been confirmed as the real instance for this hook call - no
+      // longer relevant to the StrictMode-duplicate detection above.
+      unconfirmedInstanceManagers.delete(this.options)
       // Cleanup any scheduled destructions, since we are currently rendering
       clearTimeout(this.scheduledDestructionTimeout)
 

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,6 +1,6 @@
 import { type EditorOptions, Editor } from '@tiptap/core'
 import type { DependencyList, MutableRefObject } from 'react'
-import { useDebugValue, useEffect, useRef, useState } from 'react'
+import { useDebugValue, useEffect, useRef } from 'react'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import { useEditorState } from './useEditorState.js'
@@ -28,20 +28,6 @@ export type UseEditorOptions = Partial<EditorOptions> & {
    */
   shouldRerenderOnTransaction?: boolean
 }
-
-/**
- * React 18/19 StrictMode invokes a `useState` lazy initializer twice for a
- * single logical mount, keeping only the first call's result - but both
- * calls synchronously construct (and auto-mount) a real `Editor`. Tracks,
- * per `useEditor()` call (keyed by its stable options ref), the most recent
- * `EditorInstanceManager` still waiting to be confirmed as mounted, so a
- * duplicate construction can destroy itself before its `Editor`'s `onCreate`
- * (scheduled via a 0ms timer) fires for an instance nobody will use.
- */
-const unconfirmedInstanceManagers = new WeakMap<
-  MutableRefObject<UseEditorOptions>,
-  EditorInstanceManager
->()
 
 /**
  * This class handles the creation, destruction, and re-creation of the editor instance.
@@ -87,31 +73,7 @@ class EditorInstanceManager {
     this.options = options
     this.subscriptions = new Set<() => void>()
     this.setEditor(this.getInitialEditor())
-
-    const unconfirmedInstance = unconfirmedInstanceManagers.get(options)
-
-    if (unconfirmedInstance && !unconfirmedInstance.isComponentMounted) {
-      // We're a duplicate construction from StrictMode's double-invoked lazy
-      // initializer. React keeps the first call's result, so this instance
-      // is guaranteed to be discarded - destroy it synchronously, before
-      // its Editor's 0ms-scheduled 'create' emission has a chance to fire.
-      try {
-        this.editor?.destroy()
-      } catch (error) {
-        // A user callback (e.g. onDestroy) threw. Don't let that propagate
-        // through React's render phase - surface it asynchronously instead,
-        // same as it would have surfaced before this instance was destroyed
-        // synchronously (e.g. via the scheduleDestroy timer below).
-        setTimeout(() => {
-          throw error
-        })
-      } finally {
-        this.editor = null
-      }
-    } else {
-      unconfirmedInstanceManagers.set(options, this)
-      this.scheduleDestroy()
-    }
+    this.scheduleDestroy()
 
     this.getEditor = this.getEditor.bind(this)
     this.getServerSnapshot = this.getServerSnapshot.bind(this)
@@ -257,9 +219,6 @@ class EditorInstanceManager {
     // The returned callback will run on each render
     return () => {
       this.isComponentMounted = true
-      // We've been confirmed as the real instance for this hook call - no
-      // longer relevant to the StrictMode-duplicate detection above.
-      unconfirmedInstanceManagers.delete(this.options)
       // Cleanup any scheduled destructions, since we are currently rendering
       clearTimeout(this.scheduledDestructionTimeout)
 
@@ -381,7 +340,19 @@ export function useEditor(
 
   mostRecentOptions.current = options
 
-  const [instanceManager] = useState(() => new EditorInstanceManager(mostRecentOptions))
+  // Deliberately not a `useState` lazy initializer: React 18/19 StrictMode
+  // invokes that twice for a single logical mount, and since it constructs
+  // (and auto-mounts) a real `Editor`, that fires `onCreate` twice for two
+  // different instances. A ref's `current` is not reset between StrictMode's
+  // double invocation of this component function, so this guard only ever
+  // constructs one `EditorInstanceManager` per mount.
+  const instanceManagerRef = useRef<EditorInstanceManager | null>(null)
+
+  if (instanceManagerRef.current === null) {
+    instanceManagerRef.current = new EditorInstanceManager(mostRecentOptions)
+  }
+
+  const instanceManager = instanceManagerRef.current
 
   const editor = useSyncExternalStore(
     instanceManager.subscribe,


### PR DESCRIPTION
## Fixes

Fixes #7091

## Changes and Review

`useEditor()`'s `EditorInstanceManager` is created via a `useState` lazy initializer. React 18/19 StrictMode invokes that initializer twice for a single mount, and both calls construct (and auto-mount, since `Editor` defaults to a detached div) a real `Editor`, so both used to schedule their own `create` event.

`onCreate` is now buffered until the owning `EditorInstanceManager` is confirmed mounted (i.e. its render effect actually runs), and only forwarded to the user's callback then. An instance whose effect never runs - the StrictMode duplicate - simply never forwards its buffered event. This doesn't depend on any cross-invocation persistence (e.g. a ref surviving StrictMode's double-invoke), which turned out not to be reliable across React versions: verified against real React 17.0.2, 18.2.0, 18.3.1, and 19.1.0 builds using the actual built `@tiptap/react` dist, not just this repo's own React 19 devDependency.

Added `useEditor.spec.ts` (`@testing-library/react`, matching `BubbleMenu.spec.ts`'s existing pattern) covering: single `onCreate` under StrictMode, independent sibling editors, `immediatelyRender: false`, a full unmount/remount cycle, and mounting without StrictMode.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.