### PR TITLE
fix(extension-table): stop rendering default colspan and rowspan on cells

### DIFF
--- a/.changeset/2026-08-11-table-default-spans.md
+++ b/.changeset/2026-08-11-table-default-spans.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-table': patch
 ---
 
-Table cells and headers no longer render `colspan="1"` and `rowspan="1"`. Both attributes are only written to the HTML when a cell actually spans more than one column or row, which matches how prosemirror-tables serializes them.
+Table cells and headers only serialize `colspan` and `rowspan` when a cell spans more than one column or row.

--- a/.changeset/2026-08-11-table-default-spans.md
+++ b/.changeset/2026-08-11-table-default-spans.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Table cells and headers no longer render `colspan="1"` and `rowspan="1"`. Both attributes are only written to the HTML when a cell actually spans more than one column or row, which matches how prosemirror-tables serializes them.

--- a/packages/extension-table/__tests__/tableCell.spec.ts
+++ b/packages/extension-table/__tests__/tableCell.spec.ts
@@ -127,6 +127,26 @@ describe('extension table cell', () => {
     getEditorEl()?.remove()
   })
 
+  it('should only render colspan and rowspan when they are not the default', () => {
+    const content =
+      '<table><tbody><tr><td>Name</td><td colspan="2">Description</td></tr><tr><td rowspan="2">Cyndi Lauper</td><td>Singer</td><td>Songwriter</td></tr></tbody></table>'
+
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Text, Paragraph, TableCell, TableHeader, TableRow, Table],
+      content,
+    })
+
+    const html = editor.getHTML()
+
+    expect(html).toContain('<td><p>Name</p></td>')
+    expect(html).toContain('<td colspan="2"><p>Description</p></td>')
+    expect(html).toContain('<td rowspan="2"><p>Cyndi Lauper</p></td>')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
   it('should prefer the colwidth attribute over the colgroup col width', () => {
     const content =
       '<table><colgroup><col width="64" /><col /></colgroup><tbody><tr><td colwidth="200">hello</td><td>world</td></tr></tbody></table>'

--- a/packages/extension-table/__tests__/tableCell.spec.ts
+++ b/packages/extension-table/__tests__/tableCell.spec.ts
@@ -142,6 +142,8 @@ describe('extension table cell', () => {
     expect(html).toContain('<td><p>Name</p></td>')
     expect(html).toContain('<td colspan="2"><p>Description</p></td>')
     expect(html).toContain('<td rowspan="2"><p>Cyndi Lauper</p></td>')
+    expect(html).not.toContain('colspan="1"')
+    expect(html).not.toContain('rowspan="1"')
 
     editor?.destroy()
     getEditorEl()?.remove()

--- a/packages/extension-table/__tests__/tableCommands.spec.ts
+++ b/packages/extension-table/__tests__/tableCommands.spec.ts
@@ -268,7 +268,7 @@ describe('Table commands', () => {
     editor.commands.clearContent()
     editor.commands.insertTable({ cols: 1, rows: 1, withHeaderRow: false })
     expect(editor.getHTML()).toBe(
-      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>',
+      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><td><p></p></td></tr></tbody></table>',
     )
   })
 
@@ -276,7 +276,7 @@ describe('Table commands', () => {
     editor.commands.clearContent()
     editor.commands.insertTable({ cols: 1, rows: 1, withHeaderRow: true })
     expect(editor.getHTML()).toBe(
-      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>',
+      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><th><p></p></th></tr></tbody></table>',
     )
   })
 

--- a/packages/extension-table/__tests__/tableHeader.spec.ts
+++ b/packages/extension-table/__tests__/tableHeader.spec.ts
@@ -98,6 +98,25 @@ describe('extension table header', () => {
     getEditorEl()?.remove()
   })
 
+  it('should only render colspan and rowspan when they are not the default', () => {
+    const content =
+      '<table><tbody><tr><th>Name</th><th colspan="2">Description</th></tr><tr><td>Cyndi Lauper</td><td>Singer</td><td>Songwriter</td></tr></tbody></table>'
+
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Text, Paragraph, TableCell, TableHeader, TableRow, Table],
+      content,
+    })
+
+    const html = editor.getHTML()
+
+    expect(html).toContain('<th><p>Name</p></th>')
+    expect(html).toContain('<th colspan="2"><p>Description</p></th>')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
   it('should parse the colgroup col widths for a header row', () => {
     const content =
       '<table><colgroup><col width="64" /><col width="128" /></colgroup><tbody><tr><th>Name</th><th>Description</th></tr><tr><td>Cyndi Lauper</td><td>Singer</td></tr></tbody></table>'

--- a/packages/extension-table/__tests__/tableHeader.spec.ts
+++ b/packages/extension-table/__tests__/tableHeader.spec.ts
@@ -100,7 +100,7 @@ describe('extension table header', () => {
 
   it('should only render colspan and rowspan when they are not the default', () => {
     const content =
-      '<table><tbody><tr><th>Name</th><th colspan="2">Description</th></tr><tr><td>Cyndi Lauper</td><td>Singer</td><td>Songwriter</td></tr></tbody></table>'
+      '<table><tbody><tr><th>Name</th><th colspan="2">Description</th></tr><tr><th rowspan="2">Cyndi Lauper</th><td>Singer</td><td>Songwriter</td></tr><tr><td>Marie Curie</td><td>Scientist</td></tr></tbody></table>'
 
     editor = new Editor({
       element: createEditorEl(),
@@ -112,6 +112,9 @@ describe('extension table header', () => {
 
     expect(html).toContain('<th><p>Name</p></th>')
     expect(html).toContain('<th colspan="2"><p>Description</p></th>')
+    expect(html).toContain('<th rowspan="2"><p>Cyndi Lauper</p></th>')
+    expect(html).not.toContain('colspan="1"')
+    expect(html).not.toContain('rowspan="1"')
 
     editor?.destroy()
     getEditorEl()?.remove()

--- a/packages/extension-table/src/cell/table-cell.ts
+++ b/packages/extension-table/src/cell/table-cell.ts
@@ -34,9 +34,27 @@ export const TableCell = Node.create<TableCellOptions>({
     return {
       colspan: {
         default: 1,
+        renderHTML: attributes => {
+          if (attributes.colspan === 1) {
+            return {}
+          }
+
+          return {
+            colspan: attributes.colspan,
+          }
+        },
       },
       rowspan: {
         default: 1,
+        renderHTML: attributes => {
+          if (attributes.rowspan === 1) {
+            return {}
+          }
+
+          return {
+            rowspan: attributes.rowspan,
+          }
+        },
       },
       colwidth: {
         default: null,

--- a/packages/extension-table/src/header/table-header.ts
+++ b/packages/extension-table/src/header/table-header.ts
@@ -34,9 +34,27 @@ export const TableHeader = Node.create<TableHeaderOptions>({
     return {
       colspan: {
         default: 1,
+        renderHTML: attributes => {
+          if (attributes.colspan === 1) {
+            return {}
+          }
+
+          return {
+            colspan: attributes.colspan,
+          }
+        },
       },
       rowspan: {
         default: 1,
+        renderHTML: attributes => {
+          if (attributes.rowspan === 1) {
+            return {}
+          }
+
+          return {
+            rowspan: attributes.rowspan,
+          }
+        },
       },
       colwidth: {
         default: null,


### PR DESCRIPTION
## Fixes

Fixes #8176

## Changes and Review

Every `<td>` and `<th>` came out with `colspan="1" rowspan="1"`, because both attributes default to 1 in the schema and that default was rendered like any other value. Parsing existing table HTML and serializing it again therefore changed the markup. Both attributes now render only when they are greater than 1, which is what prosemirror-tables does.

To verify: load a table with plain cells into the editor and call `getHTML()`. Cells come back as `<td><p>Cell</p></td>`, and cells that really span still carry `colspan`/`rowspan`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.