### PR TITLE
fix(core): make editor usable in onContentError for invalid initial content (#7493)

### DIFF
--- a/.changeset/fix-oncontenterror-editor-usable-quiet-lake-drift.md
+++ b/.changeset/fix-oncontenterror-editor-usable-quiet-lake-drift.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fixed `onContentError` throwing when calling `editor.commands` from inside the handler on initial load with invalid content. The editor now has a usable state (seeded from the stripped fallback document) before `onContentError` fires.

--- a/packages/core/__tests__/onContentError.spec.ts
+++ b/packages/core/__tests__/onContentError.spec.ts
@@ -208,4 +208,79 @@ describe('onContentError', () => {
     expect(editor.getText()).toBe('Example Text')
     expect(editor.storage.collaboration.isDisabled).toBe(false)
   })
+
+  it('does not throw when calling setContent(valid) from the onContentError handler', () => {
+    const json = {
+      invalid: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Example Text',
+            },
+          ],
+        },
+      ],
+    }
+
+    const validJson = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Recovered',
+            },
+          ],
+        },
+      ],
+    }
+
+    let editor: Editor | undefined
+
+    expect(() => {
+      editor = new Editor({
+        content: json,
+        extensions: [Document, Paragraph, Text],
+        enableContentCheck: true,
+        onContentError: ({ editor: contentErrorEditor }) => {
+          contentErrorEditor.commands.setContent(validJson)
+        },
+      })
+    }).not.toThrow()
+
+    expect(editor?.getText()).toBe('Recovered')
+  })
+
+  // Invalid HTML whose fallback keeps a distinguishable "keepme" paragraph, so these
+  // tests fail if the fallback doc is ever discarded rather than preserved.
+  const invalidHtmlWithSalvageableText = '<p>keepme</p><foobar></foobar>'
+
+  it('preserves the fallback content when the handler runs a non-setContent command', () => {
+    const editor = new Editor({
+      content: invalidHtmlWithSalvageableText,
+      extensions: [Document, Paragraph, Text],
+      enableContentCheck: true,
+      onContentError: ({ editor: contentErrorEditor }) => {
+        contentErrorEditor.commands.setTextSelection(0)
+      },
+    })
+
+    expect(editor.getText()).toBe('keepme')
+  })
+
+  it('keeps the stripped fallback doc when the handler does nothing', () => {
+    const editor = new Editor({
+      content: invalidHtmlWithSalvageableText,
+      extensions: [Document, Paragraph, Text],
+      enableContentCheck: true,
+      onContentError: () => {},
+    })
+
+    expect(editor.getText()).toBe('keepme')
+  })
 })

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -143,14 +143,17 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.on('delete', this.options.onDelete)
 
     const initialDoc = this.createDoc()
-    const selection = resolveFocusPosition(initialDoc, this.options.autofocus)
 
-    // Set editor state immediately, so that it's available independently from the view
-    this.editorState = EditorState.create({
-      doc: initialDoc,
-      schema: this.schema,
-      selection: selection || undefined,
-    })
+    // createDoc() already seeds editorState from the fallback doc on a content error
+    if (!this.editorState) {
+      const selection = resolveFocusPosition(initialDoc, this.options.autofocus)
+
+      this.editorState = EditorState.create({
+        doc: initialDoc,
+        schema: this.schema,
+        selection: selection || undefined,
+      })
+    }
 
     if (this.options.element) {
       this.mount(this.options.element)
@@ -497,6 +500,24 @@ export class Editor extends EventEmitter<EditorEvents> {
         // Not the content error we were expecting
         throw e
       }
+
+      // Content is invalid, but attempt to create it anyway, stripping out the invalid parts
+      const fallbackDoc = createDocument(
+        this.options.content,
+        this.schema,
+        this.options.parseOptions,
+        {
+          errorOnInvalidContent: false,
+        },
+      )
+
+      // Seed editorState with the fallback doc so a handler can safely use `editor.commands`
+      this.editorState = EditorState.create({
+        doc: fallbackDoc,
+        schema: this.schema,
+        selection: resolveFocusPosition(fallbackDoc, this.options.autofocus) || undefined,
+      })
+
       this.emit('contentError', {
         editor: this,
         error: e as Error,
@@ -518,10 +539,7 @@ export class Editor extends EventEmitter<EditorEvents> {
         },
       })
 
-      // Content is invalid, but attempt to create it anyway, stripping out the invalid parts
-      doc = createDocument(this.options.content, this.schema, this.options.parseOptions, {
-        errorOnInvalidContent: false,
-      })
+      return this.editorState.doc
     }
     return doc
   }

--- a/packages/extension-collaboration/__tests__/filterInvalidContent.spec.ts
+++ b/packages/extension-collaboration/__tests__/filterInvalidContent.spec.ts
@@ -152,4 +152,31 @@ describe('filterInvalidContent', () => {
     disableCollab!()
     expect(destroySpy).toHaveBeenCalled()
   })
+
+  it('recovers from invalid initial content via disableCollaboration + setContent (#7493)', () => {
+    const ydoc = new Y.Doc()
+
+    el = document.createElement('div')
+    document.body.appendChild(el)
+
+    let ranHandler = false
+
+    expect(() => {
+      editor = new Editor({
+        element: el as HTMLElement,
+        extensions: [Document, Paragraph, Text, Collaboration.configure({ document: ydoc })],
+        content: '<p>keepme</p><foobar></foobar>',
+        enableContentCheck: true,
+        onContentError: ({ editor: contentErrorEditor, disableCollaboration }) => {
+          ranHandler = true
+          disableCollaboration()
+          contentErrorEditor.commands.setContent('<p>recovered</p>')
+        },
+      })
+    }).not.toThrow()
+
+    expect(ranHandler).toBe(true)
+    expect(editor!.storage.collaboration).toBeUndefined()
+    expect(editor!.getText()).toBe('recovered')
+  })
 })


### PR DESCRIPTION
## Fixes

Fixes #7493

## Changes and Review

When an editor was created with invalid initial content plus `enableContentCheck` + `emitContentError`, `onContentError({ editor })` fired before the editor had a state, so calling `editor.commands.setContent(…)` (the documented recovery path) inside the handler threw `Cannot destructure property 'tr' of 'state'`.

- `createDoc()` now parses the stripped fallback document and seeds `editor.state` from it **before** emitting `contentError`, so the handler receives a usable editor.
- The constructor only builds the initial state itself when the error path didn't already seed one, so a handler's `setContent` (or any other command) is preserved and the fallback content isn't discarded.
- Scope is `@tiptap/core` only (patch); `disableCollaboration()` stays synchronous and unchanged.
- To verify: create an editor with invalid content + `enableContentCheck: true` + `emitContentError: true` and call `editor.commands.setContent(valid)` in `onContentError`, and it no longer throws and the content is fixed.

AI usage disclosure: prepared with AI assistance (Claude Code) and independently reviewed with Codex; the author has reviewed and verified it.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
