### PR TITLE
fix(demos): replace the ad-blocked placeholder image host

### DIFF
--- a/demos/src/Examples/Images/React/index.jsx
+++ b/demos/src/Examples/Images/React/index.jsx
@@ -13,8 +13,8 @@ export default () => {
     extensions: [Document, Paragraph, Text, Image, Dropcursor],
     content: `
       <p>This is a basic example of implementing images. Drag to re-order.</p>
-      <img src="https://placehold.co/600x400" />
-      <img src="https://placehold.co/800x400" />
+      <img src="https://dummyimage.com/600x400" />
+      <img src="https://dummyimage.com/800x400" />
     `,
   })
 

--- a/demos/src/Examples/Images/Vue/index.vue
+++ b/demos/src/Examples/Images/Vue/index.vue
@@ -43,8 +43,8 @@ export default {
       extensions: [Document, Paragraph, Text, Image, Dropcursor],
       content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/600x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
     })
   },

--- a/demos/src/Examples/NodePos/React/index.jsx
+++ b/demos/src/Examples/NodePos/React/index.jsx
@@ -21,7 +21,7 @@ export default () => {
       <p>
         This is a <strong>simple</strong> paragraph.
       </p>
-      <img src="https://placehold.co/200x200" alt="A 200x200 square thumbnail from placehold.co." />
+      <img src="https://dummyimage.com/200x200" alt="A 200x200 square thumbnail from dummyimage.com." />
       <p>
         Here is another paragraph inside this document.
       </p>
@@ -75,11 +75,11 @@ export default () => {
       <blockquote>
         <p>Here we have another paragraph inside a blockquote.</p>
         <blockquote>
-          <img src="https://placehold.co/260x200" alt="A 260x200 landscape thumbnail from placehold.co." />
-          <img src="https://placehold.co/100x200" alt="A 100x200 portrait thumbnail from placehold.co." />
+          <img src="https://dummyimage.com/260x200" alt="A 260x200 landscape thumbnail from dummyimage.com." />
+          <img src="https://dummyimage.com/100x200" alt="A 100x200 portrait thumbnail from dummyimage.com." />
         </blockquote>
       </blockquote>
-      <img src="https://placehold.co/260x200" alt="A 260x200 landscape thumbnail from placehold.co." />
+      <img src="https://dummyimage.com/260x200" alt="A 260x200 landscape thumbnail from dummyimage.com." />
     `,
   })
 
@@ -163,7 +163,9 @@ export default () => {
   }, [editor])
 
   const findSquaredImage = useCallback(() => {
-    const nodePosition = editor.$doc.querySelector('image', { src: 'https://placehold.co/200x200' })
+    const nodePosition = editor.$doc.querySelector('image', {
+      src: 'https://dummyimage.com/200x200',
+    })
 
     if (!nodePosition) {
       setFoundNodes(null)
@@ -174,7 +176,9 @@ export default () => {
   }, [editor])
 
   const findLandscapeImage = useCallback(() => {
-    const nodePosition = editor.$doc.querySelector('image', { src: 'https://placehold.co/260x200' })
+    const nodePosition = editor.$doc.querySelector('image', {
+      src: 'https://dummyimage.com/260x200',
+    })
 
     if (!nodePosition) {
       setFoundNodes(null)
@@ -186,7 +190,7 @@ export default () => {
 
   const findAllLandscapeImages = useCallback(() => {
     const nodePosition = editor.$doc.querySelectorAll('image', {
-      src: 'https://placehold.co/260x200',
+      src: 'https://dummyimage.com/260x200',
     })
 
     if (!nodePosition) {
@@ -200,7 +204,7 @@ export default () => {
   const findFirstLandscapeImageWithAllQuery = useCallback(() => {
     const nodePosition = editor.$doc.querySelectorAll(
       'image',
-      { src: 'https://placehold.co/260x200' },
+      { src: 'https://dummyimage.com/260x200' },
       true,
     )
 
@@ -213,7 +217,9 @@ export default () => {
   }, [editor])
 
   const findPortraitImageInBlockquote = useCallback(() => {
-    const nodePosition = editor.$doc.querySelector('image', { src: 'https://placehold.co/100x200' })
+    const nodePosition = editor.$doc.querySelector('image', {
+      src: 'https://dummyimage.com/100x200',
+    })
 
     if (!nodePosition) {
       setFoundNodes(null)

--- a/demos/src/Examples/ResizableImages/React/index.jsx
+++ b/demos/src/Examples/ResizableImages/React/index.jsx
@@ -24,8 +24,8 @@ export default () => {
     ],
     content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/600x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
   })
 

--- a/demos/src/Examples/ResizableImages/Vue/index.vue
+++ b/demos/src/Examples/ResizableImages/Vue/index.vue
@@ -54,8 +54,8 @@ export default {
       ],
       content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/600x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
     })
   },

--- a/demos/src/Experiments/All/Vue/index.vue
+++ b/demos/src/Experiments/All/Vue/index.vue
@@ -274,7 +274,7 @@ export default {
         </table>
         <p>This is a basic example of implementing images. Drag to re-order.</p>
         <img src="https://dummyimage.com/800x400" />
-        <img src="https://dummyimage.com/800x400/6A00F5/white" />
+        <img src="https://dummyimage.com/800x400/6A00F5/ffffff" />
       `,
     })
   },

