### PR TITLE
feat(core): sink and lift list items across list types

### DIFF
--- a/.changeset/2026-08-17-list-item-sink-lift-across-list-types.md
+++ b/.changeset/2026-08-17-list-item-sink-lift-across-list-types.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': minor
+---
+
+`sinkListItem` and `liftListItem` now work across list types. Pressing Tab on an item right after a sublist of another type (for example a task list inside a bullet list) moves the item into that sublist and gives it the sublist's item type instead of starting a second sublist. Pressing Shift+Tab on an item nested in a list of another type lifts it into that list as one of its items, and any items after it move along as its sublist. Nothing changes for lists of a single type.

--- a/.changeset/2026-08-17-list-item-sink-lift-across-list-types.md
+++ b/.changeset/2026-08-17-list-item-sink-lift-across-list-types.md
@@ -2,4 +2,4 @@
 '@tiptap/core': minor
 ---
 
-`sinkListItem` and `liftListItem` now work across list types. Pressing Tab on an item right after a sublist of another type (for example a task list inside a bullet list) moves the item into that sublist and gives it the sublist's item type instead of starting a second sublist. Pressing Shift+Tab on an item nested in a list of another type lifts it into that list as one of its items, and any items after it move along as its sublist. Nothing changes for lists of a single type.
+`sinkListItem` and `liftListItem` now work across list types. Pressing Tab on an item right after a nested list of another type (for example a task list inside a bullet list) moves the item into that nested list instead of starting a second one. Pressing Shift+Tab on an item nested in a list of another type lifts it into that list as one of its items, and any items after it move along as its nested list. Nothing changes for lists of a single type.

--- a/demos/src/Extensions/ListKeymap/React/index.jsx
+++ b/demos/src/Extensions/ListKeymap/React/index.jsx
@@ -1,7 +1,14 @@
 import './styles.scss'
 
 import Document from '@tiptap/extension-document'
-import { BulletList, ListItem, ListKeymap } from '@tiptap/extension-list'
+import {
+  BulletList,
+  ListItem,
+  ListKeymap,
+  OrderedList,
+  TaskItem,
+  TaskList,
+} from '@tiptap/extension-list'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import { EditorContent, useEditor, useEditorState } from '@tiptap/react'
@@ -9,11 +16,27 @@ import React from 'react'
 
 export default () => {
   const editor = useEditor({
-    extensions: [Document, Paragraph, Text, BulletList, ListItem, ListKeymap],
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      BulletList,
+      OrderedList,
+      ListItem,
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      ListKeymap,
+    ],
     content: `
         <ul>
           <li>A list item</li>
-          <li>And another one</li>
+          <li>
+            And another one
+            <ul data-type="taskList">
+              <li data-type="taskItem" data-checked="false">A nested task</li>
+            </ul>
+          </li>
+          <li>Press Tab here to join the nested task list</li>
         </ul>
       `,
   })

--- a/demos/src/Extensions/ListKeymap/React/styles.scss
+++ b/demos/src/Extensions/ListKeymap/React/styles.scss
@@ -15,34 +15,4 @@
       margin-bottom: 0.25em;
     }
   }
-
-  /* Task list specific styles */
-  ul[data-type='taskList'] {
-    list-style: none;
-    margin-left: 0;
-    padding: 0;
-
-    li {
-      align-items: flex-start;
-      display: flex;
-
-      > label {
-        flex: 0 0 auto;
-        margin-right: 0.5rem;
-        user-select: none;
-      }
-
-      > div {
-        flex: 1 1 auto;
-      }
-    }
-
-    input[type='checkbox'] {
-      cursor: pointer;
-    }
-
-    ul[data-type='taskList'] {
-      margin: 0;
-    }
-  }
 }

--- a/demos/src/Extensions/ListKeymap/React/styles.scss
+++ b/demos/src/Extensions/ListKeymap/React/styles.scss
@@ -15,4 +15,34 @@
       margin-bottom: 0.25em;
     }
   }
+
+  /* Task list specific styles */
+  ul[data-type='taskList'] {
+    list-style: none;
+    margin-left: 0;
+    padding: 0;
+
+    li {
+      align-items: flex-start;
+      display: flex;
+
+      > label {
+        flex: 0 0 auto;
+        margin-right: 0.5rem;
+        user-select: none;
+      }
+
+      > div {
+        flex: 1 1 auto;
+      }
+    }
+
+    input[type='checkbox'] {
+      cursor: pointer;
+    }
+
+    ul[data-type='taskList'] {
+      margin: 0;
+    }
+  }
 }

