### PR TITLE
fix(react): update useEditorState when editable changes (#7498)

### DIFF
--- a/.changeset/fix-useeditorstate-editable-quiet-amber-fox.md
+++ b/.changeset/fix-useeditorstate-editable-quiet-amber-fox.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Fixed `useEditorState` not re-rendering components when `editor.setEditable()` changes the editor's editable state, since that call only emits an `update` event and never a `transaction`.

--- a/packages/react/src/useEditorState.spec.ts
+++ b/packages/react/src/useEditorState.spec.ts
@@ -1,0 +1,121 @@
+import { act, render } from '@testing-library/react'
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { TextSelection } from '@tiptap/pm/state'
+import React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useEditorState } from './useEditorState.js'
+
+const createTestEditor = () => {
+  return new Editor({
+    extensions: [Document, Paragraph, Text],
+    content: '<p>Hello</p>',
+  })
+}
+
+const EditableIndicator = ({ editor }: { editor: Editor }) => {
+  const isEditable = useEditorState({
+    editor,
+    selector: ctx => ctx.editor.isEditable,
+  })
+
+  return React.createElement('div', { 'data-testid': 'editable-state' }, String(isEditable))
+}
+
+const ContentIndicator = ({ editor }: { editor: Editor }) => {
+  const text = useEditorState({
+    editor,
+    selector: ctx => ctx.editor.getText(),
+  })
+
+  return React.createElement('div', { 'data-testid': 'content-state' }, text)
+}
+
+const TransactionCountIndicator = ({ editor }: { editor: Editor }) => {
+  const transactionNumber = useEditorState({
+    editor,
+    selector: ctx => ctx.transactionNumber,
+  })
+
+  return React.createElement('div', { 'data-testid': 'tx-number' }, String(transactionNumber))
+}
+
+describe('useEditorState', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('re-renders when editor.setEditable() toggles the editable state', () => {
+    const editor = createTestEditor()
+    const { getByTestId } = render(React.createElement(EditableIndicator, { editor }))
+
+    expect(getByTestId('editable-state').textContent).toBe('true')
+
+    act(() => {
+      editor.setEditable(false)
+    })
+
+    expect(getByTestId('editable-state').textContent).toBe('false')
+
+    act(() => {
+      editor.setEditable(true)
+    })
+
+    expect(getByTestId('editable-state').textContent).toBe('true')
+
+    editor.destroy()
+  })
+
+  it('still re-renders on a normal content-changing transaction (regression)', () => {
+    const editor = createTestEditor()
+    const { getByTestId } = render(React.createElement(ContentIndicator, { editor }))
+
+    expect(getByTestId('content-state').textContent).toBe('Hello')
+
+    act(() => {
+      editor.commands.setContent('<p>World</p>')
+    })
+
+    expect(getByTestId('content-state').textContent).toBe('World')
+
+    editor.destroy()
+  })
+
+  it('notifies once per document change (transaction + update are deduped)', () => {
+    const editor = createTestEditor()
+    const { getByTestId } = render(React.createElement(TransactionCountIndicator, { editor }))
+
+    const before = Number(getByTestId('tx-number').textContent)
+
+    act(() => {
+      // A single doc-changing transaction emits both `transaction` and `update`.
+      editor.view.dispatch(editor.state.tr.insertText('!'))
+    })
+
+    const after = Number(getByTestId('tx-number').textContent)
+
+    expect(after - before).toBe(1)
+
+    editor.destroy()
+  })
+
+  it('still notifies on selection-only transactions (which emit no update event)', () => {
+    const editor = createTestEditor()
+    const { getByTestId } = render(React.createElement(TransactionCountIndicator, { editor }))
+
+    const before = Number(getByTestId('tx-number').textContent)
+
+    act(() => {
+      editor.view.dispatch(editor.state.tr.setSelection(TextSelection.atStart(editor.state.doc)))
+    })
+
+    const after = Number(getByTestId('tx-number').textContent)
+
+    expect(after - before).toBe(1)
+
+    editor.destroy()
+  })
+})

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -95,9 +95,7 @@ class EditorStateManager<TEditor extends Editor | null = Editor | null> {
        * This is to support things like `editor.can().toggleBold()` in components that `useEditor`.
        * This could be more efficient, but it's a good trade-off for now.
        */
-      // A document change emits both `transaction` and `update` carrying the same
-      // transaction; dedupe by identity so consumers are notified once. `setEditable()`
-      // emits only `update` (with a distinct transaction), so it still gets through.
+      // Changes can emit both events, so notify only once
       let lastTransaction: unknown
       const fn = (props?: { transaction?: unknown }) => {
         if (props?.transaction !== undefined && props.transaction === lastTransaction) {

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -95,7 +95,16 @@ class EditorStateManager<TEditor extends Editor | null = Editor | null> {
        * This is to support things like `editor.can().toggleBold()` in components that `useEditor`.
        * This could be more efficient, but it's a good trade-off for now.
        */
-      const fn = () => {
+      // A document change emits both `transaction` and `update` carrying the same
+      // transaction; dedupe by identity so consumers are notified once. `setEditable()`
+      // emits only `update` (with a distinct transaction), so it still gets through.
+      let lastTransaction: unknown
+      const fn = (props?: { transaction?: unknown }) => {
+        if (props?.transaction !== undefined && props.transaction === lastTransaction) {
+          return
+        }
+        lastTransaction = props?.transaction
+
         this.transactionNumber += 1
         this.subscribers.forEach(callback => callback())
       }
@@ -103,8 +112,10 @@ class EditorStateManager<TEditor extends Editor | null = Editor | null> {
       const currentEditor = this.editor
 
       currentEditor.on('transaction', fn)
+      currentEditor.on('update', fn)
       return () => {
         currentEditor.off('transaction', fn)
+        currentEditor.off('update', fn)
       }
     }
 


### PR DESCRIPTION
## Fixes

Fixes #7498

## Changes and Review

`useEditorState` did not re-run its selector when the editor's editable state changed via `editor.setEditable(...)`, so `ctx.editor.isEditable` (and anything else affected by editability) stayed stale in React.

Root cause: `setEditable()` emits only the `update` event (it doesn't dispatch a transaction), but `useEditorState`'s internal subscription listened only to `transaction`.

- `useEditorState` now also subscribes to `update`, so editable changes propagate.
- A document-changing transaction emits both `transaction` and `update` with the same transaction object, so notifications are deduped by transaction identity to keep exactly one update per change (verified by a test that fails with a double count). `setEditable`'s `update` carries a distinct transaction and still gets through; selection-only transactions are unaffected.
- Scope is `@tiptap/react` only (patch).

AI usage disclosure: prepared with AI assistance (Claude Code) and independently reviewed with Codex; the author has reviewed and verified it.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
