### PR TITLE
fix(vue-3): use NodeViewContent element as contentDOM instead of nesting a wrapper (#7950)

### DIFF
--- a/.changeset/fix-vue-nodeview-content-tbody-quiet-lake-fox.md
+++ b/.changeset/fix-vue-nodeview-content-tbody-quiet-lake-fox.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/vue-3": patch
+---
+
+Fix `<node-view-content as="tbody">` (and similar restricted-content elements) rendering with an extra wrapper `<div>` nested inside them, which broke tables in Vue node views. Note: keep `<node-view-content>` mounted (use `v-show`, not `v-if`) — conditionally remounting it can leave ProseMirror attached to the old element.

--- a/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
+++ b/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
@@ -30,6 +30,13 @@ const ComponentWithContent = defineComponent({
   components: { NodeViewWrapper, NodeViewContent },
 })
 
+const ComponentWithTbodyContent = defineComponent({
+  name: 'WithTbodyContent',
+  props: nodeViewProps,
+  template: '<node-view-wrapper as="table"><node-view-content as="tbody" /></node-view-wrapper>',
+  components: { NodeViewWrapper, NodeViewContent },
+})
+
 const LeafComponent = defineComponent({
   name: 'LeafComponent',
   props: nodeViewProps,
@@ -138,16 +145,50 @@ describe('VueNodeViewRenderer contentDOM', () => {
     expect(content!.textContent).toContain('Hello World')
   })
 
+  it('adopts <node-view-content as="tbody"> as the contentDOM instead of nesting a wrapper div inside it (#7950)', async () => {
+    await withEditor('<custom-block>Hello World</custom-block>', ComponentWithTbodyContent)
+    const tbody = el!.querySelector('tbody[data-node-view-content]')
+    expect(tbody).toBeTruthy()
+    // A <tbody> may only contain <tr> elements, so the placeholder wrapper div
+    // must never be nested inside it.
+    expect(tbody!.querySelector('[data-node-view-content-vue]')).toBeFalsy()
+    expect(tbody!.children.length).toBe(0)
+    expect(tbody!.textContent).toContain('Hello World')
+  })
+
   it('does not throw on destroy', async () => {
     await withEditor('<custom-block>Hello World</custom-block>', ComponentWithoutContent)
     expect(() => editor!.destroy()).not.toThrow()
   })
 
-  it('use custom content dom element tag', async () => {
+  // SEMANTICS CHANGE (#7950): previously the contentDOMElementTag placeholder was
+  // always created up front and then nested inside the rendered <node-view-content>
+  // element, so it showed up in the DOM even when a real <node-view-content> was
+  // present. That nesting is exactly the bug being fixed here (e.g. it broke
+  // <tbody>, which may only contain <tr>). Now, when the component renders a real
+  // <node-view-content>, that element is adopted as the contentDOM directly and
+  // contentDOMElementTag is not used — it only applies to the fallback placeholder
+  // used when a component has NO <node-view-content> at all.
+  it('ignores contentDOMElementTag when a real <node-view-content> is present', async () => {
     await withEditor('<custom-block>Hello World</custom-block>', ComponentWithContent, false, {
       contentDOMElementTag: 'custom-content-dom',
     })
-    const content = el!.querySelector('custom-content-dom')
+    expect(el!.querySelector('custom-content-dom')).toBeFalsy()
+    const content = el!.querySelector('[data-node-view-content]')
     expect(content).toBeTruthy()
+    expect(content!.tagName.toLowerCase()).toBe('div')
+    expect(content!.textContent).toContain('Hello World')
+  })
+
+  it('use custom content dom element tag as the fallback when there is no <node-view-content>', async () => {
+    await withEditor('<custom-block>Hello World</custom-block>', ComponentWithoutContent, false, {
+      contentDOMElementTag: 'custom-content-dom',
+    })
+    // The fallback placeholder stays detached (see "does not thrash the DOM" above),
+    // so we assert on the internal contentDOM rather than querying the live DOM.
+    const wrapperDesc = (el!.querySelector('[data-node-view-wrapper]') as any)?.pmViewDesc
+    const contentDOM = wrapperDesc?.spec?.contentDOM as HTMLElement | undefined
+    expect(contentDOM).toBeTruthy()
+    expect(contentDOM!.tagName.toLowerCase()).toBe('custom-content-dom')
   })
 })

--- a/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
+++ b/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
@@ -161,14 +161,7 @@ describe('VueNodeViewRenderer contentDOM', () => {
     expect(() => editor!.destroy()).not.toThrow()
   })
 
-  // SEMANTICS CHANGE (#7950): previously the contentDOMElementTag placeholder was
-  // always created up front and then nested inside the rendered <node-view-content>
-  // element, so it showed up in the DOM even when a real <node-view-content> was
-  // present. That nesting is exactly the bug being fixed here (e.g. it broke
-  // <tbody>, which may only contain <tr>). Now, when the component renders a real
-  // <node-view-content>, that element is adopted as the contentDOM directly and
-  // contentDOMElementTag is not used — it only applies to the fallback placeholder
-  // used when a component has NO <node-view-content> at all.
+  // Uses `<node-view-content>` as `contentDOM`; `contentDOMElementTag` only defines the fallback when none is rendered.
   it('ignores contentDOMElementTag when a real <node-view-content> is present', async () => {
     await withEditor('<custom-block>Hello World</custom-block>', ComponentWithContent, false, {
       contentDOMElementTag: 'custom-content-dom',

--- a/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
+++ b/packages/vue-3/__tests__/VueNodeViewRenderer.spec.ts
@@ -145,7 +145,7 @@ describe('VueNodeViewRenderer contentDOM', () => {
     expect(content!.textContent).toContain('Hello World')
   })
 
-  it('adopts <node-view-content as="tbody"> as the contentDOM instead of nesting a wrapper div inside it (#7950)', async () => {
+  it('adopts <node-view-content as="tbody"> as the contentDOM instead of nesting a wrapper div inside it', async () => {
     await withEditor('<custom-block>Hello World</custom-block>', ComponentWithTbodyContent)
     const tbody = el!.querySelector('tbody[data-node-view-content]')
     expect(tbody).toBeTruthy()

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -162,12 +162,17 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
         provide('onDragStart', onDragStart)
         provide('decorationClasses', this.decorationClasses)
         provide('nodeViewContentRef', (el: HTMLElement | null) => {
-          if (!this.contentDOMElement) return
+          if (!el || el === this.contentDOMElement) return
 
-          if (el && el.firstChild !== this.contentDOMElement) {
-            // NodeViewContent mounted: move the contentDOMElement inside it
-            el.appendChild(this.contentDOMElement)
+          // Adopt the NodeViewContent element as the contentDOM instead of nesting
+          // the placeholder inside it (nesting breaks restricted parents like <tbody>).
+          // Assumes a stable element — don't conditionally remount it (use v-show, not v-if).
+          if (this.contentDOMElement) {
+            while (this.contentDOMElement.firstChild) {
+              el.appendChild(this.contentDOMElement.firstChild)
+            }
           }
+          this.contentDOMElement = el
         })
 
         return (this.component as any).setup?.(reactiveProps, {

--- a/packages/vue-3/src/VueNodeViewRenderer.ts
+++ b/packages/vue-3/src/VueNodeViewRenderer.ts
@@ -164,9 +164,8 @@ class VueNodeView extends NodeView<Component, Editor, VueNodeViewRendererOptions
         provide('nodeViewContentRef', (el: HTMLElement | null) => {
           if (!el || el === this.contentDOMElement) return
 
-          // Adopt the NodeViewContent element as the contentDOM instead of nesting
-          // the placeholder inside it (nesting breaks restricted parents like <tbody>).
-          // Assumes a stable element — don't conditionally remount it (use v-show, not v-if).
+          // Adopt this stable element as contentDOM, preserving existing children.
+          // Do not conditionally remount it; use v-show instead of v-if).
           if (this.contentDOMElement) {
             while (this.contentDOMElement.firstChild) {
               el.appendChild(this.contentDOMElement.firstChild)


### PR DESCRIPTION
## Fixes

Fixes #7950

## Changes and Review

Since `@tiptap/vue-3` 3.25, a custom node view using `<node-view-content as="tbody" />` rendered an extra `<div data-node-view-content-vue>` inside the `<tbody>` (`<tbody><div><tr>…</tr></div></tbody>`), which breaks table layout because `<tbody>` may only contain `<tr>`.

- The renderer used to append its placeholder `contentDOM` element inside the mounted `<node-view-content>` element. It now **adopts** that element as the content DOM directly, so no wrapper is nested. The placeholder is still used for the fallback case where a component has no `<node-view-content>`.
- Because of this, `contentDOMElementTag` now only applies to that no-`<node-view-content>` fallback (it previously forced the nested tag, which was the bug); the option is recent and unreleased, so no migration is needed.
- To verify: a table-like node view with `<node-view-content as="tbody" />` now yields `<tbody>` containing its rows directly. Covered by new vue-3 tests; full vue-3 suite passes.

Known limitation (documented in code): adoption assumes the `<node-view-content>` element is stable for the node view's lifetime, because ProseMirror caches `contentDOM` once. Conditionally remounting it via `v-if` isn't supported; use `v-show`/CSS to keep it mounted.

AI usage disclosure: prepared with AI assistance (Claude Code) and independently reviewed with Codex; the author has reviewed and verified it.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
