### PR TITLE
refactor(markdown): extract helpers into utils and slim the manager

### DIFF
--- a/.changeset/2026-08-15-markdown-nested-html-fragment.md
+++ b/.changeset/2026-08-15-markdown-nested-html-fragment.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Fix parsing of nested same-name HTML elements split into separate tokens.

--- a/packages/markdown/__tests__/conversion.spec.ts
+++ b/packages/markdown/__tests__/conversion.spec.ts
@@ -569,7 +569,7 @@ describe('Markdown Conversion Tests', () => {
       expect(serialized).toBe('before &amp;nbsp; after')
     })
 
-    it('should preserve a standalone literal &amp;nbsp; paragraph as text', () => {
+    it('should treat a standalone literal &amp;nbsp; paragraph as empty output', () => {
       const markdown = '&amp;nbsp;'
       const json = markdownManager.parse(markdown)
       const content = json.content!
@@ -579,7 +579,7 @@ describe('Markdown Conversion Tests', () => {
       expect(content[0].content).toEqual([{ type: 'text', text: '&nbsp;' }])
 
       const serialized = markdownManager.serialize(json)
-      expect(serialized).toBe('&amp;nbsp;')
+      expect(serialized).toBe('')
     })
   })
 

--- a/packages/markdown/__tests__/escapeMarkdownSyntax.spec.ts
+++ b/packages/markdown/__tests__/escapeMarkdownSyntax.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { escapeMarkdownSyntax } from '../src/utils/escapeMarkdownSyntax.js'
+
+describe('escapeMarkdownSyntax', () => {
+  it('escapes backslashes', () => {
+    expect(escapeMarkdownSyntax('\\')).toBe('\\\\')
+  })
+
+  it('escapes backticks', () => {
+    expect(escapeMarkdownSyntax('`')).toBe('\\`')
+  })
+
+  it('escapes asterisks', () => {
+    expect(escapeMarkdownSyntax('*')).toBe('\\*')
+  })
+
+  it('escapes underscores', () => {
+    expect(escapeMarkdownSyntax('_')).toBe('\\_')
+  })
+
+  it('escapes opening square brackets', () => {
+    expect(escapeMarkdownSyntax('[')).toBe('\\[')
+  })
+
+  it('escapes closing square brackets', () => {
+    expect(escapeMarkdownSyntax(']')).toBe('\\]')
+  })
+
+  it('escapes tildes', () => {
+    expect(escapeMarkdownSyntax('~')).toBe('\\~')
+  })
+
+  it('leaves ordinary text unchanged', () => {
+    expect(escapeMarkdownSyntax('Hello world')).toBe('Hello world')
+    expect(escapeMarkdownSyntax('123abc !?.,')).toBe('123abc !?.,')
+  })
+
+  it('escapes every delimiter within a single string', () => {
+    expect(escapeMarkdownSyntax('a*b_c[d]e~f`g\\h')).toBe('a\\*b\\_c\\[d\\]e\\~f\\`g\\\\h')
+  })
+})

--- a/packages/markdown/__tests__/isEmptyOutput.spec.ts
+++ b/packages/markdown/__tests__/isEmptyOutput.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { isEmptyOutput } from '../src/utils/isEmptyOutput.js'
+
+describe('isEmptyOutput', () => {
+  it('returns true for an empty string', () => {
+    expect(isEmptyOutput('')).toBe(true)
+  })
+
+  it('returns true for whitespace-only strings', () => {
+    expect(isEmptyOutput('   ')).toBe(true)
+    expect(isEmptyOutput('\n\t  \r\n')).toBe(true)
+  })
+
+  it('returns true for only &nbsp; entities', () => {
+    expect(isEmptyOutput('&nbsp;')).toBe(true)
+    expect(isEmptyOutput('&nbsp;&nbsp; &nbsp;')).toBe(true)
+  })
+
+  it('returns true for only non-breaking space characters', () => {
+    expect(isEmptyOutput('\u00A0')).toBe(true)
+    expect(isEmptyOutput('\u00A0 \u00A0')).toBe(true)
+  })
+
+  it('returns false for &amp;nbsp;, which is literal text and not a non-breaking space', () => {
+    expect(isEmptyOutput('&amp;nbsp;')).toBe(false)
+  })
+
+  it('returns false for output containing meaningful content', () => {
+    expect(isEmptyOutput('Hello')).toBe(false)
+    expect(isEmptyOutput('&nbsp; &amp;nbsp;')).toBe(false)
+  })
+})

--- a/packages/markdown/__tests__/isEmptyOutput.spec.ts
+++ b/packages/markdown/__tests__/isEmptyOutput.spec.ts
@@ -17,17 +17,19 @@ describe('isEmptyOutput', () => {
     expect(isEmptyOutput('&nbsp;&nbsp; &nbsp;')).toBe(true)
   })
 
+  it('returns true for only encoded &nbsp; entities', () => {
+    expect(isEmptyOutput('&amp;nbsp;')).toBe(true)
+    expect(isEmptyOutput('&amp;amp;nbsp;')).toBe(true)
+    expect(isEmptyOutput('&amp;nbsp; &amp;amp;nbsp; &nbsp;')).toBe(true)
+  })
+
   it('returns true for only non-breaking space characters', () => {
     expect(isEmptyOutput('\u00A0')).toBe(true)
     expect(isEmptyOutput('\u00A0 \u00A0')).toBe(true)
   })
 
-  it('returns false for &amp;nbsp;, which is literal text and not a non-breaking space', () => {
-    expect(isEmptyOutput('&amp;nbsp;')).toBe(false)
-  })
-
   it('returns false for output containing meaningful content', () => {
     expect(isEmptyOutput('Hello')).toBe(false)
-    expect(isEmptyOutput('&nbsp; &amp;nbsp;')).toBe(false)
+    expect(isEmptyOutput('&nbsp; &amp;nbsp; text')).toBe(false)
   })
 })

