### PR TITLE
fix(ai-toolkit): stop adding _hash to inline nodes

### DIFF
--- a/.changeset/2026-08-21-fix-hash-on-inline-nodes.md
+++ b/.changeset/2026-08-21-fix-hash-on-inline-nodes.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/ai-toolkit': patch
+---
+
+The Server AI Toolkit no longer adds `_hash` to inline nodes. Inline nodes were only detected when they declared a static `group`, so nodes that set it from options, like Image, Audio, YouTube and Twitch with `inline: true`, were treated as block nodes.

--- a/.changeset/2026-08-21-fix-hash-on-inline-nodes.md
+++ b/.changeset/2026-08-21-fix-hash-on-inline-nodes.md
@@ -2,4 +2,4 @@
 '@tiptap/ai-toolkit': patch
 ---
 
-The Server AI Toolkit no longer adds `_hash` to inline nodes. Inline nodes were only detected when they declared a static `group`, so nodes that set it from options, like Image, Audio, YouTube and Twitch with `inline: true`, were treated as block nodes.
+The Server AI Toolkit no longer adds `_hash` to inline nodes, including inline Image, Audio, YouTube and Twitch nodes.

--- a/packages/ai-toolkit/src/hash-extension/server-ai-toolkit-hash-extension.ts
+++ b/packages/ai-toolkit/src/hash-extension/server-ai-toolkit-hash-extension.ts
@@ -40,7 +40,8 @@ function isInlineNode(extension: AnyExtension): boolean {
       ) === true
     )
   } catch {
-    return false
+    // Fall back to the previous static check when `inline` needs an editor
+    return typeof extension.config?.group === 'string' && extension.config.group.includes('inline')
   }
 }
 

