### PR TITLE
Do not use globalThis to reference the DOM Node interface

### DIFF
--- a/packages/core/src/decorations/Decoration.ts
+++ b/packages/core/src/decorations/Decoration.ts
@@ -12,7 +12,7 @@ export interface WidgetDecorationOptions {
    * skipped on teardown for widgets made with the React or Vue widget renderer.
    * receives the DOM node, not a ProseMirror node.
    */
-  destroy?: (node: globalThis.Node) => void
+  destroy?: (node: Node) => void
 }
 
 export type DecorationKind = 'inline' | 'node' | 'widget'

--- a/packages/core/src/decorations/createWidgetDecoration.ts
+++ b/packages/core/src/decorations/createWidgetDecoration.ts
@@ -201,7 +201,7 @@ export function createWidgetDecoration<TRenderer extends WidgetRenderer>(
     marks,
     stopEvent,
     ignoreSelection,
-    destroy: (rendererElement: globalThis.Node) => {
+    destroy: (rendererElement: Node) => {
       // Keep the renderer if the widget is still live (being reassigned, not removed).
       // Only correct because ProseMirror sets `view.state` before dropping widget descs.
       if (liveWidgetKeys(editor).has(key)) {


### PR DESCRIPTION
## Changes and Review

After renaming ProseMirror Node class to PMNode, it is not necessary to reference the DOM Node interface as `globalThis.Node`, instead it can be referenced as just `Node`

This is a refactor, and it does not change the behaviour of the code, so it does not require a changeset 

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