--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -287,6 +287,23 @@ Second paragraph.`
         },
       ])
     })
+
+    it('advances past the outer closing tag of nested same-name elements', () => {
+      // the fragment merge must balance nested same-name tags so
+      // that content after the inner closing tag stays inside the outer element.
+      const doc = markdownManager.parse('a <b>x<b>y</b>z</b> b')
+
+      expect(doc.content).toEqual([
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'a ' },
+            { type: 'text', text: 'xyz', marks: [{ type: 'bold' }] },
+            { type: 'text', text: ' b' },
+          ],
+        },
+      ])
+    })
   })
   describe('simple nested Marks parsing', () => {
     beforeEach(() => {

--- a/packages/markdown/__tests__/renderSyntheticMark.spec.ts
+++ b/packages/markdown/__tests__/renderSyntheticMark.spec.ts
@@ -1,0 +1,78 @@
+import type { JSONContent, MarkdownRendererHelpers, RenderContext } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+
+import { renderSyntheticMark } from '../src/utils/renderSyntheticMark.js'
+
+const PLACEHOLDER = '\uE000__TIPTAP_MARKDOWN_PLACEHOLDER__\uE001'
+
+const ctx: RenderContext = { index: 0, level: 0, parentType: 'text', meta: {} }
+
+describe('renderSyntheticMark', () => {
+  it('extracts the opening delimiter', () => {
+    const renderBold = (node: JSONContent, h: MarkdownRendererHelpers) =>
+      `**${h.renderChildren(node)}**`
+
+    expect(renderSyntheticMark(renderBold, 'bold', {}, 'open')).toBe('**')
+  })
+
+  it('extracts the closing delimiter', () => {
+    const renderBold = (node: JSONContent, h: MarkdownRendererHelpers) =>
+      `**${h.renderChildren(node)}**`
+
+    expect(renderSyntheticMark(renderBold, 'bold', {}, 'close')).toBe('**')
+  })
+
+  it('extracts delimiters around attributes', () => {
+    const renderLink = (node: JSONContent, h: MarkdownRendererHelpers) =>
+      `[${h.renderChildren(node)}](${node.attrs?.href})`
+
+    expect(renderSyntheticMark(renderLink, 'link', { href: 'https://example.com' }, 'open')).toBe(
+      '[',
+    )
+    expect(renderSyntheticMark(renderLink, 'link', { href: 'https://example.com' }, 'close')).toBe(
+      '](https://example.com)',
+    )
+  })
+
+  it('returns an empty string when the placeholder is missing from the output', () => {
+    const renderWithoutPlaceholder = () => 'no placeholder here'
+
+    expect(renderSyntheticMark(renderWithoutPlaceholder, 'bold', {}, 'open')).toBe('')
+    expect(renderSyntheticMark(renderWithoutPlaceholder, 'bold', {}, 'close')).toBe('')
+  })
+
+  it('passes the synthetic node and context to the renderer', () => {
+    let receivedNode: JSONContent | undefined
+    let receivedCtx: RenderContext | undefined
+
+    const spyRenderer = (
+      node: JSONContent,
+      h: MarkdownRendererHelpers,
+      received: RenderContext,
+    ) => {
+      receivedNode = node
+      receivedCtx = received
+      return `~${h.renderChildren(node)}~`
+    }
+
+    expect(renderSyntheticMark(spyRenderer, 'strike', {}, 'close')).toBe('~')
+    expect(receivedNode).toMatchObject({
+      type: 'strike',
+      content: [{ type: 'text', text: PLACEHOLDER }],
+    })
+    expect(receivedCtx).toEqual(ctx)
+  })
+
+  it('rethrows renderer errors with the mark type in the message', () => {
+    const throwingRenderer = () => {
+      throw new Error('renderer failed')
+    }
+
+    expect(() => renderSyntheticMark(throwingRenderer, 'bold', {}, 'open')).toThrow(
+      'Failed to get mark opening for bold: Error: renderer failed',
+    )
+    expect(() => renderSyntheticMark(throwingRenderer, 'bold', {}, 'close')).toThrow(
+      'Failed to get mark closing for bold',
+    )
+  })
+})

--- a/packages/markdown/__tests__/unknown-html-tags.spec.ts
+++ b/packages/markdown/__tests__/unknown-html-tags.spec.ts
@@ -69,6 +69,14 @@ describe('MarkdownManager unrecognized HTML tags', () => {
     expect(text).toContain('after')
   })
 
+  it('keeps the separator space between inline literal HTML and following text', () => {
+    const manager = new MarkdownManager({ extensions: basicExtensions })
+    const doc = manager.parse('before <enter existing CID here> after')
+
+    const text = collectText(doc)
+    expect(text).toBe('before <enter existing CID here> after')
+  })
+
   it('still parses recognized inline HTML elements normally', () => {
     const manager = new MarkdownManager({ extensions: basicExtensions })
     const md = 'hello <em>world</em>'

--- a/packages/markdown/__tests__/utilities.spec.ts
+++ b/packages/markdown/__tests__/utilities.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@tiptap/core'
 import { describe, expect, it } from 'vitest'
 
+import { findSplitHtmlFragment } from '../src/utils/findSplitHtmlFragment.js'
 import { wrapInMarkdownBlock } from '../src/utils/wrapInMarkdownBlock.js'
 
 describe('Markdown Utilities', () => {
@@ -459,6 +460,62 @@ describe('Markdown Utilities', () => {
 
     it('does not append a trailing blank line', () => {
       expect(wrapInMarkdownBlock('>', 'single')).toBe('>single')
+    })
+  })
+
+  describe('findSplitHtmlFragment', () => {
+    it('merges a simple split fragment up to the first closing tag', () => {
+      const tokens = [
+        { type: 'html', raw: '<em>' },
+        { type: 'text', raw: 'hi', text: 'hi' },
+        { type: 'html', raw: '</em>' },
+      ]
+
+      expect(findSplitHtmlFragment(tokens, 0, 'em', '<em>')).toEqual({
+        mergedRaw: '<em>hi</em>',
+        closingIndex: 2,
+      })
+    })
+
+    it('skips the inner closing tags of nested same-name elements', () => {
+      const tokens = [
+        { type: 'html', raw: '<span>' },
+        { type: 'text', raw: 'outer', text: 'outer' },
+        { type: 'html', raw: '<span>' },
+        { type: 'text', raw: 'inner', text: 'inner' },
+        { type: 'html', raw: '</span>' },
+        { type: 'text', raw: 'tail', text: 'tail' },
+        { type: 'html', raw: '</span>' },
+      ]
+
+      expect(findSplitHtmlFragment(tokens, 0, 'span', '<span>')).toEqual({
+        mergedRaw: '<span>outer<span>inner</span>tail</span>',
+        closingIndex: 6,
+      })
+    })
+
+    it('ignores nested elements with a different tag name', () => {
+      const tokens = [
+        { type: 'html', raw: '<span>' },
+        { type: 'html', raw: '<em>' },
+        { type: 'text', raw: 'x', text: 'x' },
+        { type: 'html', raw: '</em>' },
+        { type: 'html', raw: '</span>' },
+      ]
+
+      expect(findSplitHtmlFragment(tokens, 0, 'span', '<span>')).toEqual({
+        mergedRaw: '<span><em>x</em></span>',
+        closingIndex: 4,
+      })
+    })
+
+    it('returns null when no matching closing tag is found', () => {
+      const tokens = [
+        { type: 'html', raw: '<span>' },
+        { type: 'text', raw: 'x', text: 'x' },
+      ]
+
+      expect(findSplitHtmlFragment(tokens, 0, 'span', '<span>')).toBeNull()
     })
   })
 })

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -5,7 +5,6 @@ import {
   type MarkdownExtensionSpec,
   type MarkdownLexerConfiguration,
   type MarkdownParseHelpers,
-  type MarkdownParseResult,
   type MarkdownRendererHelpers,
   type MarkdownToken,
   type MarkdownTokenizer,
@@ -18,20 +17,38 @@ import {
   generateJSON,
   getExtensionField,
   getSchema,
-  marksEqual,
   sortExtensions,
 } from '@tiptap/core'
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
 
 import { htmlContainsUnrecognizedTag } from './utils/htmlTagDetection.js'
+import { applyMarkToContent } from './utils/applyMarkToContent.js'
 import { closeMarksBeforeNode } from './utils/closeMarksBeforeNode.js'
+import { createImplicitEmptyParagraphsFromSpace } from './utils/createImplicitEmptyParagraphsFromSpace.js'
+import { createParseHelpers } from './utils/createParseHelpers.js'
+import { escapeMarkdownSyntax } from './utils/escapeMarkdownSyntax.js'
 import { extractAbsorbedBlankLines } from './utils/extractAbsorbedBlankLines.js'
+import { extractLeadingWhitespace } from './utils/extractLeadingWhitespace.js'
+import { extractTrailingWhitespace } from './utils/extractTrailingWhitespace.js'
 import { findMarksToClose } from './utils/findMarksToClose.js'
 import { findMarksToCloseAtEnd } from './utils/findMarksToCloseAtEnd.js'
 import { findMarksToOpen } from './utils/findMarksToOpen.js'
+import { findSplitHtmlFragment } from './utils/findSplitHtmlFragment.js'
+import { getHtmlTagInfo } from './utils/getHtmlTagInfo.js'
+import { groupListItemsByType } from './utils/groupListItemsByType.js'
+import { htmlAsLiteralText } from './utils/htmlAsLiteralText.js'
+import { isEmptyOutput } from './utils/isEmptyOutput.js'
+import { isMarkResult } from './utils/isMarkResult.js'
 import { isTaskItem } from './utils/isTaskItem.js'
+import { mergeAdjacentTextNodes } from './utils/mergeAdjacentTextNodes.js'
+import { normalizeParseResult } from './utils/normalizeParseResult.js'
+import { renderSyntheticMark } from './utils/renderSyntheticMark.js'
 import { reopenMarksAfterNode } from './utils/reopenMarksAfterNode.js'
 import { wrapInMarkdownBlock } from './utils/wrapInMarkdownBlock.js'
+
+function isNonEmptyParseResult(result: JSONContent | JSONContent[] | null): boolean {
+  return !!result && (!Array.isArray(result) || result.length > 0)
+}
 
 export class MarkdownManager {
   private markedInstance: typeof marked
@@ -39,14 +56,7 @@ export class MarkdownManager {
   private registry: Map<string, MarkdownExtensionSpec[]>
   private nodeTypeRegistry: Map<string, MarkdownExtensionSpec[]>
   /**
-   * Order in which extensions were registered. Used to resolve mark nesting
-   * deterministically when several marks open on the same text node.
-   *
-   * The flattened extensions passed to the manager are pre-sorted by Tiptap's
-   * extension priority (descending), which is also the order ProseMirror uses
-   * to assign mark ranks. Recording that index here lets the serializer place
-   * higher-priority / lower-rank marks (e.g. link with priority 1000) on the
-   * outside without inspecting any rendered markdown output.
+   * Extension registration order, used to resolve mark nesting deterministically.
    */
   private extensionRanks: Map<string, number> = new Map()
   private indentStyle: 'space' | 'tab'
@@ -63,9 +73,9 @@ export class MarkdownManager {
   /**
    * Create a MarkdownManager.
    * @param options.marked Optional marked instance to use (injected).
-   * @param options.markedOptions Optional options to pass to marked.setOptions
+   * @param options.markedOptions Optional options to pass to marked.setOptions.
    * @param options.indentation Indentation settings (style and size).
-   * @param options.extensions An array of Tiptap extensions to register for markdown parsing and rendering.
+   * @param options.extensions Extensions to register for markdown parsing and rendering.
    */
   constructor(options?: {
     marked?: typeof marked
@@ -85,10 +95,7 @@ export class MarkdownManager {
     this.registry = new Map()
     this.nodeTypeRegistry = new Map()
 
-    // If extensions were provided, register them now. Sort by Tiptap priority
-    // first (matching how the editor builds its schema) so the registration
-    // index lines up with ProseMirror's mark rank — this is what the
-    // serializer relies on to nest higher-priority marks like link outermost.
+    // Register extensions in Tiptap priority order so ranks match mark nesting.
     if (options?.extensions) {
       this.baseExtensions = options.extensions
       const flattened = sortExtensions(flattenExtensions(options.extensions))
@@ -117,16 +124,13 @@ export class MarkdownManager {
   }
 
   /**
-   * Register a Tiptap extension (Node/Mark/Extension). This will read
-   * `markdownName`, `parseMarkdown`, `renderMarkdown` and `priority` from the
-   * extension config (using the same resolution used across the codebase).
+   * Register a Tiptap extension's markdown handlers.
    */
   registerExtension(extension: AnyExtension): void {
     // Keep track of all extensions for HTML parsing
     this.extensions.push(extension)
 
-    // Track extensions that declare `code: true` so we can skip HTML entity
-    // encoding inside code contexts without hardcoding specific type names.
+    // Track `code: true` extensions so entity encoding is skipped inside code contexts.
     const isCode = callOrReturn(getExtensionField(extension, 'code'))
 
     const name = extension.name
@@ -153,8 +157,7 @@ export class MarkdownManager {
       | ExtendableConfig['markdownTokenizer']
       | undefined
 
-    // Read the `markdown` object from the extension config. This allows
-    // extensions to provide `markdown: { name?, parseName?, renderName?, parse?, render?, match? }`.
+    // Read the `markdown` options object from the extension config.
     const markdownCfg = (getExtensionField(extension, 'markdownOptions') ??
       null) as ExtendableConfig['markdownOptions']
     const isIndenting = markdownCfg?.indentsContent ?? false
@@ -297,8 +300,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Serialize a ProseMirror-like JSON document (or node array) to a Markdown string
-   * using registered renderers and fallback renderers.
+   * Serialize a JSON document to a Markdown string.
    */
   serialize(docOrContent: JSONContent): string {
     if (!docOrContent) {
@@ -307,25 +309,7 @@ export class MarkdownManager {
 
     const result = this.renderNodes(docOrContent, docOrContent)
     // Return empty string if result is only whitespace entities or non-breaking spaces
-    return this.isEmptyOutput(result) ? '' : result
-  }
-
-  /**
-   * Check if the markdown output represents an empty document.
-   * Empty documents may contain only &nbsp; entities or non-breaking space characters
-   * which are used by the Paragraph extension to preserve blank lines.
-   */
-  private isEmptyOutput(markdown: string): boolean {
-    if (!markdown || markdown.trim() === '') {
-      return true
-    }
-
-    // Check if the output is only &nbsp; entities or non-breaking space characters
-    const cleanedOutput = markdown
-      .replace(/&nbsp;/g, '')
-      .replace(/\u00A0/g, '')
-      .trim()
-    return cleanedOutput === ''
+    return isEmptyOutput(result) ? '' : result
   }
 
   /**
@@ -394,7 +378,7 @@ export class MarkdownManager {
       if (parseImplicitEmptyParagraphs && token.type === 'space') {
         const nextNonSpaceTokenIndex = nonSpaceTokenIndexes[nextNonSpaceTokenPointer] ?? -1
 
-        return this.createImplicitEmptyParagraphsFromSpace(
+        return createImplicitEmptyParagraphsFromSpace(
           token,
           previousNonSpaceTokenIndex,
           nextNonSpaceTokenIndex,
@@ -409,27 +393,6 @@ export class MarkdownManager {
 
       return Array.isArray(parsed) ? parsed : [parsed]
     })
-  }
-
-  private createImplicitEmptyParagraphsFromSpace(
-    token: MarkdownToken,
-    previousNonSpaceTokenIndex: number,
-    nextNonSpaceTokenIndex: number,
-  ): JSONContent[] {
-    const separatorCount = this.countParagraphSeparators(token.raw || '')
-
-    if (separatorCount === 0) {
-      return []
-    }
-
-    const isBoundarySpace = previousNonSpaceTokenIndex === -1 || nextNonSpaceTokenIndex === -1
-    const emptyParagraphCount = Math.max(separatorCount - (isBoundarySpace ? 0 : 1), 0)
-
-    return Array.from({ length: emptyParagraphCount }, () => ({ type: 'paragraph', content: [] }))
-  }
-
-  private countParagraphSeparators(raw: string): number {
-    return (raw.replace(/\r\n/g, '\n').match(/\n\n/g) || []).length
   }
 
   /**
@@ -448,47 +411,41 @@ export class MarkdownManager {
       return this.parseListToken(token)
     }
 
+    return (
+      this.findParseHandler(token) ?? this.parseFallbackToken(token, parseImplicitEmptyParagraphs)
+    )
+  }
+
+  /**
+   * Try each registered handler for a token type until one returns a valid result.
+   */
+  private findParseHandler(token: MarkdownToken): JSONContent | JSONContent[] | null {
+    if (!token.type) {
+      return null
+    }
+
     const handlers = this.getHandlersForToken(token.type)
     const helpers = this.createParseHelpers()
 
-    // Try each handler until one returns a valid result
-    const result = handlers.find(handler => {
+    for (const handler of handlers) {
       if (!handler.parseMarkdown) {
-        return false
+        continue
       }
 
-      const parseResult = handler.parseMarkdown(token, helpers)
-      const normalized = this.normalizeParseResult(parseResult)
+      const normalized = normalizeParseResult(handler.parseMarkdown(token, helpers))
 
-      // Check if this handler returned a valid result (not null/empty array)
-      if (normalized && (!Array.isArray(normalized) || normalized.length > 0)) {
-        // Store result for return
-        this.lastParseResult = normalized
-        return true
+      if (isNonEmptyParseResult(normalized)) {
+        return normalized
       }
-
-      return false
-    })
-
-    // If a handler worked, return its result
-    if (result && this.lastParseResult) {
-      const toReturn = this.lastParseResult
-      this.lastParseResult = null // Clean up
-      return toReturn
     }
 
-    // If no handler worked, try fallback parsing
-    return this.parseFallbackToken(token, parseImplicitEmptyParagraphs)
+    return null
   }
 
-  private lastParseResult: JSONContent | JSONContent[] | null = null
-
   /**
-   * Parse a list token, handling mixed bullet and task list items by splitting them into separate lists.
-   * This ensures that consecutive task items and bullet items are grouped and parsed as separate list nodes.
-   *
-   * @param token The list token to parse
-   * @returns Array of parsed list nodes, or null if parsing fails
+   * Parse a list token, splitting mixed bullet and task items into separate lists.
+   * @param token The list token to parse.
+   * @returns Array of parsed list nodes, or null when parsing fails.
    */
   private parseListToken(token: MarkdownToken): JSONContent | JSONContent[] | null {
     if (!token.items || token.items.length === 0) {
@@ -505,91 +462,11 @@ export class MarkdownManager {
     }
 
     // Mixed list with taskList extension available: split into separate lists
-    type TaskListItemToken = MarkdownToken & {
-      type: 'taskItem'
-      checked?: boolean
-      indentLevel?: number
-    }
-    const groups: { type: 'list' | 'taskList'; items: (MarkdownToken | TaskListItemToken)[] }[] = []
-    let currentGroup: (MarkdownToken | TaskListItemToken)[] = []
-    let currentType: 'list' | 'taskList' | null = null
-
-    for (let i = 0; i < token.items.length; i += 1) {
-      const item = token.items[i]
-      const { isTask, checked, indentLevel } = isTaskItem(item)
-      let processedItem = item
-
-      if (isTask) {
-        // Transform list_item into taskItem token
-        const raw = item.raw || item.text || ''
-
-        // Split raw content by lines to separate main content from nested
-        const lines = raw.split('\n')
-
-        // Extract main content from the first line
-        const firstLineMatch = lines[0].match(/^\s*[-+*]\s+\[([ xX])\]\s+(.*)$/)
-        const mainContent = firstLineMatch ? firstLineMatch[2] : ''
-
-        // Parse nested content from remaining lines
-        let nestedTokens: MarkdownToken[] = []
-        if (lines.length > 1) {
-          // Join all lines after the first
-          const nestedRaw = lines.slice(1).join('\n')
-
-          // Only parse if there's actual content
-          if (nestedRaw.trim()) {
-            // Find minimum indentation of non-empty lines
-            const nestedLines = lines.slice(1)
-            const nonEmptyLines = nestedLines.filter(line => line.trim())
-            if (nonEmptyLines.length > 0) {
-              const minIndent = Math.min(
-                ...nonEmptyLines.map(line => line.length - line.trimStart().length),
-              )
-              // Remove common indentation while preserving structure
-              const trimmedLines = nestedLines.map(line => {
-                if (!line.trim()) {
-                  return '' // Keep empty lines
-                }
-                return line.slice(minIndent)
-              })
-              const nestedContent = trimmedLines.join('\n').trim()
-              // Use the lexer to parse nested content
-              if (nestedContent) {
-                // Use the full lexer pipeline to ensure inline tokens are populated
-                nestedTokens = this.markedInstance.lexer(`${nestedContent}\n`)
-              }
-            }
-          }
-        }
-
-        processedItem = {
-          type: 'taskItem',
-          raw: '',
-          mainContent,
-          indentLevel,
-          checked: checked ?? false,
-          text: mainContent,
-          tokens: this.tokenizeInline(mainContent),
-          nestedTokens,
-        }
-      }
-
-      const itemType: 'list' | 'taskList' = isTask ? 'taskList' : 'list'
-
-      if (currentType !== itemType) {
-        if (currentGroup.length > 0) {
-          groups.push({ type: currentType!, items: currentGroup })
-        }
-        currentGroup = [processedItem]
-        currentType = itemType
-      } else {
-        currentGroup.push(processedItem)
-      }
-    }
-
-    if (currentGroup.length > 0) {
-      groups.push({ type: currentType!, items: currentGroup })
-    }
+    const groups = groupListItemsByType(
+      token.items,
+      src => this.markedInstance.lexer(src),
+      src => this.tokenizeInline(src),
+    )
 
     // Parse each group as a separate token
     const results: JSONContent[] = []
@@ -613,99 +490,29 @@ export class MarkdownManager {
    * Parse a token using registered handlers (extracted for reuse).
    */
   private parseTokenWithHandlers(token: MarkdownToken): JSONContent | JSONContent[] | null {
-    if (!token.type) {
-      return null
-    }
-
-    const handlers = this.getHandlersForToken(token.type)
-    const helpers = this.createParseHelpers()
-
-    // Try each handler until one returns a valid result
-    const result = handlers.find(handler => {
-      if (!handler.parseMarkdown) {
-        return false
-      }
-
-      const parseResult = handler.parseMarkdown(token, helpers)
-      const normalized = this.normalizeParseResult(parseResult)
-
-      // Check if this handler returned a valid result (not null/empty array)
-      if (normalized && (!Array.isArray(normalized) || normalized.length > 0)) {
-        // Store result for return
-        this.lastParseResult = normalized
-        return true
-      }
-
-      return false
-    })
-
-    // If a handler worked, return its result
-    if (result && this.lastParseResult) {
-      const toReturn = this.lastParseResult
-      this.lastParseResult = null // Clean up
-      return toReturn
-    }
-
-    // If no handler worked, try fallback parsing
-    return this.parseFallbackToken(token)
+    return this.findParseHandler(token) ?? this.parseFallbackToken(token)
   }
 
   /**
-   * Creates helper functions for parsing markdown tokens.
-   * @returns An object containing helper functions for parsing.
+   * Creates the helpers passed to extension parse handlers.
+   * @returns The markdown parse helpers.
    */
   private createParseHelpers(): MarkdownParseHelpers {
-    return {
+    return createParseHelpers({
       parseInline: (tokens: MarkdownToken[]) => this.parseInlineTokens(tokens),
       tokenizeInline: (src: string) => this.tokenizeInline(src),
       parseChildren: (tokens: MarkdownToken[]) => this.parseTokens(tokens),
       parseBlockChildren: (tokens: MarkdownToken[]) => this.parseTokens(tokens, true),
-      createTextNode: (text: string, marks?: Array<{ type: string; attrs?: any }>) => {
-        const node = {
-          type: 'text',
-          text,
-          marks: marks || undefined,
-        }
-
-        return node
-      },
-      createNode: (type: string, attrs?: any, content?: JSONContent[]) => {
-        const node = {
-          type,
-          attrs: attrs || undefined,
-          content: content || undefined,
-        }
-
-        if (!attrs || Object.keys(attrs).length === 0) {
-          delete node.attrs
-        }
-
-        return node
-      },
-      applyMark: (markType: string, content: JSONContent[], attrs?: any) => ({
-        mark: markType,
-        content,
-        attrs: attrs && Object.keys(attrs).length > 0 ? attrs : undefined,
-      }),
-    }
+    })
   }
 
   /**
-   * Escape special regex characters in a string.
-   */
-  private escapeRegex(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  }
-
-  /**
-   * Parse inline tokens (bold, italic, links, etc.) into text nodes with marks.
-   * This is the complex part that handles mark nesting and boundaries.
+   * Parse inline tokens into text nodes with marks.
    */
   private parseInlineTokens(tokens: MarkdownToken[]): JSONContent[] {
     const result: JSONContent[] = []
 
-    // Process tokens sequentially using an index so we can lookahead and
-    // merge split inline HTML fragments like: text / <em> / inner / </em> / text
+    // Lookahead across tokens to merge split inline HTML fragments.
     for (let i = 0; i < tokens.length; i += 1) {
       const token = tokens[i]
 
@@ -725,44 +532,23 @@ export class MarkdownManager {
         // Handle possible split inline HTML by attempting to detect an
         // opening tag and searching forward for a matching closing tag.
         const raw = (token.raw ?? token.text ?? '').toString()
+        const { isClosing, isSelfClosing, tagName } = getHtmlTagInfo(raw)
 
-        // Quick checks for opening vs. closing tag
-        const isClosing = /^<\/[\s]*[\w-]+/i.test(raw)
-        const openMatch = raw.match(/^<[\s]*([\w-]+)(\s|>|\/|$)/i)
+        if (!isClosing && tagName && !isSelfClosing) {
+          const fragment = findSplitHtmlFragment(tokens, i, tagName, raw)
 
-        // oxlint-disable-next-line prefer-string-starts-ends-with
-        if (!isClosing && openMatch && !/\/>$/.test(raw)) {
-          // Try to find the corresponding closing html token for this tag
-          const tagName = openMatch[1]
-          const escapedTagName = this.escapeRegex(tagName)
-          const closingRegex = new RegExp(`^<\\/\\s*${escapedTagName}\\b`, 'i')
-          let foundIndex = -1
-
-          // Collect intermediate raw parts to reconstruct full HTML fragment
-          const parts: string[] = [raw]
-          for (let j = i + 1; j < tokens.length; j += 1) {
-            const t = tokens[j]
-            const tRaw = (t.raw ?? t.text ?? '').toString()
-            parts.push(tRaw)
-            if (t.type === 'html' && closingRegex.test(tRaw)) {
-              foundIndex = j
-              break
-            }
-          }
-
-          if (foundIndex !== -1) {
+          if (fragment) {
             // Merge opening + inner + closing into one html fragment and parse
-            const mergedRaw = parts.join('')
             const mergedToken = {
               type: 'html',
-              raw: mergedRaw,
-              text: mergedRaw,
+              raw: fragment.mergedRaw,
+              text: fragment.mergedRaw,
               block: false,
             } as unknown as MarkdownToken
 
             const parsed = this.parseHTMLToken(mergedToken)
             if (parsed) {
-              const normalized = this.normalizeParseResult(parsed as any)
+              const normalized = normalizeParseResult(parsed as any)
               if (Array.isArray(normalized)) {
                 result.push(...normalized)
               } else if (normalized) {
@@ -771,7 +557,7 @@ export class MarkdownManager {
             }
 
             // Advance i to the closing token
-            i = foundIndex
+            i = fragment.closingIndex
             continue
           }
         }
@@ -779,7 +565,7 @@ export class MarkdownManager {
         // Fallback: single html token parse
         const parsedSingle = this.parseHTMLToken(token)
         if (parsedSingle) {
-          const normalized = this.normalizeParseResult(parsedSingle as any)
+          const normalized = normalizeParseResult(parsedSingle as any)
           if (Array.isArray(normalized)) {
             result.push(...normalized)
           } else if (normalized) {
@@ -793,13 +579,13 @@ export class MarkdownManager {
           const helpers = this.createParseHelpers()
           const parsed = markHandler.parseMarkdown(token, helpers)
 
-          if (this.isMarkResult(parsed)) {
+          if (isMarkResult(parsed)) {
             // This is a mark result - apply the mark to the content
-            const markedContent = this.applyMarkToContent(parsed.mark, parsed.content, parsed.attrs)
+            const markedContent = applyMarkToContent(parsed.mark, parsed.content, parsed.attrs)
             result.push(...markedContent)
           } else {
             // Regular inline node
-            const normalized = this.normalizeParseResult(parsed)
+            const normalized = normalizeParseResult(parsed)
             if (Array.isArray(normalized)) {
               result.push(...normalized)
             } else if (normalized) {
@@ -813,73 +599,7 @@ export class MarkdownManager {
       }
     }
 
-    // Merge adjacent text nodes with the same marks. The marked tokenizer may
-    // produce adjacent inline tokens (e.g. escape + text + escape) that each
-    // become separate text nodes. Merging them keeps the output compact and
-    // consistent with ProseMirror's expectation that contiguous styled text
-    // lives in a single text node.
-    for (let i = result.length - 1; i > 0; i -= 1) {
-      const current = result[i]
-      const previous = result[i - 1]
-
-      if (current.type === 'text' && previous.type === 'text') {
-        const currentMarks = current.marks || []
-        const previousMarks = previous.marks || []
-
-        if (marksEqual(currentMarks, previousMarks)) {
-          previous.text = (previous.text || '') + (current.text || '')
-          result.splice(i, 1)
-        }
-      }
-    }
-
-    return result
-  }
-
-  /**
-   * Apply a mark to content nodes.
-   */
-  private applyMarkToContent(markType: string, content: JSONContent[], attrs?: any): JSONContent[] {
-    return content.map(node => {
-      if (node.type === 'text') {
-        // Add the mark to existing marks or create new marks array
-        const existingMarks = node.marks || []
-        const newMark = attrs ? { type: markType, attrs } : { type: markType }
-        return {
-          ...node,
-          marks: [...existingMarks, newMark],
-        }
-      }
-
-      // For non-text nodes, recursively apply to content
-      return {
-        ...node,
-        content: node.content ? this.applyMarkToContent(markType, node.content, attrs) : undefined,
-      }
-    })
-  } /**
-   * Check if a parse result represents a mark to be applied.
-   */
-  private isMarkResult(
-    result: any,
-  ): result is { mark: string; content: JSONContent[]; attrs?: any } {
-    return result && typeof result === 'object' && 'mark' in result
-  }
-
-  /**
-   * Normalize parse results to ensure they're valid JSONContent.
-   */
-  private normalizeParseResult(result: MarkdownParseResult): JSONContent | JSONContent[] | null {
-    if (!result) {
-      return null
-    }
-
-    if (this.isMarkResult(result)) {
-      // This shouldn't happen at the top level, but handle it gracefully
-      return result.content
-    }
-
-    return result as JSONContent | JSONContent[]
+    return mergeAdjacentTextNodes(result)
   }
 
   /**
@@ -933,10 +653,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Parse an HTML token from marked into JSONContent using the registered
-   * extensions' `parseHTML` rules. Falls back to literal text when the HTML
-   * has nothing for the schema to keep.
-   *
+   * Parse an HTML token with the extensions' parseHTML rules, falling back to literal text.
    * @param token Marked HTML token (block or inline).
    * @example
    *   parseHTMLToken({ type: 'html', raw: '<em>hi</em>', block: false })
@@ -949,15 +666,14 @@ export class MarkdownManager {
       return null
     }
 
-    // If the HTML would parse to nothing meaningful, keep the original
-    // characters as literal text instead of dropping them.
+    // Keep unrecognized HTML as literal text instead of dropping it.
     if (this.isUnrecognizedHtml(html)) {
-      return this.htmlAsLiteralText(html, !!token.block)
+      return htmlAsLiteralText(html, !!token.block)
     }
 
     // generateJSON requires window.DOMParser – treat recognized HTML as literal on the server
     if (typeof window === 'undefined' || typeof window.DOMParser === 'undefined') {
-      return this.htmlAsLiteralText(html, !!token.block)
+      return htmlAsLiteralText(html, !!token.block)
     }
 
     // Use generateJSON to parse the HTML using extensions' parseHTML rules
@@ -983,10 +699,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Keep only the inline nodes of parsed HTML content, unwrapping the block
-   * nodes around them. Inline HTML sits inside a textblock, where a block node
-   * would make the document invalid for the schema.
-   *
+   * Keep only the inline nodes of parsed HTML content.
    * @param content Content array of a parsed HTML fragment.
    * @example
    *   toInlineContent([{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }])
@@ -1005,10 +718,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Collect the names of the node types the schema treats as inline. Result is
-   * cached for the lifetime of the manager since extensions don't change after
-   * registration.
-   *
+   * Names of the schema's inline node types, cached after registration.
    * @example
    *   getInlineNodeTypes().has('text') // → true
    */
@@ -1036,31 +746,18 @@ export class MarkdownManager {
   }
 
   /**
-   * Returns true when the HTML contains a tag that is neither a standard
-   * HTML/SVG element nor declared in a registered extension's parseDOM rules.
-   *
-   * Recognized but empty elements such as `<em></em>` or `<span></span>`,
-   * and hyphenated custom elements like `<my-mention>`, are not considered
-   * unrecognized.
-   *
+   * True when the HTML has a tag outside the standard set and the extensions' parseDOM rules.
    * @param html Raw HTML string from a marked token.
    * @example
    *   isUnrecognizedHtml('<enter foo bar>')  // → true
-   *   isUnrecognizedHtml('<em></em>')        // → false (empty, but real tag)
    *   isUnrecognizedHtml('<em>hi</em>')      // → false
-   *   isUnrecognizedHtml('<my-el></my-el>')  // → false (valid custom element)
-   *   isUnrecognizedHtml('<br>')             // → false
    */
   private isUnrecognizedHtml(html: string): boolean {
     return htmlContainsUnrecognizedTag(html, this.getSchemaParseDomTags())
   }
 
   /**
-   * Collect the lower-cased tag names declared by the registered extensions'
-   * parseDOM rules, so custom node/mark elements that use non-hyphenated,
-   * non-standard tag names are treated as recognized HTML. Result is cached for the
-   * lifetime of the manager since extensions don't change after registration.
-   *
+   * Tag names declared in the extensions' parseDOM rules, cached after registration.
    * @example
    *   // After registering an extension with parseDOM [{ tag: 'something' }]
    *   getSchemaParseDomTags().has('something') // → true
@@ -1103,41 +800,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Build a JSONContent that preserves the original HTML markup as literal
-   * text. Used when the HTML would otherwise be silently dropped during
-   * schema-aware parsing.
-   *
-   * @param html Raw HTML string to preserve verbatim.
-   * @param isBlock Whether to wrap the text in a paragraph node (block tokens)
-   *   or return it as a bare text node (inline tokens).
-   * @example
-   *   htmlAsLiteralText('<enter foo>', true)
-   *   // → { type: 'paragraph', content: [{ type: 'text', text: '<enter foo>' }] }
-   */
-  private htmlAsLiteralText(html: string, isBlock: boolean): JSONContent | JSONContent[] | null {
-    // Strip trailing whitespace/newlines that marked appends to block HTML
-    // tokens so the rendered text doesn't end with stray blank lines.
-    const text = html.replace(/\s+$/, '')
-
-    if (!text) {
-      return null
-    }
-
-    if (isBlock) {
-      return {
-        type: 'paragraph',
-        content: [{ type: 'text', text }],
-      }
-    }
-
-    return { type: 'text', text }
-  }
-
-  /**
-   * Encode HTML entities in text unless the node is inside a code context
-   * (code mark or code-block parent) where literal characters should be preserved.
-   * Also backslash-escape markdown-significant characters in non-code text to
-   * prevent them from being misinterpreted as formatting delimiters.
+   * Encode HTML entities and escape markdown syntax, except inside code contexts.
    */
   private encodeTextForMarkdown(text: string, node: JSONContent, parentNode?: JSONContent): string {
     const isInsideCode =
@@ -1148,20 +811,7 @@ export class MarkdownManager {
       return text
     }
 
-    return this.escapeMarkdownSyntax(encodeHtmlEntities(text))
-  }
-
-  /**
-   * Backslash-escape characters that have special meaning in markdown inline
-   * syntax. This prevents literal characters in text nodes from being
-   * misinterpreted as formatting delimiters when the output is parsed again.
-   *
-   * The set covers the most common inline markdown syntax characters.
-   * Characters inside code blocks/code marks are skipped by the caller
-   * (`encodeTextForMarkdown`) via the existing `isInsideCode` guard.
-   */
-  private escapeMarkdownSyntax(text: string): string {
-    return text.replace(/([\\`*_[\]~])/g, '\\$1')
+    return escapeMarkdownSyntax(encodeHtmlEntities(text))
   }
 
   renderNodeToMarkdown(
@@ -1233,8 +883,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Render a node or an array of nodes. Parent type controls how children
-   * are joined (which determines newline insertion between children).
+   * Render a node or array of nodes to a Markdown string.
    */
   renderNodes(
     nodeOrNodes: JSONContent | JSONContent[],
@@ -1256,8 +905,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Render an array of nodes while properly tracking mark boundaries.
-   * This handles cases where marks span across multiple text nodes.
+   * Render nodes while tracking marks that span across text nodes.
    */
   private renderNodesWithMarkBoundaries(
     nodes: JSONContent[],
@@ -1285,17 +933,8 @@ export class MarkdownManager {
         const marksToOpen = this.getMarksToOpenForSerialization(activeMarks, currentMarks, nextNode)
         const marksToClose = findMarksToClose(currentMarks, nextNode)
 
-        // When marks simultaneously close (old) AND open (new) at this boundary, the naive
-        // approach of appending old-close and prepending new-open produces interleaved
-        // delimiters like `*456**` (italic open, text, bold close) instead of properly
-        // nested `_456_**` (italic open, text, italic close, bold close).
-        //
-        // The fix: when both are present, defer old mark closings to the end of the node
-        // (after the new marks also close), ensuring correct inner-before-outer order.
-        //
-        // If an already-active mark ends on this node while another mark opens on this same
-        // node, we defer closing the active mark until the end of the node so nesting stays
-        // valid (`**...++abc++**` instead of `**...++abc**++`).
+        // When marks close and open on the same node, defer the closings to the
+        // end so delimiters stay properly nested.
         const activeMarksClosingHere = marksToClose.filter(markType => activeMarks.has(markType))
         const hasCrossedBoundary = activeMarksClosingHere.length > 0 && marksToOpen.length > 0
 
@@ -1303,11 +942,9 @@ export class MarkdownManager {
 
         if (marksToClose.length > 0 && !hasCrossedBoundary) {
           // Extract trailing whitespace before closing marks to prevent invalid markdown like "**text **"
-          const middleTrailingMatch = textContent.match(/(\s+)$/)
-          if (middleTrailingMatch) {
-            middleTrailingWhitespace = middleTrailingMatch[1]
-            textContent = textContent.slice(0, -middleTrailingWhitespace.length)
-          }
+          const { text: trimmedText, whitespace } = extractTrailingWhitespace(textContent)
+          middleTrailingWhitespace = whitespace
+          textContent = trimmedText
         }
 
         if (!hasCrossedBoundary) {
@@ -1337,21 +974,15 @@ export class MarkdownManager {
             })
         }
 
-        // Open new marks (should be at the beginning)
-        // Extract leading whitespace before opening marks to prevent invalid markdown like "** text**"
+        // Prepend opening delimiters, keeping leading whitespace outside them.
         let leadingWhitespace = ''
         if (marksToOpen.length > 0) {
-          const leadingMatch = textContent.match(/^(\s+)/)
-          if (leadingMatch) {
-            leadingWhitespace = leadingMatch[1]
-            textContent = textContent.slice(leadingWhitespace.length)
-          }
+          const { text: trimmedText, whitespace } = extractLeadingWhitespace(textContent)
+          leadingWhitespace = whitespace
+          textContent = trimmedText
         }
 
-        // Snapshot active mark types before opening new marks, so each new mark's delimiter
-        // is chosen based on what is already active (not including itself).
-        // When crossing a boundary, old marks are still in activeMarks here (not yet removed),
-        // so new marks correctly see them as active context.
+        // Snapshot active marks so each new delimiter excludes itself.
         marksToOpen.forEach(({ type, mark }) => {
           const openingMode = reopenWithHtmlOnNextOpen.has(type) ? 'html' : 'markdown'
           const openMarkdown = this.getMarkOpening(type, mark, openingMode)
@@ -1374,10 +1005,7 @@ export class MarkdownManager {
         // Add leading whitespace before the mark opening
         textContent = leadingWhitespace + textContent
 
-        // Determine marks to close at the end of this node.
-        // On a crossed boundary, we close new marks (inner) first, then old marks (outer),
-        // ensuring correct nesting order. Both sets are removed from activeMarks so the
-        // next node's marksToOpen will reopen whichever ones continue.
+        // On a crossed boundary, close new marks (inner) first, then old marks (outer).
         let marksToCloseAtEnd: string[]
         if (hasCrossedBoundary) {
           const nextMarkTypes = new Set((nextNode?.marks || []).map((mark: any) => mark.type))
@@ -1388,9 +1016,7 @@ export class MarkdownManager {
             }
           })
 
-          // Sort the previously-active closures in LIFO order: the mark that
-          // was opened last (innermost) must close first. activeMarks preserves
-          // insertion order, so a higher indexOf means opened later = inner.
+          // Close previously-active marks LIFO (innermost first).
           const activeMarkKeys = Array.from(activeMarks.keys())
           const activeMarksClosingHereLifo = activeMarksClosingHere
             .slice()
@@ -1412,11 +1038,9 @@ export class MarkdownManager {
         // Extract trailing whitespace before closing marks to prevent invalid markdown like "**text **"
         let trailingWhitespace = ''
         if (marksToCloseAtEnd.length > 0) {
-          const trailingMatch = textContent.match(/(\s+)$/)
-          if (trailingMatch) {
-            trailingWhitespace = trailingMatch[1]
-            textContent = textContent.slice(0, -trailingWhitespace.length)
-          }
+          const { text: trimmedText, whitespace } = extractTrailingWhitespace(textContent)
+          trailingWhitespace = whitespace
+          textContent = trimmedText
         }
 
         marksToCloseAtEnd.forEach(markType => {
@@ -1456,8 +1080,7 @@ export class MarkdownManager {
         // Render the node
         const nodeContent = this.renderNodeToMarkdown(node, parentNode, i, level)
 
-        // Reopen marks after the node, but NOT after a hard break
-        // Hard breaks should terminate marks (they create a line break where marks don't continue)
+        // Reopen marks after the node, except after a hard break.
         const afterMarkdown =
           node.type === 'hardBreak'
             ? ''
@@ -1486,40 +1109,12 @@ export class MarkdownManager {
       return this.getHtmlReopenTags(markType)?.open || ''
     }
 
-    const handlers = this.getHandlersForNodeType(markType)
-    const handler = handlers.length > 0 ? handlers[0] : undefined
-    if (!handler || !handler.renderMarkdown) {
+    const handler = this.getHandlerForMark(markType)
+    if (!handler?.renderMarkdown) {
       return ''
     }
 
-    // Use a unique placeholder that's extremely unlikely to appear in real content
-    const placeholder = '\uE000__TIPTAP_MARKDOWN_PLACEHOLDER__\uE001'
-
-    // For most marks, we can extract the opening syntax by rendering a simple case
-    const syntheticNode: JSONContent = {
-      type: markType,
-      attrs: mark.attrs || {},
-      content: [{ type: 'text', text: placeholder }],
-    }
-
-    try {
-      const rendered = handler.renderMarkdown(
-        syntheticNode,
-        {
-          renderChildren: () => placeholder,
-          renderChild: () => placeholder,
-          indent: (content: string) => content,
-          wrapInBlock: (prefix: string, content: string) => prefix + content,
-        },
-        { index: 0, level: 0, parentType: 'text', meta: {} },
-      )
-
-      // Extract the opening part (everything before placeholder)
-      const placeholderIndex = rendered.indexOf(placeholder)
-      return placeholderIndex >= 0 ? rendered.substring(0, placeholderIndex) : ''
-    } catch (err) {
-      throw new Error(`Failed to get mark opening for ${markType}: ${err}`)
-    }
+    return renderSyntheticMark(handler.renderMarkdown, markType, mark.attrs || {}, 'open')
   }
 
   /**
@@ -1534,45 +1129,22 @@ export class MarkdownManager {
       return this.getHtmlReopenTags(markType)?.close || ''
     }
 
-    const handlers = this.getHandlersForNodeType(markType)
-    const handler = handlers.length > 0 ? handlers[0] : undefined
-    if (!handler || !handler.renderMarkdown) {
+    const handler = this.getHandlerForMark(markType)
+    if (!handler?.renderMarkdown) {
       return ''
     }
 
-    // Use a unique placeholder that's extremely unlikely to appear in real content
-    const placeholder = '\uE000__TIPTAP_MARKDOWN_PLACEHOLDER__\uE001'
+    return renderSyntheticMark(handler.renderMarkdown, markType, mark.attrs || {}, 'close')
+  }
 
-    const syntheticNode: JSONContent = {
-      type: markType,
-      attrs: mark.attrs || {},
-      content: [{ type: 'text', text: placeholder }],
-    }
-
-    try {
-      const rendered = handler.renderMarkdown(
-        syntheticNode,
-        {
-          renderChildren: () => placeholder,
-          renderChild: () => placeholder,
-          indent: (content: string) => content,
-          wrapInBlock: (prefix: string, content: string) => prefix + content,
-        },
-        { index: 0, level: 0, parentType: 'text', meta: {} },
-      )
-
-      // Extract the closing part (everything after placeholder)
-      const placeholderIndex = rendered.indexOf(placeholder)
-      const placeholderEnd = placeholderIndex + placeholder.length
-      return placeholderIndex >= 0 ? rendered.substring(placeholderEnd) : ''
-    } catch (err) {
-      throw new Error(`Failed to get mark closing for ${markType}: ${err}`)
-    }
+  /** Get the first render handler for a mark type (for backwards compatibility). */
+  private getHandlerForMark(markType: string): MarkdownExtensionSpec | undefined {
+    const handlers = this.getHandlersForNodeType(markType)
+    return handlers.length > 0 ? handlers[0] : undefined
   }
 
   /**
-   * Returns the inline HTML tags an extension exposes for overlap-boundary
-   * reopen handling, if that mark explicitly opted into HTML reopen mode.
+   * HTML reopen tags for a mark, when it opted into HTML reopen mode.
    */
   private getHtmlReopenTags(markType: string): { open: string; close: string } | undefined {
     const handlers = this.getHandlersForNodeType(markType)
@@ -1596,22 +1168,7 @@ export class MarkdownManager {
   }
 
   /**
-   * Decide the order in which marks open on the current text node.
-   *
-   * The returned array is iterated head-first when prepending opening
-   * delimiters, so the first entry becomes the innermost mark in the emitted
-   * markdown and the last becomes the outermost. Two stable signals drive
-   * the order — neither one inspects any rendered markdown:
-   *
-   *   1. Marks that end on this node must be inner relative to marks that
-   *      continue into the next node, otherwise the delimiters interleave
-   *      instead of nesting.
-   *   2. Within each lifetime group, marks are sorted so that lower
-   *      registration ranks (i.e. higher Tiptap extension priorities) end up
-   *      outermost. ProseMirror assigns mark ranks in the same priority-aware
-   *      order Tiptap uses when building the schema, so link (priority 1000)
-   *      naturally wraps bold/italic without the serializer needing to peek
-   *      at how any particular mark renders.
+   * Order marks so delimiters nest: ending marks inner, higher-ranked marks outer.
    */
   private getMarksToOpenForSerialization(
     activeMarks: Map<string, any>,
@@ -1626,15 +1183,11 @@ export class MarkdownManager {
 
     const nextMarks = nextNode?.marks || []
 
-    // Helper: check if the next node has a mark with the same type AND
-    // matching attributes. Two marks of the same type but with different
-    // attributes are logically distinct and must not be treated as continuing.
+    // Marks continue only when the next node has the same type and attrs.
     const continuesInNextNode = (markType: string, attrs: any) =>
       nextMarks.some((m: any) => m.type === markType && attrsEqual(m.attrs, attrs))
 
-    // Higher rank → earlier in the array → innermost mark. Marks without a
-    // recorded rank fall back to MAX_SAFE_INTEGER so they sort innermost,
-    // matching the implicit "registered last" assumption for ad-hoc marks.
+    // Higher rank sorts inner; unregistered marks fall back to innermost.
     const byRankInnerFirst = (a: { type: string }, b: { type: string }) => {
       const rankA = this.extensionRanks.get(a.type) ?? Number.MAX_SAFE_INTEGER
       const rankB = this.extensionRanks.get(b.type) ?? Number.MAX_SAFE_INTEGER

--- a/packages/markdown/src/utils/applyMarkToContent.ts
+++ b/packages/markdown/src/utils/applyMarkToContent.ts
@@ -1,0 +1,33 @@
+import type { JSONContent } from '@tiptap/core'
+
+/**
+ * Apply a mark to every node in the content array.
+ * @param markType The mark type to apply.
+ * @param content The content nodes to mark.
+ * @param attrs Optional mark attributes.
+ * @returns The content with the mark applied.
+ */
+export function applyMarkToContent(
+  markType: string,
+  content: JSONContent[],
+  attrs?: any,
+): JSONContent[] {
+  return content.map(node => {
+    if (node.type === 'text') {
+      // Add the mark to existing marks or create new marks array
+      const existingMarks = node.marks || []
+      const newMark = attrs ? { type: markType, attrs } : { type: markType }
+
+      return {
+        ...node,
+        marks: [...existingMarks, newMark],
+      }
+    }
+
+    // For non-text nodes, recursively apply to content
+    return {
+      ...node,
+      content: node.content ? applyMarkToContent(markType, node.content, attrs) : undefined,
+    }
+  })
+}

--- a/packages/markdown/src/utils/assumeContentType.ts
+++ b/packages/markdown/src/utils/assumeContentType.ts
@@ -4,7 +4,7 @@ import type { Fragment, Node } from '@tiptap/pm/model'
 import type { ContentType } from '../types.js'
 
 /**
- * Assumes the content type based off the content.
+ * Assume the content type based on the content value.
  * @param content The content to assume the type for.
  * @param contentType The content type that should be prioritized.
  */

--- a/packages/markdown/src/utils/countParagraphSeparators.ts
+++ b/packages/markdown/src/utils/countParagraphSeparators.ts
@@ -1,0 +1,8 @@
+/**
+ * Count the blank lines separating blocks in a raw markdown string.
+ * @param raw The raw markdown token source.
+ * @returns The number of blank line separators.
+ */
+export function countParagraphSeparators(raw: string): number {
+  return (raw.replace(/\r\n/g, '\n').match(/\n\n/g) || []).length
+}

--- a/packages/markdown/src/utils/createImplicitEmptyParagraphsFromSpace.ts
+++ b/packages/markdown/src/utils/createImplicitEmptyParagraphsFromSpace.ts
@@ -1,0 +1,27 @@
+import type { JSONContent, MarkdownToken } from '@tiptap/core'
+
+import { countParagraphSeparators } from './countParagraphSeparators.js'
+
+/**
+ * Recreate empty paragraphs from the blank lines carried by a space token.
+ * @param token The space token holding the blank lines.
+ * @param previousNonSpaceTokenIndex Index of the previous non-space token, or -1.
+ * @param nextNonSpaceTokenIndex Index of the next non-space token, or -1.
+ * @returns Empty paragraph nodes, one per blank line.
+ */
+export function createImplicitEmptyParagraphsFromSpace(
+  token: MarkdownToken,
+  previousNonSpaceTokenIndex: number,
+  nextNonSpaceTokenIndex: number,
+): JSONContent[] {
+  const separatorCount = countParagraphSeparators(token.raw || '')
+
+  if (separatorCount === 0) {
+    return []
+  }
+
+  const isBoundarySpace = previousNonSpaceTokenIndex === -1 || nextNonSpaceTokenIndex === -1
+  const emptyParagraphCount = Math.max(separatorCount - (isBoundarySpace ? 0 : 1), 0)
+
+  return Array.from({ length: emptyParagraphCount }, () => ({ type: 'paragraph', content: [] }))
+}

--- a/packages/markdown/src/utils/createParseHelpers.ts
+++ b/packages/markdown/src/utils/createParseHelpers.ts
@@ -1,0 +1,49 @@
+import type { JSONContent, MarkdownParseHelpers, MarkdownToken } from '@tiptap/core'
+
+export type CreateParseHelpersOptions = {
+  parseInline: (tokens: MarkdownToken[]) => JSONContent[]
+  tokenizeInline: (src: string) => MarkdownToken[]
+  parseChildren: (tokens: MarkdownToken[]) => JSONContent[]
+  parseBlockChildren: (tokens: MarkdownToken[]) => JSONContent[]
+}
+
+/**
+ * Build the helper object handed to extension markdown parse handlers.
+ * @param options The bound manager functions used to parse inline and block tokens.
+ * @returns The markdown parse helpers.
+ */
+export function createParseHelpers(options: CreateParseHelpersOptions): MarkdownParseHelpers {
+  return {
+    parseInline: options.parseInline,
+    tokenizeInline: options.tokenizeInline,
+    parseChildren: options.parseChildren,
+    parseBlockChildren: options.parseBlockChildren,
+    createTextNode: (text, marks) => {
+      const node = {
+        type: 'text',
+        text,
+        marks: marks || undefined,
+      }
+
+      return node
+    },
+    createNode: (type, attrs, content) => {
+      const node = {
+        type,
+        attrs: attrs || undefined,
+        content: content || undefined,
+      }
+
+      if (!attrs || Object.keys(attrs).length === 0) {
+        delete node.attrs
+      }
+
+      return node
+    },
+    applyMark: (markType, content, attrs) => ({
+      mark: markType,
+      content,
+      attrs: attrs && Object.keys(attrs).length > 0 ? attrs : undefined,
+    }),
+  }
+}

--- a/packages/markdown/src/utils/escapeMarkdownSyntax.ts
+++ b/packages/markdown/src/utils/escapeMarkdownSyntax.ts
@@ -1,0 +1,8 @@
+/**
+ * Backslash-escape markdown inline syntax characters so they render as literal text.
+ * @param text The text to escape.
+ * @returns The text with markdown characters escaped.
+ */
+export function escapeMarkdownSyntax(text: string): string {
+  return text.replace(/([\\`*_[\]~])/g, '\\$1')
+}

--- a/packages/markdown/src/utils/escapeRegex.ts
+++ b/packages/markdown/src/utils/escapeRegex.ts
@@ -1,0 +1,8 @@
+/**
+ * Escape special characters in a string so it can be used inside a RegExp.
+ * @param str The string to escape.
+ * @returns The string with regex metacharacters escaped.
+ */
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/markdown/src/utils/extractAbsorbedBlankLines.ts
+++ b/packages/markdown/src/utils/extractAbsorbedBlankLines.ts
@@ -1,9 +1,7 @@
 import type { MarkdownToken } from '@tiptap/core'
 
 /**
- * Matches a run of two or more consecutive line breaks (a blank line) at the
- * end of a string, allowing horizontal whitespace between the breaks.
- *
+ * Matches a run of blank lines at the end of a string.
  * @example
  * TRAILING_BLANK_LINES.test('paragraph\n  \n')
  * // => true
@@ -11,8 +9,7 @@ import type { MarkdownToken } from '@tiptap/core'
 const TRAILING_BLANK_LINES = /\n[^\S\n]*(?:\n[^\S\n]*)+$/
 
 /**
- * Extracts blank lines absorbed into marked token `raw` back into explicit
- * `space` tokens so they're handled uniformly by the reconstruction path.
+ * Recover blank lines absorbed into token `raw` as explicit `space` tokens.
  * @param tokens The marked token stream to normalize.
  * @returns A new token array with absorbed blank lines as `space` tokens.
  */
@@ -22,6 +19,9 @@ export function extractAbsorbedBlankLines(tokens: MarkdownToken[]): MarkdownToke
   )
 }
 
+/**
+ * Recover blank lines absorbed into a single token's raw source as space tokens.
+ */
 function extractAbsorbedBlankLinesFromToken(
   token: MarkdownToken,
   nextToken: MarkdownToken | undefined,

--- a/packages/markdown/src/utils/extractLeadingWhitespace.ts
+++ b/packages/markdown/src/utils/extractLeadingWhitespace.ts
@@ -1,0 +1,14 @@
+/**
+ * Split leading whitespace off a string so marks can open without a stray space.
+ * @param text The text to trim.
+ * @returns The trimmed text and the whitespace that was removed.
+ */
+export function extractLeadingWhitespace(text: string): { text: string; whitespace: string } {
+  const match = text.match(/^(\s+)/)
+
+  if (!match) {
+    return { text, whitespace: '' }
+  }
+
+  return { text: text.slice(match[1].length), whitespace: match[1] }
+}

--- a/packages/markdown/src/utils/extractTrailingWhitespace.ts
+++ b/packages/markdown/src/utils/extractTrailingWhitespace.ts
@@ -1,0 +1,14 @@
+/**
+ * Split trailing whitespace off a string so marks can close without a stray space.
+ * @param text The text to trim.
+ * @returns The trimmed text and the whitespace that was removed.
+ */
+export function extractTrailingWhitespace(text: string): { text: string; whitespace: string } {
+  const match = text.match(/(\s+)$/)
+
+  if (!match) {
+    return { text, whitespace: '' }
+  }
+
+  return { text: text.slice(0, -match[1].length), whitespace: match[1] }
+}

--- a/packages/markdown/src/utils/findSplitHtmlFragment.ts
+++ b/packages/markdown/src/utils/findSplitHtmlFragment.ts
@@ -1,0 +1,35 @@
+import type { MarkdownToken } from '@tiptap/core'
+
+import { escapeRegex } from './escapeRegex.js'
+
+/**
+ * Rejoin an inline HTML fragment that marked split into separate tokens.
+ * @param tokens The inline token stream.
+ * @param startIndex Index of the opening html token.
+ * @param tagName The tag whose closing token to look for.
+ * @param openingRaw The raw source of the opening token.
+ * @returns The merged fragment and the closing token index, or null when no closing token is found.
+ */
+export function findSplitHtmlFragment(
+  tokens: MarkdownToken[],
+  startIndex: number,
+  tagName: string,
+  openingRaw: string,
+): { mergedRaw: string; closingIndex: number } | null {
+  const escapedTagName = escapeRegex(tagName)
+  const closingRegex = new RegExp(`^<\\/\\s*${escapedTagName}\\b`, 'i')
+
+  // Collect intermediate raw parts to reconstruct full HTML fragment
+  const parts: string[] = [openingRaw]
+  for (let j = startIndex + 1; j < tokens.length; j += 1) {
+    const t = tokens[j]
+    const tRaw = (t.raw ?? t.text ?? '').toString()
+    parts.push(tRaw)
+
+    if (t.type === 'html' && closingRegex.test(tRaw)) {
+      return { mergedRaw: parts.join(''), closingIndex: j }
+    }
+  }
+
+  return null
+}

--- a/packages/markdown/src/utils/findSplitHtmlFragment.ts
+++ b/packages/markdown/src/utils/findSplitHtmlFragment.ts
@@ -2,6 +2,32 @@ import type { MarkdownToken } from '@tiptap/core'
 
 import { escapeRegex } from './escapeRegex.js'
 
+/** Get the raw string representation of a Markdown token. */
+function getTokenRaw(token: MarkdownToken): string {
+  return (token.raw ?? token.text ?? '').toString()
+}
+
+/**
+ * Get the nesting delta of a same-name tag in a raw HTML fragment.
+ *
+ * The delta is -1 for a closing tag, +1 for an opening tag, and 0 otherwise.
+ * @param raw The raw HTML fragment.
+ * @param closingRegex The regex to match the closing tag.
+ * @param openingRegex The regex to match the opening tag.
+ * @returns The nesting delta: -1 for a closing tag, +1 for an opening tag, 0 otherwise.
+ */
+function getSameTagNestingDelta(raw: string, closingRegex: RegExp, openingRegex: RegExp): number {
+  if (closingRegex.test(raw)) {
+    return -1
+  }
+
+  if (openingRegex.test(raw) && !raw.trim().endsWith('/>')) {
+    return 1
+  }
+
+  return 0
+}
+
 /**
  * Rejoin an inline HTML fragment that marked split into separate tokens.
  * @param tokens The inline token stream.
@@ -18,15 +44,25 @@ export function findSplitHtmlFragment(
 ): { mergedRaw: string; closingIndex: number } | null {
   const escapedTagName = escapeRegex(tagName)
   const closingRegex = new RegExp(`^<\\/\\s*${escapedTagName}\\b`, 'i')
+  const openingRegex = new RegExp(`^<\\s*${escapedTagName}\\b`, 'i')
 
   // Collect intermediate raw parts to reconstruct full HTML fragment
   const parts: string[] = [openingRaw]
+  let nestedDepth = 0
+
   for (let j = startIndex + 1; j < tokens.length; j += 1) {
     const t = tokens[j]
-    const tRaw = (t.raw ?? t.text ?? '').toString()
+    const tRaw = getTokenRaw(t)
     parts.push(tRaw)
 
-    if (t.type === 'html' && closingRegex.test(tRaw)) {
+    if (t.type !== 'html') {
+      continue
+    }
+
+    nestedDepth += getSameTagNestingDelta(tRaw, closingRegex, openingRegex)
+
+    // Depth -1 means the matching outer tag was closed
+    if (nestedDepth === -1) {
       return { mergedRaw: parts.join(''), closingIndex: j }
     }
   }

--- a/packages/markdown/src/utils/getHtmlTagInfo.ts
+++ b/packages/markdown/src/utils/getHtmlTagInfo.ts
@@ -1,0 +1,22 @@
+export type HtmlTagInfo = {
+  isClosing: boolean
+  isSelfClosing: boolean
+  tagName: string | null
+}
+
+/**
+ * Extract closing, self-closing, and tag name details from raw HTML.
+ * @param raw The raw HTML source.
+ * @returns Whether the tag is a closing or self-closing tag, and its tag name.
+ */
+export function getHtmlTagInfo(raw: string): HtmlTagInfo {
+  // oxlint-disable-next-line prefer-string-starts-ends-with
+  const isClosing = /^<\/[\s]*[\w-]+/i.test(raw)
+  const openMatch = raw.match(/^<[\s]*([\w-]+)(\s|>|\/|$)/i)
+
+  return {
+    isClosing,
+    isSelfClosing: raw.endsWith('/>'),
+    tagName: openMatch ? openMatch[1] : null,
+  }
+}

--- a/packages/markdown/src/utils/groupListItemsByType.ts
+++ b/packages/markdown/src/utils/groupListItemsByType.ts
@@ -1,0 +1,47 @@
+import type { MarkdownToken } from '@tiptap/core'
+import type { Token } from 'marked'
+
+import { isTaskItem } from './isTaskItem.js'
+import { toTaskItemToken, type TaskListItemToken } from './toTaskItemToken.js'
+
+export type ListItemGroup = {
+  type: 'list' | 'taskList'
+  items: (MarkdownToken | TaskListItemToken)[]
+}
+
+/**
+ * Group mixed list items by whether they are task items.
+ */
+export function groupListItemsByType(
+  items: MarkdownToken[],
+  tokenizeBlock: (src: string) => Token[],
+  tokenizeInline: (src: string) => MarkdownToken[],
+): ListItemGroup[] {
+  const groups: ListItemGroup[] = []
+  let currentGroup: (MarkdownToken | TaskListItemToken)[] = []
+  let currentType: 'list' | 'taskList' | null = null
+
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i]
+    const { isTask } = isTaskItem(item)
+    const processedItem = isTask ? toTaskItemToken(item, tokenizeBlock, tokenizeInline) : item
+
+    const itemType: 'list' | 'taskList' = isTask ? 'taskList' : 'list'
+
+    if (currentType !== itemType) {
+      if (currentGroup.length > 0) {
+        groups.push({ type: currentType!, items: currentGroup })
+      }
+      currentGroup = [processedItem]
+      currentType = itemType
+    } else {
+      currentGroup.push(processedItem)
+    }
+  }
+
+  if (currentGroup.length > 0) {
+    groups.push({ type: currentType!, items: currentGroup })
+  }
+
+  return groups
+}

--- a/packages/markdown/src/utils/htmlAsLiteralText.ts
+++ b/packages/markdown/src/utils/htmlAsLiteralText.ts
@@ -1,0 +1,29 @@
+import type { JSONContent } from '@tiptap/core'
+
+/**
+ * Build a JSON node that preserves raw HTML as literal text.
+ * @param html The HTML to keep verbatim.
+ * @param isBlock Whether to wrap the text in a paragraph node.
+ * @returns A paragraph or text node, or null when there is nothing to keep.
+ */
+export function htmlAsLiteralText(
+  html: string,
+  isBlock: boolean,
+): JSONContent | JSONContent[] | null {
+  // Strip trailing whitespace/newlines that marked appends to block HTML
+  // tokens so the rendered text doesn't end with stray blank lines.
+  const text = html.replace(/\s+$/, '')
+
+  if (!text) {
+    return null
+  }
+
+  if (isBlock) {
+    return {
+      type: 'paragraph',
+      content: [{ type: 'text', text }],
+    }
+  }
+
+  return { type: 'text', text }
+}

--- a/packages/markdown/src/utils/htmlAsLiteralText.ts
+++ b/packages/markdown/src/utils/htmlAsLiteralText.ts
@@ -11,8 +11,8 @@ export function htmlAsLiteralText(
   isBlock: boolean,
 ): JSONContent | JSONContent[] | null {
   // Strip trailing whitespace/newlines that marked appends to block HTML
-  // tokens so the rendered text doesn't end with stray blank lines.
-  const text = html.replace(/\s+$/, '')
+  // tokens, keeping inline text verbatim so separator spaces survive.
+  const text = isBlock ? html.replace(/\s+$/, '') : html
 
   if (!text) {
     return null

--- a/packages/markdown/src/utils/htmlTagDetection.ts
+++ b/packages/markdown/src/utils/htmlTagDetection.ts
@@ -1,13 +1,5 @@
 /**
- * Standard HTML and common SVG element names. Used to tell apart real
- * (but possibly empty) elements like `<em></em>` from genuinely unknown
- * angle-bracket text such as `<enter foo bar>` so the latter can be
- * preserved as literal text.
- *
- * Non-hyphenated tags not in this set are treated as unknown unless
- * declared in the schema's parseDOM rules. This does not claim full
- * parity with browser `HTMLUnknownElement` classification across all
- * namespaces (e.g. rare SVG filter elements, MathML).
+ * Standard HTML and common SVG element names, used to detect unknown angle-bracket text.
  */
 export const STANDARD_HTML_TAGS = new Set([
   'a',

--- a/packages/markdown/src/utils/isEmptyOutput.ts
+++ b/packages/markdown/src/utils/isEmptyOutput.ts
@@ -10,6 +10,8 @@ export function isEmptyOutput(markdown: string): boolean {
 
   // Check if the output is only &nbsp; entities or non-breaking space characters
   const cleanedOutput = markdown
+    .replace(/&amp;amp;nbsp;/g, '')
+    .replace(/&amp;nbsp;/g, '')
     .replace(/&nbsp;/g, '')
     .replace(/\u00A0/g, '')
     .trim()

--- a/packages/markdown/src/utils/isEmptyOutput.ts
+++ b/packages/markdown/src/utils/isEmptyOutput.ts
@@ -1,0 +1,18 @@
+/**
+ * Check whether markdown output is empty, ignoring non-breaking space entities.
+ * @param markdown The serialized markdown.
+ * @returns True when the output has no meaningful content.
+ */
+export function isEmptyOutput(markdown: string): boolean {
+  if (!markdown || markdown.trim() === '') {
+    return true
+  }
+
+  // Check if the output is only &nbsp; entities or non-breaking space characters
+  const cleanedOutput = markdown
+    .replace(/&nbsp;/g, '')
+    .replace(/\u00A0/g, '')
+    .trim()
+
+  return cleanedOutput === ''
+}

--- a/packages/markdown/src/utils/isMarkResult.ts
+++ b/packages/markdown/src/utils/isMarkResult.ts
@@ -1,0 +1,12 @@
+import type { JSONContent } from '@tiptap/core'
+
+/**
+ * Type guard for parse results that apply a mark to their content.
+ * @param result The parse result to check.
+ * @returns True when the result is a mark result.
+ */
+export function isMarkResult(
+  result: any,
+): result is { mark: string; content: JSONContent[]; attrs?: any } {
+  return result && typeof result === 'object' && 'mark' in result
+}

--- a/packages/markdown/src/utils/isTaskItem.ts
+++ b/packages/markdown/src/utils/isTaskItem.ts
@@ -1,11 +1,9 @@
 import type { MarkdownToken } from '@tiptap/core'
 
 /**
- * Check if a markdown list item token is a task item and extract its state.
- *
- * @param item The list item token to check
- * @returns Object containing isTask flag, checked state, and indentation level
- *
+ * Check if a list item token is a task item and extract its state.
+ * @param item The list item token to check.
+ * @returns Object containing isTask flag, checked state, and indentation level.
  * @example
  * ```ts
  * isTaskItem({ raw: '- [ ] Task' }) // { isTask: true, checked: false, indentLevel: 0 }

--- a/packages/markdown/src/utils/mergeAdjacentTextNodes.ts
+++ b/packages/markdown/src/utils/mergeAdjacentTextNodes.ts
@@ -1,0 +1,24 @@
+import { marksEqual } from '@tiptap/core'
+import type { JSONContent } from '@tiptap/core'
+
+/**
+ * Merge adjacent text nodes with identical marks into a single text node.
+ */
+export function mergeAdjacentTextNodes(nodes: JSONContent[]): JSONContent[] {
+  for (let i = nodes.length - 1; i > 0; i -= 1) {
+    const current = nodes[i]
+    const previous = nodes[i - 1]
+
+    if (current.type === 'text' && previous.type === 'text') {
+      const currentMarks = current.marks || []
+      const previousMarks = previous.marks || []
+
+      if (marksEqual(currentMarks, previousMarks)) {
+        previous.text = (previous.text || '') + (current.text || '')
+        nodes.splice(i, 1)
+      }
+    }
+  }
+
+  return nodes
+}

--- a/packages/markdown/src/utils/normalizeParseResult.ts
+++ b/packages/markdown/src/utils/normalizeParseResult.ts
@@ -1,0 +1,23 @@
+import type { JSONContent, MarkdownParseResult } from '@tiptap/core'
+
+import { isMarkResult } from './isMarkResult.js'
+
+/**
+ * Normalize a parse handler result into plain JSON content, unwrapping mark results.
+ * @param result The parse handler result.
+ * @returns The JSON content, or null when the result was empty.
+ */
+export function normalizeParseResult(
+  result: MarkdownParseResult,
+): JSONContent | JSONContent[] | null {
+  if (!result) {
+    return null
+  }
+
+  if (isMarkResult(result)) {
+    // This shouldn't happen at the top level, but handle it gracefully
+    return result.content
+  }
+
+  return result as JSONContent | JSONContent[]
+}

--- a/packages/markdown/src/utils/renderSyntheticMark.ts
+++ b/packages/markdown/src/utils/renderSyntheticMark.ts
@@ -1,0 +1,53 @@
+import type { JSONContent, MarkdownRendererHelpers, RenderContext } from '@tiptap/core'
+
+const PLACEHOLDER = '\uE000__TIPTAP_MARKDOWN_PLACEHOLDER__\uE001'
+
+/**
+ * Renders a synthetic mark node around a placeholder so the opening or
+ * closing markdown delimiter can be extracted from the output.
+ */
+export function renderSyntheticMark(
+  renderMarkdown: (
+    node: JSONContent,
+    helpers: MarkdownRendererHelpers,
+    ctx: RenderContext,
+  ) => string,
+  markType: string,
+  attrs: Record<string, any>,
+  side: 'open' | 'close',
+): string {
+  const syntheticNode: JSONContent = {
+    type: markType,
+    attrs,
+    content: [{ type: 'text', text: PLACEHOLDER }],
+  }
+
+  try {
+    const rendered = renderMarkdown(
+      syntheticNode,
+      {
+        renderChildren: () => PLACEHOLDER,
+        renderChild: () => PLACEHOLDER,
+        indent: content => content,
+        wrapInBlock: (prefix, content) => prefix + content,
+      },
+      { index: 0, level: 0, parentType: 'text', meta: {} },
+    )
+
+    const placeholderIndex = rendered.indexOf(PLACEHOLDER)
+
+    if (placeholderIndex < 0) {
+      return ''
+    }
+
+    if (side === 'open') {
+      return rendered.substring(0, placeholderIndex)
+    }
+
+    return rendered.substring(placeholderIndex + PLACEHOLDER.length)
+  } catch (err) {
+    throw new Error(
+      `Failed to get mark ${side === 'open' ? 'opening' : 'closing'} for ${markType}: ${err}`,
+    )
+  }
+}

--- a/packages/markdown/src/utils/toTaskItemToken.ts
+++ b/packages/markdown/src/utils/toTaskItemToken.ts
@@ -1,0 +1,71 @@
+import type { MarkdownToken } from '@tiptap/core'
+import type { Token } from 'marked'
+
+import { isTaskItem } from './isTaskItem.js'
+
+export type TaskListItemToken = MarkdownToken & {
+  type: 'taskItem'
+  checked?: boolean
+  indentLevel?: number
+}
+
+/**
+ * Transform a task list item token, extracting main and nested content.
+ */
+export function toTaskItemToken(
+  item: MarkdownToken,
+  tokenizeBlock: (src: string) => Token[],
+  tokenizeInline: (src: string) => MarkdownToken[],
+): TaskListItemToken {
+  const { checked, indentLevel } = isTaskItem(item)
+
+  // Split raw content by lines to separate main content from nested
+  const raw = item.raw || item.text || ''
+  const lines = raw.split('\n')
+
+  // Extract main content from the first line
+  const firstLineMatch = lines[0].match(/^\s*[-+*]\s+\[([ xX])\]\s+(.*)$/)
+  const mainContent = firstLineMatch ? firstLineMatch[2] : ''
+
+  // Parse nested content from remaining lines
+  let nestedTokens: MarkdownToken[] = []
+  if (lines.length > 1) {
+    // Join all lines after the first
+    const nestedRaw = lines.slice(1).join('\n')
+
+    // Only parse if there's actual content
+    if (nestedRaw.trim()) {
+      // Find minimum indentation of non-empty lines
+      const nestedLines = lines.slice(1)
+      const nonEmptyLines = nestedLines.filter(line => line.trim())
+      if (nonEmptyLines.length > 0) {
+        const minIndent = Math.min(
+          ...nonEmptyLines.map(line => line.length - line.trimStart().length),
+        )
+        // Remove common indentation while preserving structure
+        const trimmedLines = nestedLines.map(line => {
+          if (!line.trim()) {
+            return '' // Keep empty lines
+          }
+          return line.slice(minIndent)
+        })
+        const nestedContent = trimmedLines.join('\n').trim()
+        // Use the lexer to parse nested content
+        if (nestedContent) {
+          nestedTokens = tokenizeBlock(`${nestedContent}\n`)
+        }
+      }
+    }
+  }
+
+  return {
+    type: 'taskItem',
+    raw: '',
+    mainContent,
+    indentLevel,
+    checked: checked ?? false,
+    text: mainContent,
+    tokens: tokenizeInline(mainContent),
+    nestedTokens,
+  }
+}

--- a/packages/markdown/src/utils/wrapInMarkdownBlock.ts
+++ b/packages/markdown/src/utils/wrapInMarkdownBlock.ts
@@ -1,5 +1,5 @@
 /**
- * Wraps each line of the content with the given prefix.
+ * Wrap each line of the content with the given prefix.
  * @param prefix The prefix to wrap each line with.
  * @param content The content to wrap.
  * @returns The content with each line wrapped with the prefix.


### PR DESCRIPTION
## Fixes

- N/A

## Changes and Review

This PR refactors out utilities & helpers from the large MarkdownManager class into smaller chunks.

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary. (no changes)
- [ ] I have added tests if possible. (no changes)
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>