--- a/demos/src/Extensions/ListKeymap/index.spec.ts
+++ b/demos/src/Extensions/ListKeymap/index.spec.ts
@@ -168,6 +168,58 @@ test.describe(`${demoPath}/${demoName}`, () => {
         const html = await editor.evaluate((el: any) => el.editor.getHTML())
         expect(html).toBe('<ul><li><p>A</p></li></ul>')
       })
+
+      test('tab in a list item after a task sublist joins it as a task item', async ({ page }) => {
+        const editor = await getEditor(page)
+        await placeCaretBefore(
+          editor,
+          '<ul><li><p>A</p><ul data-type="taskList"><li data-type="taskItem" data-checked="false"><p>T</p></li></ul></li><li><p>B</p></li></ul>',
+          'B',
+        )
+        await editor.press('Tab')
+        const json = await editor.evaluate((el: any) => el.editor.getJSON())
+        const items = json.content[0].content
+        expect(items).toHaveLength(1)
+        const sublist = items[0].content[1]
+        expect(sublist.type).toBe('taskList')
+        expect(sublist.content.map((item: any) => item.type)).toEqual(['taskItem', 'taskItem'])
+        expect(sublist.content[1].content[0].content[0].text).toBe('B')
+      })
+
+      test('tab in a bullet item after an ordered sublist joins the ordered sublist', async ({
+        page,
+      }) => {
+        const editor = await getEditor(page)
+        await placeCaretBefore(
+          editor,
+          '<ul><li><p>A</p><ol><li><p>one</p></li></ol></li><li><p>B</p></li></ul>',
+          'B',
+        )
+        await editor.press('Tab')
+        const html = await editor.evaluate((el: any) => el.editor.getHTML())
+        expect(html).toBe('<ul><li><p>A</p><ol><li><p>one</p></li><li><p>B</p></li></ol></li></ul>')
+      })
+
+      test('shift+tab in a nested task item lifts it into the bullet list as a list item', async ({
+        page,
+      }) => {
+        const editor = await getEditor(page)
+        await placeCaretBefore(
+          editor,
+          '<ul><li><p>A</p><ul data-type="taskList"><li data-type="taskItem" data-checked="false"><p>T</p></li><li data-type="taskItem" data-checked="true"><p>U</p></li></ul></li></ul>',
+          'T',
+        )
+        await editor.press('Shift+Tab')
+        const json = await editor.evaluate((el: any) => el.editor.getJSON())
+        const items = json.content[0].content
+        expect(items.map((item: any) => item.type)).toEqual(['listItem', 'listItem'])
+        expect(items[0].content).toHaveLength(1)
+        expect(items[1].content[0].content[0].text).toBe('T')
+        const sublist = items[1].content[1]
+        expect(sublist.type).toBe('taskList')
+        expect(sublist.content[0].attrs.checked).toBe(true)
+        expect(sublist.content[0].content[0].content[0].text).toBe('U')
+      })
     })
   })
 })

