### PR TITLE
Quick fixes to agent skill bugs.

### DIFF
--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -12,10 +12,10 @@ metadata:
 This skill contains instructions for integrating the Tiptap rich text editor into an app and
 developing new features with it.
 
-This is not the Tiptap editor you know. Before you implement any feature with Tiptap, reference
-the Tiptap code and documentation to make sure you implement it correctly. Make sure any decision
-you make is in accordance to the "Best Practices" section and is grounded in the tiptap documentation
-and source code. Do not guess or invent patterns, make sure the code you write matches the library
+This is not the Tiptap editor you know: it may have evolved and changed since the version you're familiar with. 
+Before you implement any feature with Tiptap, reference the Tiptap code and documentation to make sure you implement 
+it correctly. Make sure any decision you make is in accordance to the "Best Practices" section and is grounded in the 
+Tiptap documentation and source code. Do not guess or invent patterns, make sure the code you write matches the library
 source code and the documentation.
 
 ## Initial setup
@@ -36,12 +36,23 @@ Before doing any task that involves the Tiptap editor:
 1. Pull the latest changes of the `main` branch in the local tiptap and tiptap-docs repositories
 2. Research the documentation and source code to see how to implement it
 
+Never implement new features from `tiptap-docs/src/content/ai/deprecated/`. Those pages document the
+retired AI Agent, AI Changes, and AI Suggestion extensions. Use the AI Toolkit or (less preferred) Basic AI Generation instead. 
+To move an existing integration off those deprecated products, see
+`tiptap-docs/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/`.
+
 ## Best Practices
 
 ### General
 
-- Use the latest stable version of **Tiptap 3**.
-- All packages that start with `@tiptap/` must have the **same version number**.
+- For a new install, use the latest stable version. Resolve it with `npm view @tiptap/core version`.
+- The editor and extension packages published from the tiptap monorepo share one version line. Pin
+  every one of them to that same version. Mixing versions risks introducing bugs. 
+- Some packages have their own version line. Resolve these from the registry, never from
+  `@tiptap/core`: `@tiptap/ai-toolkit`, `@tiptap/y-tiptap`, `@tiptap-pro/*` (private registry),
+  `@hocuspocus/*`.
+- Do not mix majors. For a project still on Tiptap 2, upgrade first. See
+  `tiptap-docs/src/content/guides/upgrade-tiptap-v2.mdx`.
 - When integrating Tiptap for the first time, read the corresponding installation guide in tiptap-docs.
 - When server-side rendering (e.g. Next.js), set the `immediatelyRender: false` option when initializing the editor. Otherwise, the editor will crash. Learn more about this in tiptap-docs.
 
@@ -99,21 +110,21 @@ Track, accept, and reject document edits. See `tiptap-docs/src/content/tracked-c
 
 Convert documents to and from DOCX, PDF, Markdown, and other formats. See `tiptap-docs/src/content/conversion/`.
 
-### AI content generation
-
-Generate text content into the document using AI. See `tiptap-docs/src/content/content-ai/capabilities/ai-toolkit/workflows/insert-content.mdx`.
-
 ### AI agent document editing
 
-Give an AI agent the ability to edit Tiptap documents. See `tiptap-docs/src/content/content-ai/capabilities/ai-toolkit/`.
+Give an AI agent the ability to read, write to, and accurately edit Tiptap documents. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
 
 ### AI review and proofreading
 
-Review, proofread, and suggest style improvements. See `tiptap-docs/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx`.
+Review, proofread, and suggest style improvements. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
 
-### AI server-side processing
+### AI client-side agent tools
 
-Run AI workflows that edit rich text documents on the server. See `tiptap-docs/src/content/content-ai/capabilities/server-ai-toolkit/`.
+Run AI workflows that edit rich text documents in the browser by interacting directly with the Tiptap editor. See `tiptap-docs/src/content/ai/ai-toolkit/client/overview.mdx`.
+
+### Basic (non-agent) AI content generation
+
+Generate and edit text content via basic one-shot prompts. See `tiptap-docs/src/content/ai/basic/overview.mdx`.
 
 ### Version history
 

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -37,8 +37,11 @@ Before doing any task that involves the Tiptap editor:
 2. Research the documentation and source code to see how to implement it
 
 Never implement new features from `tiptap-docs/src/content/ai/deprecated/`. Those pages document the
-retired AI Agent, AI Changes, and AI Suggestion extensions. Use the AI Toolkit or (less preferred) Basic AI Generation instead. 
-To move an existing integration off those deprecated products, see
+retired AI Agent, AI Changes, and AI Suggestion extensions. In general, prefer the more powerful and flexible
+AI Toolkit: it supports robust AI functionality with agents reading, editing, and commenting on docs in various ways.
+For simple, non-agentic (one-shot) use cases, Basic AI Generation may be sufficient.
+
+To move an existing integration off the deprecated products, see
 `tiptap-docs/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/`.
 
 ## Best Practices


### PR DESCRIPTION
## Fixes
- Added a note to discourage agents from creating new projects with deprecated AI features.
- Fixed an issue where we were instructing the agent to use nonexistent version numbers.
- Updated version-number guidance to be dynamic so we don't have to update the skill on every release.
- Fixed some links broken after the recent AI Toolkit launch.
