### PR TITLE
fixed `editor.can` and `editor.chain` to not be accessible on editor …

### DIFF
--- a/.changeset/giant-schools-speak.md
+++ b/.changeset/giant-schools-speak.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/core": patch
+---
+
+Fixed a bug where `editor.chain` and `editor.can` can not be accessed on editor initialization

--- a/packages/core/src/CommandManager.ts
+++ b/packages/core/src/CommandManager.ts
@@ -103,11 +103,22 @@ export class CommandManager {
     return chain
   }
 
+  /**
+   * Creates a chain that safely returns `false` when run.
+   * @returns A non-dispatching command chain.
+   * @example
+   * const chain = CommandManager.createFakeChain()
+   * chain.focus().run() // false
+   */
   public static createFakeChain(): ChainedCommands {
     const chain = new Proxy(
       {},
       {
         get: (_target, property) => {
+          if (property === 'then') {
+            return undefined
+          }
+
           if (property === 'run') {
             return () => false
           }
@@ -138,8 +149,11 @@ export class CommandManager {
   }
 
   /**
-   * Creates a fake `CanCommands` for when the CommandManager is destroyed
-   * @returns A `CanCommands` object that always returns false
+   * Creates capability checks that safely return `false`.
+   * @returns A non-dispatching capability checker.
+   * @example
+   * const can = CommandManager.createFallbackCan()
+   * can.focus() // false
    */
   public static createFallbackCan(): CanCommands {
     const chain = CommandManager.createFakeChain()
@@ -149,6 +163,10 @@ export class CommandManager {
       },
       {
         get: (target, property) => {
+          if (property === 'then') {
+            return undefined
+          }
+
           if (property === 'chain') {
             return target.chain
           }

--- a/packages/core/src/CommandManager.ts
+++ b/packages/core/src/CommandManager.ts
@@ -103,6 +103,23 @@ export class CommandManager {
     return chain
   }
 
+  public static createFakeChain(): ChainedCommands {
+    const chain = new Proxy(
+      {},
+      {
+        get: (_target, property) => {
+          if (property === 'run') {
+            return () => false
+          }
+
+          return () => chain
+        },
+      },
+    ) as ChainedCommands
+
+    return chain
+  }
+
   public createCan(startTr?: Transaction): CanCommands {
     const { rawCommands, state } = this
     const dispatch = false
@@ -118,6 +135,30 @@ export class CommandManager {
       ...formattedCommands,
       chain: () => this.createChain(tr, dispatch),
     } as CanCommands
+  }
+
+  /**
+   * Creates a fake `CanCommands` for when the CommandManager is destroyed
+   * @returns A `CanCommands` object that always returns false
+   */
+  public static createFallbackCan(): CanCommands {
+    const chain = CommandManager.createFakeChain()
+    const can = new Proxy(
+      {
+        chain: () => chain,
+      },
+      {
+        get: (target, property) => {
+          if (property === 'chain') {
+            return target.chain
+          }
+
+          return () => false
+        },
+      },
+    ) as CanCommands
+
+    return can
   }
 
   public buildProps(tr: Transaction, shouldDispatch = true): CommandProps {

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -252,6 +252,10 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Create a command chain to call multiple commands at once.
    */
   public chain(): ChainedCommands {
+    if (!this.commandManager) {
+      return CommandManager.createFakeChain()
+    }
+
     return this.commandManager.chain()
   }
 
@@ -259,6 +263,10 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Check if a command or a command chain can be executed. Without executing it.
    */
   public can(): CanCommands {
+    if (!this.commandManager) {
+      return CommandManager.createFallbackCan()
+    }
+
     return this.commandManager.can()
   }
 
@@ -828,15 +836,13 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.destroyed = true
 
     this.emit('destroy')
-
     this.unmount()
-
     this.removeAllListeners()
 
     this.extensionManager.destroy()
     this.extensionManager = null as any
     this.schema = null as any
-    this.commandManager = null as any
+    this.commandManager = null as unknown as CommandManager
     this.extensionStorage = {} as Storage
   }
 

--- a/packages/core/src/__tests__/Editor.spec.ts
+++ b/packages/core/src/__tests__/Editor.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { Editor } from '../Editor.js'
+import StarterKit from '@tiptap/starter-kit'
+
+const createTestEditor = () =>
+  new Editor({
+    element: document.createElement('div'),
+    extensions: [StarterKit],
+  })
+
+describe('Editor', () => {
+  describe('destroy', () => {
+    it('should keep the command chain accessible after the editor is destroyed', () => {
+      const editor = createTestEditor()
+
+      expect(editor.isDestroyed).toBe(false)
+      expect(editor.chain).not.toBe(null)
+
+      editor.destroy()
+
+      expect(editor.isDestroyed).toBe(true)
+      expect(editor.chain).not.toBe(null)
+      expect(editor.chain().setContent('').run()).toBe(false)
+    })
+
+    it('should keep the command can accessible after the editor is destroyed', () => {
+      const editor = createTestEditor()
+
+      expect(editor.isDestroyed).toBe(false)
+      expect(editor.can).not.toBe(null)
+
+      editor.destroy()
+
+      expect(editor.isDestroyed).toBe(true)
+      expect(editor.can).not.toBe(null)
+
+      // can on command
+      expect(editor.can().setContent('')).toBe(false)
+
+      // can on chain
+      expect(editor.can().chain().setContent('').blur().run()).toBe(false)
+    })
+  })
+})

--- a/packages/core/src/__tests__/Editor.spec.ts
+++ b/packages/core/src/__tests__/Editor.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { Editor } from '../Editor.js'
+import { Extension } from '../Extension.js'
 import StarterKit from '@tiptap/starter-kit'
 
 const createTestEditor = () =>
@@ -9,6 +10,34 @@ const createTestEditor = () =>
   })
 
 describe('Editor', () => {
+  it('keeps command fallbacks available while commands initialize', async () => {
+    let chain: ReturnType<Editor['chain']> | undefined
+    let can: ReturnType<Editor['can']> | undefined
+
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        StarterKit,
+        Extension.create({
+          name: 'initialization-test',
+          addCommands() {
+            chain = this.editor.chain()
+            can = this.editor.can()
+
+            return {}
+          },
+        }),
+      ],
+    })
+
+    expect(chain?.focus().run()).toBe(false)
+    expect(can?.focus()).toBe(false)
+    expect(await Promise.resolve(chain)).toBe(chain)
+    expect(await Promise.resolve(can)).toBe(can)
+
+    editor.destroy()
+  })
+
   describe('destroy', () => {
     it('should keep the command chain accessible after the editor is destroyed', () => {
       const editor = createTestEditor()


### PR DESCRIPTION
## Fixes

- N/A

## Changes and Review

This PR fixes a bug where calling `editor.can()` or `editor.chain()` could run into an `Uncaught TypeError: can't access property "can", this.commandManager is null` error by creating fake functions via proxies that always return `false`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
