### PR TITLE
fix(static-renderer): map table spans to React props

### DIFF
--- a/.changeset/fair-tips-watch.md
+++ b/.changeset/fair-tips-watch.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/static-renderer": patch
+---
+
+Fixed a bug where `colspan` and `rowspan` would not correctly map into React's `colSpan` and `rowSpan` props

--- a/.changeset/fair-tips-watch.md
+++ b/.changeset/fair-tips-watch.md
@@ -2,4 +2,4 @@
 "@tiptap/static-renderer": patch
 ---
 
-Fixed a bug where `colspan` and `rowspan` would not correctly map into React's `colSpan` and `rowSpan` props
+Fixed table cell and header spans in the React static renderer.

--- a/packages/static-renderer/__tests__/react-string.spec.ts
+++ b/packages/static-renderer/__tests__/react-string.spec.ts
@@ -15,6 +15,8 @@ describe('static renderer: react', () => {
       class: 'my-class',
       style: 'color: red; font-size: 16px; transform: translateX(15px) translateY(10px);',
       id: 'my-id',
+      colspan: 2,
+      rowspan: 3,
     }
 
     const result = mapAttrsToHTMLAttributes(attrs, 'test-key')
@@ -23,6 +25,8 @@ describe('static renderer: react', () => {
       className: 'my-class',
       style: { color: 'red', fontSize: '16px', transform: 'translateX(15px) translateY(10px)' },
       id: 'my-id',
+      colSpan: 2,
+      rowSpan: 3,
       key: 'test-key',
     })
   })

--- a/packages/static-renderer/src/pm/react/react.ts
+++ b/packages/static-renderer/src/pm/react/react.ts
@@ -8,6 +8,11 @@ import type { TiptapStaticRendererOptions } from '../../json/renderer.js'
 import type { StaticEditorOptions } from '../extensionRenderer.js'
 import { applyStaticEditorOptionsToExtensions, renderToElement } from '../extensionRenderer.js'
 
+const HTML_ATTRIBUTE_TO_REACT_ATTRIBUTE: Record<string, string> = {
+  colspan: 'colSpan',
+  rowspan: 'rowSpan',
+}
+
 /**
  * This function maps the attributes of a node or mark to HTML attributes
  * @param attrs The attributes to map
@@ -43,7 +48,9 @@ export function mapAttrsToHTMLAttributes(
         return Object.assign(acc, { style: styleObject })
       }
 
-      return Object.assign(acc, { [name]: value })
+      const reactName = HTML_ATTRIBUTE_TO_REACT_ATTRIBUTE[name] ?? name
+
+      return Object.assign(acc, { [reactName]: value })
     },
     { key },
   )


### PR DESCRIPTION
Fixes ueberdosis/tiptap-docs#519

Map ProseMirror table `colspan` and `rowspan` attributes to React’s `colSpan` and `rowSpan` props in the static renderer. Add a regression assertion for the attribute mapper.