--- a/demos/src/Experiments/All/Vue/index.vue
+++ b/demos/src/Experiments/All/Vue/index.vue
@@ -273,8 +273,8 @@ export default {
           </tbody>
         </table>
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/800x400" />
-        <img src="https://placehold.co/800x400/6A00F5/white" />
+        <img src="https://dummyimage.com/800x400" />
+        <img src="https://dummyimage.com/800x400/6A00F5/white" />
       `,
     })
   },

--- a/demos/src/Experiments/Figure/Vue/index.vue
+++ b/demos/src/Experiments/Figure/Vue/index.vue
@@ -61,14 +61,14 @@ export default {
       content: `
         <p>Figure + Figcaption</p>
         <figure>
-          <img src="https://dummyimage.com/800x400/orange/white" alt="Random photo of something" title="Who’s dat?">
+          <img src="https://dummyimage.com/800x400/ffa500/ffffff" alt="Random photo of something" title="Who’s dat?">
           <figcaption>
             <p>Amazing caption</p>
           </figcaption>
         </figure>
-        <img src="https://dummyimage.com/800x400/green/white">
-        <img src="https://dummyimage.com/800x400/blue/white">
-        <img src="https://dummyimage.com/800x400/black/white">
+        <img src="https://dummyimage.com/800x400/008000/ffffff">
+        <img src="https://dummyimage.com/800x400/0000ff/ffffff">
+        <img src="https://dummyimage.com/800x400/000000/ffffff">
         <p>That’s it.</p>
       `,
     })

--- a/demos/src/Experiments/Figure/Vue/index.vue
+++ b/demos/src/Experiments/Figure/Vue/index.vue
@@ -61,14 +61,14 @@ export default {
       content: `
         <p>Figure + Figcaption</p>
         <figure>
-          <img src="https://placehold.co/800x400/orange/white" alt="Random photo of something" title="Who’s dat?">
+          <img src="https://dummyimage.com/800x400/orange/white" alt="Random photo of something" title="Who’s dat?">
           <figcaption>
             <p>Amazing caption</p>
           </figcaption>
         </figure>
-        <img src="https://placehold.co/800x400/green/white">
-        <img src="https://placehold.co/800x400/blue/white">
-        <img src="https://placehold.co/800x400/black/white">
+        <img src="https://dummyimage.com/800x400/green/white">
+        <img src="https://dummyimage.com/800x400/blue/white">
+        <img src="https://dummyimage.com/800x400/black/white">
         <p>That’s it.</p>
       `,
     })

--- a/demos/src/Experiments/GenericFigure/Vue/index.vue
+++ b/demos/src/Experiments/GenericFigure/Vue/index.vue
@@ -62,7 +62,7 @@ export default {
             {
               type: 'image',
               attrs: {
-                src: 'https://placehold.co/800x400/orange/white',
+                src: 'https://dummyimage.com/800x400/orange/white',
               },
             },
           ],
@@ -158,10 +158,10 @@ export default {
           <figcaption>
             Image caption
           </figcaption>
-          <img src="https://placehold.co/800x400/black/white" alt="Random photo of something" title="Who’s dat?">
+          <img src="https://dummyimage.com/800x400/black/white" alt="Random photo of something" title="Who’s dat?">
         </figure>
         <p>Some text</p>
-        <img src="https://placehold.co/800x400">
+        <img src="https://dummyimage.com/800x400">
         <p>Some text</p>
         <figure data-type="capturedTable">
           <figcaption>

--- a/demos/src/Experiments/GenericFigure/Vue/index.vue
+++ b/demos/src/Experiments/GenericFigure/Vue/index.vue
@@ -62,7 +62,7 @@ export default {
             {
               type: 'image',
               attrs: {
-                src: 'https://dummyimage.com/800x400/orange/white',
+                src: 'https://dummyimage.com/800x400/ffa500/ffffff',
               },
             },
           ],
@@ -158,7 +158,7 @@ export default {
           <figcaption>
             Image caption
           </figcaption>
-          <img src="https://dummyimage.com/800x400/black/white" alt="Random photo of something" title="Who’s dat?">
+          <img src="https://dummyimage.com/800x400/000000/ffffff" alt="Random photo of something" title="Who’s dat?">
         </figure>
         <p>Some text</p>
         <img src="https://dummyimage.com/800x400">

--- a/demos/src/Extensions/Dropcursor/React/index.jsx
+++ b/demos/src/Extensions/Dropcursor/React/index.jsx
@@ -13,7 +13,7 @@ export default () => {
     extensions: [Document, Paragraph, Text, Image, Dropcursor],
     content: `
         <p>Try to drag around the image. While you drag, the editor should show a decoration under your cursor. The so called dropcursor.</p>
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
   })
 

