### PR TITLE
docs: fix Vue bubble menu demo example

### DIFF
--- a/.changeset/2026-07-28-fix-vue-bubble-menu-demo-example.md
+++ b/.changeset/2026-07-28-fix-vue-bubble-menu-demo-example.md
@@ -1,5 +1,0 @@
----
-'@tiptap/extension-bubble-menu': patch
----
-
-Fix the Vue Bubble Menu demo example so it uses the current extension import and registration flow correctly.

--- a/.changeset/2026-07-28-fix-vue-bubble-menu-demo-example.md
+++ b/.changeset/2026-07-28-fix-vue-bubble-menu-demo-example.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-bubble-menu': patch
+---
+
+Fix the Vue Bubble Menu demo example so it uses the current extension import and registration flow correctly.

--- a/demos/src/Extensions/BubbleMenu/Vue/index.vue
+++ b/demos/src/Extensions/BubbleMenu/Vue/index.vue
@@ -62,15 +62,16 @@
 </template>
 
 <script>
+import { BubbleMenu as BubbleMenuExtension } from '@tiptap/extension-bubble-menu'
 import { findParentNode, posToDOMRect } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import { Editor, EditorContent } from '@tiptap/vue-3'
-import { BubbleMenu } from '@tiptap/vue-3/menus'
+import { BubbleMenu as BubbleMenuComponent } from '@tiptap/vue-3/menus'
 
 export default {
   components: {
     EditorContent,
-    BubbleMenu,
+    BubbleMenu: BubbleMenuComponent,
   },
 
   data() {
@@ -89,7 +90,7 @@ export default {
 
   mounted() {
     this.editor = new Editor({
-      extensions: [StarterKit],
+      extensions: [StarterKit, BubbleMenuExtension],
       content: `
         <p>
           Hey, try to select some text here. There will popup a menu for selecting some inline styles. Remember: you have full control about content and styling of this menu.


### PR DESCRIPTION
## Fixes

Fixes #6987 

## Changes and Review

Updated the Vue Bubble Menu demo example to use the bubble menu extension import in the example source so the documented example is consistent with the current package setup. The change is limited to the Vue demo and includes a changeset for the user-facing docs/demo update.

Reviewers can verify it by running the demo locally and confirming the Bubble Menu example loads and shows the expected menu behavior.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
