### PR TITLE
fix(extension-list): fill the empty task item checkbox label for accessibility

### DIFF
--- a/.changeset/2026-08-10-task-item-a11y-label.md
+++ b/.changeset/2026-08-10-task-item-a11y-label.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-list': patch
+---
+
+TaskItem: the checkbox label now also fills the wrapping label element, so accessibility audits no longer flag it as empty.

--- a/demos/src/Nodes/TaskList/index.spec.ts
+++ b/demos/src/Nodes/TaskList/index.spec.ts
@@ -30,7 +30,7 @@ test.describe(`${demoPath}/${demoName}`, () => {
           return el.editor.getHTML()
         })
         expect(html).toBe(
-          '<ul data-type="taskList"><li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span></span></label><div><p>Example Text</p></div></li></ul>',
+          '<ul data-type="taskList"><li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;">Task item checkbox for Example Text</span></label><div><p>Example Text</p></div></li></ul>',
         )
       })
 

--- a/demos/src/Nodes/TaskList/index.spec.ts
+++ b/demos/src/Nodes/TaskList/index.spec.ts
@@ -30,7 +30,7 @@ test.describe(`${demoPath}/${demoName}`, () => {
           return el.editor.getHTML()
         })
         expect(html).toBe(
-          '<ul data-type="taskList"><li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;">Task item checkbox for Example Text</span></label><div><p>Example Text</p></div></li></ul>',
+          '<ul data-type="taskList"><li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span></span></label><div><p>Example Text</p></div></li></ul>',
         )
       })
 

--- a/packages/extension-list/__tests__/taskItem.spec.ts
+++ b/packages/extension-list/__tests__/taskItem.spec.ts
@@ -13,6 +13,207 @@ describe('TaskItem', () => {
     editor?.destroy()
   })
 
