### PR TITLE
fix(extension-table): keep cursor inside table when deleting last row or column

### DIFF
--- a/.changeset/fix-table-delete-cursor-escape.md
+++ b/.changeset/fix-table-delete-cursor-escape.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Deleting the last row or column of a table no longer moves the cursor outside the table when there is content below it.

--- a/packages/extension-table/__tests__/tableCommands.spec.ts
+++ b/packages/extension-table/__tests__/tableCommands.spec.ts
@@ -8,6 +8,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 const countCells = (editor: Editor, selector: string) =>
   editor.view.dom.querySelectorAll(selector).length
 
+const firstTableBounds = (editor: Editor) => {
+  let start = -1
+  let end = -1
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'table' && start === -1) {
+      start = pos
+      end = pos + node.nodeSize
+    }
+  })
+  return { start, end }
+}
+
 const selectFirstTwoHeaderCells = (editor: Editor) => {
   const positions: number[] = []
   editor.state.doc.descendants((node, pos) => {
@@ -111,6 +123,62 @@ describe('Table commands', () => {
 
     expect(countCells(editor, 'table th')).toBe(2)
     expect(editor.isActive('table')).toBe(true)
+  })
+
+  it('keeps the cursor in the edited table when deleting the last row with a table below', () => {
+    editor.commands.insertContentAt(
+      editor.state.doc.content.size,
+      '<table><tbody><tr><td><p>Following table</p></td></tr></tbody></table>',
+    )
+
+    const { end: firstTableEnd } = firstTableBounds(editor)
+    let lastCellPos = 0
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell' && pos < firstTableEnd) {
+        lastCellPos = pos
+      }
+    })
+    editor
+      .chain()
+      .focus()
+      .setTextSelection(lastCellPos + 2)
+      .run()
+
+    editor.commands.deleteRow()
+
+    const { start, end } = firstTableBounds(editor)
+    const cursor = editor.state.selection.from
+    expect(editor.isActive('table')).toBe(true)
+    expect(cursor).toBeGreaterThan(start)
+    expect(cursor).toBeLessThan(end)
+  })
+
+  it('keeps the cursor in the edited table when deleting the last column with a table below', () => {
+    editor.commands.insertContentAt(
+      editor.state.doc.content.size,
+      '<table><tbody><tr><td><p>Following table</p></td></tr></tbody></table>',
+    )
+
+    const { end: firstTableEnd } = firstTableBounds(editor)
+    let lastCellPos = 0
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell' && pos < firstTableEnd) {
+        lastCellPos = pos
+      }
+    })
+    editor
+      .chain()
+      .focus()
+      .setTextSelection(lastCellPos + 2)
+      .run()
+
+    editor.commands.deleteColumn()
+
+    const { start, end } = firstTableBounds(editor)
+    const cursor = editor.state.selection.from
+    expect(editor.isActive('table')).toBe(true)
+    expect(cursor).toBeGreaterThan(start)
+    expect(cursor).toBeLessThan(end)
   })
 
   it('deletes the table', () => {

--- a/packages/extension-table/__tests__/tableCommands.spec.ts
+++ b/packages/extension-table/__tests__/tableCommands.spec.ts
@@ -71,6 +71,48 @@ describe('Table commands', () => {
     expect(countCells(editor, 'table tr')).toBe(3)
   })
 
+  it('keeps the cursor inside the table when deleting the last row', () => {
+    editor.commands.insertContentAt(editor.state.doc.content.size, '<p>Text below table</p>')
+
+    let lastCellPos = 0
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell') {
+        lastCellPos = pos
+      }
+    })
+    editor
+      .chain()
+      .focus()
+      .setTextSelection(lastCellPos + 2)
+      .run()
+
+    editor.commands.deleteRow()
+
+    expect(countCells(editor, 'table tr')).toBe(2)
+    expect(editor.isActive('table')).toBe(true)
+  })
+
+  it('keeps the cursor inside the table when deleting the last column', () => {
+    editor.commands.insertContentAt(editor.state.doc.content.size, '<p>Text below table</p>')
+
+    let lastCellPos = 0
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell') {
+        lastCellPos = pos
+      }
+    })
+    editor
+      .chain()
+      .focus()
+      .setTextSelection(lastCellPos + 2)
+      .run()
+
+    editor.commands.deleteColumn()
+
+    expect(countCells(editor, 'table th')).toBe(2)
+    expect(editor.isActive('table')).toBe(true)
+  })
+
   it('deletes the table', () => {
     editor.commands.deleteTable()
     expect(countCells(editor, 'table')).toBe(0)

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -4,12 +4,13 @@ import {
   type JSONContent,
   type MarkdownToken,
   callOrReturn,
+  findParentNodeClosestToPos,
   getExtensionField,
   mergeAttributes,
   Node,
 } from '@tiptap/core'
 import type { DOMOutputSpec, Node as ProseMirrorNode } from '@tiptap/pm/model'
-import { TextSelection } from '@tiptap/pm/state'
+import { type EditorState, TextSelection, type Transaction } from '@tiptap/pm/state'
 import {
   addColumnAfter,
   addColumnBefore,
@@ -256,6 +257,40 @@ declare module '@tiptap/core' {
   }
 }
 
+// prosemirror-tables does not move the selection after a deletion, so removing the
+// last row or column can push the cursor out of the table into the content below.
+const keepCursorInTable =
+  (command: (state: EditorState, dispatch?: (tr: Transaction) => void) => boolean) =>
+  (state: EditorState, dispatch?: (tr: Transaction) => void): boolean => {
+    if (!dispatch) {
+      return command(state)
+    }
+
+    const table = findParentNodeClosestToPos(
+      state.selection.$from,
+      node => node.type.name === 'table',
+    )
+
+    return command(state, tr => {
+      const stillInTable = findParentNodeClosestToPos(
+        tr.selection.$from,
+        node => node.type.name === 'table',
+      )
+
+      if (table && !stillInTable) {
+        const tableNode = tr.doc.nodeAt(table.pos)
+
+        if (tableNode) {
+          const endOfTable = table.pos + tableNode.nodeSize - 1
+
+          tr.setSelection(TextSelection.near(tr.doc.resolve(endOfTable), -1))
+        }
+      }
+
+      dispatch(tr)
+    })
+  }
+
 /**
  * This extension allows you to create tables.
  * @see https://www.tiptap.dev/api/nodes/table
@@ -445,7 +480,7 @@ export const Table = Node.create<TableOptions>({
       deleteColumn:
         () =>
         ({ state, dispatch }) => {
-          return deleteColumn(state, dispatch)
+          return keepCursorInTable(deleteColumn)(state, dispatch)
         },
       addRowBefore:
         () =>
@@ -460,7 +495,7 @@ export const Table = Node.create<TableOptions>({
       deleteRow:
         () =>
         ({ state, dispatch }) => {
-          return deleteRow(state, dispatch)
+          return keepCursorInTable(deleteRow)(state, dispatch)
         },
       deleteTable:
         () =>

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -257,6 +257,18 @@ declare module '@tiptap/core' {
   }
 }
 
+const moveCursorToTableEnd = (tr: Transaction, tablePos: number) => {
+  const tableNode = tr.doc.nodeAt(tablePos)
+
+  if (!tableNode) {
+    return
+  }
+
+  const endOfTable = tablePos + tableNode.nodeSize - 1
+
+  tr.setSelection(TextSelection.near(tr.doc.resolve(endOfTable), -1))
+}
+
 // prosemirror-tables does not move the selection after a deletion, so removing the
 // last row or column can push the cursor out of the table into the content below.
 const keepCursorInTable =
@@ -277,13 +289,13 @@ const keepCursorInTable =
         node => node.type.name === 'table',
       )
 
-      if (table && !stillInTable) {
-        const tableNode = tr.doc.nodeAt(table.pos)
+      if (table) {
+        // The delete can push the cursor into a following table, so compare the
+        // mapped position to confirm it is still the table we edited.
+        const originalTablePos = tr.mapping.map(table.pos)
 
-        if (tableNode) {
-          const endOfTable = table.pos + tableNode.nodeSize - 1
-
-          tr.setSelection(TextSelection.near(tr.doc.resolve(endOfTable), -1))
+        if (stillInTable?.pos !== originalTablePos) {
+          moveCursorToTableEnd(tr, originalTablePos)
         }
       }
 

--- a/packages/extension-table/src/table/table.ts
+++ b/packages/extension-table/src/table/table.ts
@@ -10,7 +10,7 @@ import {
   Node,
 } from '@tiptap/core'
 import type { DOMOutputSpec, Node as ProseMirrorNode } from '@tiptap/pm/model'
-import { type EditorState, TextSelection, type Transaction } from '@tiptap/pm/state'
+import { TextSelection } from '@tiptap/pm/state'
 import {
   addColumnAfter,
   addColumnBefore,
@@ -37,6 +37,7 @@ import { TableView } from './TableView.js'
 import { createColGroup } from './utilities/createColGroup.js'
 import { createTable } from './utilities/createTable.js'
 import { deleteTableWhenAllCellsSelected } from './utilities/deleteTableWhenAllCellsSelected.js'
+import { keepCursorInTable } from './utilities/keepCursorInTable.js'
 import renderTableToMarkdown, { preprocessTablePipes } from './utilities/markdown.js'
 
 type MarkdownTableToken = {
@@ -257,52 +258,6 @@ declare module '@tiptap/core' {
   }
 }
 
-const moveCursorToTableEnd = (tr: Transaction, tablePos: number) => {
-  const tableNode = tr.doc.nodeAt(tablePos)
-
-  if (!tableNode) {
-    return
-  }
-
-  const endOfTable = tablePos + tableNode.nodeSize - 1
-
-  tr.setSelection(TextSelection.near(tr.doc.resolve(endOfTable), -1))
-}
-
-// prosemirror-tables does not move the selection after a deletion, so removing the
-// last row or column can push the cursor out of the table into the content below.
-const keepCursorInTable =
-  (command: (state: EditorState, dispatch?: (tr: Transaction) => void) => boolean) =>
-  (state: EditorState, dispatch?: (tr: Transaction) => void): boolean => {
-    if (!dispatch) {
-      return command(state)
-    }
-
-    const table = findParentNodeClosestToPos(
-      state.selection.$from,
-      node => node.type.name === 'table',
-    )
-
-    return command(state, tr => {
-      const stillInTable = findParentNodeClosestToPos(
-        tr.selection.$from,
-        node => node.type.name === 'table',
-      )
-
-      if (table) {
-        // The delete can push the cursor into a following table, so compare the
-        // mapped position to confirm it is still the table we edited.
-        const originalTablePos = tr.mapping.map(table.pos)
-
-        if (stillInTable?.pos !== originalTablePos) {
-          moveCursorToTableEnd(tr, originalTablePos)
-        }
-      }
-
-      dispatch(tr)
-    })
-  }
-
 /**
  * This extension allows you to create tables.
  * @see https://www.tiptap.dev/api/nodes/table
@@ -492,7 +447,22 @@ export const Table = Node.create<TableOptions>({
       deleteColumn:
         () =>
         ({ state, dispatch }) => {
-          return keepCursorInTable(deleteColumn)(state, dispatch)
+          const table = findParentNodeClosestToPos(
+            state.selection.$from,
+            node => node.type.name === 'table',
+          )
+
+          return deleteColumn(
+            state,
+            dispatch &&
+              (tr => {
+                if (table) {
+                  keepCursorInTable(tr, table.pos)
+                }
+
+                dispatch(tr)
+              }),
+          )
         },
       addRowBefore:
         () =>
@@ -507,7 +477,22 @@ export const Table = Node.create<TableOptions>({
       deleteRow:
         () =>
         ({ state, dispatch }) => {
-          return keepCursorInTable(deleteRow)(state, dispatch)
+          const table = findParentNodeClosestToPos(
+            state.selection.$from,
+            node => node.type.name === 'table',
+          )
+
+          return deleteRow(
+            state,
+            dispatch &&
+              (tr => {
+                if (table) {
+                  keepCursorInTable(tr, table.pos)
+                }
+
+                dispatch(tr)
+              }),
+          )
         },
       deleteTable:
         () =>

--- a/packages/extension-table/src/table/utilities/keepCursorInTable.ts
+++ b/packages/extension-table/src/table/utilities/keepCursorInTable.ts
@@ -1,0 +1,29 @@
+import { findParentNodeClosestToPos } from '@tiptap/core'
+import { TextSelection, type Transaction } from '@tiptap/pm/state'
+
+// prosemirror-tables does not move the selection after a deletion, so removing the
+// last row or column can push the cursor out of the table into the content below.
+export function keepCursorInTable(tr: Transaction, tablePos: number) {
+  const mappedTablePos = tr.mapping.map(tablePos)
+
+  // The delete can push the cursor into a following table, so compare the
+  // mapped position to confirm it is still the table we edited.
+  const stillInTable = findParentNodeClosestToPos(
+    tr.selection.$from,
+    node => node.type.name === 'table',
+  )
+
+  if (stillInTable?.pos === mappedTablePos) {
+    return
+  }
+
+  const tableNode = tr.doc.nodeAt(mappedTablePos)
+
+  if (!tableNode) {
+    return
+  }
+
+  const endOfTable = mappedTablePos + tableNode.nodeSize - 1
+
+  tr.setSelection(TextSelection.near(tr.doc.resolve(endOfTable), -1))
+}


### PR DESCRIPTION
## Fixes

Fixes #8149

## Changes and Review

When you delete the last row or column of a table that has content below it, the cursor jumps out of the table and into that content. prosemirror-tables doesn't set a new selection after deleting, so the old cursor position maps to just outside the table. `deleteRow` and `deleteColumn` now move the selection back into the table when the cursor would otherwise land outside it.

To verify: put the cursor in the last row of a table that has a paragraph below it and run `deleteRow()`. The cursor stays inside the table.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
