### PR TITLE
fix(core): toggle lists across all selected table cells

### DIFF
--- a/packages/core/src/commands/toggleList.ts
+++ b/packages/core/src/commands/toggleList.ts
@@ -134,6 +134,42 @@ export const toggleList: RawCommands['toggleList'] =
     const listType = getNodeType(listTypeOrName, state.schema)
     const itemType = getNodeType(itemTypeOrName, state.schema)
     const { selection, storedMarks } = state
+
+    // A table `CellSelection` (multiple cells selected at once) exposes one
+    // `SelectionRange` per selected cell through `selection.ranges`, but its
+    // `$from`/`$to` resolve to the first cell only (prosemirror-tables builds it
+    // with `super(ranges[0].$from, ranges[0].$to, ranges)`). The single-range
+    // logic below therefore toggled just the first selected cell. When more than
+    // one range is selected, toggle each range independently so every selected
+    // cell is affected, reusing the exact same per-cell logic (wrap / lift /
+    // change type). Ranges are processed from the last document position to the
+    // first so that edits to later cells do not shift the positions of earlier,
+    // not-yet-processed cells.
+    if (selection.ranges.length > 1) {
+      const cellRanges = selection.ranges
+        .map(selectionRange => ({ from: selectionRange.$from.pos, to: selectionRange.$to.pos }))
+        .sort((a, b) => b.from - a.from)
+
+      const listChain = chain()
+
+      cellRanges.forEach(({ from, to }) => {
+        listChain
+          .command(({ tr: cellTr }) => {
+            // Resolve against the current transaction doc so positions stay valid
+            // as earlier iterations mutate later cells.
+            const $cellFrom = cellTr.doc.resolve(from)
+            const $cellTo = cellTr.doc.resolve(to)
+
+            cellTr.setSelection(TextSelection.between($cellFrom, $cellTo))
+
+            return true
+          })
+          .toggleList(listTypeOrName, itemTypeOrName, keepMarks, attributes)
+      })
+
+      return listChain.run()
+    }
+
     const { $from, $to } = selection
     const range = $from.blockRange($to)
 

