### PR TITLE
fix(extension-find-and-replace): current result highlighting in find and replace

### DIFF
--- a/.changeset/thirty-frogs-repeat.md
+++ b/.changeset/thirty-frogs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/extension-find-and-replace": patch
+---
+
+Ensure only the active find-and-replace result keeps the current-result highlight while navigating matches.

--- a/packages/extension-find-and-replace/__tests__/find-and-replace.spec.ts
+++ b/packages/extension-find-and-replace/__tests__/find-and-replace.spec.ts
@@ -288,19 +288,31 @@ describe('FindAndReplace', () => {
     editor = createEditor('<p>one two one two one</p>')
     editor.commands.setSearchTerm('one')
 
+    const currentResultPositions = () => {
+      return Array.from(editor.view.dom.querySelectorAll('.find-and-replace-result-current')).map(
+        element => editor.view.posAtDOM(element, 0),
+      )
+    }
+
     expect(editor.storage.findAndReplace.currentIndex).toBe(0)
+    expect(currentResultPositions()).toEqual([1])
 
     editor.commands.goToNextResult()
     expect(editor.storage.findAndReplace.currentIndex).toBe(1)
     expect(editor.state.selection.from).toBe(9)
     expect(editor.state.selection.to).toBe(12)
+    expect(currentResultPositions()).toEqual([9])
 
     editor.commands.goToNextResult()
+    expect(currentResultPositions()).toEqual([17])
+
     editor.commands.goToNextResult()
     expect(editor.storage.findAndReplace.currentIndex).toBe(0)
+    expect(currentResultPositions()).toEqual([1])
 
     editor.commands.goToPreviousResult()
     expect(editor.storage.findAndReplace.currentIndex).toBe(2)
+    expect(currentResultPositions()).toEqual([17])
   })
 
   it('replaces the current result and jumps to the next one', () => {

--- a/packages/extension-find-and-replace/src/utils/findDecorations.ts
+++ b/packages/extension-find-and-replace/src/utils/findDecorations.ts
@@ -17,7 +17,8 @@ export function findDecorations(
 
   results.forEach(result => {
     decorations
-      .find(result.from, result.to, decoration => {
+      .find(result.from, result.to)
+      .filter(decoration => {
         return decoration.from === result.from && decoration.to === result.to
       })
       .forEach(decoration => found.add(decoration))


### PR DESCRIPTION
## Fixes

<!-- Use GitHub keywords to link the issue or issues fixed by this PR, for example: Fixes #123 or Closes #456. -->
Found during manual testing

## Changes and Review

<!-- Explain what changed, why it changed, and how reviewers can verify it. -->
<!-- Keep this section short: use 2–4 short sentences or a few bullets. Do not write a technical deep dive, a full implementation explanation, or a large wall of text. -->

Fix find-and-replace navigation so only the active result retains the current-result highlight. Add regression coverage for Next, Previous, and wrap-around navigation. Reviewers can search for multiple matches and verify that only one match uses `find-and-replace-result-current` while navigating.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

## Issue proof

<img width="747" height="450" alt="Screenshot 2026-07-28 at 14 46 05" src="https://github.com/user-attachments/assets/db0e45cc-afc5-446a-bd8b-6b5546a0116e" />
