### PR TITLE
fix(markdown): drop empty delimiters for whitespace-only marked text

### DIFF
--- a/.changeset/2026-08-26-fix-markdown-whitespace-only-marked-text.md
+++ b/.changeset/2026-08-26-fix-markdown-whitespace-only-marked-text.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/markdown': patch
+---
+
+Fix Markdown serialization of whitespace-only marked text.

--- a/packages/markdown/__tests__/whitespace-only-marked-text.spec.ts
+++ b/packages/markdown/__tests__/whitespace-only-marked-text.spec.ts
@@ -1,0 +1,178 @@
+import { Bold } from '@tiptap/extension-bold'
+import { Code } from '@tiptap/extension-code'
+import { Document } from '@tiptap/extension-document'
+import { Italic } from '@tiptap/extension-italic'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import Strike from '@tiptap/extension-strike'
+import { Text } from '@tiptap/extension-text'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { MarkdownManager } from '../src/MarkdownManager.js'
+
+describe('Whitespace-only marked text nodes', () => {
+  const extensions = [Document, Paragraph, Text, Bold, Italic, Code, Strike]
+  const markdownManager = new MarkdownManager({ extensions })
+
+  const paragraph = (content: Array<Record<string, any>>) => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content }],
+  })
+
+  it.each([
+    ['bold', 'a b'],
+    ['italic', 'a b'],
+    ['code', 'a b'],
+    ['strike', 'a b'],
+  ])('emits no delimiters for a whitespace-only %s node', (markType, expected) => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: ' ', marks: [{ type: markType }] },
+        { type: 'text', text: 'b' },
+      ]),
+    )
+
+    expect(markdown).toBe(expected)
+  })
+
+  it.each([
+    ['tab', '\t'],
+    ['non-breaking space', '\u00a0'],
+    ['newline', '\n'],
+  ])('emits no delimiters for a whitespace-only node containing a %s', (_name, whitespace) => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: whitespace, marks: [{ type: 'bold' }] },
+        { type: 'text', text: 'b' },
+      ]),
+    )
+
+    expect(markdown).toBe(`a${whitespace}b`)
+  })
+
+  it('emits no delimiters for a multi-space whitespace-only node', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: '  ', marks: [{ type: 'bold' }] },
+        { type: 'text', text: 'b' },
+      ]),
+    )
+
+    expect(markdown).toBe('a  b')
+  })
+
+  it('emits no delimiters when a whitespace-only node carries nested marks', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: ' ', marks: [{ type: 'bold' }, { type: 'italic' }] },
+        { type: 'text', text: 'b' },
+      ]),
+    )
+
+    expect(markdown).toBe('a b')
+  })
+
+  it('opens a continuing mark after the whitespace (Issue #8212)', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: ' ', marks: [{ type: 'bold' }] },
+        { type: 'text', text: 'b', marks: [{ type: 'bold' }] },
+      ]),
+    )
+
+    expect(markdown).toBe('a **b**')
+  })
+
+  it('keeps a continuing mark and drops the transient one', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: ' ', marks: [{ type: 'bold' }, { type: 'italic' }] },
+        { type: 'text', text: 'b', marks: [{ type: 'bold' }] },
+      ]),
+    )
+
+    expect(markdown).toBe('a **b**')
+  })
+
+  it('keeps a continuing italic when bold is the transient mark', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: ' ', marks: [{ type: 'bold' }, { type: 'italic' }] },
+        { type: 'text', text: 'b', marks: [{ type: 'italic' }] },
+      ]),
+    )
+
+    expect(markdown).toBe('a *b*')
+  })
+
+  it('spans a mark across the whitespace when it opened on an earlier node', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a', marks: [{ type: 'bold' }] },
+        { type: 'text', text: ' ', marks: [{ type: 'bold' }, { type: 'italic' }] },
+        { type: 'text', text: 'b', marks: [{ type: 'bold' }] },
+      ]),
+    )
+
+    expect(markdown).toBe('**a b**')
+  })
+
+  it('closes an already-open mark before a whitespace-only node that ends it', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a', marks: [{ type: 'bold' }] },
+        { type: 'text', text: ' ', marks: [{ type: 'bold' }] },
+        { type: 'text', text: 'b' },
+      ]),
+    )
+
+    expect(markdown).toBe('**a** b')
+  })
+
+  it('keeps expelling trailing whitespace out of a mark that has text', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'Label: ', marks: [{ type: 'bold' }] },
+        { type: 'text', text: 'value' },
+      ]),
+    )
+
+    expect(markdown).toBe('**Label:** value')
+  })
+
+  it.each([
+    ['a single mark', [{ type: 'bold' }]],
+    ['nested marks', [{ type: 'bold' }, { type: 'italic' }]],
+  ])('survives repeated serialize/parse cycles with %s', (_name, marks) => {
+    // Parsing `****` reads it as literal asterisks, which the next serialize escapes.
+    // Assert the value on every cycle, not that it settles: the broken output settles too.
+    let markdown = markdownManager.serialize(
+      paragraph([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: ' ', marks },
+        { type: 'text', text: 'b' },
+      ]),
+    )
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      expect(markdown).toBe('a b')
+      markdown = markdownManager.serialize(markdownManager.parse(markdown))
+    }
+
+    expect(markdown).toBe('a b')
+  })
+
+  it('still emphasises a node that is only punctuation', () => {
+    const markdown = markdownManager.serialize(
+      paragraph([{ type: 'text', text: ')', marks: [{ type: 'bold' }] }]),
+    )
+
+    expect(markdown).toBe('**)**')
+  })
+})

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -1281,11 +1281,27 @@ export class MarkdownManager {
 
       if (node.type === 'text') {
         let textContent = this.encodeTextForMarkdown(node.text || '', node, parentNode)
-        const currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
+        let currentMarks = new Map((node.marks || []).map(mark => [mark.type, mark]))
 
         // Find marks that need to be closed and opened
-        const marksToOpen = this.getMarksToOpenForSerialization(activeMarks, currentMarks, nextNode)
-        const marksToClose = findMarksToClose(currentMarks, nextNode)
+        let marksToOpen = this.getMarksToOpenForSerialization(activeMarks, currentMarks, nextNode)
+        let marksToClose = findMarksToClose(currentMarks, nextNode)
+
+        // Whitespace-only text has nothing to wrap; drop marks that open and close here
+        const isWhitespaceOnly = textContent.length > 0 && textContent.trim().length === 0
+        if (isWhitespaceOnly && currentMarks.size > 0) {
+          const transientMarks = new Set(
+            marksToClose.filter(markType => !activeMarks.has(markType)),
+          )
+
+          if (transientMarks.size > 0) {
+            currentMarks = new Map(
+              Array.from(currentMarks).filter(([markType]) => !transientMarks.has(markType)),
+            )
+            marksToOpen = this.getMarksToOpenForSerialization(activeMarks, currentMarks, nextNode)
+            marksToClose = findMarksToClose(currentMarks, nextNode)
+          }
+        }
 
         // When marks simultaneously close (old) AND open (new) at this boundary, the naive
         // approach of appending old-close and prepending new-open produces interleaved


### PR DESCRIPTION
## Fixes

Fixes #8212

## Changes and Review

`MarkdownManager.serialize()` no longer wraps whitespace-only text nodes in empty delimiter runs. A bolded space between two words now serializes as `a b` instead of `a**** b` (same for italic, code, and strike).

Marks that continue into the next node still open after the whitespace (`a **b**`). Trailing-space expulsion for marked text that has content (`**Label:** value`) is unchanged.

Verified locally: 18 new cases pass; full `@tiptap/markdown` suite is 284 passing. `oxfmt` and `oxlint` are clean on the touched files. `fallow audit --changed-since origin/main` reports no new issues.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
