### PR TITLE
fix(markdown): isolate marked instance per manager

### DIFF
--- a/packages/markdown/__tests__/manager.spec.ts
+++ b/packages/markdown/__tests__/manager.spec.ts
@@ -18,7 +18,7 @@ import { Text } from '@tiptap/extension-text'
 import Underline from '@tiptap/extension-underline'
 import { Youtube } from '@tiptap/extension-youtube'
 import { MarkdownManager } from '@tiptap/markdown'
-import { Marked } from 'marked'
+import { Marked, marked } from 'marked'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Create test extensions
@@ -213,11 +213,24 @@ Second paragraph.`
 
 **After** ordered list`
       const isolatedManager = new MarkdownManager({
-        marked: new Marked() as unknown as typeof import('marked').marked,
+        marked: new Marked(),
         extensions: basicExtensions,
       })
 
       expect(markdownManager.parse(markdown)).toEqual(isolatedManager.parse(markdown))
+    })
+
+    it('keeps the shared global marked instance unmodified', () => {
+      const blockTokenizersBefore = (marked.defaults as any).extensions?.block?.length ?? 0
+
+      // Creating a manager registers tokenizers and options; these must stay
+      // on the manager's own instance instead of the global `marked` singleton.
+      new MarkdownManager({
+        markedOptions: { gfm: false },
+        extensions: [...basicExtensions, TestProbe],
+      })
+
+      expect((marked.defaults as any).extensions?.block?.length ?? 0).toBe(blockTokenizersBefore)
     })
 
     it('keeps later inline parsing stable after a custom tokenizer uses inlineTokens', () => {
@@ -264,7 +277,7 @@ Second paragraph.`
       // Regression: custom tokenizers must still fire when a dedicated `marked`
       // instance is injected, not only on the default shared instance.
       const manager = new MarkdownManager({
-        marked: new Marked() as unknown as typeof import('marked').marked,
+        marked: new Marked(),
         extensions: [...basicExtensions, TestProbe],
       })
 

--- a/packages/markdown/src/Extension.ts
+++ b/packages/markdown/src/Extension.ts
@@ -5,7 +5,7 @@ import {
   commands,
   Extension,
 } from '@tiptap/core'
-import type { marked } from 'marked'
+import type { Marked, marked } from 'marked'
 
 import MarkdownManager from './MarkdownManager.js'
 import type { ContentType } from './types.js'
@@ -75,9 +75,9 @@ export type MarkdownExtensionOptions = {
 
   /**
    * Use a custom version of `marked` for markdown parsing and serialization.
-   * If not provided, the default `marked` instance will be used.
+   * If not provided, an isolated `marked` instance is created per editor.
    */
-  marked?: typeof marked
+  marked?: typeof marked | Marked
 
   /**
    * Options to pass to `marked.setOptions()`.

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -20,7 +20,14 @@ import {
   getSchema,
   sortExtensions,
 } from '@tiptap/core'
-import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
+import {
+  Marked,
+  type Lexer,
+  type Token,
+  type TokenizerExtension,
+  type TokenizerThis,
+  marked,
+} from 'marked'
 
 import { htmlContainsUnrecognizedTag } from './utils/htmlTagDetection.js'
 import { applyMarkToContent } from './utils/applyMarkToContent.js'
@@ -52,7 +59,7 @@ function isNonEmptyParseResult(result: JSONContent | JSONContent[] | null): bool
 }
 
 export class MarkdownManager {
-  private markedInstance: typeof marked
+  private markedInstance: typeof marked | Marked
   private activeParseLexer: Lexer | null = null
   private registry: Map<string, MarkdownExtensionSpec[]>
   private nodeTypeRegistry: Map<string, MarkdownExtensionSpec[]>
@@ -79,12 +86,14 @@ export class MarkdownManager {
    * @param options.extensions Extensions to register for markdown parsing and rendering.
    */
   constructor(options?: {
-    marked?: typeof marked
+    marked?: typeof marked | Marked
     markedOptions?: Parameters<typeof marked.setOptions>[0]
     indentation?: { style?: 'space' | 'tab'; size?: number }
     extensions: AnyExtension[]
   }) {
-    this.markedInstance = options?.marked ?? marked
+    // Use an isolated marked instance so options and tokenizers don't leak
+    // into the shared global `marked` singleton across editors.
+    this.markedInstance = options?.marked ?? new Marked()
     this.indentStyle = options?.indentation?.style ?? 'space'
     this.indentSize = options?.indentation?.size ?? 2
     this.baseExtensions = options?.extensions || []
@@ -105,7 +114,7 @@ export class MarkdownManager {
   }
 
   /** Returns the underlying marked instance. */
-  get instance(): typeof marked {
+  get instance(): typeof marked | Marked {
     return this.markedInstance
   }
 


### PR DESCRIPTION
## Fixes

- N/A

## Changes and Review

This PR isolates the Marked instance so the global Marked instance is not changed from within extensions.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>