### PR TITLE
docs: update onClick handler to include position parameter

### DIFF
--- a/demos/src/Extensions/Mathematics/React/index.jsx
+++ b/demos/src/Extensions/Mathematics/React/index.jsx
@@ -25,12 +25,12 @@ export default () => {
           },
         },
         inlineOptions: {
-          onClick: node => {
+          onClick: (node, pos) => {
             const newCalculation = prompt('Enter new calculation:', node.attrs.latex)
             if (newCalculation) {
               editor
                 .chain()
-                .setNodeSelection(node.pos)
+                .setNodeSelection(pos)
                 .updateInlineMath({ latex: newCalculation })
                 .focus()
                 .run()


### PR DESCRIPTION
## Fixes

A bug in the docs

## Changes and Review

For the page [Extensions - Mathematics](https://tiptap.dev/docs/editor/extensions/nodes/mathematics), `index.jsx` script uses `node.pos` which is not valid.
This PR uses `pos` gotten as an argument from the `inlineOptions.onClick` function

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
