### PR TITLE
fix(extension-image): reveal resizable node view when the image is already cached

### DIFF
--- a/.changeset/fix-image-resize-cached-image-hidden.md
+++ b/.changeset/fix-image-resize-cached-image-hidden.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-image': patch
 ---
 
-Fix resizable images staying invisible when the image is already cached. The resize node view hid the element and only revealed it inside `el.onload`, but a cached image is already `complete` before the node view mounts, so `load` never fires again. The node view now reveals immediately when the image is already loaded, and also on `error` so a broken `src` renders as an inspectable broken image instead of an invisible node.
+Fix resizable images staying hidden when the image is cached or fails to load.

--- a/.changeset/fix-image-resize-cached-image-hidden.md
+++ b/.changeset/fix-image-resize-cached-image-hidden.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-image': patch
+---
+
+Fix resizable images staying invisible when the image is already cached. The resize node view hid the element and only revealed it inside `el.onload`, but a cached image is already `complete` before the node view mounts, so `load` never fires again. The node view now reveals immediately when the image is already loaded, and also on `error` so a broken `src` renders as an inspectable broken image instead of an invisible node.

--- a/packages/extension-image/__tests__/image.spec.ts
+++ b/packages/extension-image/__tests__/image.spec.ts
@@ -3,7 +3,7 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { Markdown } from '@tiptap/markdown'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import Image from '../src/index.js'
 
@@ -497,6 +497,60 @@ describe('extension-image', () => {
       expect(img?.hasAttribute('alt')).toBe(false)
       expect(img?.hasAttribute('title')).toBe(false)
       expect(img?.hasAttribute('data-custom-id')).toBe(false)
+    })
+  })
+
+  describe('resizable image visibility', () => {
+    const setImageLoaded = (loaded: boolean) => {
+      vi.spyOn(HTMLImageElement.prototype, 'complete', 'get').mockReturnValue(loaded)
+      vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(loaded ? 100 : 0)
+    }
+
+    const mountResizableImage = () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Paragraph, Text, Image.configure({ resize: { enabled: true } })],
+        content: {
+          type: 'doc',
+          content: [{ type: 'image', attrs: { src: imgSrc } }],
+        },
+      })
+
+      return editor.view.dom.querySelector('[data-resize-container]') as HTMLElement
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should show the node view when the image is already loaded on mount', () => {
+      // A cached image is already complete before the node view mounts, so
+      // `load` never fires again and the image would stay hidden forever.
+      setImageLoaded(true)
+
+      expect(mountResizableImage().style.visibility).toBe('')
+    })
+
+    it('should hide the node view until a not-yet-loaded image fires load', () => {
+      setImageLoaded(false)
+
+      const container = mountResizableImage()
+
+      expect(container.style.visibility).toBe('hidden')
+
+      container.querySelector('img')?.dispatchEvent(new Event('load'))
+
+      expect(container.style.visibility).toBe('')
+    })
+
+    it('should show the node view when the image fails to load', () => {
+      setImageLoaded(false)
+
+      const container = mountResizableImage()
+
+      container.querySelector('img')?.dispatchEvent(new Event('error'))
+
+      expect(container.style.visibility).toBe('')
     })
   })
 })

--- a/packages/extension-image/src/image.ts
+++ b/packages/extension-image/src/image.ts
@@ -278,11 +278,23 @@ export const Image = Node.create<ImageOptions>({
       const dom = nodeView.dom as HTMLElement
 
       // when image is loaded, show the node view to get the correct dimensions
-      dom.style.visibility = 'hidden'
-      dom.style.pointerEvents = 'none'
-      el.onload = () => {
+      const showNodeView = () => {
         dom.style.visibility = ''
         dom.style.pointerEvents = ''
+      }
+
+      dom.style.visibility = 'hidden'
+      dom.style.pointerEvents = 'none'
+
+      if (el.complete && el.naturalWidth > 0) {
+        // A cached image is already complete before this node view mounts, so
+        // `load` never fires again and the image would stay hidden forever.
+        showNodeView()
+      } else {
+        el.onload = showNodeView
+        // Reveal on error too, so a broken src renders as an inspectable broken
+        // image instead of an invisible node.
+        el.onerror = showNodeView
       }
 
       return nodeView


### PR DESCRIPTION
Closes #8187

### Problem

The resize node view hides itself and clears that **only** inside `el.onload`:

```js
dom.style.visibility = 'hidden'
dom.style.pointerEvents = 'none'
el.onload = () => {
  dom.style.visibility = ''
  dom.style.pointerEvents = ''
}
```

A cached image is already `complete` before the node view mounts, so `load` never fires again and the image stays permanently invisible. This is why an image renders after insert but is blank when the same content is loaded a second time.

A failing `src` lands in the same place from the other direction: `error` fires instead of `load`, so the node stays invisible rather than showing a broken-image icon you can inspect.

### Fix

Reveal immediately when the image is already loaded, and bind `error` alongside `load` otherwise.

```js
const showNodeView = () => {
  dom.style.visibility = ''
  dom.style.pointerEvents = ''
}

dom.style.visibility = 'hidden'
dom.style.pointerEvents = 'none'

if (el.complete && el.naturalWidth > 0) {
  showNodeView()
} else {
  el.onload = showNodeView
  el.onerror = showNodeView
}
```

`naturalWidth > 0` is what separates a genuinely decoded image from one that is `complete` because it errored or has no `src`, so the error path still routes through the `error` listener.

### Tests

Three cases added to `packages/extension-image/__tests__/image.spec.ts`:

- already loaded at mount → node view is visible
- not yet loaded → stays hidden, becomes visible after `load`
- load fails → becomes visible on `error`

The first and third **fail on `main`** (`expected 'hidden' to be ''`) and pass with this change. The second guards the existing behaviour.

`vitest run packages/extension-image` is green (16 tests), and `oxlint` / `oxfmt` are clean.

### Note

I could not produce a CodeSandbox repro, since the bug needs a real second page load to populate the browser cache. The two failing tests reproduce it deterministically instead. Happy to add a sandbox if you would still like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
