### PR TITLE
fix(pm): point schema-list types at the emitted declaration files

### DIFF
--- a/.changeset/fix-pm-schema-list-types-path.md
+++ b/.changeset/fix-pm-schema-list-types-path.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/pm': patch
+---
+
+Fix the `./schema-list` export map pointing `types` at `dist/schema/`, which is not emitted. Tools that read the `types` condition directly could not resolve `@tiptap/pm/schema-list`.

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -106,8 +106,8 @@
     },
     "./schema-list": {
       "types": {
-        "import": "./dist/schema/index.d.ts",
-        "require": "./dist/schema/index.d.cts"
+        "import": "./dist/schema-list/index.d.ts",
+        "require": "./dist/schema-list/index.d.cts"
       },
       "import": "./dist/schema-list/index.js",
       "require": "./dist/schema-list/index.cjs"


### PR DESCRIPTION
## Changes and Review

`./schema-list` was the only subpath whose `types` condition pointed somewhere the build doesn't emit: `dist/schema/index.d.ts`, while `tsup.config.ts` builds `schema-list/index.ts` into `dist/schema-list/`. All 12 other subpaths already match their runtime path.

TypeScript with `moduleResolution: "bundler"` masked it by falling back to the `import` condition, so this only surfaces in tools that read `types` directly. `eslint-import-resolver-typescript` returns `{ found: false }` for `@tiptap/pm/schema-list`, making `import-x/no-unresolved` error on a valid import.

To verify:

```bash
pnpm -F @tiptap/pm build && ls packages/pm/dist/schema*
# only dist/schema-list exists; dist/schema does not
```

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
