### PR TITLE
fix(extension-table): omit default colspan and rowspan when rendering cells

### DIFF
--- a/.changeset/omit-default-table-cell-spans.md
+++ b/.changeset/omit-default-table-cell-spans.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-table': patch
 ---
 
-Table cells no longer serialize `colspan="1"` and `rowspan="1"`. The attributes are only rendered when a cell actually spans, so parsing and serializing existing table HTML leaves the markup unchanged.
+Default `colspan="1"` and `rowspan="1"` attributes are omitted from serialized table cells and headers.

--- a/.changeset/omit-default-table-cell-spans.md
+++ b/.changeset/omit-default-table-cell-spans.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Table cells no longer serialize `colspan="1"` and `rowspan="1"`. The attributes are only rendered when a cell actually spans, so parsing and serializing existing table HTML leaves the markup unchanged.

--- a/packages/extension-table/__tests__/tableCell.spec.ts
+++ b/packages/extension-table/__tests__/tableCell.spec.ts
@@ -153,4 +153,41 @@ describe('extension table cell', () => {
     editor?.destroy()
     getEditorEl()?.remove()
   })
+
+  it('should not serialize the default colspan and rowspan', () => {
+    const content = '<table><tbody><tr><th>Name</th><td>Cyndi Lauper</td></tr></tbody></table>'
+
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Text, Paragraph, TableCell, TableHeader, TableRow, Table],
+      content,
+    })
+
+    expect(editor.getHTML()).toContain('<th><p>Name</p></th>')
+    expect(editor.getHTML()).toContain('<td><p>Cyndi Lauper</p></td>')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
+
+  it('should keep colspan and rowspan when a cell actually spans', () => {
+    const content =
+      '<table><tbody><tr><td colspan="2">Wide</td><td rowspan="2">Tall</td></tr><tr><td>a</td><td>b</td></tr></tbody></table>'
+
+    editor = new Editor({
+      element: createEditorEl(),
+      extensions: [Document, Text, Paragraph, TableCell, TableHeader, TableRow, Table],
+      content,
+    })
+
+    const html = editor.getHTML()
+
+    expect(html).toContain('<td colspan="2"><p>Wide</p></td>')
+    expect(html).toContain('<td rowspan="2"><p>Tall</p></td>')
+    expect(html).not.toContain('colspan="1"')
+    expect(html).not.toContain('rowspan="1"')
+
+    editor?.destroy()
+    getEditorEl()?.remove()
+  })
 })

--- a/packages/extension-table/__tests__/tableCommands.spec.ts
+++ b/packages/extension-table/__tests__/tableCommands.spec.ts
@@ -268,7 +268,7 @@ describe('Table commands', () => {
     editor.commands.clearContent()
     editor.commands.insertTable({ cols: 1, rows: 1, withHeaderRow: false })
     expect(editor.getHTML()).toBe(
-      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><td colspan="1" rowspan="1"><p></p></td></tr></tbody></table>',
+      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><td><p></p></td></tr></tbody></table>',
     )
   })
 
@@ -276,7 +276,7 @@ describe('Table commands', () => {
     editor.commands.clearContent()
     editor.commands.insertTable({ cols: 1, rows: 1, withHeaderRow: true })
     expect(editor.getHTML()).toBe(
-      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p></p></th></tr></tbody></table>',
+      '<table style="min-width: 25px;"><colgroup><col style="min-width: 25px;"></colgroup><tbody><tr><th><p></p></th></tr></tbody></table>',
     )
   })
 

--- a/packages/extension-table/src/cell/table-cell.ts
+++ b/packages/extension-table/src/cell/table-cell.ts
@@ -4,6 +4,7 @@ import { mergeAttributes, Node } from '@tiptap/core'
 
 import { createAlignAttribute } from '../utils/parseAlign.js'
 import { parseColwidth } from '../utils/parseColwidth.js'
