### PR TITLE
refactor(markdown): replace loose any types with a shared JSONMark type

### DIFF
--- a/packages/markdown/__tests__/isMarkResult.spec.ts
+++ b/packages/markdown/__tests__/isMarkResult.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { isMarkResult } from '../src/utils/isMarkResult.js'
+
+describe('isMarkResult', () => {
+  it('should accept a mark with content', () => {
+    expect(isMarkResult({ mark: 'bold', content: [{ type: 'text', text: 'hello' }] })).toBe(true)
+  })
+
+  it('should accept a mark with content and attrs', () => {
+    expect(
+      isMarkResult({
+        mark: 'link',
+        content: [{ type: 'text', text: 'hello' }],
+        attrs: { href: 'https://tiptap.dev' },
+      }),
+    ).toBe(true)
+  })
+
+  it('should reject an object with a mark but no content', () => {
+    expect(isMarkResult({ mark: 'bold' })).toBe(false)
+  })
+
+  it('should reject an object with a non-array content', () => {
+    expect(isMarkResult({ mark: 'bold', content: 'not an array' })).toBe(false)
+  })
+
+  it('should reject a non-string mark', () => {
+    expect(isMarkResult({ mark: 42, content: [] })).toBe(false)
+  })
+
+  it('should reject null attrs', () => {
+    expect(isMarkResult({ mark: 'bold', content: [], attrs: null })).toBe(false)
+  })
+
+  it('should reject array attrs', () => {
+    expect(isMarkResult({ mark: 'bold', content: [], attrs: [] })).toBe(false)
+  })
+
+  it('should reject unrelated objects', () => {
+    expect(isMarkResult({ type: 'paragraph' })).toBe(false)
+    expect(isMarkResult(null)).toBe(false)
+    expect(isMarkResult(undefined)).toBe(false)
+    expect(isMarkResult('bold')).toBe(false)
+    expect(isMarkResult(['bold'])).toBe(false)
+  })
+})

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -20,8 +20,10 @@ import {
   getSchema,
   sortExtensions,
 } from '@tiptap/core'
+import type { MarkSpec, NodeSpec, ParseRule } from '@tiptap/pm/model'
 import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
 
+import type { JSONMark } from './types.js'
 import { htmlContainsUnrecognizedTag } from './utils/htmlTagDetection.js'
 import { applyMarkToContent } from './utils/applyMarkToContent.js'
 import { closeMarksBeforeNode } from './utils/closeMarksBeforeNode.js'