--- a/demos/src/Extensions/Dropcursor/Vue/index.vue
+++ b/demos/src/Extensions/Dropcursor/Vue/index.vue
@@ -26,7 +26,7 @@ export default {
       extensions: [Document, Paragraph, Text, Image, Dropcursor],
       content: `
         <p>Try to drag around the image. While you drag, the editor should show a decoration under your cursor. The so called dropcursor.</p>
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
     })
   },

--- a/demos/src/Extensions/Gapcursor/React/index.jsx
+++ b/demos/src/Extensions/Gapcursor/React/index.jsx
@@ -13,7 +13,7 @@ export default () => {
     extensions: [Document, Paragraph, Text, Image, Gapcursor],
     content: `
         <p>Try to move the cursor after the image with your arrow keys! You should see a horizontal blinking cursor below the image. This is the gapcursor.</p>
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
   })
 

--- a/demos/src/Extensions/Gapcursor/Vue/index.vue
+++ b/demos/src/Extensions/Gapcursor/Vue/index.vue
@@ -26,7 +26,7 @@ export default {
       extensions: [Document, Paragraph, Text, Image, Gapcursor],
       content: `
         <p>Try to move the cursor after the image with your arrow keys! You should see a horizontal blinking cursor below the image. This is the gapcursor.</p>
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
     })
   },

--- a/demos/src/Nodes/Image/React/index.jsx
+++ b/demos/src/Nodes/Image/React/index.jsx
@@ -13,8 +13,8 @@ export default () => {
     extensions: [Document, Paragraph, Text, Image, Dropcursor],
     content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/600x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
   })
 

--- a/demos/src/Nodes/Image/Vue/index.vue
+++ b/demos/src/Nodes/Image/Vue/index.vue
@@ -43,8 +43,8 @@ export default {
       extensions: [Document, Paragraph, Text, Image, Dropcursor],
       content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://dummyimage.com/600x400" />
+        <img src="https://dummyimage.com/800x400" />
       `,
     })
   },


### PR DESCRIPTION
## Fixes

Fixes #8222

## Changes and Review

- The demo images all used `placehold.co`, and EasyList Annoyances blocks that domain (`||placehold.co^$third-party`). Anyone running a common ad blocker sees empty images on every docs page that embeds these demos, including the Image extension page from the issue.
- Swapped the host to `dummyimage.com`. Same URL shape, same sizes. Colors are hex now, since that host does not read CSS color names.
- Three lines in the NodePos demo grew past 100 characters, so oxfmt rewrapped them. No changeset, nothing under `packages/` changed.
- Happy to self-host the images under `demos/public` instead, if you would rather not depend on another placeholder service.
- To verify, open the Image, Dropcursor, Gapcursor or NodePos demo with an ad blocker on.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
