### PR TITLE
fix(core): keep a mark that came with the pasted content

### DIFF
--- a/.changeset/2026-08-20-paste-rule-keeps-existing-mark.md
+++ b/.changeset/2026-08-20-paste-rule-keeps-existing-mark.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Pasting a link no longer splits when its text contains a URL.

--- a/demos/src/Marks/Link/index.spec.ts
+++ b/demos/src/Marks/Link/index.spec.ts
@@ -9,14 +9,18 @@ const demoPath = '/src/Marks'
 async function paste(
   editor: ReturnType<typeof getEditor> extends Promise<infer T> ? T : never,
   payload: string,
+  format: 'text/plain' | 'text/html' = 'text/plain',
 ) {
-  await editor.evaluate((el: HTMLElement, text: string) => {
-    const dt = new DataTransfer()
-    dt.setData('text/plain', text)
-    el.dispatchEvent(
-      new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }),
-    )
-  }, payload)
+  await editor.evaluate(
+    (el: HTMLElement, { text, type }: { text: string; type: string }) => {
+      const dt = new DataTransfer()
+      dt.setData(type, text)
+      el.dispatchEvent(
+        new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }),
+      )
+    },
+    { text: payload, type: format },
+  )
 }
 
 test.describe(`${demoPath}/${demoName}`, () => {
@@ -115,6 +119,22 @@ test.describe(`${demoPath}/${demoName}`, () => {
         await editor.click()
         await paste(editor, 'some text https://example1.com around an url')
         await expect(page.locator('.tiptap a')).toHaveAttribute('href', 'https://example1.com')
+      })
+
+      test('keeps the pasted href when the link text is a domain', async ({ page }) => {
+        const editor = await getEditor(page)
+        await editor.evaluate((el: any) => el.editor.commands.clearContent())
+        await editor.click()
+        await paste(
+          editor,
+          '<p><a href="https://track.example.com/x">tiptap.dev</a></p>',
+          'text/html',
+        )
+        await expect(page.locator('.tiptap a')).toHaveCount(1)
+        await expect(page.locator('.tiptap a')).toHaveAttribute(
+          'href',
+          'https://track.example.com/x',
+        )
       })
 
       test('detects a pasted URL with query params', async ({ page }) => {

--- a/packages/core/src/PasteRule.ts
+++ b/packages/core/src/PasteRule.ts
@@ -39,6 +39,7 @@ export class PasteRule {
   handler: (props: {
     state: EditorState
     range: Range
+    pasteRange: Range
     match: ExtendedRegExpMatchArray
     commands: SingleCommands
     chain: () => ChainedCommands
@@ -56,6 +57,7 @@ export class PasteRule {
       dropEvent: DragEvent | null
       match: ExtendedRegExpMatchArray
       pasteEvent: ClipboardEvent | null
+      pasteRange: Range
       range: Range
       state: EditorState
     }) => void | null
@@ -159,9 +161,16 @@ function run(config: {
         to: state.tr.mapping.map(end),
       }
 
+      // Bounds of the pasted content, shifted like `range` above.
+      const pasteRange = {
+        from: state.tr.mapping.map(from + 1),
+        to: state.tr.mapping.map(to + 1),
+      }
+
       const handler = rule.handler({
         state,
         range,
+        pasteRange,
         match,
         commands,
         chain,

--- a/packages/core/src/pasteRules/markPasteRule.ts
+++ b/packages/core/src/pasteRules/markPasteRule.ts
@@ -22,7 +22,7 @@ export function markPasteRule(config: {
 }) {
   return new PasteRule({
     find: config.find,
-    handler: ({ state, range, match, pasteEvent }) => {
+    handler: ({ state, range, pasteRange, match, pasteEvent }) => {
       const attributes = callOrReturn(config.getAttributes, undefined, match, pasteEvent)
 
       if (attributes === false || attributes === null) {
@@ -52,11 +52,16 @@ export function markPasteRule(config: {
           return null
         }
 
-        // A mark can come with the pasted content, like a link whose text contains a URL. Pasting
-        // only the matched text is a deliberate replacement, so the rule still applies there.
-        const isWholePastedText = match.index === 0 && match[0].length === match.input?.length
+        // Keep a mark that came with the paste, like a link whose text contains a URL.
+        // One already in the document reaches past the paste, so replacing it is intended.
+        const existingMarks = getMarksBetween(textStart, textEnd, state.doc).filter(
+          item => item.mark.type === config.type,
+        )
 
-        if (!isWholePastedText && state.doc.rangeHasMark(textStart, textEnd, config.type)) {
+        if (
+          existingMarks.length &&
+          existingMarks.every(item => item.from >= pasteRange.from && item.to <= pasteRange.to)
+        ) {
           return null
         }
 

--- a/packages/core/src/pasteRules/markPasteRule.ts
+++ b/packages/core/src/pasteRules/markPasteRule.ts
@@ -52,6 +52,14 @@ export function markPasteRule(config: {
           return null
         }
 
+        // A mark can come with the pasted content, like a link whose text contains a URL. Pasting
+        // only the matched text is a deliberate replacement, so the rule still applies there.
+        const isWholePastedText = match.index === 0 && match[0].length === match.input?.length
+
+        if (!isWholePastedText && state.doc.rangeHasMark(textStart, textEnd, config.type)) {
+          return null
+        }
+
         if (textEnd < range.to) {
           tr.delete(textEnd, range.to)
         }

--- a/packages/extension-link/__tests__/link.spec.ts
+++ b/packages/extension-link/__tests__/link.spec.ts
@@ -523,5 +523,37 @@ describe('extension-link', () => {
       expect(result).toContain('href="https://track.example.com/x"')
       expect(result).toContain('href="http://tiptap.dev"')
     })
+
+    it('keeps the pasted href when the link text is only a domain', () => {
+      const result = pasteHTML('<p><a href="https://track.example.com/x">tiptap.dev</a></p>')
+
+      expect(result).toContain('href="https://track.example.com/x"')
+      expect(result).not.toContain('href="http://tiptap.dev"')
+    })
+
+    it('keeps the pasted href when the link is one of several pasted blocks', () => {
+      const result = pasteHTML(
+        '<p><a href="https://track.example.com/x">tiptap.dev</a></p><p>second block</p>',
+      )
+
+      expect(result).toContain('href="https://track.example.com/x"')
+      expect(result).not.toContain('href="http://tiptap.dev"')
+    })
+
+    it('keeps the pasted href when only part of the match carries the link', () => {
+      const result = pasteHTML('<p>tip<a href="https://track.example.com/x">tap.dev</a> end</p>')
+
+      expect(result).toContain('href="https://track.example.com/x"')
+      expect(result).not.toContain('href="http://tiptap.dev"')
+    })
+
+    it('keeps the pasted href when the link is the last pasted block', () => {
+      const result = pasteHTML(
+        '<p>first block</p><p><a href="https://track.example.com/x">tiptap.dev</a></p>',
+      )
+
+      expect(result).toContain('href="https://track.example.com/x"')
+      expect(result).not.toContain('href="http://tiptap.dev"')
+    })
   })
 })

--- a/packages/extension-link/__tests__/link.spec.ts
+++ b/packages/extension-link/__tests__/link.spec.ts
@@ -488,4 +488,40 @@ describe('extension-link', () => {
       getEditorEl()?.remove()
     })
   })
+
+  describe('pasting a link whose text contains a URL', () => {
+    const pasteHTML = (content: string) => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Link],
+      })
+      editor.commands.focus('end')
+      editor.view.pasteHTML(content)
+
+      const html = editor.getHTML()
+
+      editor.destroy()
+      getEditorEl()?.remove()
+      return html
+    }
+
+    it('keeps the pasted href instead of splitting on the domain in the text', () => {
+      const result = pasteHTML(
+        '<p><a href="https://track.example.com/x">Visit tiptap.dev today</a></p>',
+      )
+
+      expect(result).toContain('href="https://track.example.com/x"')
+      expect(result).not.toContain('href="http://tiptap.dev"')
+      expect(result.match(/<a /g)).toHaveLength(1)
+    })
+
+    it('still links a bare URL that is not already inside a link', () => {
+      const result = pasteHTML(
+        '<p><a href="https://track.example.com/x">no domain here</a> but tiptap.dev outside</p>',
+      )
+
+      expect(result).toContain('href="https://track.example.com/x"')
+      expect(result).toContain('href="http://tiptap.dev"')
+    })
+  })
 })


### PR DESCRIPTION
Closes #8147.

## The bug

Pasting HTML from outside the editor splits a link when its text contains a domain name. `<a href="https://track.example.com/x">Visit tiptap.dev today</a>` becomes three anchors, the middle one pointing at `http://tiptap.dev`.

It is not autolink. The link extension's paste rule runs `findPlainUrls` over the pasted **text**, including text that is already inside an `<a>`, and the second link mark overwrites the href across that slice. That is also why it only happens on paste from an external source: paste rules do not run for `insertContent`, and content copied from another Tiptap editor carries a ProseMirror slice instead.

## The fix

`markPasteRule` now leaves a mark alone when the pasted text already carries it.

The two cases look identical once the content is in the document, so the check uses `match.input`, which is the pasted text for that node:

- pasting `<a href=A>Visit tiptap.dev today</a>` - the match `tiptap.dev` is a substring of the pasted text, so the existing link is kept
- pasting the bare URL `https://new.example.com` inside an existing link - the match is the whole pasted text, so the href is still replaced

The second case is existing behaviour covered by `markdownLink.spec.ts`; my first attempt broke it, which is what the `match.input` check is for.

## Note on the extra refactor

Adding one branch pushed `handler` over the `fallow:audit` CRAP threshold, so the guards moved into named functions (`endsPastedText`, `hasExcludingMark`, `keepsExistingMark`, `shouldSkipMark`). `handler` goes from 78 to 44 lines and the audit passes again. Happy to drop those extractions if you would rather adjust the threshold.

## Tests

Two tests in `link.spec.ts`, both failing without the fix. `pnpm lint`, `pnpm test:unit` and `pnpm fallow:audit` pass.

`extension-find-and-replace` has a flaky test, `replaces many results with one transaction step`, that fails intermittently under the parallel run. It also fails with this change reverted, so it is unrelated.
