### PR TITLE
fix(extension-code-block): exit on ArrowUp when no node exists before

### DIFF
--- a/.changeset/fix-code-block-arrow-up-exit.md
+++ b/.changeset/fix-code-block-arrow-up-exit.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-code-block': patch
+---
+
+Fixed a bug where pressing `ArrowUp` in a code block that is the first node in the document did nothing, leaving no way to insert content above it. A new default block is now inserted above the code block, mirroring the existing `ArrowDown` behavior. The behavior can be disabled via the new `exitOnArrowUp` option.

--- a/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
+++ b/packages/extension-code-block-lowlight/src/code-block-lowlight.ts
@@ -22,6 +22,7 @@ export const CodeBlockLowlight = CodeBlock.extend<CodeBlockLowlightOptions>({
       languageClassPrefix: 'language-',
       exitOnTripleEnter: true,
       exitOnArrowDown: true,
+      exitOnArrowUp: true,
       defaultLanguage: null,
       enableTabIndentation: false,
       tabSize: 4,

--- a/packages/extension-code-block/__tests__/code-block.spec.ts
+++ b/packages/extension-code-block/__tests__/code-block.spec.ts
@@ -1,0 +1,93 @@
+import { Editor } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { CodeBlock } from '../src/code-block.js'
+
+const pressArrowUp = (editor: Editor) => {
+  editor.view.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', code: 'ArrowUp' }))
+}
+
+describe('CodeBlock ArrowUp exit', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('inserts a paragraph above when the code block is the only node', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, CodeBlock],
+      content: '<pre><code>hello</code></pre>',
+    })
+    editor.commands.setTextSelection(1)
+
+    pressArrowUp(editor)
+
+    expect(editor.getHTML()).toBe('<p></p><pre><code>hello</code></pre>')
+    expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+  })
+
+  it('inserts a paragraph above when the code block is the first node in the doc', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, CodeBlock],
+      content: '<pre><code>hello</code></pre><p>after</p>',
+    })
+    editor.commands.setTextSelection(1)
+
+    pressArrowUp(editor)
+
+    expect(editor.getHTML()).toBe('<p></p><pre><code>hello</code></pre><p>after</p>')
+    expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+  })
+
+  it('does nothing when exitOnArrowUp is disabled', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, CodeBlock.configure({ exitOnArrowUp: false })],
+      content: '<pre><code>hello</code></pre>',
+    })
+    editor.commands.setTextSelection(1)
+    const before = editor.getHTML()
+
+    pressArrowUp(editor)
+
+    expect(editor.getHTML()).toBe(before)
+  })
+
+  it('does nothing when a node precedes the code block', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, CodeBlock],
+      content: '<p>before</p><pre><code>hello</code></pre>',
+    })
+
+    let codeBlockContentStart = 0
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'codeBlock') {
+        codeBlockContentStart = pos + 1
+        return false
+      }
+      return true
+    })
+    editor.commands.setTextSelection(codeBlockContentStart)
+    const before = editor.getHTML()
+
+    pressArrowUp(editor)
+
+    expect(editor.getHTML()).toBe(before)
+  })
+
+  it('does nothing when the caret is not at the start of the code block', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, CodeBlock],
+      content: '<pre><code>hello</code></pre>',
+    })
+    editor.commands.setTextSelection(3)
+    const before = editor.getHTML()
+
+    pressArrowUp(editor)
+
+    expect(editor.getHTML()).toBe(before)
+  })
+})

--- a/packages/extension-code-block/__tests__/code-block.spec.ts
+++ b/packages/extension-code-block/__tests__/code-block.spec.ts
@@ -28,6 +28,8 @@ describe('CodeBlock ArrowUp exit', () => {
 
     expect(editor.getHTML()).toBe('<p></p><pre><code>hello</code></pre>')
     expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+    expect(editor.state.selection.from).toBe(1)
+    expect(editor.state.selection.to).toBe(1)
   })
 
   it('inserts a paragraph above when the code block is the first node in the doc', () => {
@@ -41,6 +43,8 @@ describe('CodeBlock ArrowUp exit', () => {
 
     expect(editor.getHTML()).toBe('<p></p><pre><code>hello</code></pre><p>after</p>')
     expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+    expect(editor.state.selection.from).toBe(1)
+    expect(editor.state.selection.to).toBe(1)
   })
 
   it('does nothing when exitOnArrowUp is disabled', () => {

--- a/packages/extension-code-block/src/code-block.ts
+++ b/packages/extension-code-block/src/code-block.ts
@@ -20,6 +20,11 @@ export interface CodeBlockOptions {
    */
   exitOnArrowDown: boolean | null | undefined
   /**
+   * Define whether the node should be exited on arrow up if there is no node before it.
+   * @default true
+   */
+  exitOnArrowUp: boolean | null | undefined
+  /**
    * The default language.
    * @default null
    * @example 'js'
@@ -84,6 +89,7 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
       languageClassPrefix: 'language-',
       exitOnTripleEnter: true,
       exitOnArrowDown: true,
+      exitOnArrowUp: true,
       defaultLanguage: null,
       enableTabIndentation: false,
       tabSize: DEFAULT_TAB_SIZE,
@@ -360,6 +366,33 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
           })
           .exitCode()
           .run()
+      },
+
+      // exit node on arrow up if there is no node before it
+      ArrowUp: ({ editor }) => {
+        if (!this.options.exitOnArrowUp) {
+          return false
+        }
+
+        const { state } = editor
+        const { selection } = state
+        const { $from, empty } = selection
+
+        if (!empty || $from.parent.type !== this.type) {
+          return false
+        }
+
+        if ($from.parentOffset !== 0) {
+          return false
+        }
+
+        const before = $from.before()
+
+        if (before > 0) {
+          return false
+        }
+
+        return editor.commands.insertDefaultBlock({ pos: before })
       },
 
       // exit node on arrow down


### PR DESCRIPTION
## Summary

Fixes #5472.

When a code block is the **first (or only) node** in the document, pressing <kbd>ArrowUp</kbd> did nothing, leaving no way to insert content above it. Users had to delete the code block, write the content, then recreate it.

This PR adds an `ArrowUp` keyboard handler that mirrors the existing `ArrowDown` exit behavior: when the caret is at the very start of a code block and there is no node before it, a default block is inserted above the code block and the caret is moved into it.

## Behavior

- Cursor at start of a code block that is the first node in the doc → new default block inserted above, caret moves into it. ✅ (previously did nothing)
- Cursor at start of a code block with any node before it → default browser cursor navigation (unchanged).
- Cursor mid-line or on a later line inside the code block → default cursor navigation (unchanged).

## Implementation notes

- Adds an `exitOnArrowUp` option to `CodeBlockOptions` (default `true`), symmetric with the existing `exitOnArrowDown`.
- Reuses the existing `insertDefaultBlock` core command instead of reimplementing the "find default block type at position" logic.
- `CodeBlockLowlight`'s `addOptions()` fully re-declares the option object, so it gets the new key too.

## Test plan

- [x] `pnpm -w -F @tiptap/extension-code-block build` and `pnpm -w -F @tiptap/extension-code-block-lowlight build` pass.
- [x] `oxlint` and `oxfmt --check` on the changed files pass.
- [x] Manually verified against the `demos/src/Nodes/CodeBlock/React` and `Vue` demos:
  - Empty doc → toggle code block → ArrowUp → paragraph inserted above, cursor lands in it.
  - Paragraph typed → ArrowDown returns into the code block.
  - Multi-line code block, cursor on line 2 → ArrowUp still moves to line 1 within the block.
- [x] Changeset added (`@tiptap/extension-code-block` patch).