--- a/packages/extension-list/__tests__/toggleListInTable.spec.ts
+++ b/packages/extension-list/__tests__/toggleListInTable.spec.ts
@@ -1,0 +1,140 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import { TableKit } from '@tiptap/extension-table'
+import Text from '@tiptap/extension-text'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { BulletList, ListItem, OrderedList } from '../src/index.js'
+
+/**
+ * Regression tests for https://github.com/ueberdosis/tiptap/issues/7208
+ *
+ * When several table cells are selected (a ProseMirror `CellSelection`) and a
+ * list toggle is triggered, every selected cell should be toggled - not only
+ * the first one. A `CellSelection` exposes one range per cell via
+ * `selection.ranges`, but its `$from`/`$to` resolve to the first cell only, so
+ * the single-range toggle logic previously affected just that first cell.
+ */
+describe('toggleList across a table CellSelection', () => {
+  let editor: Editor
+
+  const collectCellPositions = (): number[] => {
+    const positions: number[] = []
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+        positions.push(pos)
+      }
+    })
+    return positions
+  }
+
+  // The type name of each cell's first child, in row-major order.
+  const cellChildTypes = (): string[] => {
+    const types: string[] = []
+    editor.state.doc.descendants(node => {
+      if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+        types.push(node.firstChild?.type.name ?? '')
+      }
+    })
+    return types
+  }
+
+  beforeEach(() => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    editor = new Editor({
+      element,
+      extensions: [Document, Paragraph, Text, ListItem, BulletList, OrderedList, TableKit],
+      content:
+        '<table><tbody>' +
+        '<tr><td>A1</td><td>B1</td></tr>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '</tbody></table>',
+    })
+  })
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  it('toggles a bullet list in every selected cell, not just the first', () => {
+    const cells = collectCellPositions()
+    // Row-major order: A1, B1, A2, B2. Select the whole first row (A1..B1).
+    editor.chain().focus().setCellSelection({ anchorCell: cells[0], headCell: cells[1] }).run()
+
+    const result = editor.commands.toggleBulletList()
+
+    expect(result).toBe(true)
+
+    const types = cellChildTypes()
+    // Both selected cells become lists.
+    expect(types[0]).toBe('bulletList') // A1
+    expect(types[1]).toBe('bulletList') // B1
+    // Unselected cells are untouched.
+    expect(types[2]).toBe('paragraph') // A2
+    expect(types[3]).toBe('paragraph') // B2
+
+    // The original cell text is preserved inside the new lists.
+    const contents: string[] = []
+    editor.state.doc.descendants(node => {
+      if (node.type.name === 'tableCell') {
+        contents.push(node.textContent)
+      }
+    })
+    expect(contents).toEqual(['A1', 'B1', 'A2', 'B2'])
+  })
+
+  it('toggles an ordered list in all cells of a multi-row, multi-column selection', () => {
+    const cells = collectCellPositions()
+    // Select the full 2x2 block A1..B2.
+    editor.chain().focus().setCellSelection({ anchorCell: cells[0], headCell: cells[3] }).run()
+
+    const result = editor.commands.toggleOrderedList()
+
+    expect(result).toBe(true)
+
+    const types = cellChildTypes()
+    expect(types).toEqual(['orderedList', 'orderedList', 'orderedList', 'orderedList'])
+  })
+
+  it('toggles a list off again in every selected cell on a second toggle', () => {
+    const cells = collectCellPositions()
+    editor.chain().focus().setCellSelection({ anchorCell: cells[0], headCell: cells[1] }).run()
+
+    editor.commands.toggleBulletList()
+    expect(cellChildTypes().slice(0, 2)).toEqual(['bulletList', 'bulletList'])
+
+    // Re-select the same cells and toggle again - both cells should revert.
+    const cellsAfter = collectCellPositions()
+    editor
+      .chain()
+      .focus()
+      .setCellSelection({ anchorCell: cellsAfter[0], headCell: cellsAfter[1] })
+      .run()
+    editor.commands.toggleBulletList()
+
+    expect(cellChildTypes()).toEqual(['paragraph', 'paragraph', 'paragraph', 'paragraph'])
+  })
+})
+
+describe('toggleList outside tables (regression guard)', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('still toggles a single paragraph into a bullet list', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ListItem, BulletList],
+      content: '<p>Hello</p>',
+    })
+
+    editor.commands.selectAll()
+    const result = editor.commands.toggleBulletList()
+
+    expect(result).toBe(true)
+    expect(editor.getHTML()).toBe('<ul><li><p>Hello</p></li></ul>')
+  })
+})


### PR DESCRIPTION
## What

In a table, selecting multiple cells and toggling a bulleted/ordered list only converted the first selected cell (#7208). This makes the toggle apply to every selected cell.

## Root cause

`toggleList` (in `packages/core`) derived a single block range from `selection.$from` / `selection.$to`. A prosemirror-tables `CellSelection` is built as `super(ranges[0].$from, ranges[0].$to, ranges)`, so its `$from`/`$to` resolve to the **first cell only** — even though `selection.ranges` already holds one range per selected cell. The single-range logic therefore toggled just the first cell.

## Fix

When `selection.ranges.length > 1` (a `CellSelection`, or any multi-range selection), toggle each range independently within one chained transaction: set a `TextSelection` inside each cell and re-invoke `toggleList` for it, reusing the exact per-cell wrap/lift/change-type logic. Ranges are processed last-position-first so edits to later cells don't shift the positions of earlier, not-yet-processed cells. The single-range (non-table) path is left completely unchanged — the new branch only fires for multi-range selections, and each per-cell re-invocation sees a 1-range selection (so no recursion).

## Tests

New `packages/extension-list/__tests__/toggleListInTable.spec.ts` with 4 cases: two selected cells in a row both become a list; a full 2x2 selection converts all four; a second toggle reverts every selected cell; and a plain non-table paragraph still toggles (regression guard).

## Verification

- New spec: 4 pass. Red/green check: against the original `toggleList`, the three multi-cell cases fail as expected while the non-table case passes.
- No regressions: `packages/extension-list` (104), `packages/core` + `packages/extension-table` (565) all pass; `@tiptap/core` build + DTS type-check succeed; oxlint / oxfmt clean.

Closes #7208.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Verified with the new test (including a red/green check) and the full extension-list / core / extension-table suites (no regressions).*
