### PR TITLE
fix(react): capture and restore DOM selection when moving contentDOM in ReactNodeViews

### DIFF
--- a/.changeset/fix-react-nodeview-caret-content-dom-move.md
+++ b/.changeset/fix-react-nodeview-caret-content-dom-move.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Fixed the caret jumping back to the previous block when pressing Enter inside a React node view.

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -11,6 +11,7 @@ import type { Decoration, DecorationSource, NodeView as ProseMirrorNodeView } fr
 import type { ComponentType, NamedExoticComponent } from 'react'
 import { createElement, createRef, memo } from 'react'
 
+import { captureDOMSelection } from './captureDOMSelection.js'
 import type { EditorWithContentComponent } from './Editor.js'
 import { ReactRenderer } from './ReactRenderer.js'
 import type { ReactNodeViewProps } from './types.js'
@@ -193,7 +194,13 @@ export class ReactNodeView<
         if (element.hasAttribute('data-node-view-wrapper')) {
           element.removeAttribute('data-node-view-wrapper')
         }
+
+        // The caret can already be inside here. Moving would lose it.
+        const restoreSelection = captureDOMSelection(this.contentDOMElement)
+
         element.appendChild(this.contentDOMElement)
+
+        restoreSelection?.()
       }
     }
     const context = { onDragStart, nodeViewContentRef }

--- a/packages/react/src/captureDOMSelection.spec.ts
+++ b/packages/react/src/captureDOMSelection.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { captureDOMSelection } from './captureDOMSelection.js'
+
+const createContent = () => {
+  const oldParent = document.createElement('div')
+  const newParent = document.createElement('div')
+  const content = document.createElement('div')
+  const text = document.createTextNode('Alpha')
+
+  content.appendChild(text)
+  oldParent.appendChild(content)
+  document.body.append(oldParent, newParent)
+
+  return { content, newParent, text }
+}
+
+const selectInside = (node: Node, offset: number) => {
+  const selection = document.getSelection()!
+
+  selection.removeAllRanges()
+
+  const range = document.createRange()
+
+  range.setStart(node, offset)
+  range.collapse(true)
+  selection.addRange(range)
+}
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges()
+  document.body.innerHTML = ''
+})
+
+describe('captureDOMSelection', () => {
+  it('restores a selection that lives inside the element', () => {
+    const { content, newParent, text } = createContent()
+
+    selectInside(text, 3)
+
+    const restore = captureDOMSelection(content)
+
+    newParent.appendChild(content)
+
+    // jsdom keeps the selection on a move, browsers drop it. Fake that here.
+    document.getSelection()?.removeAllRanges()
+
+    restore?.()
+
+    const selection = document.getSelection()!
+
+    expect(restore).toBeTypeOf('function')
+    expect(selection.anchorNode).toBe(text)
+    expect(selection.anchorOffset).toBe(3)
+  })
+
+  it('returns null when there is no selection', () => {
+    const { content } = createContent()
+
+    document.getSelection()?.removeAllRanges()
+
+    expect(captureDOMSelection(content)).toBeNull()
+  })
+
+  it('returns null when the selection is outside of the element', () => {
+    const { content } = createContent()
+    const outside = document.createElement('div')
+
+    outside.appendChild(document.createTextNode('Beta'))
+    document.body.appendChild(outside)
+
+    selectInside(outside.firstChild!, 2)
+
+    expect(captureDOMSelection(content)).toBeNull()
+  })
+})

--- a/packages/react/src/captureDOMSelection.ts
+++ b/packages/react/src/captureDOMSelection.ts
@@ -1,0 +1,35 @@
+type SelectionRoot = Node & { getSelection?: () => Selection | null }
+
+/**
+ * Saves the DOM selection inside `element`, returns a function to put it back.
+ * Browsers drop the selection when an element moves, so restore it after the move.
+ */
+export function captureDOMSelection(element: HTMLElement): (() => void) | null {
+  const root = element.getRootNode() as SelectionRoot
+  const selection =
+    typeof root.getSelection === 'function'
+      ? root.getSelection()
+      : element.ownerDocument?.defaultView?.getSelection()
+
+  if (!selection || selection.rangeCount === 0) {
+    return null
+  }
+
+  const { anchorNode, anchorOffset, focusNode, focusOffset } = selection
+
+  if (!anchorNode || !focusNode) {
+    return null
+  }
+
+  if (!element.contains(anchorNode) || !element.contains(focusNode)) {
+    return null
+  }
+
+  return () => {
+    try {
+      selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
+    } catch {
+      // The saved nodes can be gone by now.
+    }
+  }
+}


### PR DESCRIPTION
## Fixes

Fixes #8117 

## Changes and Review

This PR is a follow up to #8117. In some occasions carets would end up at invalid positions after splitting React node views, so we restore the DOM selection outselve.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
