### PR TITLE
fix(extension-link): don't split pasted links when the link text contains a domain

### DIFF
--- a/.changeset/fix-extension-link-paste-domain-split.md
+++ b/.changeset/fix-extension-link-paste-domain-split.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-link': patch
+---
+
+Pasting a link whose text contains a domain name no longer splits it into multiple links.

--- a/packages/extension-link/__tests__/link.spec.ts
+++ b/packages/extension-link/__tests__/link.spec.ts
@@ -233,6 +233,26 @@ describe('extension-link', () => {
     })
   })
 
+  it('does not split a pasted link whose text contains a domain name', () => {
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Text, Paragraph, Link],
+      content: '<p></p>',
+    })
+
+    editor.commands.setTextSelection(1)
+    editor.view.pasteHTML('<a href="https://example.com/article">Read more at nytimes.com</a>')
+
+    const anchorCount = (editor.getHTML().match(/<a\s/g) || []).length
+
+    expect(anchorCount).toBe(1)
+    expect(editor.getHTML()).toContain('href="https://example.com/article"')
+    expect(editor.getHTML()).not.toContain('href="http://nytimes.com"')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
   describe('isAllowedUri', () => {
     it('allows whitelisted protocols', () => {
       expect(isAllowedUri('https://example.com')).toBeTruthy()

--- a/packages/extension-link/src/link.ts
+++ b/packages/extension-link/src/link.ts
@@ -1,5 +1,5 @@
 import type { PasteRuleMatch } from '@tiptap/core'
-import { Mark, markPasteRule, mergeAttributes } from '@tiptap/core'
+import { getMarksBetween, Mark, markPasteRule, mergeAttributes, PasteRule } from '@tiptap/core'
 import type { Plugin } from '@tiptap/pm/state'
 import { find, registerCustomProtocol, reset } from 'linkifyjs'
 
@@ -496,14 +496,30 @@ export const Link = Mark.create<LinkOptions>({
       ]
     }
 
+    const plainUrlPasteRule = markPasteRule({
+      find: findPlainUrls,
+      type: this.type,
+      getAttributes: match => {
+        return {
+          href: match.data?.href,
+        }
+      },
+    })
+
     return [
-      markPasteRule({
-        find: findPlainUrls,
-        type: this.type,
-        getAttributes: match => {
-          return {
-            href: match.data?.href,
+      new PasteRule({
+        find: plainUrlPasteRule.find,
+        handler: props => {
+          // Keep links pasted as HTML intact: don't relink a domain inside their text.
+          if (
+            getMarksBetween(props.range.from, props.range.to, props.state.doc).some(
+              item => item.mark.type === this.type,
+            )
+          ) {
+            return
           }
+
+          return plainUrlPasteRule.handler(props)
         },
       }),
     ]


### PR DESCRIPTION
## Fixes

Fixes #8147

## Changes and Review

When you paste HTML from another app or website, a link splits if its text contains a domain name. The plain-URL paste rule finds that domain and links it on its own, overriding part of the original link. The rule now skips text that already sits inside a link, so links pasted as HTML stay whole. Bare URLs pasted as plain text still get autolinked.

To verify, paste `<a href="https://example.com/article">Read more at nytimes.com</a>` into the editor. It now stays one link instead of splitting at `nytimes.com`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
