### PR TITLE
fix(static-renderer): keep the xmlns prefix out of closing tags

### DIFF
--- a/.changeset/fix-static-renderer-namespaced-tag.md
+++ b/.changeset/fix-static-renderer-namespaced-tag.md
@@ -2,4 +2,4 @@
 '@tiptap/static-renderer': patch
 ---
 
-`renderToHTMLString` no longer copies the `xmlns` prefix of a namespaced `DOMOutputSpec` into the closing tag, and namespaced non-self-closing tags such as `div` or `iframe` are no longer self-closed.
+`renderToHTMLString` now closes namespaced elements correctly. The closing tag no longer repeats the `xmlns` declaration, and tags that cannot self-close, such as `div` or `iframe`, are no longer written as self-closing.

--- a/.changeset/fix-static-renderer-namespaced-tag.md
+++ b/.changeset/fix-static-renderer-namespaced-tag.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/static-renderer': patch
+---
+
+`renderToHTMLString` no longer copies the `xmlns` prefix of a namespaced `DOMOutputSpec` into the closing tag, and namespaced non-self-closing tags such as `div` or `iframe` are no longer self-closed.

--- a/packages/static-renderer/src/pm/html-string/html-string.test.ts
+++ b/packages/static-renderer/src/pm/html-string/html-string.test.ts
@@ -1,4 +1,4 @@
-import { extensions as coreExtensions } from '@tiptap/core'
+import { extensions as coreExtensions, Node as CoreNode } from '@tiptap/core'
 import Bold from '@tiptap/extension-bold'
 import CodeBlock from '@tiptap/extension-code-block'
 import Document from '@tiptap/extension-document'
@@ -358,5 +358,39 @@ describe('static render json to string (with prosemirror)', () => {
 
     expect(html).toMatch(/\bid="[^"]+"/)
     expect(html).toMatch(/data-toc-id="[^"]+"/)
+  })
+})
+
+describe('namespaced DOMOutputSpec', () => {
+  // ProseMirror encodes a namespaced spec as `"<namespace> <localName>"`.
+  const Diagram = CoreNode.create({
+    name: 'diagram',
+    group: 'block',
+    content: 'text*',
+    renderHTML: () => ['http://www.w3.org/2000/svg svg', { width: '100' }, 0],
+  })
+
+  it('keeps the xmlns attribute out of the closing tag', () => {
+    const html = renderToHTMLString({
+      content: {
+        type: 'doc',
+        content: [{ type: 'diagram', content: [{ type: 'text', text: 'hi' }] }],
+      },
+      extensions: [Document, Paragraph, Text, Diagram],
+    })
+
+    // The namespace belongs on the opening tag only.
+    expect(html).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+    expect(html).toMatch(/<\/svg>$/)
+  })
+
+  it('still resolves non-self-closing tags by their local name', () => {
+    // `div` is in NON_SELF_CLOSING_TAGS, so the namespaced spec must not self-close.
+    const html = domOutputSpecToHTMLString([
+      'http://www.w3.org/1999/xhtml div',
+      { class: 'wrapper' },
+    ])()
+
+    expect(html).toContain('></div')
   })
 })