@@ -792,12 +794,12 @@ export class MarkdownManager {
     try {
       const schema = getSchema(this.baseExtensions)
 
-      const collect = (spec: any) => {
+      const collect = (spec: NodeSpec | MarkSpec) => {
         const parseDOM = spec?.parseDOM
         if (!Array.isArray(parseDOM)) {
           return
         }
-        parseDOM.forEach((rule: any) => {
+        parseDOM.forEach((rule: ParseRule) => {
           if (typeof rule?.tag === 'string') {
             // Extract the bare tag name from selectors like "something.example"
             const match = rule.tag.match(/^[a-zA-Z][\w-]*/)
@@ -808,8 +810,8 @@ export class MarkdownManager {
         })
       }
 
-      Object.values(schema.nodes).forEach(type => collect((type as any).spec))
-      Object.values(schema.marks).forEach(type => collect((type as any).spec))
+      Object.values(schema.nodes).forEach(type => collect(type.spec))
+      Object.values(schema.marks).forEach(type => collect(type.spec))
     } catch {
       // If schema construction fails, leave the set empty – detection then
       // falls back to the standard HTML tag list only.
@@ -862,14 +864,8 @@ export class MarkdownManager {
       renderChildren: (nodes, separator) => {
         const childLevel = handler.isIndenting ? level + 1 : level
 
-        if (!Array.isArray(nodes) && (nodes as any).content) {
-          return this.renderNodes(
-            (nodes as any).content as JSONContent[],
-            node,
-            separator || '',
-            index,
-            childLevel,
-          )
+        if (!Array.isArray(nodes) && nodes.content) {
+          return this.renderNodes(nodes.content, node, separator || '', index, childLevel)
         }
 
         return this.renderNodes(nodes, node, separator || '', index, childLevel)
@@ -934,7 +930,7 @@ export class MarkdownManager {
     level = 0,
   ): string {
     const result: string[] = []
-    const activeMarks: Map<string, any> = new Map()
+    const activeMarks: Map<string, JSONMark> = new Map()
     const reopenWithHtmlOnNextOpen = new Set<string>()
     const markOpeningModes = new Map<string, 'markdown' | 'html'>()
 
@@ -981,7 +977,7 @@ export class MarkdownManager {
     node: JSONContent,
     nextNode: JSONContent | null,
     parentNode: JSONContent | undefined,
-    activeMarks: Map<string, any>,
+    activeMarks: Map<string, JSONMark>,
     markOpeningModes: Map<string, 'markdown' | 'html'>,
     reopenWithHtmlOnNextOpen: Set<string>,
   ): string {
@@ -1063,8 +1059,8 @@ export class MarkdownManager {
    */
   private closeMarks(
     markTypes: string[],
-    currentMarks: Map<string, any>,
-    activeMarks: Map<string, any>,
+    currentMarks: Map<string, JSONMark>,
+    activeMarks: Map<string, JSONMark>,
     markOpeningModes: Map<string, 'markdown' | 'html'>,
     options: { reverse?: boolean; skipInactive?: boolean } = {},
   ): string {
@@ -1077,7 +1073,7 @@ export class MarkdownManager {
         return
       }
 
-      const mark = activeMarks.get(markType) ?? currentMarks.get(markType)
+      const mark = (activeMarks.get(markType) ?? currentMarks.get(markType))!
       const closing = this.getMarkClosing(markType, mark, markOpeningModes.get(markType))
       if (closing) {
         closeMarkdown += closing
@@ -1093,9 +1089,9 @@ export class MarkdownManager {
    * Prepend the opening delimiters for marks that start here and activate them.
    */
   private openStartingMarks(
-    marksToOpen: Array<{ type: string; mark: any }>,
+    marksToOpen: Array<{ type: string; mark: JSONMark }>,
     textContent: string,
-    activeMarks: Map<string, any>,
+    activeMarks: Map<string, JSONMark>,
     markOpeningModes: Map<string, 'markdown' | 'html'>,
     reopenWithHtmlOnNextOpen: Set<string>,
     hasCrossedBoundary: boolean,
@@ -1126,16 +1122,16 @@ export class MarkdownManager {
    * Decide which marks to close at the end of the current text node.
    */
   private getMarksToCloseAtEnd(
-    activeMarks: Map<string, any>,
-    currentMarks: Map<string, any>,
-    nextNode: any,
-    marksToOpen: Array<{ type: string; mark: any }>,
+    activeMarks: Map<string, JSONMark>,
+    currentMarks: Map<string, JSONMark>,
+    nextNode: JSONContent | null,
+    marksToOpen: Array<{ type: string; mark: JSONMark }>,
     activeMarksClosingHere: string[],
     hasCrossedBoundary: boolean,
     reopenWithHtmlOnNextOpen: Set<string>,
   ): string[] {
     if (hasCrossedBoundary) {
-      const nextMarkTypes = new Set((nextNode?.marks || []).map((mark: any) => mark.type))
+      const nextMarkTypes = new Set((nextNode?.marks || []).map((mark: JSONMark) => mark.type))
 
       marksToOpen.forEach(({ type }) => {
         if (nextMarkTypes.has(type) && this.getHtmlReopenTags(type)) {
@@ -1166,12 +1162,12 @@ export class MarkdownManager {
     parentNode: JSONContent | undefined,
     index: number,
     level: number,
-    activeMarks: Map<string, any>,
+    activeMarks: Map<string, JSONMark>,
     markOpeningModes: Map<string, 'markdown' | 'html'>,
   ): string {
     // Only reopen marks that the node itself carries — marks don't skip over inline atoms.
-    const nodeMarkTypes = new Set((node.marks || []).map((mark: { type: string }) => mark.type))
-    const marksToReopen = new Map<string, { type: string; attrs?: Record<string, any> }>()
+    const nodeMarkTypes = new Set((node.marks || []).map((mark: JSONMark) => mark.type))
+    const marksToReopen = new Map<string, JSONMark>()
     const openingModesToReopen = new Map<string, 'markdown' | 'html'>()
     activeMarks.forEach((mark, type) => {
       if (nodeMarkTypes.has(type)) {
@@ -1207,7 +1203,7 @@ export class MarkdownManager {
    */
   private getMarkOpening(
     markType: string,
-    mark: any,
+    mark: JSONMark,
     openingMode: 'markdown' | 'html' = 'markdown',
   ): string {
     if (openingMode === 'html') {
@@ -1227,7 +1223,7 @@ export class MarkdownManager {
    */
   private getMarkClosing(
     markType: string,
-    mark: any,
+    mark: JSONMark,
     openingMode: 'markdown' | 'html' = 'markdown',
   ): string {
     if (openingMode === 'html') {
@@ -1261,7 +1257,7 @@ export class MarkdownManager {
   /**
    * Check if two mark sets are equal (same types and matching attributes).
    */
-  private markSetsEqual(marks1: Map<string, any>, marks2: Map<string, any>): boolean {
+  private markSetsEqual(marks1: Map<string, JSONMark>, marks2: Map<string, JSONMark>): boolean {
     if (marks1.size !== marks2.size) {
       return false
     }
@@ -1276,9 +1272,9 @@ export class MarkdownManager {
    * Order marks so delimiters nest: ending marks inner, higher-ranked marks outer.
    */
   private getMarksToOpenForSerialization(
-    activeMarks: Map<string, any>,
-    currentMarks: Map<string, any>,
-    nextNode: any,
+    activeMarks: Map<string, JSONMark>,
+    currentMarks: Map<string, JSONMark>,
+    nextNode: JSONContent | null,
   ) {
     const marksToOpen = findMarksToOpen(activeMarks, currentMarks)
 
@@ -1289,8 +1285,8 @@ export class MarkdownManager {
     const nextMarks = nextNode?.marks || []
 
     // Marks continue only when the next node has the same type and attrs.
-    const continuesInNextNode = (markType: string, attrs: any) =>
-      nextMarks.some((m: any) => m.type === markType && attrsEqual(m.attrs, attrs))
+    const continuesInNextNode = (markType: string, attrs?: Record<string, any>) =>
+      nextMarks.some((m: JSONMark) => m.type === markType && attrsEqual(m.attrs, attrs))
 
     // Higher rank sorts inner; unregistered marks fall back to innermost.
     const byRankInnerFirst = (a: { type: string }, b: { type: string }) => {

--- a/packages/markdown/src/types.ts
+++ b/packages/markdown/src/types.ts
@@ -1,1 +1,6 @@
+import type { JSONContent } from '@tiptap/core'
+
 export type ContentType = 'json' | 'html' | 'markdown'
+
+/** A JSON representation of a mark on an inline node. */
+export type JSONMark = NonNullable<JSONContent['marks']>[number]

--- a/packages/markdown/src/utils/applyMarkToContent.ts
+++ b/packages/markdown/src/utils/applyMarkToContent.ts
@@ -10,7 +10,7 @@ import type { JSONContent } from '@tiptap/core'
 export function applyMarkToContent(
   markType: string,
   content: JSONContent[],
-  attrs?: any,
+  attrs?: Record<string, any>,
 ): JSONContent[] {
   return content.map(node => {
     if (node.type === 'text') {

--- a/packages/markdown/src/utils/closeMarksBeforeNode.ts
+++ b/packages/markdown/src/utils/closeMarksBeforeNode.ts
@@ -1,16 +1,17 @@
+import type { JSONMark } from '../types.js'
+
 /**
  * Closes active marks before rendering a non-text node.
  * Returns the closing markdown syntax and clears the active marks.
  */
 export function closeMarksBeforeNode(
-  activeMarks: Map<string, any>,
-  getMarkClosing: (markType: string, mark: any) => string,
+  activeMarks: Map<string, JSONMark>,
+  getMarkClosing: (markType: string, mark: JSONMark) => string,
 ): string {
   let beforeMarkdown = ''
-  Array.from(activeMarks.keys())
+  Array.from(activeMarks.entries())
     .reverse()
-    .forEach(markType => {
-      const mark = activeMarks.get(markType)
+    .forEach(([markType, mark]) => {
       const closeMarkdown = getMarkClosing(markType, mark)
       if (closeMarkdown) {
         beforeMarkdown = closeMarkdown + beforeMarkdown

--- a/packages/markdown/src/utils/findMarksToClose.ts
+++ b/packages/markdown/src/utils/findMarksToClose.ts
@@ -1,10 +1,16 @@
 import { attrsEqual } from '@tiptap/core'
+import type { JSONContent } from '@tiptap/core'
+
+import type { JSONMark } from '../types.js'
 
 /**
  * Determines which marks to close based on the next node's marks,
  * treating same-type marks with different attributes as distinct.
  */
-export function findMarksToClose(currentMarks: Map<string, any>, nextNode: any): string[] {
+export function findMarksToClose(
+  currentMarks: Map<string, JSONMark>,
+  nextNode: JSONContent | null,
+): string[] {
   const marksToClose: string[] = []
 
   Array.from(currentMarks.entries()).forEach(([markType, currentMark]) => {
@@ -15,7 +21,7 @@ export function findMarksToClose(currentMarks: Map<string, any>, nextNode: any):
 
     // Check if the next node has a mark of the same type with matching attributes
     const nextMark = (nextNode.marks || []).find(
-      (mark: any) => mark.type === markType && attrsEqual(mark.attrs, currentMark.attrs),
+      (mark: JSONMark) => mark.type === markType && attrsEqual(mark.attrs, currentMark.attrs),
     )
 
     if (!nextMark) {

--- a/packages/markdown/src/utils/findMarksToCloseAtEnd.ts
+++ b/packages/markdown/src/utils/findMarksToCloseAtEnd.ts
@@ -1,17 +1,20 @@
 import { attrsEqual } from '@tiptap/core'
+import type { JSONContent } from '@tiptap/core'
+
+import type { JSONMark } from '../types.js'
 
 /**
  * Determines which marks to close at the node end, treating same-type marks
  * with different attributes as distinct (close + reopen).
  */
 export function findMarksToCloseAtEnd(
-  activeMarks: Map<string, any>,
-  currentMarks: Map<string, any>,
-  nextNode: any,
-  markSetsEqual: (a: Map<string, { type: string }>, b: Map<string, { type: string }>) => boolean,
+  activeMarks: Map<string, JSONMark>,
+  currentMarks: Map<string, JSONMark>,
+  nextNode: JSONContent | null,
+  markSetsEqual: (a: Map<string, JSONMark>, b: Map<string, JSONMark>) => boolean,
 ): string[] {
-  const nextMarks = (nextNode?.marks as any[]) || []
-  const nextMarksByType = new Map(nextMarks.map((mark: any) => [mark.type, mark]))
+  const nextMarks = nextNode?.marks || []
+  const nextMarksByType = new Map(nextMarks.map((mark: JSONMark) => [mark.type, mark]))
 
   if (!nextNode || nextMarks.length === 0) {
     return Array.from(activeMarks.keys()).reverse()

--- a/packages/markdown/src/utils/findMarksToOpen.ts
+++ b/packages/markdown/src/utils/findMarksToOpen.ts
@@ -1,14 +1,16 @@
 import { attrsEqual } from '@tiptap/core'
 
+import type { JSONMark } from '../types.js'
+
 /**
  * Determines which marks need to open, treating same-type marks with
  * different attributes as distinct (close + reopen).
  */
 export function findMarksToOpen(
-  activeMarks: Map<string, any>,
-  currentMarks: Map<string, any>,
-): Array<{ type: string; mark: any }> {
-  const marksToOpen: Array<{ type: string; mark: any }> = []
+  activeMarks: Map<string, JSONMark>,
+  currentMarks: Map<string, JSONMark>,
+): Array<{ type: string; mark: JSONMark }> {
+  const marksToOpen: Array<{ type: string; mark: JSONMark }> = []
   Array.from(currentMarks.entries()).forEach(([markType, mark]) => {
     const activeMark = activeMarks.get(markType)
 

--- a/packages/markdown/src/utils/isMarkResult.ts
+++ b/packages/markdown/src/utils/isMarkResult.ts
@@ -8,5 +8,25 @@ import type { JSONContent } from '@tiptap/core'
 export function isMarkResult(
   result: unknown,
 ): result is { mark: string; content: JSONContent[]; attrs?: Record<string, any> } {
-  return !!result && typeof result === 'object' && 'mark' in result
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    return false
+  }
+
+  const candidate = result as { mark?: unknown; content?: unknown; attrs?: unknown }
+
+  if (typeof candidate.mark !== 'string' || !Array.isArray(candidate.content)) {
+    return false
+  }
+
+  if (candidate.attrs !== undefined) {
+    if (
+      candidate.attrs === null ||
+      typeof candidate.attrs !== 'object' ||
+      Array.isArray(candidate.attrs)
+    ) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/packages/markdown/src/utils/isMarkResult.ts
+++ b/packages/markdown/src/utils/isMarkResult.ts
@@ -6,7 +6,7 @@ import type { JSONContent } from '@tiptap/core'
  * @returns True when the result is a mark result.
  */
 export function isMarkResult(
-  result: any,
-): result is { mark: string; content: JSONContent[]; attrs?: any } {
-  return result && typeof result === 'object' && 'mark' in result
+  result: unknown,
+): result is { mark: string; content: JSONContent[]; attrs?: Record<string, any> } {
+  return !!result && typeof result === 'object' && 'mark' in result
 }

--- a/packages/markdown/src/utils/reopenMarksAfterNode.ts
+++ b/packages/markdown/src/utils/reopenMarksAfterNode.ts
@@ -1,11 +1,13 @@
+import type { JSONMark } from '../types.js'
+
 /**
  * Reopens marks after rendering a non-text node.
  * Returns the opening markdown syntax and updates the active marks.
  */
 export function reopenMarksAfterNode(
-  marksToReopen: Map<string, any>,
-  activeMarks: Map<string, any>,
-  getMarkOpening: (markType: string, mark: any) => string,
+  marksToReopen: Map<string, JSONMark>,
+  activeMarks: Map<string, JSONMark>,
+  getMarkOpening: (markType: string, mark: JSONMark) => string,
 ): string {
   let afterMarkdown = ''
   Array.from(marksToReopen.entries()).forEach(([markType, mark]) => {


### PR DESCRIPTION
## Fixes

- N/A

## Changes and Review

This PR replaces loose `any` types with more strict typings & adds a JSONMark type for mark-like structures.

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>