+import { renderSpanAttribute } from '../utils/renderSpanAttribute.js'
 import { fillEmptyCellContent, isEmptyCellElement } from '../utils/fillEmptyCellContent.js'
 
 export interface TableCellOptions {
@@ -34,9 +35,11 @@ export const TableCell = Node.create<TableCellOptions>({
     return {
       colspan: {
         default: 1,
+        renderHTML: renderSpanAttribute('colspan'),
       },
       rowspan: {
         default: 1,
+        renderHTML: renderSpanAttribute('rowspan'),
       },
       colwidth: {
         default: null,

--- a/packages/extension-table/src/header/table-header.ts
+++ b/packages/extension-table/src/header/table-header.ts
@@ -4,6 +4,7 @@ import { mergeAttributes, Node } from '@tiptap/core'
 
 import { createAlignAttribute } from '../utils/parseAlign.js'
 import { parseColwidth } from '../utils/parseColwidth.js'
+import { renderSpanAttribute } from '../utils/renderSpanAttribute.js'
 import { fillEmptyCellContent, isEmptyCellElement } from '../utils/fillEmptyCellContent.js'
 
 export interface TableHeaderOptions {
@@ -34,9 +35,11 @@ export const TableHeader = Node.create<TableHeaderOptions>({
     return {
       colspan: {
         default: 1,
+        renderHTML: renderSpanAttribute('colspan'),
       },
       rowspan: {
         default: 1,
+        renderHTML: renderSpanAttribute('rowspan'),
       },
       colwidth: {
         default: null,

--- a/packages/extension-table/src/utils/renderSpanAttribute.ts
+++ b/packages/extension-table/src/utils/renderSpanAttribute.ts
@@ -1,0 +1,19 @@
+/**
+ * Renders a cell span attribute only when it differs from the default of 1.
+ *
+ * `colspan` and `rowspan` default to 1 in the schema, so rendering them
+ * unconditionally puts `colspan="1" rowspan="1"` on every cell and rewrites
+ * table HTML on a parse/serialize round trip. prosemirror-tables omits them
+ * for the same reason.
+ */
+export function renderSpanAttribute(name: 'colspan' | 'rowspan') {
+  return (attributes: Record<string, any>): Record<string, any> => {
+    const value = attributes[name]
+
+    if (value === null || value === undefined || value === 1) {
+      return {}
+    }
+
+    return { [name]: value }
+  }
+}


### PR DESCRIPTION
Fixes #8176

`colspan` and `rowspan` default to `1` in `TableCell` and `TableHeader`, and both were rendered unconditionally, so every cell came out as:

```html
<td colspan="1" rowspan="1"><p>Cell</p></td>
```

Besides the extra markup, it means parsing existing table HTML and serializing it back changes the document. (Input that spells out `colspan="1"` now loses the attribute instead of keeping it, which is the same cell either way.)

Added a small `renderSpanAttribute` helper that returns `{}` when the value is `1` (or missing) and used it for both attributes on `TableCell` and `TableHeader`. Cells that actually span still render the attribute. This matches how prosemirror-tables serializes them.

Only the rendering changes, the schema defaults and parsing are untouched.

### Verification

New tests in `tableCell.spec.ts` cover both directions, plain cells and spanning cells:

```
Test Files  10 passed (10)
     Tests  94 passed (94)
```

Reverting just `packages/extension-table/src` turns them red, along with the two existing markup assertions this fix updates:

```
× should not serialize the default colspan and rowspan
  AssertionError: expected '<table style="min-width: 50px;"><colg…' to contain '<th><p>Name</p></th>'
× should keep colspan and rowspan when a cell actually spans
× generates correct markup for a 1x1 table
× generates correct markup for a 1x1 table with header
```

The two `tableCommands.spec.ts` expectations were pinned to the old `colspan="1" rowspan="1"` output and are updated here.

Full unit suite: `176 files, 1819 passed`. `oxlint` and `oxfmt --check` clean on `packages/extension-table`.

Changeset included (patch).


### AI usage disclosure

Per CONTRIBUTING: I used Claude Code as an assistant on this change. I reviewed every line, ran the tests myself, and confirmed the reverted-source failures listed above. Adding this late, I missed the requirement when I opened the PR.
