### PR TITLE
chore: apply formatting fixes to markdown files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,19 +62,19 @@ decorations.filter(d => d.visible)
 
 Comments are a last resort. Prefer code that explains itself through clear names, structure, and small functions.
 
-* Default to **no comment**.
-* Comment only when the **reason for a decision is not apparent from the code**.
-* Keep comments **short, local, and intent-focused**.
-* Prefer a short one-line fragment or sentence.
-* Never restate what the code does.
-* Never narrate control flow.
-* Never explain surrounding architecture, history, edge cases, or implementation details unless they are essential to understanding the decision.
-* Never use comments as a substitute for clearer code, naming, or structure.
-* Do not write prose paragraphs, mini-documentation, or essay-style explanations in implementation code.
-* Do not add examples, scenarios, or parenthetical explanations to comments.
-* Do not use multi-line comments just because an explanation can be written. If it cannot be expressed concisely, reconsider whether the comment belongs in the code at all.
-* Existing verbose comments are not a style precedent. Do not imitate them.
-* When modifying code, remove comments that merely describe code made obvious by the change.
+- Default to **no comment**.
+- Comment only when the **reason for a decision is not apparent from the code**.
+- Keep comments **short, local, and intent-focused**.
+- Prefer a short one-line fragment or sentence.
+- Never restate what the code does.
+- Never narrate control flow.
+- Never explain surrounding architecture, history, edge cases, or implementation details unless they are essential to understanding the decision.
+- Never use comments as a substitute for clearer code, naming, or structure.
+- Do not write prose paragraphs, mini-documentation, or essay-style explanations in implementation code.
+- Do not add examples, scenarios, or parenthetical explanations to comments.
+- Do not use multi-line comments just because an explanation can be written. If it cannot be expressed concisely, reconsider whether the comment belongs in the code at all.
+- Existing verbose comments are not a style precedent. Do not imitate them.
+- When modifying code, remove comments that merely describe code made obvious by the change.
 
 Prefer:
 

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -12,9 +12,9 @@ metadata:
 This skill contains instructions for integrating the Tiptap rich text editor into an app and
 developing new features with it.
 
-This is not the Tiptap editor you know: it may have evolved and changed since the version you're familiar with. 
-Before you implement any feature with Tiptap, reference the Tiptap code and documentation to make sure you implement 
-it correctly. Make sure any decision you make is in accordance to the "Best Practices" section and is grounded in the 
+This is not the Tiptap editor you know: it may have evolved and changed since the version you're familiar with.
+Before you implement any feature with Tiptap, reference the Tiptap code and documentation to make sure you implement
+it correctly. Make sure any decision you make is in accordance to the "Best Practices" section and is grounded in the
 Tiptap documentation and source code. Do not guess or invent patterns, make sure the code you write matches the library
 source code and the documentation.
 
@@ -50,7 +50,7 @@ To move an existing integration off the deprecated products, see
 
 - For a new install, use the latest stable version. Resolve it with `npm view @tiptap/core version`.
 - The editor and extension packages published from the tiptap monorepo share one version line. Pin
-  every one of them to that same version. Mixing versions risks introducing bugs. 
+  every one of them to that same version. Mixing versions risks introducing bugs.
 - Some packages have their own version line. Resolve these from the registry, never from
   `@tiptap/core`: `@tiptap/ai-toolkit`, `@tiptap/y-tiptap`, `@tiptap-pro/*` (private registry),
   `@hocuspocus/*`.


### PR DESCRIPTION
## Changes and Review

Applies formatting fixes to Markdown files. These fixes are applied automatically by running `pnpm check:fix`

This is not a feature change, so it does not need a changeset.

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
