### PR TITLE
fix(extension-text-style): keep sibling text styles when unsetting inside a blockquote

### DIFF
--- a/.changeset/2026-08-17-fix-blockquote-unset-text-style.md
+++ b/.changeset/2026-08-17-fix-blockquote-unset-text-style.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-text-style': patch
+---
+
+Unsetting one text style inside a blockquote no longer removes the other text styles in it.

--- a/packages/extension-text-style/__tests__/font-size-commands.spec.ts
+++ b/packages/extension-text-style/__tests__/font-size-commands.spec.ts
@@ -1,8 +1,9 @@
 import { Editor } from '@tiptap/core'
+import Blockquote from '@tiptap/extension-blockquote'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
-import { FontSize, TextStyle } from '@tiptap/extension-text-style'
+import { Color, FontSize, TextStyle } from '@tiptap/extension-text-style'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('FontSize commands', () => {
@@ -38,5 +39,45 @@ describe('FontSize commands', () => {
 
     editor.commands.unsetFontSize()
     expect(editor.getHTML()).not.toContain('<span')
+  })
+})
+
+describe('FontSize commands inside a wrapper node', () => {
+  let editor: Editor
+
+  const editorWith = (content: string) => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    editor = new Editor({
+      element,
+      extensions: [Document, Paragraph, Text, Blockquote, TextStyle, Color, FontSize],
+      content,
+    })
+    editor.commands.selectAll()
+    return editor
+  }
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  it('keeps the other text styles when unsetting inside a blockquote', () => {
+    editorWith(
+      '<blockquote><p><span style="color: #ff0000; font-size: 28px">Example Text</span></p></blockquote>',
+    )
+
+    editor.commands.unsetFontSize()
+
+    expect(editor.getHTML()).toContain('color: #ff0000')
+    expect(editor.getHTML()).not.toContain('font-size')
+  })
+
+  it('keeps the other text styles when unsetting inside a paragraph', () => {
+    editorWith('<p><span style="color: #ff0000; font-size: 28px">Example Text</span></p>')
+
+    editor.commands.unsetFontSize()
+
+    expect(editor.getHTML()).toContain('color: #ff0000')
+    expect(editor.getHTML()).not.toContain('font-size')
   })
 })

--- a/packages/extension-text-style/src/text-style/index.ts
+++ b/packages/extension-text-style/src/text-style/index.ts
@@ -144,9 +144,8 @@ export const TextStyle = Mark.create<TextStyleOptions>({
           // removes everything from all the nodes
           // within the selection range.
           tr.doc.nodesBetween(selection.from, selection.to, (node, pos) => {
-            // Check if it's a paragraph element, if so, skip this node as we apply
-            // the text style to inline text nodes only (span).
-            if (node.isTextblock) {
+            // Skip non-inline nodes, the text style only applies to spans
+            if (!node.isInline) {
               return true
             }
 


### PR DESCRIPTION
Fixes #7503

## Problem

`unsetFontSize()` inside a blockquote removed every other text style in that blockquote:

```
before  <blockquote><p><span style="color: #ff0000; font-size: 28px">Example Text</span></p></blockquote>
after   <blockquote><p>Example Text</p></blockquote>
```

The same content in a plain paragraph keeps its color, so the two disagree.

## Cause

`removeEmptyTextStyle` skipped nodes matching `isTextblock`. A blockquote is a block but not a textblock, so it fell through to the mark check. Having no `textStyle` mark of its own, it took `removeMark` across its whole range and stripped every span inside.

## Fix

Skip non-inline nodes instead. One line, and it matches what the surrounding code already intends.

## Tests

Two cases in `font-size-commands.spec.ts`: the blockquote regression, plus the paragraph case as a control so the diff shows the two behaving the same. Reverting the fix fails only the blockquote test.

`pnpm lint`, `pnpm build`, `pnpm test:unit` (1853 tests) and `pnpm fallow:audit` all pass. Changeset included.

## Disclosure

Written with AI assistance (Claude Code). I reviewed the change, reproduced the bug, and verified the fix locally — happy to answer questions on any part of it.
