### PR TITLE
fix(core): keep keepOnSplit attributes on the content half when splitting a list item at its start

### DIFF
--- a/.changeset/fix-split-list-item-checked-state.md
+++ b/.changeset/fix-split-list-item-checked-state.md
@@ -2,4 +2,4 @@
 '@tiptap/core': patch
 ---
 
-Splitting a list item at the very start no longer moves attributes with `keepOnSplit: false` onto the half that keeps the content. Pressing Enter before the text of a checked task item now leaves the new empty item unchecked and the item with the text checked.
+Pressing Enter before the text of a checked task item now leaves the new empty item unchecked and the item with the text checked. Attributes declared with `keepOnSplit: false` now reset on the new item, not on the one that keeps the text.

--- a/.changeset/fix-split-list-item-checked-state.md
+++ b/.changeset/fix-split-list-item-checked-state.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Splitting a list item at the very start no longer moves attributes with `keepOnSplit: false` onto the half that keeps the content. Pressing Enter before the text of a checked task item now leaves the new empty item unchecked and the item with the text checked.

--- a/packages/core/src/commands/splitListItem.ts
+++ b/packages/core/src/commands/splitListItem.ts
@@ -124,14 +124,26 @@ export const splitListItem: RawCommands['splitListItem'] =
       ...overrideAttrs,
     }
 
+    // `Transform.split` only ever applies `types` to the node created *after* the split, so
+    // attributes that should not survive a split (`keepOnSplit: false`) normally land on the
+    // trailing item, which is the newly created one. When the cursor sits at the very start
+    // of the item, that is inverted: the empty new item is the *leading* one and the trailing
+    // item is the original content. Detect that case and swap the two sets of attributes.
+    const splitsAtStartOfItem = $from.parentOffset === 0 && $from.index(-1) === 0
+    const itemStart = $from.before(-1)
+
     tr.delete($from.pos, $to.pos)
+
+    // The trailing item keeps the attributes of the item being split when it is the half that
+    // carries the content over; the reset is applied to the leading item after the split.
+    const trailingTypeAttributes = splitsAtStartOfItem ? grandParent.attrs : newTypeAttributes
 
     const types = nextType
       ? [
-          { type, attrs: newTypeAttributes },
+          { type, attrs: trailingTypeAttributes },
           { type: nextType, attrs: newNextTypeAttributes },
         ]
-      : [{ type, attrs: newTypeAttributes }]
+      : [{ type, attrs: trailingTypeAttributes }]
 
     if (!canSplit(tr.doc, $from.pos, 2)) {
       return false
@@ -143,6 +155,10 @@ export const splitListItem: RawCommands['splitListItem'] =
       const marks = storedMarks || (selection.$to.parentOffset && selection.$from.marks())
 
       tr.split($from.pos, 2, types).scrollIntoView()
+
+      if (splitsAtStartOfItem) {
+        tr.setNodeMarkup(itemStart, undefined, newTypeAttributes)
+      }
 
       if (!marks || !dispatch) {
         return true

--- a/packages/extension-list/src/task-item/task-item.test.ts
+++ b/packages/extension-list/src/task-item/task-item.test.ts
@@ -901,4 +901,97 @@ describe('TaskItem', () => {
     expect(from).toBe(1)
     expect(to).toBe(14)
   })
+
+  describe('splitListItem', () => {
+    function createTaskEditor(checked: boolean, text: string) {
+      return new Editor({
+        extensions: [Document, Paragraph, Text, TaskList, TaskItem],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'taskList',
+              content: [
+                {
+                  type: 'taskItem',
+                  attrs: { checked },
+                  content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+                },
+              ],
+            },
+          ],
+        },
+      })
+    }
+
+    /** `[checked, text]` for every task item in the first (and only) task list. */
+    function readTaskItems(instance: Editor) {
+      return (instance.getJSON().content?.[0].content ?? []).map(item => [
+        item.attrs?.checked,
+        item.content?.[0].content?.[0]?.text ?? '',
+      ])
+    }
+
+    it('leaves the checked state on the half that keeps the text when splitting at the start', () => {
+      editor = createTaskEditor(true, 'Task')
+      // Offset 0 of the paragraph inside the first task item.
+      editor.commands.setTextSelection(3)
+
+      expect(editor.commands.splitListItem('taskItem')).toBe(true)
+      expect(readTaskItems(editor)).toEqual([
+        [false, ''],
+        [true, 'Task'],
+      ])
+    })
+
+    it('resets the checked state on the trailing half when splitting mid-text', () => {
+      editor = createTaskEditor(true, 'Task')
+      editor.commands.setTextSelection(5)
+
+      expect(editor.commands.splitListItem('taskItem')).toBe(true)
+      expect(readTaskItems(editor)).toEqual([
+        [true, 'Ta'],
+        [false, 'sk'],
+      ])
+    })
+
+    it('resets the checked state on the trailing half when splitting at the end', () => {
+      editor = createTaskEditor(true, 'Task')
+      editor.commands.setTextSelection(7)
+
+      expect(editor.commands.splitListItem('taskItem')).toBe(true)
+      expect(readTaskItems(editor)).toEqual([
+        [true, 'Task'],
+        [false, ''],
+      ])
+    })
+
+    it('splits a plain list item at the start without moving its content', () => {
+      editor = new Editor({
+        extensions: [Document, Paragraph, Text, BulletList, ListItem],
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'bulletList',
+              content: [
+                {
+                  type: 'listItem',
+                  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item' }] }],
+                },
+              ],
+            },
+          ],
+        },
+      })
+      editor.commands.setTextSelection(3)
+
+      expect(editor.commands.splitListItem('listItem')).toBe(true)
+      expect(
+        (editor.getJSON().content?.[0].content ?? []).map(
+          item => item.content?.[0].content?.[0]?.text ?? '',
+        ),
+      ).toEqual(['', 'Item'])
+    })
+  })
 })


### PR DESCRIPTION
## Fixes

Fixes #6289

## Changes and Review

`Transform.split(pos, depth, typesAfter)` only applies `typesAfter` to the node created **after** the split. `splitListItem` relies on that to reset attributes declared `keepOnSplit: false`, which is correct as long as the trailing item is the newly created one. When the cursor sits at the very start of the item, it is not: the empty new item lands *before* the split and the text is carried over to the trailing item, so the reset was applied to the wrong half. Pressing Enter before the text of a checked task item left the empty item checked and unchecked the item that kept the text.

The fix detects that case (`$from.parentOffset === 0 && $from.index(-1) === 0`, i.e. nothing in the item precedes the cursor, so the leading half will be empty), gives the trailing item the attributes of the item being split, and applies the reset attributes to the leading item with `setNodeMarkup` after the split.

This is not specific to task items — it applies to any `keepOnSplit: false` attribute on a list item type. `splitListItem` is also bound to Enter on `listItem`, so I added regression tests for a mid-text split, an end-of-text split, and a plain `listItem` split alongside the new case; with the source change reverted, only the new at-start test fails and those three still pass.

One behaviour note worth a reviewer's eye: in the at-start case `overrideAttrs` now applies to the leading (new, empty) item rather than the trailing one, which matches its documented meaning of "attributes to ensure on the new node". No caller in this repo passes it.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

### AI usage disclosure

Per `CONTRIBUTING.md`: I used an AI coding assistant while preparing this change.

Adding it explicitly rather than relying on the Responsibility checkbox alone, since the contributing guide asks for it in the description. Everything stated above is measured rather than asserted — the counterfactual results come from actually reverting each half of the fix and re-running the suite, and the baseline test counts are from a clean checkout.