+  describe('accessibility', () => {
+    it('gives the checkbox label to the wrapping label element', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, TaskList, TaskItem],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked: false },
+                  content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'A list item' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const taskItemElement = editor.view.dom.querySelector('li[data-checked]')
+      const labelElement = taskItemElement?.querySelector('label')
+      const spanElement = taskItemElement?.querySelector('label > span')
+      const checkbox = taskItemElement?.querySelector('input[type="checkbox"]')
+
+      expect(labelElement?.textContent?.trim()).not.toBe('')
+      expect(spanElement?.textContent).toBe('Task item checkbox for A list item')
+      expect(checkbox?.getAttribute('aria-label')).toBe('Task item checkbox for A list item')
+      expect(labelElement?.querySelector('input')).not.toBeNull()
+    })
+
+    it('hides the checkbox label text visually', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, TaskList, TaskItem],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked: false },
+                  content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'A list item' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const spanElement = editor.view.dom.querySelector('li[data-checked] > label > span')
+
+      expect(spanElement?.style.position).toBe('absolute')
+      expect(spanElement?.style.width).toBe('1px')
+    })
+
+    it('supports a custom checkbox label', () => {
+      editor = new Editor({
+        extensions: [
+          Document,
+          Paragraph,
+          Text,
+          TaskList,
+          TaskItem.configure({
+            a11y: {
+              checkboxLabel: (node, checked) => (checked ? 'Done' : 'To do'),
+            },
+          }),
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked: false },
+                  content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'A list item' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const spanElement = editor.view.dom.querySelector('li[data-checked] > label > span')
+      const checkbox = editor.view.dom.querySelector('input[type="checkbox"]')
+
+      expect(spanElement?.textContent).toBe('To do')
+      expect(checkbox?.getAttribute('aria-label')).toBe('To do')
+    })
+
+    it('updates the checkbox label when the node changes', () => {
+      editor = new Editor({
+        extensions: [
+          Document,
+          Paragraph,
+          Text,
+          TaskList,
+          TaskItem.configure({
+            a11y: {
+              checkboxLabel: (node, checked) => (checked ? 'Done' : 'To do'),
+            },
+          }),
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked: false },
+                  content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'A list item' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const spanElement = editor.view.dom.querySelector('li[data-checked] > label > span')
+
+      expect(spanElement?.textContent).toBe('To do')
+
+      editor.chain().setTextSelection(4).updateAttributes('taskItem', { checked: true }).run()
+
+      expect(spanElement?.textContent).toBe('Done')
+    })
+
+    it('uses a fallback label for empty task items', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, TaskList, TaskItem],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked: false },
+                  content: [{ type: 'paragraph' }],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const spanElement = editor.view.dom.querySelector('li[data-checked] > label > span')
+
+      expect(spanElement?.textContent).toBe('Task item checkbox for empty task item')
+    })
+
+    it('renders the checkbox label in static HTML output', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, TaskList, TaskItem],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked: false },
+                  content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'A list item' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const html = editor.getHTML()
+      const parsed = new DOMParser().parseFromString(html, 'text/html')
+      const labelElement = parsed.querySelector('li[data-type="taskItem"] > label')
+      const spanElement = parsed.querySelector('li[data-type="taskItem"] > label > span')
+
+      expect(labelElement?.textContent?.trim()).not.toBe('')
+      expect(spanElement?.textContent).toBe('Task item checkbox for A list item')
+      expect(spanElement?.style.position).toBe('absolute')
+      expect(spanElement?.style.width).toBe('1px')
+    })
+  })
+
   it('preserves custom HTML attributes on node update', () => {
     // Extend TaskItem with a custom attribute
     const CustomTaskItem = TaskItem.extend({

--- a/packages/extension-list/__tests__/taskItem.spec.ts
+++ b/packages/extension-list/__tests__/taskItem.spec.ts
@@ -219,37 +219,35 @@ describe('TaskItem', () => {
       expect(spanElement?.textContent).toBe('Task item checkbox for empty task item')
     })
 
-    it('renders the checkbox label in static HTML output', () => {
+    it('does not parse the checkbox label as task item content', () => {
       editor = new Editor({
         extensions: [Document, Paragraph, Text, TaskList, TaskItem],
-        content: {
-          type: 'doc',
-          content: [
-            {
-              type: 'taskList',
-              content: [
-                {
-                  type: 'taskItem',
-                  attrs: { checked: false },
-                  content: [
-                    { type: 'paragraph', content: [{ type: 'text', text: 'A list item' }] },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
+        content: `
+          <ul data-type="taskList">
+            <li data-checked="true" data-type="taskItem">
+              <label><input type="checkbox"><span>Task item checkbox for A list item</span></label>
+              <div><p>A list item</p></div>
+            </li>
+          </ul>
+        `,
       })
 
-      const html = editor.getHTML()
-      const parsed = new DOMParser().parseFromString(html, 'text/html')
-      const labelElement = parsed.querySelector('li[data-type="taskItem"] > label')
-      const spanElement = parsed.querySelector('li[data-type="taskItem"] > label > span')
+      expect(editor.getText()).toContain('A list item')
+      expect(editor.getText()).not.toContain('Task item checkbox')
+    })
 
-      expect(labelElement?.textContent?.trim()).not.toBe('')
-      expect(spanElement?.textContent).toBe('Task item checkbox for A list item')
-      expect(spanElement?.style.position).toBe('absolute')
-      expect(spanElement?.style.width).toBe('1px')
+    it('still parses task items without a content wrapper', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, TaskList, TaskItem],
+        content: `
+          <ul data-type="taskList">
+            <li data-type="taskItem"><p>A list item</p></li>
+          </ul>
+        `,
+      })
+
+      expect(editor.getText()).toContain('A list item')
+      expect(editor.getText()).not.toContain('Task item checkbox')
     })
   })
 

--- a/packages/extension-list/__tests__/taskItem.spec.ts
+++ b/packages/extension-list/__tests__/taskItem.spec.ts
@@ -114,6 +114,45 @@ describe('TaskItem', () => {
       expect(checkbox?.getAttribute('aria-label')).toBe('To do')
     })
 
+    it('uses the checked state for an initially checked task item', () => {
+      editor = new Editor({
+        extensions: [
+          Document,
+          Paragraph,
+          Text,
+          TaskList,
+          TaskItem.configure({
+            a11y: {
+              checkboxLabel: (node, checked) => (checked ? 'Done' : 'To do'),
+            },
+          }),
+        ],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked: true },
+                  content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'A list item' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const spanElement = editor.view.dom.querySelector('li[data-checked] > label > span')
+      const checkbox = editor.view.dom.querySelector('input[type="checkbox"]')
+
+      expect(spanElement?.textContent).toBe('Done')
+      expect(checkbox?.getAttribute('aria-label')).toBe('Done')
+    })
+
     it('updates the checkbox label when the node changes', () => {
       editor = new Editor({
         extensions: [

--- a/packages/extension-list/src/task-item/task-item.ts
+++ b/packages/extension-list/src/task-item/task-item.ts
@@ -53,6 +53,17 @@ export interface TaskItemOptions {
     /**
      * The accessible label for the checkbox. Used as the aria-label on the input and as the
      * (visually hidden) text of the wrapping label element.
+     * @param node The prosemirror node of the task item
+     * @param checked The new checked state
+     * @returns The accessible label for the checkbox
+     * @example
+     * ```js
+     * TaskItem.configure({
+     *   a11y: {
+     *     checkboxLabel: node => `Task item: ${node.textContent || 'empty task item'}`,
+     *   },
+     * })
+     * ```
      */
     checkboxLabel?: (node: ProseMirrorNode, checked: boolean) => string
   }

--- a/packages/extension-list/src/task-item/task-item.ts
+++ b/packages/extension-list/src/task-item/task-item.ts
@@ -50,6 +50,10 @@ export interface TaskItemOptions {
    * }
    */
   a11y?: {
+    /**
+     * The accessible label for the checkbox. Used as the aria-label on the input and as the
+     * (visually hidden) text of the wrapping label element.
+     */
     checkboxLabel?: (node: ProseMirrorNode, checked: boolean) => string
   }
 }
@@ -58,6 +62,16 @@ export interface TaskItemOptions {
  * Matches a task item to a - [ ] on input.
  */
 export const inputRegex = /^\s*(\[([( |x])?\])\s$/
+
+/**
+ * Hides the checkbox label visually while keeping it in the accessibility tree.
+ */
+const visuallyHiddenStyle =
+  'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0'
+
+const getCheckboxLabel = (node: ProseMirrorNode, checked: boolean, a11y: TaskItemOptions['a11y']) =>
+  a11y?.checkboxLabel?.(node, checked) ||
+  `Task item checkbox for ${node.textContent || 'empty task item'}`
 
 /**
  * This extension allows you to create task items.
@@ -122,7 +136,11 @@ export const TaskItem = Node.create<TaskItemOptions>({
             checked: node.attrs.checked ? 'checked' : null,
           },
         ],
-        ['span'],
+        [
+          'span',
+          { style: visuallyHiddenStyle },
+          getCheckboxLabel(node, node.attrs.checked, this.options.a11y),
+        ],
       ],
       ['div', 0],
     ]
@@ -194,10 +212,13 @@ export const TaskItem = Node.create<TaskItemOptions>({
       const checkbox = document.createElement('input')
       const content = document.createElement('div')
 
+      checkboxStyler.style.cssText = visuallyHiddenStyle
+
       const updateA11Y = (currentNode: ProseMirrorNode) => {
-        checkbox.ariaLabel =
-          this.options.a11y?.checkboxLabel?.(currentNode, checkbox.checked) ||
-          `Task item checkbox for ${currentNode.textContent || 'empty task item'}`
+        const label = getCheckboxLabel(currentNode, checkbox.checked, this.options.a11y)
+
+        checkbox.setAttribute('aria-label', label)
+        checkboxStyler.textContent = label
       }
 
       updateA11Y(node)

--- a/packages/extension-list/src/task-item/task-item.ts
+++ b/packages/extension-list/src/task-item/task-item.ts
@@ -128,6 +128,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
       {
         tag: `li[data-type="${this.name}"]`,
         priority: 51,
+        contentElement: element => element.querySelector('div') ?? element,
       },
     ]
   },
@@ -147,11 +148,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
             checked: node.attrs.checked ? 'checked' : null,
           },
         ],
-        [
-          'span',
-          { style: visuallyHiddenStyle },
-          getCheckboxLabel(node, node.attrs.checked, this.options.a11y),
-        ],
+        ['span'],
       ],
       ['div', 0],
     ]

--- a/packages/extension-list/src/task-item/task-item.ts
+++ b/packages/extension-list/src/task-item/task-item.ts
@@ -226,7 +226,7 @@ export const TaskItem = Node.create<TaskItemOptions>({
       checkboxStyler.style.cssText = visuallyHiddenStyle
 
       const updateA11Y = (currentNode: ProseMirrorNode) => {
-        const label = getCheckboxLabel(currentNode, checkbox.checked, this.options.a11y)
+        const label = getCheckboxLabel(currentNode, currentNode.attrs.checked, this.options.a11y)
 
         checkbox.setAttribute('aria-label', label)
         checkboxStyler.textContent = label


### PR DESCRIPTION
## Fixes

- Fixes #6707

## Changes and Review

This PR adds missing a11y `aria-*` attributes to the task item node to improve the accessibility of task items. You can verify it yourself on the "Tasks" demo.

<img width="695" height="221" alt="image" src="https://github.com/user-attachments/assets/12f5e76b-570a-4e92-b8d0-062d316f43a7" />

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
