### PR TITLE
fix(extension-table): make markdown pipe-escape regex parseable on WebKit < Safari 16.4

### DIFF
--- a/.changeset/fix-table-markdown-lookbehind-safari.md
+++ b/.changeset/fix-table-markdown-lookbehind-safari.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Replace the negative lookbehind in the table markdown pipe-escape regex with an equivalent lookbehind-free pattern. WebKit before Safari 16.4 cannot parse lookbehind assertions, and since the regex was a literal, the entire chunk containing the table extension failed at parse time on those browsers — any bundle importing `@tiptap/extension-table` ≥ 3.27.2 was unusable on iOS/Safari < 16.4.

--- a/.changeset/fix-table-markdown-lookbehind-safari.md
+++ b/.changeset/fix-table-markdown-lookbehind-safari.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-table': patch
 ---
 
-Replace the negative lookbehind in the table markdown pipe-escape regex with an equivalent lookbehind-free pattern. WebKit before Safari 16.4 cannot parse lookbehind assertions, and since the regex was a literal, the entire chunk containing the table extension failed at parse time on those browsers — any bundle importing `@tiptap/extension-table` ≥ 3.27.2 was unusable on iOS/Safari < 16.4.
+Fixed table markdown pipe escaping so the extension loads on older Safari and iOS versions (WebKit before Safari 16.4).

--- a/packages/extension-table/__tests__/tableMarkdown.spec.ts
+++ b/packages/extension-table/__tests__/tableMarkdown.spec.ts
@@ -2,7 +2,7 @@ import { Code } from '@tiptap/extension-code'
 import Document from '@tiptap/extension-document'
 import HardBreak from '@tiptap/extension-hard-break'
 import Paragraph from '@tiptap/extension-paragraph'
-import { TableKit } from '@tiptap/extension-table'
+import { escapeTableCellPipes, TableKit } from '@tiptap/extension-table'
 import Text from '@tiptap/extension-text'
 import { MarkdownManager } from '@tiptap/markdown'
 import { describe, expect, it } from 'vitest'
@@ -271,5 +271,30 @@ describe('table markdown line breaks', () => {
 
     expect(serialized).toContain('| plain |')
     expect(serialized).not.toContain('<br>')
+  })
+})
+
+describe('escapeTableCellPipes — pipe escaping inside code spans', () => {
+  it('escapes a bare pipe inside a code span', () => {
+    expect(escapeTableCellPipes('| `a|b` |')).toBe('| `a\\|b` |')
+  })
+
+  it('escapes every pipe of a consecutive run', () => {
+    expect(escapeTableCellPipes('| `||` |')).toBe('| `\\|\\|` |')
+  })
+
+  it('keeps an already-escaped pipe untouched', () => {
+    expect(escapeTableCellPipes('| `a\\|b` |')).toBe('| `a\\|b` |')
+  })
+
+  it('keeps a pipe preceded by a backslash pair untouched', () => {
+    // In `a\\|b` the pipe's immediately-preceding character is a backslash,
+    // so it passes through unchanged.
+    expect(escapeTableCellPipes('| `a\\\\|b` |')).toBe('| `a\\\\|b` |')
+  })
+
+  it('handles mixed escaped and bare pipes in one span', () => {
+    // Span content is `|\||` — bare, escaped, bare.
+    expect(escapeTableCellPipes('| `|\\||` |')).toBe('| `\\|\\|\\|` |')
   })
 })

--- a/packages/extension-table/src/table/utilities/markdown.ts
+++ b/packages/extension-table/src/table/utilities/markdown.ts
@@ -41,9 +41,13 @@ export function escapeTableCellPipes(line: string): string {
       while (j + closeLen < line.length && line[j + closeLen] === '`') closeLen += 1
       if (closeLen === runLen) {
         const spanContent = line.slice(i + runLen, j)
+        // Matches an already-escaped pipe (`\|`, kept as-is) or a bare pipe
+        // (escaped). Deliberately avoids a negative lookbehind assertion:
+        // WebKit before Safari 16.4 cannot parse lookbehind, and a regex
+        // literal fails the whole chunk at parse time, not at call time.
         result +=
           line.slice(i, i + runLen) +
-          spanContent.replace(/(?<!\\)\|/g, '\\|') +
+          spanContent.replace(/\\\||\|/g, match => (match === '|' ? '\\|' : match)) +
           line.slice(j, j + runLen)
         i = j + runLen
         found = true


### PR DESCRIPTION
## Fixes

Fixes #8179

## Changes and Review

- `escapeTableCellPipes` used a negative-lookbehind regex literal; WebKit < Safari 16.4 cannot parse lookbehind, and a regex literal fails the **whole chunk at parse time** — any bundle including `@tiptap/extension-table` >= 3.27.2 was broken on those browsers (same class as #5889/#5916 and #6727/#6731).
- Replaced with an exact-equivalent lookbehind-free pattern: an alternation that consumes already-escaped `\|` pairs untouched and escapes bare `|`. Behavioral parity with the old regex verified over a 200k-string randomized corpus (`a` / `\` / `|` / backtick / space).
- Added unit tests pinning the escape behavior — including the already-escaped-pipe branches the suite didn't cover — and verified the built dist is free of lookbehind. All 92 extension-table tests pass.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHw12prLZYBUmTwQKv1VjB