--- a/packages/core/__tests__/liftListItemMixedLists.spec.ts
+++ b/packages/core/__tests__/liftListItemMixedLists.spec.ts
@@ -1,0 +1,293 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import { BulletList, ListItem, OrderedList, TaskItem, TaskList } from '@tiptap/extension-list'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const paragraph = (text: string) => ({ type: 'paragraph', content: [{ type: 'text', text }] })
+const listItem = (text: string, ...children: object[]) => ({
+  type: 'listItem',
+  content: [paragraph(text), ...children],
+})
+const taskItem = (text: string, checked = false, ...children: object[]) => ({
+  type: 'taskItem',
+  attrs: { checked },
+  content: [paragraph(text), ...children],
+})
+const itemTexts = (list?: {
+  content?: Array<{ content?: Array<{ content?: Array<{ text?: string }> }> }>
+}) => list?.content?.map(item => item.content?.[0]?.content?.[0]?.text)
+
+function findTextStart(editor: Editor, text: string) {
+  let position: number | null = null
+
+  editor.state.doc.descendants((node, pos) => {
+    if (position !== null) {
+      return false
+    }
+
+    if (node.isText && node.text === text) {
+      position = pos
+    }
+  })
+
+  if (position === null) {
+    throw new Error(`Could not find text position for "${text}"`)
+  }
+
+  return position
+}
+
+describe('liftListItem across list types', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  const createEditor = (content: object) => {
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        BulletList,
+        OrderedList,
+        ListItem,
+        TaskList,
+        TaskItem.configure({ nested: true }),
+      ],
+      content,
+    })
+
+    return editor
+  }
+
+  it('lifts a task item into the surrounding ordered list as a list item', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', { type: 'taskList', content: [taskItem('task')] }),
+            listItem('Second'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'task') + 2)
+
+    expect(editor.commands.liftListItem('taskItem')).toBe(true)
+
+    const orderedList = editor.getJSON().content?.[0]
+
+    expect(orderedList?.content?.map(item => item.type)).toEqual([
+      'listItem',
+      'listItem',
+      'listItem',
+    ])
+    expect(itemTexts(orderedList)).toEqual(['First', 'task', 'Second'])
+    expect(orderedList?.content?.[0]?.content).toHaveLength(1)
+
+    expect(editor.state.selection.$from.parent.textContent).toBe('task')
+    expect(editor.state.selection.$from.parentOffset).toBe(2)
+  })
+
+  it('carries following siblings along as a sublist of the lifted item', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', {
+              type: 'taskList',
+              content: [taskItem('one'), taskItem('two', true), taskItem('three')],
+            }),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'one'))
+
+    expect(editor.commands.liftListItem('taskItem')).toBe(true)
+
+    const orderedList = editor.getJSON().content?.[0]
+
+    expect(itemTexts(orderedList)).toEqual(['First', 'one'])
+
+    const lifted = orderedList?.content?.[1]
+    const sublist = lifted?.content?.[1]
+
+    expect(sublist?.type).toBe('taskList')
+    expect(itemTexts(sublist)).toEqual(['two', 'three'])
+    expect(sublist?.content?.[0]?.attrs?.checked).toBe(true)
+  })
+
+  it('merges following siblings into the lifted item’s existing sublist of the same type', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', {
+              type: 'taskList',
+              content: [
+                taskItem('one', false, { type: 'taskList', content: [taskItem('one-a')] }),
+                taskItem('two'),
+              ],
+            }),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'one'))
+
+    expect(editor.commands.liftListItem('taskItem')).toBe(true)
+
+    const lifted = editor.getJSON().content?.[0]?.content?.[1]
+
+    expect(lifted?.content?.map(node => node.type)).toEqual(['paragraph', 'taskList'])
+    expect(itemTexts(lifted?.content?.[1])).toEqual(['one-a', 'two'])
+  })
+
+  it('keeps preceding siblings in place when lifting a middle item', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            listItem('First', {
+              type: 'taskList',
+              content: [taskItem('a'), taskItem('b'), taskItem('c')],
+            }),
+            listItem('Second'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'b'))
+
+    expect(editor.commands.liftListItem('taskItem')).toBe(true)
+
+    const bulletList = editor.getJSON().content?.[0]
+
+    expect(itemTexts(bulletList)).toEqual(['First', 'b', 'Second'])
+    expect(itemTexts(bulletList?.content?.[0]?.content?.[1])).toEqual(['a'])
+    expect(itemTexts(bulletList?.content?.[1]?.content?.[1])).toEqual(['c'])
+  })
+
+  it('lifts every selected item when the selection spans several items', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', {
+              type: 'taskList',
+              content: [taskItem('one'), taskItem('two'), taskItem('three')],
+            }),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection({
+      from: findTextStart(editor, 'one'),
+      to: findTextStart(editor, 'two') + 3,
+    })
+
+    expect(editor.commands.liftListItem('taskItem')).toBe(true)
+
+    const orderedList = editor.getJSON().content?.[0]
+
+    expect(itemTexts(orderedList)).toEqual(['First', 'one', 'two'])
+    expect(itemTexts(orderedList?.content?.[2]?.content?.[1])).toEqual(['three'])
+  })
+
+  it('keeps the default behavior inside a same-type nested list', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            listItem('First', { type: 'bulletList', content: [listItem('one'), listItem('two')] }),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'one'))
+
+    expect(editor.commands.liftListItem('listItem')).toBe(true)
+
+    const bulletList = editor.getJSON().content?.[0]
+
+    expect(itemTexts(bulletList)).toEqual(['First', 'one'])
+    expect(itemTexts(bulletList?.content?.[1]?.content?.[1])).toEqual(['two'])
+  })
+
+  it('keeps the default behavior for a top-level list', () => {
+    createEditor({
+      type: 'doc',
+      content: [{ type: 'taskList', content: [taskItem('only')] }],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'only'))
+
+    expect(editor.commands.liftListItem('taskItem')).toBe(true)
+    expect(editor.getJSON().content?.map(node => node.type)).toEqual(['paragraph'])
+  })
+
+  it('inserts at the right position when chained after another step', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', { type: 'taskList', content: [taskItem('one'), taskItem('two')] }),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'one') + 3)
+
+    expect(editor.chain().insertContent('Y').liftListItem('taskItem').run()).toBe(true)
+
+    const orderedList = editor.getJSON().content?.[0]
+
+    expect(itemTexts(orderedList)).toEqual(['First', 'oneY'])
+    expect(itemTexts(orderedList?.content?.[1]?.content?.[1])).toEqual(['two'])
+  })
+
+  it('reports availability through can()', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [listItem('First', { type: 'taskList', content: [taskItem('task')] })],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'task'))
+
+    const before = editor.getJSON()
+
+    expect(editor.can().liftListItem('taskItem')).toBe(true)
+    expect(editor.getJSON()).toEqual(before)
+  })
+})

