### PR TITLE
fix(drag-handle-react): keep callbacks in a ref to avoid re-registering the plugin

### DIFF
--- a/.changeset/hip-falcons-happen.md
+++ b/.changeset/hip-falcons-happen.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-drag-handle-react": patch
+---
+
+Fixed the React `DragHandle` breaking drag-and-drop when `onNodeChange` is an inline callback, by no longer re-registering its plugin when a callback's identity changes.

--- a/packages/extension-drag-handle-react/src/DragHandle.registration.spec.ts
+++ b/packages/extension-drag-handle-react/src/DragHandle.registration.spec.ts
@@ -1,0 +1,91 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { useEditorState } from '@tiptap/react'
+import { act, render } from '@testing-library/react'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DragHandle } from './DragHandle.js'
+
+function createRealEditor() {
+  const element = document.createElement('div')
+  document.body.appendChild(element)
+
+  return new Editor({
+    element,
+    extensions: [Document, Paragraph, Text],
+    content: '<p>hello world</p>',
+  })
+}
+
+describe('DragHandle plugin registration stability', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+    document.body.innerHTML = ''
+  })
+
+  // Re-registering mid-drag tears the handle out of the DOM and breaks dragging.
+  it('does not re-register the plugin on transactions when onNodeChange is an unstable inline callback', () => {
+    editor = createRealEditor()
+    const register = vi.spyOn(editor, 'registerPlugin')
+    const unregister = vi.spyOn(editor, 'unregisterPlugin')
+
+    function Parent({ editor: ed }: { editor: Editor }) {
+      // Re-render on every transaction, like real apps using useEditor/useEditorState.
+      useEditorState({ editor: ed, selector: s => s.transactionNumber })
+      return React.createElement(DragHandle, {
+        editor: ed,
+        // A fresh arrow function on every render (the reporter's code).
+        onNodeChange: () => {},
+        children: React.createElement('span', null, 'handle'),
+      } as never)
+    }
+
+    act(() => {
+      render(React.createElement(Parent, { editor }))
+    })
+
+    const registersAfterMount = register.mock.calls.length
+    expect(registersAfterMount).toBe(1)
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        editor.view.dispatch(editor.state.tr.insertText('x', 1))
+      })
+    }
+
+    expect(register.mock.calls.length).toBe(1)
+    expect(unregister.mock.calls.length).toBe(0)
+  })
+
+  // The ref must still forward to the latest callback.
+  it('still invokes onNodeChange through the stable wrapper', () => {
+    editor = createRealEditor()
+    const seen: Array<{ node: unknown; pos: number }> = []
+
+    function Parent({ editor: ed }: { editor: Editor }) {
+      useEditorState({ editor: ed, selector: s => s.transactionNumber })
+      return React.createElement(DragHandle, {
+        editor: ed,
+        onNodeChange: (data: { node: unknown; pos: number }) => seen.push(data),
+        children: React.createElement('span', null, 'handle'),
+      } as never)
+    }
+
+    act(() => {
+      render(React.createElement(Parent, { editor }))
+    })
+
+    // `hideDragHandle` meta triggers onNodeChange(null, -1) in the plugin.
+    act(() => {
+      editor.view.dispatch(editor.state.tr.setMeta('hideDragHandle', true))
+    })
+
+    expect(seen.length).toBeGreaterThan(0)
+    expect(seen.at(-1)).toMatchObject({ node: null, pos: -1 })
+  })
+})

--- a/packages/extension-drag-handle-react/src/DragHandle.registration.spec.ts
+++ b/packages/extension-drag-handle-react/src/DragHandle.registration.spec.ts
@@ -62,30 +62,35 @@ describe('DragHandle plugin registration stability', () => {
     expect(unregister.mock.calls.length).toBe(0)
   })
 
