### PR TITLE
fix(extension-table): backfill empty cells on slice parse (#6237)

### DIFF
--- a/.changeset/fix-empty-table-cell-slice-parse-quiet-fox-glade.md
+++ b/.changeset/fix-empty-table-cell-slice-parse-quiet-fox-glade.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Fix inserting a table with an empty cell or header (e.g. via `insertContent`/`insertContentAt`) throwing `RangeError: Invalid content for node tableCell/tableHeader: <>`. Empty `<td>`/`<th>` elements are now backfilled with the cell's default block content, matching the behavior you already get from `setContent`.

--- a/packages/extension-table/__tests__/tableCellEmptyContent.spec.ts
+++ b/packages/extension-table/__tests__/tableCellEmptyContent.spec.ts
@@ -1,0 +1,226 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Heading from '@tiptap/extension-heading'
+import Paragraph from '@tiptap/extension-paragraph'
+import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/** Regression tests for empty `<td>`/`<th>` insertion — https://github.com/ueberdosis/tiptap/issues/6237 */
+describe('extension table empty cell/header parsing', () => {
+  const editorElClass = 'tiptap'
+  let editor: Editor | null = null
+
+  const createEditorEl = () => {
+    const editorEl = document.createElement('div')
+
+    editorEl.classList.add(editorElClass)
+    document.body.appendChild(editorEl)
+    return editorEl
+  }
+  const getEditorEl = () => document.querySelector(`.${editorElClass}`)
+
+  const createTableEditor = () =>
+    new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        TableCell,
+        TableHeader,
+        TableRow,
+        Table.configure({
+          resizable: true,
+        }),
+      ],
+      content: '<p></p>',
+    })
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+    getEditorEl()?.remove()
+  })
+
+  it('inserts a table with an empty cell without throwing, backfilling an empty paragraph', () => {
+    editor = createTableEditor()
+
+    expect(() => {
+      editor?.commands.insertContentAt(0, '<table><tr><td></td></tr></table>')
+    }).not.toThrow()
+
+    const cellNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(cellNode?.type).toBe('tableCell')
+    expect(cellNode?.content).toEqual([{ type: 'paragraph' }])
+  })
+
+  it('inserts a table with an empty header cell without throwing, backfilling an empty paragraph', () => {
+    editor = createTableEditor()
+
+    expect(() => {
+      editor?.commands.insertContentAt(0, '<table><tr><th></th></tr></table>')
+    }).not.toThrow()
+
+    const headerNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(headerNode?.type).toBe('tableHeader')
+    expect(headerNode?.content).toEqual([{ type: 'paragraph' }])
+  })
+
+  it('inserts an empty cell via insertContent without throwing', () => {
+    editor = createTableEditor()
+
+    expect(() => {
+      editor?.commands.insertContent('<table><tr><td></td></tr></table>')
+    }).not.toThrow()
+
+    const cellNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(cellNode?.type).toBe('tableCell')
+    expect(cellNode?.content).toEqual([{ type: 'paragraph' }])
+  })
+
+  it('inserts an empty header cell via insertContent without throwing', () => {
+    editor = createTableEditor()
+
+    expect(() => {
+      editor?.commands.insertContent('<table><tr><th></th></tr></table>')
+    }).not.toThrow()
+
+    const headerNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(headerNode?.type).toBe('tableHeader')
+    expect(headerNode?.content).toEqual([{ type: 'paragraph' }])
+  })
+
+  it('backfills a whitespace-only cell when preserveWhitespace is false', () => {
+    editor = createTableEditor()
+
+    expect(() => {
+      editor?.commands.insertContentAt(0, '<table><tr><td>   </td></tr></table>', {
+        parseOptions: { preserveWhitespace: false },
+      })
+    }).not.toThrow()
+
+    const cellNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(cellNode?.content).toEqual([{ type: 'paragraph' }])
+  })
+
+  it.each([
+    ['default (no parseOptions)', undefined],
+    ['preserveWhitespace: true', { preserveWhitespace: true as const }],
+    ['preserveWhitespace: "full"', { preserveWhitespace: 'full' as const }],
+  ])('backfills a whitespace-only cell identically to setContent — %s', (_label, parseOptions) => {
+    const tableHTML = '<table><tr><td>   </td></tr></table>'
+
+    // setContent collapses a spaces-only cell too, so no whitespace is lost.
+    const setContentEditor = createTableEditor()
+    setContentEditor.commands.setContent(tableHTML)
+    const reference = setContentEditor.getJSON().content?.[0]?.content?.[0]?.content?.[0]?.content
+    setContentEditor.destroy()
+
+    editor = createTableEditor()
+    expect(() => {
+      editor?.commands.insertContentAt(0, tableHTML, parseOptions ? { parseOptions } : undefined)
+    }).not.toThrow()
+
+    const cellContent = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]?.content
+
+    expect(cellContent).toEqual(reference)
+    expect(cellContent).toEqual([{ type: 'paragraph' }])
+  })
+
+  it('produces the same empty cell as setContent does', () => {
+    const tableHTML = '<table><tr><td></td></tr></table>'
+
+    const setContentEditor = createTableEditor()
+    setContentEditor.commands.setContent(tableHTML)
+    const setContentCell =
+      setContentEditor.getJSON().content?.[0]?.content?.[0]?.content?.[0]?.content
+    setContentEditor.destroy()
+
+    editor = createTableEditor()
+    editor.commands.insertContentAt(0, tableHTML)
+    const insertContentCell = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]?.content
+
+    expect(insertContentCell).toEqual(setContentCell)
+    expect(insertContentCell).toEqual([{ type: 'paragraph' }])
+  })
+
+  it('preserves a non-breaking-space cell instead of treating it as empty', () => {
+    editor = createTableEditor()
+
+    // trim() would strip the NBSP; it must survive as text, not be backfilled.
+    editor.commands.insertContentAt(0, '<table><tr><td>&nbsp;</td></tr></table>')
+
+    const cellNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(cellNode?.type).toBe('tableCell')
+    expect(cellNode?.content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: ' ' }] },
+    ])
+  })
+
+  it('backfills using the schema block when no paragraph node exists', () => {
+    const el = createEditorEl()
+    // A valid schema whose only block is Heading (no Paragraph).
+    const headingOnlyEditor = new Editor({
+      element: el,
+      extensions: [Document, Text, Heading, TableCell, TableHeader, TableRow, Table],
+      content: '<h1>x</h1>',
+    })
+
+    expect(() => {
+      headingOnlyEditor.commands.insertContentAt(0, '<table><tr><td></td></tr></table>')
+    }).not.toThrow()
+
+    const cellNode = headingOnlyEditor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    // Fill uses the schema's block (heading here), not a hard-coded paragraph.
+    expect(cellNode?.content?.[0]?.type).toBe('heading')
+
+    headingOnlyEditor.destroy()
+    el.remove()
+  })
+
+  it('keeps non-empty cell content intact (regression)', () => {
+    editor = createTableEditor()
+
+    editor.commands.insertContentAt(0, '<table><tr><td>hello</td></tr></table>')
+
+    const cellNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(cellNode?.content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+    ])
+  })
+
+  it('keeps non-empty header content intact (regression)', () => {
+    editor = createTableEditor()
+
+    editor.commands.insertContentAt(0, '<table><tr><th>hello</th></tr></table>')
+
+    const headerNode = editor.getJSON().content?.[0]?.content?.[0]?.content?.[0]
+
+    expect(headerNode?.content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+    ])
+  })
+
+  it('still parses colspan/colwidth on a multi-cell table (regression)', () => {
+    editor = createTableEditor()
+
+    editor.commands.insertContentAt(
+      0,
+      '<table><tr><td colwidth="200">Name</td><td colspan="2">Description</td></tr></table>',
+    )
+
+    const row = editor.getJSON().content?.[0]?.content?.[0]
+
+    expect(row?.content?.[0]?.attrs?.colwidth).toEqual([200])
+    expect(row?.content?.[1]?.attrs?.colspan).toBe(2)
+  })
+})

