### PR TITLE
fix(markdown): keep only inline content when parsing inline HTML

### DIFF
--- a/.changeset/2026-08-07-markdown-unclosed-inline-html.md
+++ b/.changeset/2026-08-07-markdown-unclosed-inline-html.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Parsing markdown with an unclosed inline HTML tag such as `<b>123` no longer produces a paragraph nested inside another paragraph, which was invalid for the default schema.

--- a/.changeset/2026-08-07-markdown-unclosed-inline-html.md
+++ b/.changeset/2026-08-07-markdown-unclosed-inline-html.md
@@ -2,4 +2,4 @@
 '@tiptap/markdown': patch
 ---
 
-Parsing markdown with an unclosed inline HTML tag such as `<b>123` no longer produces a paragraph nested inside another paragraph, which was invalid for the default schema.
+Markdown with inline HTML such as an unclosed `<b>` tag no longer parses into an invalid document. The tag is dropped and its text is kept.

--- a/packages/markdown/__tests__/mixed-html.spec.ts
+++ b/packages/markdown/__tests__/mixed-html.spec.ts
@@ -76,4 +76,20 @@ describe('MarkdownManager Mixed Markdown + HTML', () => {
       expect(hasItalic).toBe(true)
     })
   })
+
+  it('parses an unclosed inline HTML tag without nesting a paragraph', () => {
+    const md = '<b>123'
+    const doc = manager.parse(md)
+
+    expect(doc.content).toEqual([{ type: 'paragraph', content: [{ type: 'text', text: '123' }] }])
+  })
+
+  it('keeps the surrounding text of an unclosed inline HTML tag', () => {
+    const md = 'a <b> b'
+    const doc = manager.parse(md)
+
+    const paragraph = doc.content![0]
+    expect(paragraph.content!.every((n: any) => n.type === 'text')).toBe(true)
+    expect(paragraph.content!.map((n: any) => n.text).join('')).toBe('a  b')
+  })
 })

--- a/packages/markdown/__tests__/mixed-html.spec.ts
+++ b/packages/markdown/__tests__/mixed-html.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { Document } from '@tiptap/extension-document'
+import { HardBreak } from '@tiptap/extension-hard-break'
 import { Heading } from '@tiptap/extension-heading'
 import { Italic } from '@tiptap/extension-italic'
 import { Paragraph } from '@tiptap/extension-paragraph'
@@ -12,7 +13,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 describe('MarkdownManager Mixed Markdown + HTML', () => {
   let manager: MarkdownManager
-  const basicExtensions = [Document, Paragraph, Text, Heading, Italic]
+  const basicExtensions = [Document, Paragraph, Text, Heading, Italic, HardBreak]
 
   beforeEach(() => {
     manager = new MarkdownManager({ extensions: basicExtensions })
@@ -105,6 +106,22 @@ describe('MarkdownManager Mixed Markdown + HTML', () => {
 
     expect(doc.content).toEqual([
       { type: 'paragraph', content: [{ type: 'text', text: 'a title b' }] },
+    ])
+  })
+
+  it('parses inline HTML for an inline node and keeps the node', () => {
+    const md = 'a <br> b'
+    const doc = manager.parse(md)
+
+    expect(doc.content).toEqual([
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'a ' },
+          { type: 'hardBreak' },
+          { type: 'text', text: ' b' },
+        ],
+      },
     ])
   })
 })

--- a/packages/markdown/__tests__/mixed-html.spec.ts
+++ b/packages/markdown/__tests__/mixed-html.spec.ts
@@ -84,12 +84,27 @@ describe('MarkdownManager Mixed Markdown + HTML', () => {
     expect(doc.content).toEqual([{ type: 'paragraph', content: [{ type: 'text', text: '123' }] }])
   })
 
-  it('keeps the surrounding text of an unclosed inline HTML tag', () => {
+  it('parses an unclosed inline HTML tag and keeps the surrounding text', () => {
     const md = 'a <b> b'
     const doc = manager.parse(md)
 
-    const paragraph = doc.content![0]
-    expect(paragraph.content!.every((n: any) => n.type === 'text')).toBe(true)
-    expect(paragraph.content!.map((n: any) => n.text).join('')).toBe('a  b')
+    // The dropped tag leaves both of the spaces around it.
+    expect(doc.content).toEqual([{ type: 'paragraph', content: [{ type: 'text', text: 'a  b' }] }])
+  })
+
+  it('parses an empty inline HTML element without nesting a paragraph', () => {
+    const md = 'a <span></span> b'
+    const doc = manager.parse(md)
+
+    expect(doc.content).toEqual([{ type: 'paragraph', content: [{ type: 'text', text: 'a  b' }] }])
+  })
+
+  it('parses inline HTML for a block element as its inline content', () => {
+    const md = 'a <h1>title</h1> b'
+    const doc = manager.parse(md)
+
+    expect(doc.content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: 'a title b' }] },
+    ])
   })
 })

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -972,13 +972,10 @@ export class MarkdownManager {
         }
 
         // For inline HTML, we need to flatten the content appropriately
