### PR TITLE
fix(markdown): collapse soft line breaks into spaces

### DIFF
--- a/.changeset/2026-07-29-collapse-soft-line-breaks.md
+++ b/.changeset/2026-07-29-collapse-soft-line-breaks.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Collapse CommonMark soft line breaks into spaces when parsing, so a soft-wrapped paragraph no longer renders with visible line breaks.

--- a/packages/markdown/__tests__/conversion-files/soft-break-marks.ts
+++ b/packages/markdown/__tests__/conversion-files/soft-break-marks.ts
@@ -1,10 +1,8 @@
 export const name = 'Soft Break with Marks'
 
-export const expectedInput = `**Speaker:**
-John Doe.
+export const expectedInput = `**Speaker:** John Doe.
 
-**Speaker:**
-**John Doe**`.trim()
+**Speaker:** **John Doe**`.trim()
 
 export const expectedOutput = {
   type: 'doc',
@@ -13,14 +11,14 @@ export const expectedOutput = {
       type: 'paragraph',
       content: [
         { type: 'text', marks: [{ type: 'bold' }], text: 'Speaker:' },
-        { type: 'text', text: '\nJohn Doe.' },
+        { type: 'text', text: ' John Doe.' },
       ],
     },
     {
       type: 'paragraph',
       content: [
         { type: 'text', marks: [{ type: 'bold' }], text: 'Speaker:' },
-        { type: 'text', text: '\n' },
+        { type: 'text', text: ' ' },
         { type: 'text', marks: [{ type: 'bold' }], text: 'John Doe' },
       ],
     },

--- a/packages/markdown/__tests__/soft-line-break.spec.ts
+++ b/packages/markdown/__tests__/soft-line-break.spec.ts
@@ -1,0 +1,63 @@
+import { CodeBlock } from '@tiptap/extension-code-block'
+import { Document } from '@tiptap/extension-document'
+import { Link } from '@tiptap/extension-link'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { MarkdownManager } from '@tiptap/markdown'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('Soft line breaks', () => {
+  let markdownManager: MarkdownManager
+
+  beforeEach(() => {
+    markdownManager = new MarkdownManager({
+      extensions: [Document, Paragraph, Text, Link, CodeBlock],
+    })
+  })
+
+  it('collapses a soft-wrapped paragraph into a single line', () => {
+    const doc = markdownManager.parse('foo\nbar')
+
+    expect(doc.content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: 'foo bar' }] },
+    ])
+  })
+
+  it('collapses soft breaks around a link without dropping the flanking spaces', () => {
+    const doc = markdownManager.parse(
+      'You can try CommonMark here. This dingus is powered by\n[commonmark.js](https://github.com/commonmark/commonmark.js), the\nJavaScript reference implementation.',
+    )
+
+    expect(doc.content).toEqual([
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'You can try CommonMark here. This dingus is powered by ' },
+          {
+            type: 'text',
+            text: 'commonmark.js',
+            marks: [
+              {
+                type: 'link',
+                attrs: { href: 'https://github.com/commonmark/commonmark.js', title: null },
+              },
+            ],
+          },
+          { type: 'text', text: ', the JavaScript reference implementation.' },
+        ],
+      },
+    ])
+  })
+
+  it('keeps newlines inside a code block', () => {
+    const doc = markdownManager.parse('```js\nconst a = 1;\nconst b = 2;\n```')
+
+    expect(doc.content).toEqual([
+      {
+        type: 'codeBlock',
+        attrs: { language: 'js' },
+        content: [{ type: 'text', text: 'const a = 1;\nconst b = 2;' }],
+      },
+    ])
+  })
+})

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -25,6 +25,7 @@ import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, ma
 
 import {
   closeMarksBeforeNode,
+  collapseSoftBreaks,
   extractAbsorbedBlankLines,
   findMarksToClose,
   findMarksToCloseAtEnd,
@@ -713,7 +714,7 @@ export class MarkdownManager {
         // Create text node – decode HTML entities so that e.g. `&lt;` displays as `<` in the editor
         result.push({
           type: 'text',
-          text: decodeHtmlEntities(token.text || ''),
+          text: decodeHtmlEntities(collapseSoftBreaks(token.text || '')),
         })
       } else if (token.type === 'escape') {
         // Backslash-escaped character: produce a text node with the escaped character
@@ -906,7 +907,7 @@ export class MarkdownManager {
       case 'text':
         return {
           type: 'text',
-          text: decodeHtmlEntities(token.text || ''),
+          text: decodeHtmlEntities(collapseSoftBreaks(token.text || '')),
         }
 
       case 'html':

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -41,6 +41,24 @@ export function extractAbsorbedBlankLines(tokens: MarkdownToken[]): MarkdownToke
 }
 
 /**
+ * Collapses CommonMark soft line breaks into single spaces.
+ *
+ * marked leaves a soft-wrapped paragraph's newlines inside its `text` tokens,
+ * relying on HTML whitespace collapsing that ProseMirror text nodes don't have.
+ * Taking the flanking whitespace matches the spec: spaces at a line's end and
+ * the next line's start are removed.
+ *
+ * @param text The text token value to normalize.
+ * @returns The text with each soft break collapsed to a single space.
+ * @example
+ * collapseSoftBreaks('foo\nbar')
+ * // => 'foo bar'
+ */
+export function collapseSoftBreaks(text: string): string {
+  return text.replace(/[ \t]*\n[ \t]*/g, ' ')
+}
+
+/**
  * Wraps each line of the content with the given prefix.
  * @param prefix The prefix to wrap each line with.
  * @param content The content to wrap.


### PR DESCRIPTION
## Fixes

Fixes #8136

## Changes and Review

marked keeps a soft-wrapped paragraph's newlines inside its `text` tokens, leaning on the CommonMark rule that a soft break may render as either a space or a line ending in HTML, where whitespace collapses. `MarkdownManager` lowers that text straight into a ProseMirror node, which has no whitespace collapsing, so under `white-space: break-spaces` a wrapped paragraph renders across several lines instead of one. This collapses each soft break and its flanking spaces to a single space in the two branches that turn a `text` token into a text node; code blocks and code spans don't route through those branches so they keep their newlines, and explicit hard breaks stay `hardBreak`. One existing round-trip fixture is updated to the collapsed form, reflecting the trade-off that a markdown to doc to markdown round trip loses the author's original wrap columns.

To verify, parse `foo\nbar` and check it yields a single paragraph `foo bar`, or run `pnpm vitest run packages/markdown`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
