### PR TITLE
fix: stop vitest's global esbuild jsx default from overriding React JSX

### DIFF
--- a/packages/react/src/EditorContent.spec.ts
+++ b/packages/react/src/EditorContent.spec.ts
@@ -1,8 +1,13 @@
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { render } from '@testing-library/react'
 import React from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createContentComponent } from './EditorContent.js'
+import { EditorContent, createContentComponent } from './EditorContent.js'
 import type { ReactRenderer } from './ReactRenderer.js'
+import { useEditor } from './useEditor.js'
 
 const createRenderer = (id: string) =>
   ({
@@ -35,5 +40,35 @@ describe('createContentComponent', () => {
     await Promise.resolve()
 
     expect(subscriber).toHaveBeenCalledTimes(2)
+  })
+})
+
+function flushTimers(ms: number) {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe('EditorContent', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('mounts a real editor view into the DOM', async () => {
+    function TestComponent() {
+      const editor = useEditor({
+        extensions: [Document, Text, Paragraph],
+        content: '<p>hello</p>',
+      })
+      return React.createElement(EditorContent, { editor })
+    }
+
+    render(React.createElement(TestComponent))
+    await flushTimers(50)
+
+    const tiptapElements = document.querySelectorAll('.tiptap')
+
+    expect(tiptapElements.length).toBe(1)
+    expect(tiptapElements[0].textContent).toBe('hello')
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -90,8 +90,4 @@ export default defineConfig({
       })),
     ],
   },
-  esbuild: {
-    jsx: 'automatic',
-    jsxImportSource: '@tiptap/core',
-  },
 })


### PR DESCRIPTION
## Fixes

Not tied to a filed issue - found this while investigating a different issue and figured it was worth fixing directly since I already had a verified fix.

## Changes and Review

`vitest.config.ts` sets `esbuild.jsxImportSource` to `@tiptap/core` globally, but that's only meant for the few files (`bold.tsx`, `blockquote.tsx`) that already opt into it themselves via a local `@jsxImportSource` pragma. The global default silently overrides plain React JSX for every other `.tsx` file under vitest too, including `packages/react`'s own components - rendering `<EditorContent>` in a vitest test throws `Objects are not valid as a React child` immediately, since the compiled output is Tiptap's own PM-array format instead of real React elements.

Removing the global default fixes that. It doesn't touch real builds (tsup reads `tsconfig.build.json` directly), and the two files that need the custom JSX keep working via their own pragma. Added a small regression test for `<EditorContent>` and confirmed the full suite still passes (150 files, 1517 tests).

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary. (Not needed - no published package is affected, this only changes test config.)
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
