### PR TITLE
fix(core): collapse selection after deleting an AllSelection

### DIFF
--- a/.changeset/fix-allselection-delete-phantom-selection.md
+++ b/.changeset/fix-allselection-delete-phantom-selection.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fixed a bug where deleting an `AllSelection` (for example right after Ctrl/Cmd+A) left a lingering "phantom" selection highlight over the emptied document instead of a text cursor. `deleteSelection` now collapses the selection to a cursor.

--- a/packages/core/__tests__/delete.spec.ts
+++ b/packages/core/__tests__/delete.spec.ts
@@ -3,6 +3,7 @@ import Bold from '@tiptap/extension-bold'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
+import { AllSelection } from '@tiptap/pm/state'
 import { describe, expect, it, vi } from 'vitest'
 
 const InlineDocument = Document.extend({
@@ -140,6 +141,21 @@ describe('delete extension', () => {
 
     // The node should remain with remaining text
     expect(editor.getHTML()).toBe('<p>before <span data-test-node="">st</span> after</p>')
+    editor.destroy()
+  })
+
+  it('collapses the selection to a cursor after deleting an AllSelection', () => {
+    const editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>hello world</p>',
+    })
+
+    editor.chain().selectAll().deleteSelection().run()
+
+    expect(editor.getHTML()).toBe('<p></p>')
+    expect(editor.state.selection.empty).toBe(true)
+    expect(editor.state.selection instanceof AllSelection).toBe(false)
+
     editor.destroy()
   })
 

--- a/packages/core/src/commands/deleteSelection.ts
+++ b/packages/core/src/commands/deleteSelection.ts
@@ -1,4 +1,5 @@
 import type { ResolvedPos, Schema } from '@tiptap/pm/model'
+import { TextSelection } from '@tiptap/pm/state'
 
 import type { RawCommands } from '../types.js'
 
@@ -92,6 +93,13 @@ export const deleteSelection: RawCommands['deleteSelection'] =
         const { from, to } = expandSelectionForInlineText($from, $to, state.schema)
         tr.deleteRange(from, to)
       })
+
+      // after deleting the selection we restore a text selection
+      // near the from position to avoid having confusing selections
+      // after the deletion (for example after deleting via Ctrl/Cmd+A)
+      if (!tr.selection.empty) {
+        tr.setSelection(TextSelection.near(tr.doc.resolve(tr.selection.from)))
+      }
 
       tr.scrollIntoView()
       dispatch(tr)


### PR DESCRIPTION
Fixes #7961

## Problem
After Ctrl/Cmd+A (an `AllSelection`) then Backspace, the document empties but a
selection highlight lingers in the top-left. `AllSelection.map()` returns another
`AllSelection`, so the custom `deleteSelection` command emptied the doc while the
selection stayed a whole-document range instead of collapsing to a cursor.

## Fix
`deleteSelection` now collapses any surviving non-empty selection to a text cursor
after the deletion, so an emptied editor shows a caret rather than a phantom
highlight.

## Testing
- Added a regression test in `packages/core/__tests__/delete.spec.ts` asserting the
  selection is empty and no longer an `AllSelection` after `selectAll().deleteSelection()`.
- All existing core / table / list / selection delete tests pass; `oxlint` clean.
- Included a changeset.

## AI disclosure
Claude (Anthropic) assisted in diagnosing the root cause and drafting this fix.