### PR TITLE
fix(extension-youtube): guard isValidYoutubeUrl against a missing url

### DIFF
--- a/.changeset/2026-08-23-youtube-missing-src.md
+++ b/.changeset/2026-08-23-youtube-missing-src.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-youtube': patch
+---
+
+A YouTube iframe pasted without a `src` attribute no longer throws `Cannot read properties of null (reading 'match')`; the node is now rendered without a source instead.

--- a/.changeset/2026-08-23-youtube-missing-src.md
+++ b/.changeset/2026-08-23-youtube-missing-src.md
@@ -2,4 +2,4 @@
 '@tiptap/extension-youtube': patch
 ---
 
-A YouTube iframe pasted without a `src` attribute no longer throws `Cannot read properties of null (reading 'match')`; the node is now rendered without a source instead.
+Pasting a YouTube iframe without a `src` attribute no longer crashes the editor. The embed is kept without a source.

--- a/packages/extension-youtube/__tests__/youtube.spec.ts
+++ b/packages/extension-youtube/__tests__/youtube.spec.ts
@@ -5,7 +5,11 @@ import Text from '@tiptap/extension-text'
 import Youtube from '@tiptap/extension-youtube'
 import { describe, expect, it } from 'vite-plus/test'
 
-import { getAttributesFromYoutubeEmbedUrl, getEmbedUrlFromYoutubeUrl } from '../src/utils.ts'
+import {
+  getAttributesFromYoutubeEmbedUrl,
+  getEmbedUrlFromYoutubeUrl,
+  isValidYoutubeUrl,
+} from '../src/utils.ts'
 
 /**
  * Most youtube tests should actually exist in the demo/ app folder
@@ -440,5 +444,52 @@ describe('extension-youtube', () => {
     'https://example.com/embed/dQw4w9WgXcQ',
   ])('returns null for unsupported youtube embed urls: %s', embedUrl => {
     expect(getAttributesFromYoutubeEmbedUrl(embedUrl)).toBeNull()
+  })
+
+  describe('missing src attribute', () => {
+    // The `src` attribute is declared with `default: null` and its `parseHTML` returns
+    // `undefined` when the iframe carries no `src`, so a node with a null `src` is a
+    // legitimate parse result rather than a malformed document.
+    const iframeWithoutSrc =
+      '<div data-youtube-video=""><iframe class="w-full aspect-video" width="640" height="480" allowfullscreen="true" start="0"></iframe></div>'
+
+    it('accepts a well-formed youtube url', () => {
+      expect(isValidYoutubeUrl('https://www.youtube.com/watch?v=EkRHhOCdZjw')).toBeTruthy()
+    })
+
+    it('returns null for a missing url instead of throwing', () => {
+      expect(isValidYoutubeUrl(null as unknown as string)).toBe(null)
+    })
+
+    it('returns null from getEmbedUrlFromYoutubeUrl when the url is missing', () => {
+      expect(getEmbedUrlFromYoutubeUrl({ url: null as unknown as string })).toBe(null)
+    })
+
+    it('refuses setYoutubeVideo with a missing src instead of throwing', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+      })
+
+      expect(editor.commands.setYoutubeVideo({ src: null as unknown as string })).toBe(false)
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+
+    it('parses an iframe without a src attribute without throwing', () => {
+      expect(() => {
+        editor = new Editor({
+          element: createEditorEl(),
+          extensions: [Document, Text, Paragraph, Youtube],
+          content: iframeWithoutSrc,
+        })
+      }).not.toThrow()
+
+      expect(editor?.getHTML()).not.toContain('src=')
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
   })
 })

--- a/packages/extension-youtube/__tests__/youtube.spec.ts
+++ b/packages/extension-youtube/__tests__/youtube.spec.ts
@@ -458,7 +458,7 @@ describe('extension-youtube', () => {
     })
 
     it('returns null for a missing url instead of throwing', () => {
-      expect(isValidYoutubeUrl(null as unknown as string)).toBe(null)
+      expect(isValidYoutubeUrl(null)).toBe(null)
     })
 
     it('returns null from getEmbedUrlFromYoutubeUrl when the url is missing', () => {

--- a/packages/extension-youtube/src/utils.ts
+++ b/packages/extension-youtube/src/utils.ts
@@ -3,7 +3,18 @@ export const YOUTUBE_REGEX =
 export const YOUTUBE_REGEX_GLOBAL =
   /^((?:https?:)?\/\/)?((?:www|m|music)\.)?((?:youtube\.com|youtu\.be|youtube-nocookie\.com))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/g
 
-export const isValidYoutubeUrl = (url: string) => {
+/**
+ * Checks whether a url is a youtube url that the extension can embed.
+ *
+ * The `src` attribute of a youtube node is declared with `default: null`, so a node
+ * parsed from an iframe without a `src` attribute legitimately carries no url. Guard
+ * against that here instead of letting the caller dereference it.
+ */
+export const isValidYoutubeUrl = (url: string | null | undefined) => {
+  if (!url) {
+    return null
+  }
+
   return url.match(YOUTUBE_REGEX)
 }
 