--- a/packages/extension-table/src/cell/table-cell.ts
+++ b/packages/extension-table/src/cell/table-cell.ts
@@ -4,6 +4,7 @@ import { mergeAttributes, Node } from '@tiptap/core'
 
 import { createAlignAttribute } from '../utils/parseAlign.js'
 import { parseColwidth } from '../utils/parseColwidth.js'
+import { fillEmptyCellContent, isEmptyCellElement } from '../utils/fillEmptyCellContent.js'
 
 export interface TableCellOptions {
   /**
@@ -50,7 +51,15 @@ export const TableCell = Node.create<TableCellOptions>({
   isolating: true,
 
   parseHTML() {
-    return [{ tag: 'td' }]
+    return [
+      {
+        // Backfill empty cells; non-empty cells fall through to the rule below.
+        tag: 'td',
+        getAttrs: node => (isEmptyCellElement(node) ? {} : false),
+        getContent: (_node, schema) => fillEmptyCellContent(schema.nodes[this.name]),
+      },
+      { tag: 'td' },
+    ]
   },
 
   renderHTML({ HTMLAttributes }) {

--- a/packages/extension-table/src/header/table-header.ts
+++ b/packages/extension-table/src/header/table-header.ts
@@ -4,6 +4,7 @@ import { mergeAttributes, Node } from '@tiptap/core'
 
 import { createAlignAttribute } from '../utils/parseAlign.js'
 import { parseColwidth } from '../utils/parseColwidth.js'
+import { fillEmptyCellContent, isEmptyCellElement } from '../utils/fillEmptyCellContent.js'
 
 export interface TableHeaderOptions {
   /**
@@ -50,7 +51,15 @@ export const TableHeader = Node.create<TableHeaderOptions>({
   isolating: true,
 
   parseHTML() {
-    return [{ tag: 'th' }]
+    return [
+      {
+        // Backfill empty cells; non-empty cells fall through to the rule below.
+        tag: 'th',
+        getAttrs: node => (isEmptyCellElement(node) ? {} : false),
+        getContent: (_node, schema) => fillEmptyCellContent(schema.nodes[this.name]),
+      },
+      { tag: 'th' },
+    ]
   },
 
   renderHTML({ HTMLAttributes }) {

--- a/packages/extension-table/src/utils/fillEmptyCellContent.ts
+++ b/packages/extension-table/src/utils/fillEmptyCellContent.ts
@@ -1,0 +1,25 @@
+import type { NodeType } from '@tiptap/pm/model'
+import { Fragment } from '@tiptap/pm/model'
+
+// ASCII whitespace only, so a non-breaking-space cell is not treated as empty.
+const COLLAPSIBLE_WHITESPACE = /[ \t\r\n\f]+/g
+
+/** Whether a cell/header element has no child elements and only collapsible whitespace. */
+export function isEmptyCellElement(element: HTMLElement): boolean {
+  if (element.children.length > 0) {
+    return false
+  }
+
+  return (element.textContent ?? '').replace(COLLAPSIBLE_WHITESPACE, '') === ''
+}
+
+/** Builds a cell/header's minimal `block+` content, derived from the node type. */
+export function fillEmptyCellContent(cellType: NodeType): Fragment {
+  const filled = cellType.createAndFill()
+
+  if (!filled) {
+    throw new Error(`[tiptap error]: "${cellType.name}" has no default content to backfill.`)
+  }
+
+  return filled.content
+}


### PR DESCRIPTION
## Fixes

Fixes #6237

## Changes and Review

Inserting a table that contains an empty cell or header (e.g. `insertContent`/`insertContentAt('<table><tr><td></td></tr></table>')`) threw `RangeError: Invalid content for node tableCell: <>`. Unlike `setContent` (full-document parse), the slice-parse path used by `insertContent` does not backfill the required `block+` content of a cell, so an empty cell is invalid.

- `tableCell`/`tableHeader` now add a parse rule that matches **only** empty cells and backfills their default block content, falling through to the original rule (unchanged) for non-empty cells.
- The backfill is derived from the cell node type, so it works for schemas whose default block isn't `paragraph`; non-breaking-space and other meaningful cells are preserved, not treated as empty.
- Fix is localized to `@tiptap/extension-table` (patch), with no `@tiptap/core` changes.
- To verify: insert `<table><tr><td></td></tr></table>` via `insertContentAt`, and it no longer throws and yields `<td><p></p></td>`, matching `setContent`.

AI usage disclosure: this change was implemented with AI assistance (Claude Code) and independently reviewed with Codex; the author has reviewed and verified it.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