--- a/packages/static-renderer/src/pm/html-string/html-string.ts
+++ b/packages/static-renderer/src/pm/html-string/html-string.ts
@@ -46,47 +46,47 @@ export function domOutputSpecToHTMLString(
   }
   if (typeof content === 'object' && 'length' in content) {
     const [_tag, attrs, children, ...rest] = content as DOMOutputSpecArray
-    let tag = _tag
-    const parts = tag.split(' ')
-
-    if (parts.length > 1) {
-      tag = `${parts[1]} xmlns="${parts[0]}"`
-    }
+    // ProseMirror encodes a namespaced spec as `"<namespace> <localName>"`.
+    // Only the opening tag carries the `xmlns` attribute: the closing tag and the
+    // `NON_SELF_CLOSING_TAGS` lookup below both need the bare local name.
+    const parts = _tag.split(' ')
+    const tag = parts.length > 1 ? parts[1] : _tag
+    const openTag = parts.length > 1 ? `${parts[1]} xmlns="${parts[0]}"` : _tag
 
     if (attrs === undefined) {
-      return () => `<${tag}/>`
+      return () => `<${openTag}/>`
     }
     if (attrs === 0) {
-      return child => `<${tag}>${serializeChildrenToHTMLString(child)}</${tag}>`
+      return child => `<${openTag}>${serializeChildrenToHTMLString(child)}</${tag}>`
     }
     if (typeof attrs === 'object') {
       if (Array.isArray(attrs)) {
         if (children === undefined) {
           return child =>
-            `<${tag}>${domOutputSpecToHTMLString(attrs as DOMOutputSpecArray)(child)}</${tag}>`
+            `<${openTag}>${domOutputSpecToHTMLString(attrs as DOMOutputSpecArray)(child)}</${tag}>`
         }
         if (children === 0) {
           return child =>
-            `<${tag}>${domOutputSpecToHTMLString(attrs as DOMOutputSpecArray)(child)}</${tag}>`
+            `<${openTag}>${domOutputSpecToHTMLString(attrs as DOMOutputSpecArray)(child)}</${tag}>`
         }
         return child =>
-          `<${tag}>${domOutputSpecToHTMLString(attrs as DOMOutputSpecArray)(child)}${[children]
+          `<${openTag}>${domOutputSpecToHTMLString(attrs as DOMOutputSpecArray)(child)}${[children]
             .concat(rest)
             .map(a => domOutputSpecToHTMLString(a)(child))}</${tag}>`
       }
       if (children === undefined) {
         if (NON_SELF_CLOSING_TAGS.has(tag)) {
-          return () => `<${tag}${serializeAttrsToHTMLString(attrs)}></${tag}>`
+          return () => `<${openTag}${serializeAttrsToHTMLString(attrs)}></${tag}>`
         }
-        return () => `<${tag}${serializeAttrsToHTMLString(attrs)}/>`
+        return () => `<${openTag}${serializeAttrsToHTMLString(attrs)}/>`
       }
       if (children === 0) {
         return child =>
-          `<${tag}${serializeAttrsToHTMLString(attrs)}>${serializeChildrenToHTMLString(child)}</${tag}>`
+          `<${openTag}${serializeAttrsToHTMLString(attrs)}>${serializeChildrenToHTMLString(child)}</${tag}>`
       }
 
       return child =>
-        `<${tag}${serializeAttrsToHTMLString(attrs)}>${[children]
+        `<${openTag}${serializeAttrsToHTMLString(attrs)}>${[children]
           .concat(rest)
           .map(a => domOutputSpecToHTMLString(a)(child))
           .join('')}</${tag}>`


### PR DESCRIPTION
## Fixes

Fixes #8155

## Changes and Review

ProseMirror encodes a namespaced `DOMOutputSpec` as `"<namespace> <localName>"`. `domOutputSpecToHTMLString` rewrote the `tag` variable in place to `` `${parts[1]} xmlns="${parts[0]}"` ``, so the decorated string reached every position that only wanted the local name. That produced two bugs from one root cause:

- Every closing tag reused it, so `["http://www.w3.org/2000/svg svg", …]` rendered `</svg xmlns="http://www.w3.org/2000/svg">`. Browsers ignore it, but an XML parser rejects the string and `editor.getHTML()` gives plain `</svg>`.
- `NON_SELF_CLOSING_TAGS.has(tag)` tested it too, so a namespaced `div`, `iframe` or `span` could never match the set and was self-closed as `<div xmlns="…"/>`. This half was not in the issue report — I hit it while writing the fix.

The fix splits the two roles: `tag` keeps the bare local name (used for closing tags and the set lookup) and a new `openTag` carries the `xmlns` attribute for opening positions. This matches what `pm/react/react.ts` already does — it keeps `parts[1]` as the tag and puts `parts[0]` into the attributes.

Two regression tests in `json-string.spec.ts`, one per symptom. I verified they are independent: reverting only the closing-tag change fails only the first, and reverting only the `NON_SELF_CLOSING_TAGS` lookup fails only the second.

Note for reviewers: #8138 is open against the same function and edits the `NON_SELF_CLOSING_TAGS` set contents. This PR does not touch the set, only the value looked up in it, so the two should merge cleanly in either order.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

### AI usage disclosure

Per `CONTRIBUTING.md`: I used an AI coding assistant while preparing this change.

Adding it explicitly rather than relying on the Responsibility checkbox alone, since the contributing guide asks for it in the description. Everything stated above is measured rather than asserted — the counterfactual results come from actually reverting each half of the fix and re-running the suite, and the baseline test counts are from a clean checkout.