### PR TITLE
fix(react): avoid stale position when syncing node view selection

### DIFF
--- a/.changeset/2026-08-06-react-nodeview-stale-selection.md
+++ b/.changeset/2026-08-06-react-nodeview-stale-selection.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+React node views no longer show the selected state when the selection covers a position the node view has moved away from.

--- a/packages/react/src/ReactNodeViewRenderer.spec.ts
+++ b/packages/react/src/ReactNodeViewRenderer.spec.ts
@@ -86,6 +86,10 @@ const ItemComponent = () => {
   return React.createElement(NodeViewWrapper, null, React.createElement(NodeViewContent))
 }
 
+const WidgetComponent = () => {
+  return React.createElement(NodeViewWrapper, null)
+}
+
 const ReactParagraphComponent = () => {
   return React.createElement(NodeViewWrapper, null, React.createElement(NodeViewContent))
 }
@@ -120,9 +124,23 @@ const Container = Node.create({
   },
 })
 
-const WidgetComponent = () => {
-  return React.createElement(NodeViewWrapper, null)
-}
+const Item = Node.create({
+  name: 'item',
+  group: 'block',
+  content: 'paragraph+',
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="item"]' }]
+  },
+
+  renderHTML() {
+    return ['div', { 'data-type': 'item' }, 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ItemComponent)
+  },
+})
 
 const Widget = Node.create({
   name: 'widget',
@@ -139,24 +157,6 @@ const Widget = Node.create({
 
   addNodeView() {
     return ReactNodeViewRenderer(WidgetComponent)
-  },
-})
-
-const Item = Node.create({
-  name: 'item',
-  group: 'block',
-  content: 'paragraph+',
-
-  parseHTML() {
-    return [{ tag: 'div[data-type="item"]' }]
-  },
-
-  renderHTML() {
-    return ['div', { 'data-type': 'item' }, 0]
-  },
-
-  addNodeView() {
-    return ReactNodeViewRenderer(ItemComponent)
   },
 })
 
@@ -297,9 +297,27 @@ describe('ReactNodeViewRenderer', () => {
 
     await flushAnimationFrame()
 
-    const widget = container.querySelector('.node-widget')
+    const widget = container.querySelector('.node-widget')!
 
-    expect(widget?.classList.contains('ProseMirror-selectednode')).toBe(false)
+    expect(widget.classList.contains('ProseMirror-selectednode')).toBe(false)
+
+    editor.destroy()
+  })
+
+  it('selects the node view when it is selected at its new position', async () => {
+    const editor = createEditorWithWidget()
+    const { container } = render(React.createElement(EditorContent, { editor }))
+
+    await flushMicrotasks()
+
+    editor.commands.insertContentAt(4, 'def')
+    editor.commands.setNodeSelection(8)
+
+    await flushAnimationFrame()
+
+    const widget = container.querySelector('.node-widget')!
+
+    expect(widget.classList.contains('ProseMirror-selectednode')).toBe(true)
 
     editor.destroy()
   })

--- a/packages/react/src/ReactNodeViewRenderer.spec.ts
+++ b/packages/react/src/ReactNodeViewRenderer.spec.ts
@@ -120,6 +120,28 @@ const Container = Node.create({
   },
 })
 
+const WidgetComponent = () => {
+  return React.createElement(NodeViewWrapper, null)
+}
+
+const Widget = Node.create({
+  name: 'widget',
+  group: 'block',
+  atom: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="widget"]' }]
+  },
+
+  renderHTML() {
+    return ['div', { 'data-type': 'widget' }]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(WidgetComponent)
+  },
+})
+
 const Item = Node.create({
   name: 'item',
   group: 'block',
@@ -154,9 +176,24 @@ const createEditorWithReactParagraph = () => {
   })
 }
 
+const createEditorWithWidget = () => {
+  return new Editor({
+    extensions: [Document, Paragraph, Text, Widget],
+    content: '<p>abc</p><div data-type="widget"></div>',
+  })
+}
+
 const flushMicrotasks = async () => {
   await act(async () => {
     await Promise.resolve()
+  })
+}
+
+const flushAnimationFrame = async () => {
+  await act(async () => {
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
   })
 }
 
@@ -244,6 +281,25 @@ describe('ReactNodeViewRenderer', () => {
 
     expect(renderErrors).toEqual([])
     expect(renderedPositions).toEqual([undefined])
+
+    editor.destroy()
+  })
+
+  it('does not select the node view when the selection covers its former position', async () => {
+    const editor = createEditorWithWidget()
+    const { container } = render(React.createElement(EditorContent, { editor }))
+
+    await flushMicrotasks()
+
+    // The widget starts at position 5 and moves to 8 when text is typed above it.
+    editor.commands.insertContentAt(4, 'def')
+    editor.commands.setTextSelection({ from: 5, to: 6 })
+
+    await flushAnimationFrame()
+
+    const widget = container.querySelector('.node-widget')
+
+    expect(widget?.classList.contains('ProseMirror-selectednode')).toBe(false)
 
     editor.destroy()
   })

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -280,7 +280,7 @@ export class ReactNodeView<
 
     this.selectionRafId = requestAnimationFrame(() => {
       this.selectionRafId = null
-      // getPos() returns undefined once ProseMirror has detached this node view.
+      // getPos() is undefined while the node view is mid-update, so fall back to the last known position.
       const pos = this.getPos() ?? this.currentPos
       if (typeof pos !== 'number') {
         return

--- a/packages/react/src/ReactNodeViewRenderer.tsx
+++ b/packages/react/src/ReactNodeViewRenderer.tsx
@@ -280,8 +280,8 @@ export class ReactNodeView<
 
     this.selectionRafId = requestAnimationFrame(() => {
       this.selectionRafId = null
-      // Avoid resolving getPos() after ProseMirror has detached this node view.
-      const pos = this.currentPos
+      // getPos() returns undefined once ProseMirror has detached this node view.
+      const pos = this.getPos() ?? this.currentPos
       if (typeof pos !== 'number') {
         return
       }


### PR DESCRIPTION
## Fixes

Fixes #8164

## Changes and Review

`handleSelectionUpdate` compared the selection against the cached `currentPos`, which only refreshes when the node object changes. Typing above a node view left it pointing at the old position, so selecting text there added `.ProseMirror-selectednode` to a node that was not selected. It now reads `getPos()` and falls back to `currentPos` only when the node view is detached, which keeps the crash from #7688 covered. Verify with the added test, or type a few characters before a React node view and select them.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.