### PR TITLE
test(extension-link): guard non-link click selection with enableClickSelection (#7347)

### DIFF
--- a/packages/extension-link/__tests__/link.spec.ts
+++ b/packages/extension-link/__tests__/link.spec.ts
@@ -351,6 +351,51 @@ describe('extension-link', () => {
     getEditorEl()?.remove()
   })
 
+  // Regression guard for #7347: with enableClickSelection, clicking a non-link
+  // element (e.g. an image) must not be handled by the link plugin, otherwise
+  // ProseMirror's own NodeSelection is blocked.
+  it('should return false when clicking non-link elements with enableClickSelection', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        // inline so the image is valid content inside the paragraph (pos 1)
+        Image.configure({ inline: true }),
+        Link.configure({
+          enableClickSelection: true,
+        }),
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'image', attrs: { src: 'https://placehold.co/400' } }],
+          },
+        ],
+      },
+    })
+
+    const img = getEditorEl()?.querySelector('img')
+
+    expect(img).toBeTruthy()
+
+    // A left click whose target is the image itself (not a link).
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 })
+    Object.defineProperty(clickEvent, 'target', { value: img })
+
+    // The link plugin must report the click unhandled (falsy) so the editor's
+    // default NodeSelection on the image can run.
+    const handled = editor.view.someProp('handleClick', fn => fn(editor!.view, 1, clickEvent))
+
+    expect(handled).toBeFalsy()
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
   describe('shouldAutoLink', () => {
     it('default shouldAutoLink rejects bare hostnames without TLD', () => {
       // Test using Link extension's default options

--- a/packages/extension-link/__tests__/link.spec.ts
+++ b/packages/extension-link/__tests__/link.spec.ts
@@ -351,9 +351,6 @@ describe('extension-link', () => {
     getEditorEl()?.remove()
   })
 
-  // Regression guard for #7347: with enableClickSelection, clicking a non-link
-  // element (e.g. an image) must not be handled by the link plugin, otherwise
-  // ProseMirror's own NodeSelection is blocked.
   it('should return false when clicking non-link elements with enableClickSelection', () => {
     editor = new Editor({
       element: createEditorEl(),


### PR DESCRIPTION
## Fixes

Refs #7347

## Changes and Review

#7347 (images hard to select when Link's `enableClickSelection` is on) was a regression introduced in v3.13.0 and already fixed in **v3.16.0** (#7359), which restored an unconditional `if (!link) return false` guard in the link click handler. This PR adds a regression test so that exact path can't silently break again.

- The existing "non-link elements" test only covered `openOnClick: false`, not `enableClickSelection: true`, which is the option named in #7347.
- The new test asserts the link plugin's `handleClick` reports **unhandled** (falsy) for a click on a non-link image, so the editor's own `NodeSelection` isn't blocked. Verified it fails if the guard is removed.
- Test-only change, so no changeset (no user-facing/behavior change).

AI usage disclosure: prepared with AI assistance (Claude Code); the author has reviewed and verified it.

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary. (n/a: test-only)
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
