### PR TITLE
fix(ci): filter released packages before passing through to mapping

### DIFF
--- a/scripts/aggregate-changeset.js
+++ b/scripts/aggregate-changeset.js
@@ -374,12 +374,12 @@ async function main() {
 
     const packageMap = await loadWorkspacePackages(cwd)
     const releasesWithPackages = plan.releases
+      .filter(release => {
+        const pkg = packageMap.get(release.name)
+        return !!pkg
+      })
       .map(release => {
         const pkg = packageMap.get(release.name)
-
-        if (!pkg) {
-          throw new Error(`Could not find package metadata for ${release.name}`)
-        }
 
         return {
           ...release,


### PR DESCRIPTION
## Fixes

- the currently broken ci for publishing new packages 🙃

## Changes and Review

The CI fails because the new codemod package is not providing the metadata the changelog aggregator expects - so we just filter out non-valid packages now instead of throwing

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
