### PR TITLE
fix(markdown): escape leading block syntax when serializing paragraphs

### DIFF
--- a/.changeset/markdown-escape-block-syntax.md
+++ b/.changeset/markdown-escape-block-syntax.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Escape block-level syntax like `\#` and `\-` at the start of a paragraph so escaped text survives a serialize/parse round-trip instead of turning into a heading or list.

--- a/packages/markdown/__tests__/conversion.spec.ts
+++ b/packages/markdown/__tests__/conversion.spec.ts
@@ -779,6 +779,57 @@ describe('Markdown Conversion Tests', () => {
       })
     })
 
+    describe('serializing: leading block syntax → backslash-escaped markdown', () => {
+      const paragraph = (text: string) => ({
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+      })
+
+      it('should escape a leading heading marker', () => {
+        expect(markdownManager.serialize(paragraph('# not a heading'))).toBe('\\# not a heading')
+      })
+
+      it('should escape a leading multi-level heading marker', () => {
+        expect(markdownManager.serialize(paragraph('## not a heading'))).toBe('\\## not a heading')
+      })
+
+      it('should escape a leading bullet-list marker', () => {
+        expect(markdownManager.serialize(paragraph('- not a list'))).toBe('\\- not a list')
+        expect(markdownManager.serialize(paragraph('+ not a list'))).toBe('\\+ not a list')
+      })
+
+      it('should escape a leading ordered-list marker', () => {
+        expect(markdownManager.serialize(paragraph('1. not a list'))).toBe('1\\. not a list')
+        expect(markdownManager.serialize(paragraph('1) not a list'))).toBe('1\\) not a list')
+      })
+
+      it('should escape a thematic-break line', () => {
+        expect(markdownManager.serialize(paragraph('---'))).toBe('\\---')
+      })
+
+      it('should not escape a block marker in the middle of a line', () => {
+        expect(markdownManager.serialize(paragraph('a # b'))).toBe('a # b')
+      })
+
+      it('should not escape a heading marker without a following space', () => {
+        expect(markdownManager.serialize(paragraph('#tag'))).toBe('#tag')
+      })
+    })
+
+    describe('round-trip: leading block syntax stays a paragraph', () => {
+      const roundTripType = (input: string) => {
+        const md = markdownManager.serialize(markdownManager.parse(input))
+        return markdownManager.parse(md).content[0].type
+      }
+
+      it('should keep escaped block syntax as a paragraph after round-trip', () => {
+        expect(roundTripType('\\# not a heading')).toBe('paragraph')
+        expect(roundTripType('1\\. not a list')).toBe('paragraph')
+        expect(roundTripType('\\- not a list')).toBe('paragraph')
+        expect(roundTripType('\\+ not a list')).toBe('paragraph')
+      })
+    })
+
     describe('edge cases: code blocks and nested syntax', () => {
       it('should NOT backslash-escape inside inline code marks (parsing)', () => {
         const json = markdownManager.parse('`\\*not italic\\*`')

--- a/packages/markdown/__tests__/conversion.spec.ts
+++ b/packages/markdown/__tests__/conversion.spec.ts
@@ -908,6 +908,41 @@ describe('Markdown Conversion Tests', () => {
         expect(markdownManager.serialize(input)).toBe('\\# not a heading')
       })
 
+      it('should escape a block marker after a newline inside a later text node', () => {
+        const input = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'text' },
+                { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+                { type: 'text', text: '\n# not a heading' },
+              ],
+            },
+          ],
+        }
+
+        expect(markdownManager.serialize(input)).toBe('text**bold**\n\\# not a heading')
+      })
+
+      it('should not escape the first line of a text node that starts mid-line', () => {
+        const input = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'a', marks: [{ type: 'bold' }] },
+                { type: 'text', text: '# b' },
+              ],
+            },
+          ],
+        }
+
+        expect(markdownManager.serialize(input)).toBe('**a**# b')
+      })
+
       it('should escape a leading block marker inside a list item', () => {
         expect(markdownManager.serialize(listItem('# not a heading'))).toBe('- \\# not a heading')
         expect(markdownManager.serialize(listItem('- not a list'))).toBe('- \\- not a list')
@@ -948,6 +983,25 @@ describe('Markdown Conversion Tests', () => {
           paragraph('| a | b |\n| - | - |'),
         )
         expect(roundTrip(paragraph('a | b\n--- | ---'))).toEqual(paragraph('a | b\n--- | ---'))
+      })
+
+      it('should keep a block marker after a mark and a newline as text after round-trip', () => {
+        const input = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'text' },
+                { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+                { type: 'text', text: '\n# not a heading' },
+              ],
+            },
+          ],
+        }
+
+        expect(roundTrip(input).content).toHaveLength(1)
+        expect(roundTrip(input).content[0].type).toBe('paragraph')
       })
 
       it('should keep block syntax in a list item as text after round-trip', () => {

--- a/packages/markdown/__tests__/conversion.spec.ts
+++ b/packages/markdown/__tests__/conversion.spec.ts
@@ -814,6 +814,43 @@ describe('Markdown Conversion Tests', () => {
       it('should not escape a heading marker without a following space', () => {
         expect(markdownManager.serialize(paragraph('#tag'))).toBe('#tag')
       })
+
+      it('should escape a setext heading underline on a later line', () => {
+        expect(markdownManager.serialize(paragraph('Title\n---'))).toBe('Title\n\\---')
+        expect(markdownManager.serialize(paragraph('Title\n==='))).toBe('Title\n\\===')
+      })
+
+      it('should escape a two-dash underline (invalid as a thematic break, valid as setext)', () => {
+        expect(markdownManager.serialize(paragraph('Title\n--'))).toBe('Title\n\\--')
+      })
+
+      it('should escape a leading table-row pipe on a later line', () => {
+        expect(markdownManager.serialize(paragraph('a\n| b | c |'))).toBe('a\n\\| b | c |')
+      })
+
+      it('should escape a block marker indented up to three spaces', () => {
+        expect(markdownManager.serialize(paragraph('  # not a heading'))).toBe(
+          '  \\# not a heading',
+        )
+      })
+
+      it('should escape a leading block marker after a hard break', () => {
+        const input = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'Title' },
+                { type: 'hardBreak' },
+                { type: 'text', text: '# not a heading' },
+              ],
+            },
+          ],
+        }
+
+        expect(markdownManager.serialize(input)).toBe('Title  \n\\# not a heading')
+      })
     })
 
     describe('round-trip: leading block syntax stays a paragraph', () => {

--- a/packages/markdown/__tests__/conversion.spec.ts
+++ b/packages/markdown/__tests__/conversion.spec.ts
@@ -1000,8 +1000,7 @@ describe('Markdown Conversion Tests', () => {
           ],
         }
 
-        expect(roundTrip(input).content).toHaveLength(1)
-        expect(roundTrip(input).content[0].type).toBe('paragraph')
+        expect(roundTrip(input)).toEqual(input)
       })
 
       it('should keep block syntax in a list item as text after round-trip', () => {

--- a/packages/markdown/__tests__/conversion.spec.ts
+++ b/packages/markdown/__tests__/conversion.spec.ts
@@ -1,4 +1,5 @@
 import type { Extension } from '@tiptap/core'
+import { Blockquote } from '@tiptap/extension-blockquote'
 import { Bold } from '@tiptap/extension-bold'
 import { Code } from '@tiptap/extension-code'
 import { CodeBlock } from '@tiptap/extension-code-block'
@@ -29,6 +30,7 @@ describe('Markdown Conversion Tests', () => {
     Heading,
     HardBreak,
     CodeBlock,
+    Blockquote,
     BulletList,
     OrderedList,
     ListItem,
@@ -584,6 +586,36 @@ describe('Markdown Conversion Tests', () => {
   })
 
   describe('markdown escape character handling', () => {
+    const paragraph = (text: string) => ({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+    })
+
+    const listItem = (text: string) => ({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+            },
+          ],
+        },
+      ],
+    })
+
+    const blockquote = (text: string) => ({
+      type: 'doc',
+      content: [
+        {
+          type: 'blockquote',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+        },
+      ],
+    })
+
     describe('parsing: escape tokens in markdown → text nodes', () => {
       it('should parse a backslash-escaped asterisk as a literal asterisk', () => {
         const json = markdownManager.parse('\\*text\\*')
@@ -780,11 +812,6 @@ describe('Markdown Conversion Tests', () => {
     })
 
     describe('serializing: leading block syntax → backslash-escaped markdown', () => {
-      const paragraph = (text: string) => ({
-        type: 'doc',
-        content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
-      })
-
       it('should escape a leading heading marker', () => {
         expect(markdownManager.serialize(paragraph('# not a heading'))).toBe('\\# not a heading')
       })
@@ -824,8 +851,20 @@ describe('Markdown Conversion Tests', () => {
         expect(markdownManager.serialize(paragraph('Title\n--'))).toBe('Title\n\\--')
       })
 
-      it('should escape a leading table-row pipe on a later line', () => {
-        expect(markdownManager.serialize(paragraph('a\n| b | c |'))).toBe('a\n\\| b | c |')
+      it('should escape a table delimiter row, which is what turns the line above into a table', () => {
+        expect(markdownManager.serialize(paragraph('| a | b |\n| - | - |'))).toBe(
+          '| a | b |\n| \\- | - |',
+        )
+        expect(markdownManager.serialize(paragraph('a | b\n--- | ---'))).toBe('a | b\n\\--- | ---')
+      })
+
+      it('should not escape a table row without a delimiter row under it', () => {
+        expect(markdownManager.serialize(paragraph('a\n| b | c |'))).toBe('a\n| b | c |')
+      })
+
+      it('should not escape an underline on the first line, where nothing is above it', () => {
+        expect(markdownManager.serialize(paragraph('==='))).toBe('===')
+        expect(markdownManager.serialize(paragraph('--'))).toBe('--')
       })
 
       it('should escape a block marker indented up to three spaces', () => {
@@ -851,6 +890,37 @@ describe('Markdown Conversion Tests', () => {
 
         expect(markdownManager.serialize(input)).toBe('Title  \n\\# not a heading')
       })
+
+      it('should escape a leading block marker when the node before it renders nothing', () => {
+        const input = {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: '' },
+                { type: 'text', text: '# not a heading' },
+              ],
+            },
+          ],
+        }
+
+        expect(markdownManager.serialize(input)).toBe('\\# not a heading')
+      })
+
+      it('should escape a leading block marker inside a list item', () => {
+        expect(markdownManager.serialize(listItem('# not a heading'))).toBe('- \\# not a heading')
+        expect(markdownManager.serialize(listItem('- not a list'))).toBe('- \\- not a list')
+      })
+
+      it('should escape a leading block marker inside a blockquote', () => {
+        expect(markdownManager.serialize(blockquote('# not a heading'))).toBe('> \\# not a heading')
+      })
+
+      it('should not escape an ordered-list marker inside a list item, where it stays text', () => {
+        expect(markdownManager.serialize(listItem('123.'))).toBe('- 123.')
+        expect(markdownManager.serialize(listItem('1. not a list'))).toBe('- 1. not a list')
+      })
     })
 
     describe('round-trip: leading block syntax stays a paragraph', () => {
@@ -859,11 +929,36 @@ describe('Markdown Conversion Tests', () => {
         return markdownManager.parse(md).content[0].type
       }
 
+      const roundTrip = (json: any) => markdownManager.parse(markdownManager.serialize(json))
+
       it('should keep escaped block syntax as a paragraph after round-trip', () => {
         expect(roundTripType('\\# not a heading')).toBe('paragraph')
         expect(roundTripType('1\\. not a list')).toBe('paragraph')
         expect(roundTripType('\\- not a list')).toBe('paragraph')
         expect(roundTripType('\\+ not a list')).toBe('paragraph')
+        expect(roundTripType('\\---')).toBe('paragraph')
+      })
+
+      it('should keep a thematic break as text after round-trip', () => {
+        expect(roundTrip(paragraph('---'))).toEqual(paragraph('---'))
+      })
+
+      it('should keep a table as text after round-trip', () => {
+        expect(roundTrip(paragraph('| a | b |\n| - | - |'))).toEqual(
+          paragraph('| a | b |\n| - | - |'),
+        )
+        expect(roundTrip(paragraph('a | b\n--- | ---'))).toEqual(paragraph('a | b\n--- | ---'))
+      })
+
+      it('should keep block syntax in a list item as text after round-trip', () => {
+        expect(roundTrip(listItem('# not a heading'))).toEqual(listItem('# not a heading'))
+        expect(roundTrip(listItem('- not a list'))).toEqual(listItem('- not a list'))
+        expect(roundTrip(listItem('123.'))).toEqual(listItem('123.'))
+      })
+
+      it('should keep block syntax in a blockquote as text after round-trip', () => {
+        expect(roundTrip(blockquote('# not a heading'))).toEqual(blockquote('# not a heading'))
+        expect(roundTrip(blockquote('1. not a list'))).toEqual(blockquote('1. not a list'))
       })
     })
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1094,7 +1094,12 @@ export class MarkdownManager {
    * Also backslash-escape markdown-significant characters in non-code text to
    * prevent them from being misinterpreted as formatting delimiters.
    */
-  private encodeTextForMarkdown(text: string, node: JSONContent, parentNode?: JSONContent): string {
+  private encodeTextForMarkdown(
+    text: string,
+    node: JSONContent,
+    parentNode?: JSONContent,
+    isLineStart = false,
+  ): string {
     const isInsideCode =
       (parentNode?.type != null && this.codeTypes.has(parentNode.type)) ||
       (node.marks || []).some(m => this.codeTypes.has(typeof m === 'string' ? m : m.type))
@@ -1103,7 +1108,8 @@ export class MarkdownManager {
       return text
     }
 
-    return this.escapeMarkdownSyntax(encodeHtmlEntities(text))
+    const escaped = this.escapeMarkdownSyntax(encodeHtmlEntities(text))
+    return isLineStart ? this.escapeBlockSyntax(escaped) : escaped
   }
 
   /**
@@ -1117,6 +1123,22 @@ export class MarkdownManager {
    */
   private escapeMarkdownSyntax(text: string): string {
     return text.replace(/([\\`*_[\]~])/g, '\\$1')
+  }
+
+  /**
+   * Backslash-escape leading syntax that would otherwise start a block, so a
+   * text node keeps its meaning when the serialized markdown is parsed again.
+   *
+   * Only relevant at the start of a line: block markers like `#`, `-`, `+` and
+   * ordered-list numbers are significant just after a line break. The caller
+   * passes `isLineStart` for the first inline child of a top-level paragraph.
+   */
+  private escapeBlockSyntax(text: string): string {
+    return text
+      .replace(/^(#{1,6})(\s|$)/, '\\$1$2')
+      .replace(/^([-+])(\s|$)/, '\\$1$2')
+      .replace(/^(\d{1,9})([.)])(\s|$)/, '$1\\$2$3')
+      .replace(/^(-{3,})(\s*)$/, '\\$1$2')
   }
 
   renderNodeToMarkdown(
@@ -1233,7 +1255,9 @@ export class MarkdownManager {
       }
 
       if (node.type === 'text') {
-        let textContent = this.encodeTextForMarkdown(node.text || '', node, parentNode)
+        const isLineStart =
+          level === 0 && i === 0 && parentNode?.type === 'paragraph' && !node.marks?.length
+        let textContent = this.encodeTextForMarkdown(node.text || '', node, parentNode, isLineStart)
         const currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
 
         // Find marks that need to be closed and opened

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1099,6 +1099,7 @@ export class MarkdownManager {
     node: JSONContent,
     parentNode?: JSONContent,
     isLineStart = false,
+    isIndented = false,
   ): string {
     const isInsideCode =
       (parentNode?.type != null && this.codeTypes.has(parentNode.type)) ||
@@ -1109,7 +1110,7 @@ export class MarkdownManager {
     }
 
     const escaped = this.escapeMarkdownSyntax(encodeHtmlEntities(text))
-    return isLineStart ? this.escapeBlockSyntax(escaped) : escaped
+    return isLineStart ? this.escapeBlockSyntax(escaped, isIndented) : escaped
   }
 
   /**
@@ -1126,27 +1127,35 @@ export class MarkdownManager {
   }
 
   /**
-   * Backslash-escape leading syntax that would otherwise start a block, so a
-   * text node keeps its meaning when the serialized markdown is parsed again.
-   *
-   * Relevant at the start of every line, not just the start of the whole
-   * string: a text node can contain literal `\n` characters (e.g. pasted or
-   * API-constructed content), and each of those lines is its own block-start
-   * context once serialized. Up to three leading spaces are still considered
-   * "line start" per CommonMark's block-indentation rule. The caller passes
-   * `isLineStart` for the first inline child of a top-level paragraph, and
-   * for the text run right after a hard break.
+   * Backslash-escape leading block syntax so the text stays text when the markdown is parsed
+   * again. Runs per line, since a text node can contain literal `\n`.
    */
-  private escapeBlockSyntax(text: string): string {
-    const escapeLine = (line: string): string =>
-      line
-        .replace(/^( {0,3})(#{1,6})(\s|$)/, '$1\\$2$3')
-        .replace(/^( {0,3})([-+])(\s|$)/, '$1\\$2$3')
-        .replace(/^( {0,3})(\d{1,9})([.)])(\s|$)/, '$1$2\\$3$4')
-        .replace(/^( {0,3})(-{2,}|={1,})(\s*)$/, '$1\\$2$3')
-        .replace(/^( {0,3})(\|)/, '$1\\$2')
+  private escapeBlockSyntax(text: string, isIndented = false): string {
+    const lines = text.split('\n')
+    const isTableDelimiter = (line = '') => /^ {0,3}\|?[\s:|-]*-[\s:|-]*$/.test(line)
 
-    return text.split('\n').map(escapeLine).join('\n')
+    return lines
+      .map((line, index) => {
+        // marked reads the line above a delimiter row as a table header, so break the row.
+        if (index > 0 && isTableDelimiter(line)) {
+          return line.replace('-', '\\-')
+        }
+
+        let escaped = line
+          .replace(/^( {0,3})(#{1,6})(\s|$)/, '$1\\$2$3')
+          .replace(/^( {0,3})([-+])(\s|$)/, '$1\\$2$3')
+
+        // Inside a list item marked reads `1.` as text, so escaping it would only add noise.
+        if (!isIndented) {
+          escaped = escaped.replace(/^( {0,3})(\d{1,9})([.)])(\s|$)/, '$1$2\\$3$4')
+        }
+
+        // The first line has nothing above it to underline, so only a break can start a block.
+        return index === 0
+          ? escaped.replace(/^( {0,3})(-{3,})(\s*)$/, '$1\\$2$3')
+          : escaped.replace(/^( {0,3})(={1,})(\s*)$/, '$1\\$2$3')
+      })
+      .join('\n')
   }
 
   renderNodeToMarkdown(
@@ -1263,12 +1272,20 @@ export class MarkdownManager {
       }
 
       if (node.type === 'text') {
+        // Every paragraph starts a block, nested ones too, so its line starts carry block
+        // syntax. Marked text is already protected by the mark delimiters around it.
+        const renderedSoFar = result.join(separator)
         const isLineStart =
-          level === 0 &&
           parentNode?.type === 'paragraph' &&
           !node.marks?.length &&
-          (i === 0 || nodes[i - 1]?.type === 'hardBreak')
-        let textContent = this.encodeTextForMarkdown(node.text || '', node, parentNode, isLineStart)
+          (renderedSoFar === '' || renderedSoFar.endsWith('\n'))
+        let textContent = this.encodeTextForMarkdown(
+          node.text || '',
+          node,
+          parentNode,
+          isLineStart,
+          level > 0,
+        )
         const currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
 
         // Find marks that need to be closed and opened

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1129,16 +1129,24 @@ export class MarkdownManager {
    * Backslash-escape leading syntax that would otherwise start a block, so a
    * text node keeps its meaning when the serialized markdown is parsed again.
    *
-   * Only relevant at the start of a line: block markers like `#`, `-`, `+` and
-   * ordered-list numbers are significant just after a line break. The caller
-   * passes `isLineStart` for the first inline child of a top-level paragraph.
+   * Relevant at the start of every line, not just the start of the whole
+   * string: a text node can contain literal `\n` characters (e.g. pasted or
+   * API-constructed content), and each of those lines is its own block-start
+   * context once serialized. Up to three leading spaces are still considered
+   * "line start" per CommonMark's block-indentation rule. The caller passes
+   * `isLineStart` for the first inline child of a top-level paragraph, and
+   * for the text run right after a hard break.
    */
   private escapeBlockSyntax(text: string): string {
-    return text
-      .replace(/^(#{1,6})(\s|$)/, '\\$1$2')
-      .replace(/^([-+])(\s|$)/, '\\$1$2')
-      .replace(/^(\d{1,9})([.)])(\s|$)/, '$1\\$2$3')
-      .replace(/^(-{3,})(\s*)$/, '\\$1$2')
+    const escapeLine = (line: string): string =>
+      line
+        .replace(/^( {0,3})(#{1,6})(\s|$)/, '$1\\$2$3')
+        .replace(/^( {0,3})([-+])(\s|$)/, '$1\\$2$3')
+        .replace(/^( {0,3})(\d{1,9})([.)])(\s|$)/, '$1$2\\$3$4')
+        .replace(/^( {0,3})(-{2,}|={1,})(\s*)$/, '$1\\$2$3')
+        .replace(/^( {0,3})(\|)/, '$1\\$2')
+
+    return text.split('\n').map(escapeLine).join('\n')
   }
 
   renderNodeToMarkdown(
@@ -1256,7 +1264,10 @@ export class MarkdownManager {
 
       if (node.type === 'text') {
         const isLineStart =
-          level === 0 && i === 0 && parentNode?.type === 'paragraph' && !node.marks?.length
+          level === 0 &&
+          parentNode?.type === 'paragraph' &&
+          !node.marks?.length &&
+          (i === 0 || nodes[i - 1]?.type === 'hardBreak')
         let textContent = this.encodeTextForMarkdown(node.text || '', node, parentNode, isLineStart)
         const currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -35,6 +35,16 @@ import {
 } from './utils.js'
 import { htmlContainsUnrecognizedTag } from './utils/htmlTagDetection.js'
 
+/**
+ * Where a text node sits in the line it is rendered on, so block syntax in it can be escaped.
+ */
+interface BlockLineContext {
+  /** Something already rendered on this line, so the first line of the node cannot start a block. */
+  startsMidLine: boolean
+  /** The paragraph is nested in a list item or a similar indenting block. */
+  isIndented: boolean
+}
+
 export class MarkdownManager {
   private markedInstance: typeof marked
   private activeParseLexer: Lexer | null = null
@@ -1098,8 +1108,7 @@ export class MarkdownManager {
     text: string,
     node: JSONContent,
     parentNode?: JSONContent,
-    isLineStart = false,
-    isIndented = false,
+    blockContext?: BlockLineContext,
   ): string {
     const isInsideCode =
       (parentNode?.type != null && this.codeTypes.has(parentNode.type)) ||
@@ -1110,7 +1119,7 @@ export class MarkdownManager {
     }
 
     const escaped = this.escapeMarkdownSyntax(encodeHtmlEntities(text))
-    return isLineStart ? this.escapeBlockSyntax(escaped, isIndented) : escaped
+    return blockContext ? this.escapeBlockSyntax(escaped, blockContext) : escaped
   }
 
   /**
@@ -1130,12 +1139,17 @@ export class MarkdownManager {
    * Backslash-escape leading block syntax so the text stays text when the markdown is parsed
    * again. Runs per line, since a text node can contain literal `\n`.
    */
-  private escapeBlockSyntax(text: string, isIndented = false): string {
+  private escapeBlockSyntax(text: string, { startsMidLine, isIndented }: BlockLineContext): string {
     const lines = text.split('\n')
     const isTableDelimiter = (line = '') => /^ {0,3}\|?[\s:|-]*-[\s:|-]*$/.test(line)
 
     return lines
       .map((line, index) => {
+        // Earlier nodes already put text on this line, so it cannot start a block.
+        if (index === 0 && startsMidLine) {
+          return line
+        }
+
         // marked reads the line above a delimiter row as a table header, so break the row.
         if (index > 0 && isTableDelimiter(line)) {
           return line.replace('-', '\\-')
@@ -1275,16 +1289,18 @@ export class MarkdownManager {
         // Every paragraph starts a block, nested ones too, so its line starts carry block
         // syntax. Marked text is already protected by the mark delimiters around it.
         const renderedSoFar = result.join(separator)
-        const isLineStart =
-          parentNode?.type === 'paragraph' &&
-          !node.marks?.length &&
-          (renderedSoFar === '' || renderedSoFar.endsWith('\n'))
+        const blockContext =
+          parentNode?.type === 'paragraph' && !node.marks?.length
+            ? {
+                startsMidLine: renderedSoFar !== '' && !renderedSoFar.endsWith('\n'),
+                isIndented: level > 0,
+              }
+            : undefined
         let textContent = this.encodeTextForMarkdown(
           node.text || '',
           node,
           parentNode,
-          isLineStart,
-          level > 0,
+          blockContext,
         )
         const currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
 


### PR DESCRIPTION
## Fixes

Fixes #8134

## Changes and Review

The serializer already escaped inline markdown, but not block markers at the start of a line. So a paragraph holding `# not a heading` was written back without its backslash and re-parsed as a real heading (same for `-`, `+`, ordered-list numbers and `---`). Serializing now escapes a leading block marker on the first line of a top-level paragraph, so escaped block syntax stays a paragraph across a parse → serialize → parse round-trip. To check, parse `\# not a heading`, extract the markdown, and parse it again, or run the new round-trip tests in `conversion.spec.ts`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
