### PR TITLE
fix(static-renderer): close audio and video tags instead of self-closing

### DIFF
--- a/.changeset/2026-07-29-static-renderer-audio-video.md
+++ b/.changeset/2026-07-29-static-renderer-audio-video.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/static-renderer': patch
+---
+
+Render `audio` and `video` elements with a closing tag instead of as self-closing, so browsers no longer nest following content inside them.

--- a/packages/static-renderer/__tests__/pm-self-closing-tags.spec.ts
+++ b/packages/static-renderer/__tests__/pm-self-closing-tags.spec.ts
@@ -55,4 +55,22 @@ describe('static renderer: non-void elements get a closing tag', () => {
 
     expect(html).toBe('<video src="https://example.com/v.mp4"></video>')
   })
+
+  it('keeps multiple audio players as siblings instead of nesting them', () => {
+    const html = renderToHTMLString({
+      content: {
+        type: 'doc',
+        content: [
+          { type: 'audio', attrs: { src: 'https://example.com/a.mp3' } },
+          { type: 'paragraph', content: [{ type: 'text', text: 'between' }] },
+          { type: 'audio', attrs: { src: 'https://example.com/b.mp3' } },
+        ],
+      },
+      extensions,
+    })
+
+    expect(html).toBe(
+      '<audio src="https://example.com/a.mp3"></audio><p>between</p><audio src="https://example.com/b.mp3"></audio>',
+    )
+  })
 })

--- a/packages/static-renderer/__tests__/pm-self-closing-tags.spec.ts
+++ b/packages/static-renderer/__tests__/pm-self-closing-tags.spec.ts
@@ -1,0 +1,58 @@
+import { Node } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
+import { describe, expect, it } from 'vitest'
+
+const Audio = Node.create({
+  name: 'audio',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return { src: { default: null } }
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['audio', HTMLAttributes]
+  },
+})
+
+const Video = Node.create({
+  name: 'video',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return { src: { default: null } }
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['video', HTMLAttributes]
+  },
+})
+
+const extensions = [Document, Paragraph, Text, Audio, Video]
+
+describe('static renderer: non-void elements get a closing tag', () => {
+  it('renders <audio> with a closing tag, not self-closed', () => {
+    const html = renderToHTMLString({
+      content: {
+        type: 'doc',
+        content: [{ type: 'audio', attrs: { src: 'https://example.com/a.mp3' } }],
+      },
+      extensions,
+    })
+
+    expect(html).toBe('<audio src="https://example.com/a.mp3"></audio>')
+  })
+
+  it('renders <video> with a closing tag, not self-closed', () => {
+    const html = renderToHTMLString({
+      content: {
+        type: 'doc',
+        content: [{ type: 'video', attrs: { src: 'https://example.com/v.mp4' } }],
+      },
+      extensions,
+    })
+
+    expect(html).toBe('<video src="https://example.com/v.mp4"></video>')
+  })
+})

--- a/packages/static-renderer/src/pm/html-string/html-string.ts
+++ b/packages/static-renderer/src/pm/html-string/html-string.ts
@@ -31,6 +31,8 @@ const NON_SELF_CLOSING_TAGS = new Set([
   'span',
   'a',
   'button',
+  'audio',
+  'video',
 ])
 
 /**


### PR DESCRIPTION
## Fixes

Fixes #8130

## Changes and Review

The static renderer closed a fixed set of element tags and treated everything else as self-closing. `audio` and `video` were not in that set, so they came out as `<audio/>` / `<video/>`. Browsers don't treat those as void elements, so any following content got nested inside the first one and only the first player rendered. Adding both to the set makes them render as `<audio></audio>`. Reviewers can render a doc with two audio nodes through `renderToHTMLString` and confirm each tag is closed.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