### PR DESCRIPTION
## Fixes

Fixes #6168

## Changes and Review

`isValidYoutubeUrl` dereferences its argument with `url.match(YOUTUBE_REGEX)` and had no guard. A youtube node can legitimately carry no url: `src` is declared with `default: null` and its `parseHTML` returns `getParsedYoutubeAttributes(element)?.src`, which is `undefined` for an iframe without a `src` attribute. `renderHTML` then hands `HTMLAttributes.src` to `getEmbedUrlFromYoutubeUrl`, which calls the validator — so the reporter's empty iframe threw `TypeError: Cannot read properties of null (reading 'match')` while rendering, taking the whole editor down for a document that could only be repaired outside the app.

The parse side is already correct in refusing to invent a `src`; the missing guard is one level up, in the only place that dereferences the url. So the fix is an early `if (!url) return null` in `isValidYoutubeUrl`, plus widening its parameter to `string | null | undefined` so the signature matches what callers can actually pass. This matches how the same package already handles a nullable DOM value in `getParsedDimension`. `isValidYoutubeUrl` is part of the public export surface, so this is a widening rather than a breaking change.

Both call sites are covered by that one guard, and both consumers already handle a falsy result: `getEmbedUrlFromYoutubeUrl` returns `null` at its first check, and `setYoutubeVideo` returns `false`. The node now renders without a source instead of throwing. (The second call site, in `getAttributesFromYoutubeEmbedUrl`, cannot actually receive a null in practice — the local is assigned a string in both branches before that point — so the reachable defect is the `renderHTML` path.)

Five tests in `youtube.spec.ts`. Four of them fail on `main` with the reporter's exact `TypeError` — the validator directly, `getEmbedUrlFromYoutubeUrl`, the `setYoutubeVideo` command, and an end-to-end parse of the reporter's iframe HTML — and pass with the fix. The fifth, `accepts a well-formed youtube url`, passes both before and after on purpose: without it a guard that made the validator always return `null` would look exactly like a real fix. The other 34 pre-existing tests in the file, most of which assert that valid urls do embed, stay green.

Baseline on a clean checkout of `main` is 193 files / 1920 tests; with this branch it is 193 / 1925. `pnpm lint` is clean and `oxfmt` reports no issues in the touched files.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.

### Issue assignment

Per `CONTRIBUTING.md`, I have asked to be assigned #6168 (the issue is currently unassigned) and am opening this now rather than sitting on the work; happy to close it if a maintainer would rather it went to someone else.

### AI usage disclosure

Per `CONTRIBUTING.md`: I used an AI coding assistant while preparing this change.

Everything stated above is measured rather than asserted — the counterfactual comes from running the new tests against unmodified `main` before applying the source change and re-running them after, and the baseline test counts are from a clean checkout.