-  // The ref must still forward to the latest callback.
-  it('still invokes onNodeChange through the stable wrapper', () => {
+  // The ref must forward to the newest callback, not the one from the first render.
+  it('invokes the most recent onNodeChange after a re-render', () => {
     editor = createRealEditor()
-    const seen: Array<{ node: unknown; pos: number }> = []
+    const calls: Array<{ tag: string; pos: number }> = []
+    let bumpTag: (() => void) | undefined
 
-    function Parent({ editor: ed }: { editor: Editor }) {
-      useEditorState({ editor: ed, selector: s => s.transactionNumber })
+    function Parent() {
+      const [tag, setTag] = React.useState('first')
+      bumpTag = () => setTag('latest')
       return React.createElement(DragHandle, {
-        editor: ed,
-        onNodeChange: (data: { node: unknown; pos: number }) => seen.push(data),
+        editor,
+        onNodeChange: (data: { pos: number }) => calls.push({ tag, pos: data.pos }),
         children: React.createElement('span', null, 'handle'),
       } as never)
     }
 
     act(() => {
-      render(React.createElement(Parent, { editor }))
+      render(React.createElement(Parent))
     })
 
+    // Re-render with a new callback identity, then fire the hide event.
+    act(() => {
+      bumpTag?.()
+    })
     // `hideDragHandle` meta triggers onNodeChange(null, -1) in the plugin.
     act(() => {
       editor.view.dispatch(editor.state.tr.setMeta('hideDragHandle', true))
     })
 
-    expect(seen.length).toBeGreaterThan(0)
-    expect(seen.at(-1)).toMatchObject({ node: null, pos: -1 })
+    expect(calls.at(-1)).toEqual({ tag: 'latest', pos: -1 })
   })
 })

--- a/packages/extension-drag-handle-react/src/DragHandle.tsx
+++ b/packages/extension-drag-handle-react/src/DragHandle.tsx
@@ -84,6 +84,16 @@ export const DragHandle = (props: DragHandleProps) => {
     elementRef.current = document.createElement('div')
   }
 
+  // Keep callbacks in a ref so an unstable identity can't re-register the plugin.
+  const callbacks = {
+    onNodeChange,
+    onElementDragStart,
+    onElementDragEnd,
+    getReferencedVirtualElement,
+  }
+  const callbacksRef = useRef(callbacks)
+  callbacksRef.current = callbacks
+
   // oxlint-disable-next-line react-hooks/exhaustive-deps
   const nestedOptions = useMemo(() => normalizeNestedOptions(nested), [JSON.stringify(nested)])
 
@@ -122,10 +132,11 @@ export const DragHandle = (props: DragHandleProps) => {
         ...defaultComputePositionConfig,
         ...computePositionConfig,
       },
-      onElementDragStart,
-      onElementDragEnd,
-      onNodeChange,
-      getReferencedVirtualElement,
+      onElementDragStart: event => callbacksRef.current.onElementDragStart?.(event),
+      onElementDragEnd: event => callbacksRef.current.onElementDragEnd?.(event),
+      onNodeChange: data => callbacksRef.current.onNodeChange?.(data),
+      getReferencedVirtualElement: () =>
+        callbacksRef.current.getReferencedVirtualElement?.() ?? null,
       nestedOptions,
     })
 
@@ -137,16 +148,7 @@ export const DragHandle = (props: DragHandleProps) => {
       }
       unbind()
     }
-  }, [
-    editor,
-    onNodeChange,
-    getReferencedVirtualElement,
-    pluginKey,
-    computePositionConfig,
-    onElementDragStart,
-    onElementDragEnd,
-    nestedOptions,
-  ])
+  }, [editor, pluginKey, computePositionConfig, nestedOptions])
 
   const element = elementRef.current
   if (!element) {


### PR DESCRIPTION
## Fixes

Closes #6432

## Changes and Review

An inline `onNodeChange` changes identity on every render, so `DragHandle` re-registered its plugin on every transaction — mid-drag that broke dragging and could throw "Maximum update depth exceeded". Callbacks now live in a ref (same pattern as `BubbleMenu`/`FloatingMenu`), so the registration effect no longer depends on their identity. Verify via the added regression test, or pass an inline `onNodeChange` and drag a block.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