-        // If there's only one paragraph with content, unwrap it
-        if (
-          parsed.content.length === 1 &&
-          parsed.content[0].type === 'paragraph' &&
-          parsed.content[0].content
-        ) {
-          return parsed.content[0].content
+        // If there's only one paragraph, unwrap it. An empty paragraph carries no
+        // inline content, so we drop it instead of nesting a block node inline.
+        if (parsed.content.length === 1 && parsed.content[0].type === 'paragraph') {
+          return parsed.content[0].content ?? null
         }
 
         return parsed.content

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -59,6 +59,8 @@ export class MarkdownManager {
   private codeTypes: Set<string> = new Set()
   /** Lazy cache of tag names declared by the registered schema's parseDOM rules. */
   private schemaParseDomTagsCache: Set<string> | null = null
+  /** Lazy cache of the names of the schema's inline node types. */
+  private inlineNodeTypesCache: Set<string> | null = null
 
   /**
    * Create a MarkdownManager.
@@ -971,20 +973,68 @@ export class MarkdownManager {
           return parsed.content
         }
 
-        // For inline HTML, we need to flatten the content appropriately
-        // If there's only one paragraph, unwrap it. An empty paragraph carries no
-        // inline content, so we drop it instead of nesting a block node inline.
-        if (parsed.content.length === 1 && parsed.content[0].type === 'paragraph') {
-          return parsed.content[0].content ?? null
-        }
+        const inlineContent = this.toInlineContent(parsed.content)
 
-        return parsed.content
+        return inlineContent.length > 0 ? inlineContent : null
       }
 
       return parsed as JSONContent
     } catch (error) {
       throw new Error(`Failed to parse HTML in markdown: ${error}`)
     }
+  }
+
+  /**
+   * Keep only the inline nodes of parsed HTML content, unwrapping the block
+   * nodes around them. Inline HTML sits inside a textblock, where a block node
+   * would make the document invalid for the schema.
+   *
+   * @param content Content array of a parsed HTML fragment.
+   * @example
+   *   toInlineContent([{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }])
+   *   // → [{ type: 'text', text: 'hi' }]
+   */
+  private toInlineContent(content: JSONContent[]): JSONContent[] {
+    const inlineTypes = this.getInlineNodeTypes()
+
+    return content.flatMap(node => {
+      if (node.type && inlineTypes.has(node.type)) {
+        return [node]
+      }
+
+      return node.content ? this.toInlineContent(node.content) : []
+    })
+  }
+
+  /**
+   * Collect the names of the node types the schema treats as inline. Result is
+   * cached for the lifetime of the manager since extensions don't change after
+   * registration.
+   *
+   * @example
+   *   getInlineNodeTypes().has('text') // → true
+   */
+  private getInlineNodeTypes(): Set<string> {
+    if (this.inlineNodeTypesCache) {
+      return this.inlineNodeTypesCache
+    }
+
+    const types = new Set<string>(['text'])
+
+    try {
+      const schema = getSchema(this.baseExtensions)
+
+      Object.values(schema.nodes).forEach(type => {
+        if (type.isInline) {
+          types.add(type.name)
+        }
+      })
+    } catch {
+      // If schema construction fails, only text nodes count as inline.
+    }
+
+    this.inlineNodeTypesCache = types
+    return types
   }
 
   /**


### PR DESCRIPTION
## Fixes

Fixes #8168

## Changes and Review

Markdown like `<b>123` has no closing tag, so the inline HTML parsed to an empty paragraph that got returned into the inline stream, producing a paragraph inside a paragraph. Inline HTML now keeps only the inline content it parses to, so `manager.parse('<b>123')` returns a plain paragraph with the text `123`. The same held for other tags that gave a block node inline, for example `<span></span>` or `<h1>`. Verify with the added tests in `packages/markdown/__tests__/mixed-html.spec.ts`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