--- a/packages/ai-toolkit/src/hash-extension/server-ai-toolkit-hash-extension.ts
+++ b/packages/ai-toolkit/src/hash-extension/server-ai-toolkit-hash-extension.ts
@@ -1,4 +1,10 @@
-import { Extension } from '@tiptap/core'
+import {
+  type AnyExtension,
+  callOrReturn,
+  Extension,
+  getExtensionField,
+  type NodeConfig,
+} from '@tiptap/core'
 
 /**
  * The attribute name used to store the hash on nodes.
@@ -13,6 +19,29 @@ const ATTRIBUTE_NAME = '_hash'
  */
 function hasAiToolkitExtension(extensionNames: string[]): boolean {
   return extensionNames.includes('aiToolkit')
+}
+
+/**
+ * Checks whether an extension declares an inline node.
+ *
+ * @param extension - The extension to check.
+ * @return `true` when the node is inline.
+ */
+function isInlineNode(extension: AnyExtension): boolean {
+  try {
+    // `inline` can be a function, and it runs here without the editor core passes
+    return (
+      callOrReturn(
+        getExtensionField<NodeConfig['inline']>(extension, 'inline', {
+          name: extension.name,
+          options: extension.options,
+          storage: extension.storage,
+        }),
+      ) === true
+    )
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -45,7 +74,7 @@ export const ServerAiToolkitHashExtension = Extension.create({
           ext.name === 'tableHeader' ||
           ext.name === 'tableCell' ||
           // Exclude inline nodes
-          (typeof ext.config?.group === 'string' && ext.config.group.includes('inline'))
+          isInlineNode(ext)
         ) {
           return false
         }

--- a/packages/ai-toolkit/src/server-ai-toolkit.spec.ts
+++ b/packages/ai-toolkit/src/server-ai-toolkit.spec.ts
@@ -184,10 +184,11 @@ describe('ServerAiToolkit', () => {
     editor.destroy()
   })
 
-  it('creates the editor when a node reads the editor in inline', async () => {
+  it('creates the editor and still skips the node when a node reads the editor in inline', async () => {
     const editor = await createEditor({ extensions: [NodeReadingEditorInInline] })
 
     expect(editor.schema.nodes.nodeReadingEditorInInline.isInline).toBe(true)
+    expect(hasHashAttribute(editor, 'nodeReadingEditorInInline')).toBe(false)
 
     editor.destroy()
   })

--- a/packages/ai-toolkit/src/server-ai-toolkit.spec.ts
+++ b/packages/ai-toolkit/src/server-ai-toolkit.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
-import { Editor, Extension } from '@tiptap/core'
+import { Editor, Extension, type Extensions, Node } from '@tiptap/core'
+import Image from '@tiptap/extension-image'
 import StarterKit from '@tiptap/starter-kit'
 import { describe, expect, it } from 'vite-plus/test'
 
@@ -18,7 +19,7 @@ interface CreateEditorOptions {
   /**
    * Additional extensions to include alongside the default ones.
    */
-  extensions?: Extension[]
+  extensions?: Extensions
 }
 
 /**
@@ -48,7 +49,7 @@ function createEditor(options: CreateEditorOptions): Promise<Editor> {
  * @return Promise resolving once the editor create lifecycle has finished.
  */
 function createEditorWithExplicitExtensions(
-  extensions: Extension[],
+  extensions: Extensions,
   content?: Record<string, unknown>,
 ): Promise<Editor> {
   return new Promise(resolve => {
@@ -66,6 +67,46 @@ function createEditorWithExplicitExtensions(
 const MockAiToolkit = Extension.create({
   name: 'aiToolkit',
 })
+
+// Inline nodes are not always grouped `inline`.
+const InlineNodeWithCustomGroup = Node.create({
+  name: 'inlineNodeWithCustomGroup',
+  inline: true,
+  group: 'someCustom',
+  parseHTML() {
+    return [{ tag: 'inline-node-with-custom-group' }]
+  },
+  renderHTML() {
+    return ['inline-node-with-custom-group']
+  },
+})
+
+// `inline` may read the editor, which is not available while attributes are built.
+const NodeReadingEditorInInline = Node.create({
+  name: 'nodeReadingEditorInInline',
+  inline() {
+    return this.editor!.isEditable
+  },
+  group: 'inline',
+  parseHTML() {
+    return [{ tag: 'node-reading-editor-in-inline' }]
+  },
+  renderHTML() {
+    return ['node-reading-editor-in-inline']
+  },
+})
+
+/**
+ * Checks whether a node type has the `_hash` attribute registered.
+ *
+ * @param editor - The editor to inspect.
+ * @param typeName - The node type name.
+ * @return `true` when `_hash` is registered on the node type.
+ */
+function hasHashAttribute(editor: Editor, typeName: string): boolean {
+  // oxlint-disable-next-line no-underscore-dangle
+  return '_hash' in (editor.schema.nodes[typeName].spec.attrs ?? {})
+}
 
 describe('ServerAiToolkit', () => {
   it('registers _hash attributes without generating values on creation', async () => {
@@ -121,6 +162,34 @@ describe('ServerAiToolkit', () => {
     expect(secondHash).toBe(firstHash)
 
     secondEditor.destroy()
+  })
+
+  it('skips inline images but still hashes block images', async () => {
+    const inlineEditor = await createEditor({ extensions: [Image.configure({ inline: true })] })
+    const blockEditor = await createEditor({ extensions: [Image.configure({ inline: false })] })
+
+    expect(hasHashAttribute(inlineEditor, 'image')).toBe(false)
+    expect(hasHashAttribute(blockEditor, 'image')).toBe(true)
+
+    inlineEditor.destroy()
+    blockEditor.destroy()
+  })
+
+  it('skips inline nodes that are not grouped inline', async () => {
+    const editor = await createEditor({ extensions: [InlineNodeWithCustomGroup] })
+
+    expect(editor.schema.nodes.inlineNodeWithCustomGroup.isInline).toBe(true)
+    expect(hasHashAttribute(editor, 'inlineNodeWithCustomGroup')).toBe(false)
+
+    editor.destroy()
+  })
+
+  it('creates the editor when a node reads the editor in inline', async () => {
+    const editor = await createEditor({ extensions: [NodeReadingEditorInInline] })
+
+    expect(editor.schema.nodes.nodeReadingEditorInInline.isInline).toBe(true)
+
+    editor.destroy()
   })
 
   it('does not synthesize hashes when the AI Toolkit extension is present', async () => {


### PR DESCRIPTION
The Server AI Toolkit registers an internal `_hash` attribute on block nodes. Inline nodes were only detected when they declared a static `group`:

```ts
typeof ext.config?.group === 'string' && ext.config.group.includes('inline')
```

`group` can also be a function, and Image, Audio, YouTube and Twitch all declare it that way:

```ts
group() { return this.options.inline ? 'inline' : 'block' },
```

So `Image.configure({ inline: true })` never matched the check and got `_hash` registered on an inline node.

## Fix

Resolve `inline` with `callOrReturn(getExtensionField(...))`, the same way core resolves the field in `getSchemaByResolvedExtensions`. `inline` is what ProseMirror uses to decide inlineness, so this also fixes two cases the substring test got wrong in both directions: an inline node with a custom group name was hashed, and a block node grouped `inlineWidget` was not.

`inline` may be a function, and it runs here without the editor core passes, so the call is guarded and falls back to the previous behaviour.

## Tests

Three tests in `server-ai-toolkit.spec.ts`, using the real `Image` extension:

- `inline: true` is skipped, `inline: false` still gets `_hash`
- an inline node with a custom group is skipped
- an `inline()` that reads the editor does not break editor creation

Reverting the fix fails the first two on `_hash` being present, and removing the guard fails the third with `TypeError: Cannot read properties of undefined`.

`lint`, `build`, `test:unit` (193 files, 1923 tests) and `fallow:audit` all pass. The four `oxfmt --check` failures on `main` are pre-existing and untouched.

## Risk

`_hash` already stored on an inline node is dropped on the next parse. It is regenerable and was never meant to be there.

---

AI assistance was used to write this change.
