### PR TITLE
Fix blocked image placeholders in Image node demos

### DIFF
--- a/.changeset/fruity-toys-slide.md
+++ b/.changeset/fruity-toys-slide.md
@@ -1,0 +1,5 @@
+---
+"tiptap-demos": patch
+---
+
+Fix blocked image placeholders in Image node demos

--- a/demos/src/Nodes/Image/React/index.jsx
+++ b/demos/src/Nodes/Image/React/index.jsx
@@ -13,8 +13,8 @@ export default () => {
     extensions: [Document, Paragraph, Text, Image, Dropcursor],
     content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://template.tiptap.dev/images/tiptap-ui-placeholder-image.jpg" width="600" />
+<img src="https://template.tiptap.dev/images/tiptap-ui-placeholder-image.jpg" width="800" />
       `,
   })
 

--- a/demos/src/Nodes/Image/Vue/index.vue
+++ b/demos/src/Nodes/Image/Vue/index.vue
@@ -43,8 +43,8 @@ export default {
       extensions: [Document, Paragraph, Text, Image, Dropcursor],
       content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+       <img src="https://template.tiptap.dev/images/tiptap-ui-placeholder-image.jpg" width="600" />
+<img src="https://template.tiptap.dev/images/tiptap-ui-placeholder-image.jpg" width="800" />
       `,
     })
   },


### PR DESCRIPTION
Fixes #8222

Replaced the placehold.co image URLs in the React and Vue Image node demos with the Tiptap-hosted placeholder image.

This avoids reliance on the blocked placehold.co domain while preserving the two image sizes used by the demos.

## Changes and Review

- Replaced the blocked `placehold.co` URLs in the React and Vue Image node demos.
- Used the Tiptap-hosted placeholder image.
- Preserved the 600px and 800px image widths.
- Reviewed the changes in both React and Vue demos.

## Checklist

- [x] I have made sure to test my changes myself.
- [x] I have reviewed the changes in both React and Vue demos.