### PR TITLE
fix(markdown): keep non-breaking-space-only content instead of serializing to empty (#7495)

### DIFF
--- a/.changeset/fix-markdown-nbsp-content-loss-quiet-amber-fox.md
+++ b/.changeset/fix-markdown-nbsp-content-loss-quiet-amber-fox.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Fixed a bug where a document containing only a non-breaking space (`&nbsp;`) serialized to an empty markdown string, silently discarding the content. `getMarkdown()`/`serialize()` now only return `""` when the document is actually empty.

--- a/packages/markdown/__tests__/empty-content.spec.ts
+++ b/packages/markdown/__tests__/empty-content.spec.ts
@@ -85,4 +85,16 @@ describe('empty markdown content', () => {
     expect(textNode.text).toBe('bold')
     expect(textNode.marks?.[0]?.type).toBe('bold')
   })
+
+  it('should keep content when the document holds only a real non-breaking space (#7495)', () => {
+    // A lone non-breaking space is real content (editor.isEmpty is false), so
+    // getMarkdown() must not silently discard it by returning "".
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, Markdown],
+      content: '<p>&nbsp;</p>',
+    })
+
+    expect(editor.isEmpty).toBe(false)
+    expect(editor.getMarkdown()).toBe(' ')
+  })
 })

--- a/packages/markdown/__tests__/empty-content.spec.ts
+++ b/packages/markdown/__tests__/empty-content.spec.ts
@@ -86,7 +86,7 @@ describe('empty markdown content', () => {
     expect(textNode.marks?.[0]?.type).toBe('bold')
   })
 