--- a/packages/core/__tests__/sinkListItemMixedLists.spec.ts
+++ b/packages/core/__tests__/sinkListItemMixedLists.spec.ts
@@ -1,0 +1,291 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import { BulletList, ListItem, OrderedList, TaskItem, TaskList } from '@tiptap/extension-list'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const paragraph = (text: string) => ({ type: 'paragraph', content: [{ type: 'text', text }] })
+const listItem = (text: string, ...children: object[]) => ({
+  type: 'listItem',
+  content: [paragraph(text), ...children],
+})
+const taskItem = (text: string, checked = false, ...children: object[]) => ({
+  type: 'taskItem',
+  attrs: { checked },
+  content: [paragraph(text), ...children],
+})
+
+function findTextStart(editor: Editor, text: string) {
+  let position: number | null = null
+
+  editor.state.doc.descendants((node, pos) => {
+    if (position !== null) {
+      return false
+    }
+
+    if (node.isText && node.text === text) {
+      position = pos
+    }
+  })
+
+  if (position === null) {
+    throw new Error(`Could not find text position for "${text}"`)
+  }
+
+  return position
+}
+
+describe('sinkListItem across list types', () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  const createEditor = (content: object) => {
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        BulletList,
+        OrderedList,
+        ListItem,
+        TaskList,
+        TaskItem.configure({ nested: true }),
+      ],
+      content,
+    })
+
+    return editor
+  }
+
+  it('joins the previous item’s task sublist and becomes a task item', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', { type: 'taskList', content: [taskItem('existing')] }),
+            listItem('Second'),
+            listItem('Third'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'Second') + 3)
+
+    expect(editor.commands.sinkListItem('listItem')).toBe(true)
+
+    const orderedList = editor.getJSON().content?.[0]
+
+    expect(orderedList?.content).toHaveLength(2)
+
+    const sublist = orderedList?.content?.[0]?.content?.[1]
+
+    expect(sublist?.type).toBe('taskList')
+    expect(sublist?.content?.map(item => item.type)).toEqual(['taskItem', 'taskItem'])
+    expect(sublist?.content?.[1]?.content?.[0]?.content?.[0]?.text).toBe('Second')
+    expect(orderedList?.content?.[1]?.content?.[0]?.content?.[0]?.text).toBe('Third')
+
+    // the caret stays at the same offset inside the moved item
+    expect(editor.state.selection.$from.parent.textContent).toBe('Second')
+    expect(editor.state.selection.$from.parentOffset).toBe(3)
+  })
+
+  it('joins the previous item’s ordered sublist from a bullet list', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            listItem('First', { type: 'orderedList', content: [listItem('one')] }),
+            listItem('Second'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'Second'))
+
+    expect(editor.commands.sinkListItem('listItem')).toBe(true)
+
+    const firstItem = editor.getJSON().content?.[0]?.content?.[0]
+
+    // one sublist, not a second bullet sublist next to the ordered one
+    expect(firstItem?.content?.map(node => node.type)).toEqual(['paragraph', 'orderedList'])
+    expect(
+      firstItem?.content?.[1]?.content?.map(item => item.content?.[0]?.content?.[0]?.text),
+    ).toEqual(['one', 'Second'])
+  })
+
+  it('moves a checked task item into a bullet sublist as a list item', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            taskItem('First', false, { type: 'bulletList', content: [listItem('existing')] }),
+            taskItem('Done', true),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'Done'))
+
+    expect(editor.commands.sinkListItem('taskItem')).toBe(true)
+
+    const sublist = editor.getJSON().content?.[0]?.content?.[0]?.content?.[1]
+
+    expect(sublist?.type).toBe('bulletList')
+    expect(sublist?.content?.map(item => item.type)).toEqual(['listItem', 'listItem'])
+    expect(sublist?.content?.[1]?.content?.[0]?.content?.[0]?.text).toBe('Done')
+  })
+
+  it('moves every selected item when the selection spans several items', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', { type: 'taskList', content: [taskItem('existing')] }),
+            listItem('Second'),
+            listItem('Third'),
+            listItem('Fourth'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection({
+      from: findTextStart(editor, 'Second'),
+      to: findTextStart(editor, 'Third') + 5,
+    })
+
+    expect(editor.commands.sinkListItem('listItem')).toBe(true)
+
+    const orderedList = editor.getJSON().content?.[0]
+    const sublist = orderedList?.content?.[0]?.content?.[1]
+
+    expect(sublist?.content?.map(item => item.content?.[0]?.content?.[0]?.text)).toEqual([
+      'existing',
+      'Second',
+      'Third',
+    ])
+    expect(orderedList?.content?.[1]?.content?.[0]?.content?.[0]?.text).toBe('Fourth')
+  })
+
+  it('keeps the default behavior when the sublist has the same list type', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            listItem('First', { type: 'bulletList', content: [listItem('one')] }),
+            listItem('Second'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'Second'))
+
+    expect(editor.commands.sinkListItem('listItem')).toBe(true)
+
+    const sublist = editor.getJSON().content?.[0]?.content?.[0]?.content?.[1]
+
+    expect(sublist?.type).toBe('bulletList')
+    expect(sublist?.content?.map(item => item.content?.[0]?.content?.[0]?.text)).toEqual([
+      'one',
+      'Second',
+    ])
+  })
+
+  it('does not run when the item cannot become the sublist item type', () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, BulletList, ListItem, TaskList, TaskItem],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              listItem('First', { type: 'taskList', content: [taskItem('existing')] }),
+              listItem('Second', { type: 'bulletList', content: [listItem('nested')] }),
+            ],
+          },
+        ],
+      },
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'Second'))
+
+    // TaskItem without `nested` cannot hold the nested bullet list, so the default sink runs
+    expect(editor.commands.sinkListItem('listItem')).toBe(true)
+
+    const firstItem = editor.getJSON().content?.[0]?.content?.[0]
+
+    expect(firstItem?.content?.map(node => node.type)).toEqual([
+      'paragraph',
+      'taskList',
+      'bulletList',
+    ])
+  })
+
+  it('inserts at the right position when chained after another step', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', { type: 'taskList', content: [taskItem('existing')] }),
+            listItem('Second'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'Second') + 6)
+
+    expect(editor.chain().insertContent('Y').sinkListItem('listItem').run()).toBe(true)
+
+    const sublist = editor.getJSON().content?.[0]?.content?.[0]?.content?.[1]
+
+    expect(sublist?.type).toBe('taskList')
+    expect(sublist?.content?.map(item => item.content?.[0]?.content?.[0]?.text)).toEqual([
+      'existing',
+      'SecondY',
+    ])
+  })
+
+  it('reports availability through can()', () => {
+    createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            listItem('First', { type: 'taskList', content: [taskItem('existing')] }),
+            listItem('Second'),
+          ],
+        },
+      ],
+    })
+
+    editor.commands.setTextSelection(findTextStart(editor, 'Second'))
+
+    const before = editor.getJSON()
+
+    expect(editor.can().sinkListItem('listItem')).toBe(true)
+    expect(editor.getJSON()).toEqual(before)
+  })
+})

--- a/packages/core/src/commands/liftListItem.ts
+++ b/packages/core/src/commands/liftListItem.ts
@@ -15,6 +15,7 @@ declare module '@tiptap/core' {
        * Create a command to lift the list item around the selection up into a wrapping list.
        * When the wrapping list has another item type, the item takes that type.
        * @param typeOrName The type or name of the node.
+       * @returns True when the item was lifted.
        * @example editor.commands.liftListItem('listItem')
        */
       liftListItem: (typeOrName: string | NodeType) => ReturnType

--- a/packages/core/src/commands/liftListItem.ts
+++ b/packages/core/src/commands/liftListItem.ts
@@ -1,14 +1,19 @@
-import type { NodeType } from '@tiptap/pm/model'
+import type { Fragment, Node as ProseMirrorNode, NodeRange, NodeType } from '@tiptap/pm/model'
 import { liftListItem as originalLiftListItem } from '@tiptap/pm/schema-list'
 
+import { changeListItemsType } from '../helpers/changeListItemsType.js'
+import { getListItemRange } from '../helpers/getListItemRange.js'
 import { getNodeType } from '../helpers/getNodeType.js'
-import type { RawCommands } from '../types.js'
+import { isList } from '../helpers/isList.js'
+import { shiftSelection } from '../helpers/shiftSelection.js'
+import type { CommandProps, Extensions, RawCommands } from '../types.js'
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     liftListItem: {
       /**
        * Create a command to lift the list item around the selection up into a wrapping list.
+       * When the wrapping list has another item type, the item takes that type.
        * @param typeOrName The type or name of the node.
        * @example editor.commands.liftListItem('listItem')
        */
@@ -17,10 +22,108 @@ declare module '@tiptap/core' {
   }
 }
 
-export const liftListItem: RawCommands['liftListItem'] =
-  typeOrName =>
-  ({ state, dispatch }) => {
-    const type = getNodeType(typeOrName, state.schema)
-
-    return originalLiftListItem(type)(state, dispatch)
+// The item of another type wrapping the range's list, when that item sits in a list
+const getParentListItem = (range: NodeRange, itemType: NodeType, extensions: Extensions) => {
+  if (range.depth < 2) {
+    return null
   }
+
+  const parentItem = range.$from.node(range.depth - 1)
+  const parentList = range.$from.node(range.depth - 2)
+
+  if (parentItem.type === itemType || !isList(parentList.type.name, extensions)) {
+    return null
+  }
+
+  return parentItem
+}
+
+// Nest `followers` under `item` as a sublist like `list`, joining an existing one of the same type
+const nestFollowingItems = (item: ProseMirrorNode, list: ProseMirrorNode, followers: Fragment) => {
+  const trailingSublist = item.lastChild
+
+  if (trailingSublist?.type === list.type) {
+    const merged = trailingSublist.copy(trailingSublist.content.append(followers))
+
+    return item.copy(item.content.replaceChild(item.childCount - 1, merged))
+  }
+
+  return item.copy(item.content.addToEnd(list.copy(followers)))
+}
+
+// The range's items, with the items after the range nested under the last one
+const getItemsWithFollowers = (range: NodeRange) => {
+  const list = range.parent
+  const listStart = range.$from.start(range.depth)
+  const items = list.content.cut(range.start - listStart, range.end - listStart)
+  const followers = list.content.cut(range.end - listStart)
+
+  if (followers.childCount === 0) {
+    return items
+  }
+
+  const lastItem = nestFollowingItems(list.child(range.endIndex - 1), list, followers)
+
+  return items.replaceChild(items.childCount - 1, lastItem)
+}
+
+const canLiftItems = (range: NodeRange, items: Fragment) => {
+  const { $from } = range
+  const parentItem = $from.node(range.depth - 1)
+  const parentList = $from.node(range.depth - 2)
+  const parentItemIndex = $from.index(range.depth - 2)
+  const listIndex = $from.index(range.depth - 1)
+  const removesList = range.startIndex === 0
+
+  if (removesList && !parentItem.canReplace(listIndex, listIndex + 1)) {
+    return false
+  }
+
+  return parentList.canReplace(parentItemIndex + 1, parentItemIndex + 1, items)
+}
+
+const liftIntoParentList = (itemType: NodeType, { editor, state, tr, dispatch }: CommandProps) => {
+  const range = getListItemRange(state.selection, itemType)
+  const parentItem = range && getParentListItem(range, itemType, editor.extensionManager.extensions)
+
+  if (!range || !parentItem) {
+    return false
+  }
+
+  const items = changeListItemsType(getItemsWithFollowers(range), parentItem.type)
+
+  if (!items || !canLiftItems(range, items)) {
+    return false
+  }
+
+  if (!dispatch) {
+    return true
+  }
+
+  const { $from } = range
+  const removesList = range.startIndex === 0
+  const deleteFrom = removesList ? $from.before(range.depth) : range.start
+  const deleteTo = removesList ? $from.after(range.depth) : $from.end(range.depth)
+  const stepsBefore = tr.steps.length
+
+  tr.delete(deleteFrom, deleteTo)
+
+  // map only through this delete, earlier steps of a chain are already in `$from`
+  const insertPos = tr.mapping.slice(stepsBefore).map($from.after(range.depth - 1))
+
+  tr.insert(insertPos, items)
+  shiftSelection(tr, state.selection, insertPos - range.start)
+
+  return true
+}
+
+export const liftListItem: RawCommands['liftListItem'] = typeOrName => props => {
+  const { state, dispatch } = props
+  const type = getNodeType(typeOrName, state.schema)
+
+  if (liftIntoParentList(type, props)) {
+    return true
+  }
+
+  return originalLiftListItem(type)(state, dispatch)
+}

--- a/packages/core/src/commands/sinkListItem.ts
+++ b/packages/core/src/commands/sinkListItem.ts
@@ -1,14 +1,19 @@
-import type { NodeType } from '@tiptap/pm/model'
+import type { NodeRange, NodeType } from '@tiptap/pm/model'
 import { sinkListItem as originalSinkListItem } from '@tiptap/pm/schema-list'
 
+import { changeListItemsType } from '../helpers/changeListItemsType.js'
+import { getListItemRange } from '../helpers/getListItemRange.js'
 import { getNodeType } from '../helpers/getNodeType.js'
-import type { RawCommands } from '../types.js'
+import { isList } from '../helpers/isList.js'
+import { shiftSelection } from '../helpers/shiftSelection.js'
+import type { CommandProps, Extensions, RawCommands } from '../types.js'
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     sinkListItem: {
       /**
-       * Sink the list item down into an inner list.
+       * Sink the list item down into an inner list. When the previous item ends
+       * with a list of another type, the item joins that list and takes its item type.
        * @param typeOrName The type or name of the node.
        * @example editor.commands.sinkListItem('listItem')
        */
@@ -17,10 +22,62 @@ declare module '@tiptap/core' {
   }
 }
 
-export const sinkListItem: RawCommands['sinkListItem'] =
-  typeOrName =>
-  ({ state, dispatch }) => {
-    const type = getNodeType(typeOrName, state.schema)
-
-    return originalSinkListItem(type)(state, dispatch)
+// The list of another type that ends the item before the range, if any
+const getPreviousSublist = (range: NodeRange, extensions: Extensions) => {
+  if (range.startIndex === 0) {
+    return null
   }
+
+  const list = range.parent
+  const sublist = list.child(range.startIndex - 1).lastChild
+
+  if (!sublist || sublist.type === list.type || !isList(sublist.type.name, extensions)) {
+    return null
+  }
+
+  return sublist
+}
+
+const sinkIntoPreviousSublist = (
+  itemType: NodeType,
+  { editor, state, tr, dispatch }: CommandProps,
+) => {
+  const range = getListItemRange(state.selection, itemType)
+  const sublist = range && getPreviousSublist(range, editor.extensionManager.extensions)
+
+  if (!range || !sublist) {
+    return false
+  }
+
+  const listStart = range.$from.start(range.depth)
+  const rangeItems = range.parent.content.cut(range.start - listStart, range.end - listStart)
+  const sublistItemType = sublist.type.contentMatch.defaultType
+  const items = sublistItemType && changeListItemsType(rangeItems, sublistItemType)
+
+  if (!items || !sublist.canReplace(sublist.childCount, sublist.childCount, items)) {
+    return false
+  }
+
+  if (!dispatch) {
+    return true
+  }
+
+  // two closing tokens back: the sublist's and the previous item's
+  const insertPos = range.start - 2
+
+  tr.delete(range.start, range.end).insert(insertPos, items)
+  shiftSelection(tr, state.selection, insertPos - range.start)
+
+  return true
+}
+
+export const sinkListItem: RawCommands['sinkListItem'] = typeOrName => props => {
+  const { state, dispatch } = props
+  const type = getNodeType(typeOrName, state.schema)
+
+  if (sinkIntoPreviousSublist(type, props)) {
+    return true
+  }
+
+  return originalSinkListItem(type)(state, dispatch)
+}

--- a/packages/core/src/commands/sinkListItem.ts
+++ b/packages/core/src/commands/sinkListItem.ts
@@ -15,6 +15,7 @@ declare module '@tiptap/core' {
        * Sink the list item down into an inner list. When the previous item ends
        * with a list of another type, the item joins that list and takes its item type.
        * @param typeOrName The type or name of the node.
+       * @returns True when the item was sunk.
        * @example editor.commands.sinkListItem('listItem')
        */
       sinkListItem: (typeOrName: string | NodeType) => ReturnType

--- a/packages/core/src/helpers/changeListItemsType.ts
+++ b/packages/core/src/helpers/changeListItemsType.ts
@@ -1,0 +1,34 @@
+import { Fragment, type Node as ProseMirrorNode, type NodeType } from '@tiptap/pm/model'
+
+// Keep the content and the attributes both item types share
+const changeListItemType = (item: ProseMirrorNode, itemType: NodeType) => {
+  if (item.type === itemType) {
+    return item
+  }
+
+  const attrs = Object.fromEntries(
+    Object.entries(item.attrs).filter(([name]) => name in itemType.attrs),
+  )
+
+  return itemType.create(attrs, item.content, itemType.allowedMarks(item.marks))
+}
+
+/**
+ * Recreate every list item in `items` as `itemType`. Returns null when the
+ * content of any item does not fit `itemType`.
+ */
+export function changeListItemsType(items: Fragment, itemType: NodeType): Fragment | null {
+  const changed: ProseMirrorNode[] = []
+
+  for (let index = 0; index < items.childCount; index += 1) {
+    const item = items.child(index)
+
+    if (!itemType.validContent(item.content)) {
+      return null
+    }
+
+    changed.push(changeListItemType(item, itemType))
+  }
+
+  return Fragment.from(changed)
+}

--- a/packages/core/src/helpers/getListItemRange.ts
+++ b/packages/core/src/helpers/getListItemRange.ts
@@ -1,0 +1,12 @@
+import type { NodeType } from '@tiptap/pm/model'
+import type { Selection } from '@tiptap/pm/state'
+
+/**
+ * Get the block range of the list items around the selection, or null when
+ * the selection is not inside a list of `itemType`.
+ */
+export function getListItemRange(selection: Selection, itemType: NodeType) {
+  const { $from, $to } = selection
+
+  return $from.blockRange($to, node => node.childCount > 0 && node.firstChild?.type === itemType)
+}

--- a/packages/core/src/helpers/shiftSelection.ts
+++ b/packages/core/src/helpers/shiftSelection.ts
@@ -1,0 +1,17 @@
+import { NodeSelection, type Selection, TextSelection, type Transaction } from '@tiptap/pm/state'
+
+/**
+ * Restore `selection` on `tr.doc` moved by `offset` positions. Use after
+ * relocating the content the selection sits in.
+ */
+export function shiftSelection(tr: Transaction, selection: Selection, offset: number) {
+  if (selection instanceof NodeSelection) {
+    tr.setSelection(NodeSelection.create(tr.doc, selection.from + offset))
+    return
+  }
+
+  const $anchor = tr.doc.resolve(selection.anchor + offset)
+  const $head = tr.doc.resolve(selection.head + offset)
+
+  tr.setSelection(TextSelection.between($anchor, $head))
+}


### PR DESCRIPTION
sinkListItem joins a previous item's sublist of another type instead of starting a second one, and liftListItem lifts into an outer list of another type as one of its items, carrying following siblings as a sublist. Both paths are schema-driven and fall back to prosemirror-schema-list, so single-type lists behave as before.

## Fixes

Fixes #4424

See also these related items: #166, #2492, #2428, #4133, [Mix bullet and ordered list](https://discuss.prosemirror.net/t/mix-bullet-and-ordered-list/5515), [Question regarding sinkListItem, liftListItem commands](https://discuss.prosemirror.net/t/question-regarding-sinklistitem-liftlistitem-commands/5322)

## Changes and Review

- `sinkListItem`: when the previous item ends with a list of another type (e.g. ordered list inside a bullet list, task list inside a bullet list, …), the selected items join that list and take its item type instead of a second sublist being created next to it. See repro in #4424

- `liftListItem`: when the item's list is nested inside an item of another type, the selected items become items of that outer list, taking its item type; following siblings move along as a sublist, the same shape `liftToOuterList` produces for single-type lists. Previously the item was lifted out into a bare paragraph inside the parent item

- Both paths use the schema only (`isList`, `contentMatch.defaultType`, `validContent`/`canReplace`) and return to the prosemirror-schema-list commands whenever they cannot produce a valid document, so nothing changes for lists of one type. `can()` reports the new cases without mutating

**Verification:**

```
pnpm vp test \
   packages/core/__tests__/sinkListItemMixedLists.spec.ts \
   packages/core/__tests__/liftListItemMixedLists.spec.ts`
```

```
pnpm playwright test demos/src/Extensions/ListKeymap --project=chromium
```

...or open the ListKeymap demo and press Tab on the last item / Shift+Tab on the nested task.

AI disclosure: implemented with the aide of Claude Code (Anthropic); reviewed and tested by me.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.