-  it('should keep content when the document holds only a real non-breaking space (#7495)', () => {
+  it('should keep content when the document holds only a real non-breaking space', () => {
     // A lone non-breaking space is real content (editor.isEmpty is false), so
     // getMarkdown() must not silently discard it by returning "".
     editor = new Editor({

--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -454,6 +454,39 @@ Final paragraph.`
       expect(markdown).toBe('')
     })
 
+    it('should return empty string when serializing two consecutive empty paragraphs', () => {
+      const emptyDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [],
+          },
+          {
+            type: 'paragraph',
+            content: [],
+          },
+        ],
+      }
+
+      const markdown = markdownManager.serialize(emptyDoc)
+      expect(markdown).toBe('')
+    })
+
+    it('should not throw when serialize() is called with a bare content array', () => {
+      // serialize() accepts a bare content array (not just a `doc` node); the
+      // structural-emptiness check must not throw on it and should render normally.
+      const bareContent = [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello world' }],
+        },
+      ]
+
+      expect(() => markdownManager.serialize(bareContent as any)).not.toThrow()
+      expect(markdownManager.serialize(bareContent as any)).toBe('Hello world')
+    })
+
     it('should preserve blank lines between paragraphs with content', () => {
       // Multiple paragraphs with content should preserve blank lines
       const doc = {

--- a/packages/markdown/__tests__/paragraph.spec.ts
+++ b/packages/markdown/__tests__/paragraph.spec.ts
@@ -139,7 +139,7 @@ describe('Paragraph Markdown Rendering', () => {
         ],
       }
 
-      // Updated for #7495 (see comment above): whole-document structural emptiness
+      // whole-document structural emptiness
       // now takes precedence over rendering a bare "1. " marker.
       const markdown = markdownManager.serialize(doc)
       expect(markdown).toBe('')

--- a/packages/markdown/__tests__/paragraph.spec.ts
+++ b/packages/markdown/__tests__/paragraph.spec.ts
@@ -115,8 +115,12 @@ describe('Paragraph Markdown Rendering', () => {
         ],
       }
 
+      // Updated for #7495: serialize() now checks structural emptiness (matching
+      // editor.isEmpty) on the whole document up front. A doc containing only a
+      // bullet list whose sole item is an empty paragraph has no real content
+      // anywhere, so it now serializes to "" instead of leaking a bare "- " marker.
       const markdown = markdownManager.serialize(doc)
-      expect(markdown).toBe('- ')
+      expect(markdown).toBe('')
     })
 
     it('should not emit &nbsp; for an empty paragraph inside an ordered list item', () => {
@@ -135,8 +139,10 @@ describe('Paragraph Markdown Rendering', () => {
         ],
       }
 
+      // Updated for #7495 (see comment above): whole-document structural emptiness
+      // now takes precedence over rendering a bare "1. " marker.
       const markdown = markdownManager.serialize(doc)
-      expect(markdown).toBe('1. ')
+      expect(markdown).toBe('')
     })
 
     it('should keep the first empty paragraph inside a blockquote empty', () => {
@@ -150,8 +156,10 @@ describe('Paragraph Markdown Rendering', () => {
         ],
       }
 
+      // Updated for #7495 (see comment above): whole-document structural emptiness
+      // now takes precedence over rendering a bare ">" marker.
       const markdown = markdownManager.serialize(doc)
-      expect(markdown).toBe('>')
+      expect(markdown).toBe('')
     })
 
     it('should preserve multiple empty paragraphs inside a blockquote with &nbsp; after the first', () => {

--- a/packages/markdown/__tests__/paragraph.spec.ts
+++ b/packages/markdown/__tests__/paragraph.spec.ts
@@ -156,7 +156,7 @@ describe('Paragraph Markdown Rendering', () => {
         ],
       }
 
-      // Updated for #7495 (see comment above): whole-document structural emptiness
+      // whole-document structural emptiness
       // now takes precedence over rendering a bare ">" marker.
       const markdown = markdownManager.serialize(doc)
       expect(markdown).toBe('')

--- a/packages/markdown/src/Extension.ts
+++ b/packages/markdown/src/Extension.ts
@@ -177,6 +177,8 @@ export const Markdown = Extension.create<MarkdownExtensionOptions, MarkdownExten
       marked: this.options.marked,
       markedOptions: this.options.markedOptions,
       extensions: this.editor.extensionManager.baseExtensions,
+      // Use the editor's actual schema so emptiness matches `editor.isEmpty`.
+      schema: this.editor.schema,
     })
 
     this.editor.markdown = this.storage.manager

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -18,6 +18,7 @@ import {
   generateJSON,
   getExtensionField,
   getSchema,
+  isNodeEmpty,
   marksEqual,
   sortExtensions,
 } from '@tiptap/core'
@@ -59,6 +60,8 @@ export class MarkdownManager {
   private codeTypes: Set<string> = new Set()
   /** Lazy cache of tag names declared by the registered schema's parseDOM rules. */
   private schemaParseDomTagsCache: Set<string> | null = null
+  /** Lazy cache of the built schema (extensions don't change after registration). */
+  private schemaCache: ReturnType<typeof getSchema> | null = null
 
   /**
    * Create a MarkdownManager.
@@ -66,17 +69,20 @@ export class MarkdownManager {
    * @param options.markedOptions Optional options to pass to marked.setOptions
    * @param options.indentation Indentation settings (style and size).
    * @param options.extensions An array of Tiptap extensions to register for markdown parsing and rendering.
+   * @param options.schema The editor's schema, so emptiness checks match `editor.isEmpty`. Falls back to one built from `extensions`.
    */
   constructor(options?: {
     marked?: typeof marked
     markedOptions?: Parameters<typeof marked.setOptions>[0]
     indentation?: { style?: 'space' | 'tab'; size?: number }
     extensions: AnyExtension[]
+    schema?: ReturnType<typeof getSchema>
   }) {
     this.markedInstance = options?.marked ?? marked
     this.indentStyle = options?.indentation?.style ?? 'space'
     this.indentSize = options?.indentation?.size ?? 2
     this.baseExtensions = options?.extensions || []
+    this.schemaCache = options?.schema ?? null
 
     if (options?.markedOptions && typeof this.markedInstance.setOptions === 'function') {
       this.markedInstance.setOptions(options.markedOptions)
@@ -305,27 +311,33 @@ export class MarkdownManager {
       return ''
     }
 
-    const result = this.renderNodes(docOrContent, docOrContent)
-    // Return empty string if result is only whitespace entities or non-breaking spaces
-    return this.isEmptyOutput(result) ? '' : result
+    if (this.isStructurallyEmpty(docOrContent)) {
+      return ''
+    }
+
+    return this.renderNodes(docOrContent, docOrContent)
   }
 
   /**
-   * Check if the markdown output represents an empty document.
-   * Empty documents may contain only &nbsp; entities or non-breaking space characters
-   * which are used by the Paragraph extension to preserve blank lines.
+   * Check emptiness structurally (before rendering), using the same rules as
+   * `editor.isEmpty`. This avoids the previous string-based heuristic, which
+   * treated a real non-breaking space as empty output and discarded it.
    */
-  private isEmptyOutput(markdown: string): boolean {
-    if (!markdown || markdown.trim() === '') {
-      return true
+  private isStructurallyEmpty(docOrContent: JSONContent): boolean {
+    try {
+      return isNodeEmpty(this.getCachedSchema().nodeFromJSON(docOrContent))
+    } catch {
+      return false
+    }
+  }
+
+  /** Build and cache the schema for the registered extensions. */
+  private getCachedSchema(): ReturnType<typeof getSchema> {
+    if (!this.schemaCache) {
+      this.schemaCache = getSchema(this.baseExtensions)
     }
 
-    // Check if the output is only &nbsp; entities or non-breaking space characters
-    const cleanedOutput = markdown
-      .replace(/&nbsp;/g, '')
-      .replace(/\u00A0/g, '')
-      .trim()
-    return cleanedOutput === ''
+    return this.schemaCache
   }
 
   /**
@@ -1028,7 +1040,7 @@ export class MarkdownManager {
     const tags = new Set<string>()
 
     try {
-      const schema = getSchema(this.baseExtensions)
+      const schema = this.getCachedSchema()
 
       const collect = (spec: any) => {
         const parseDOM = spec?.parseDOM


### PR DESCRIPTION
## Fixes

Refs #7495

## Changes and Review

The literal report in #7495 (empty editor returning `&nbsp;`) was already fixed in #7497, but that fix used a string heuristic (`isEmptyOutput`) that stripped all `&nbsp;`/non-breaking-space characters from the rendered output. That caused silent data loss: a document whose only content is a real non-breaking space (`editor.isEmpty === false`) serialized to `""`.

- `MarkdownManager.serialize()` now decides emptiness structurally, before rendering, using `isNodeEmpty` (the same check behind `editor.isEmpty`), and returns the rendered output for anything non-empty. The string heuristic is removed.
- The manager is given the editor's actual `schema`, so the emptiness check matches `editor.isEmpty` exactly (no separately-rebuilt schema), and the shared cache also removes a per-call schema rebuild.
- Contract is now: `getMarkdown()` returns `""` if and only if `editor.isEmpty` is true.
- A bare content array passed to `serialize()` still renders normally (structural check falls through on non-doc input).

Behavior change worth a look: a document whose only content is an empty list item or empty blockquote now serializes to `""`, because `editor.isEmpty` is already `true` for those. Populated lists/blockquotes are unchanged. Three `paragraph.spec.ts` assertions were updated to reflect this.

AI usage disclosure: prepared with AI assistance (Claude Code) and independently reviewed with Codex; the author has reviewed and verified it.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
