### PR TITLE
fix(demos): use non-blocked unsplash placeholders instead of placehold.it

### DIFF
--- a/demos/src/Examples/Images/React/index.jsx
+++ b/demos/src/Examples/Images/React/index.jsx
@@ -13,8 +13,8 @@ export default () => {
     extensions: [Document, Paragraph, Text, Image, Dropcursor],
     content: `
       <p>This is a basic example of implementing images. Drag to re-order.</p>
-      <img src="https://placehold.co/600x400" />
-      <img src="https://placehold.co/800x400" />
+      <img src="https://unsplash.it/600/400" />
+      <img src="https://unsplash.it/800/400" />
     `,
   })
 

--- a/demos/src/Examples/Images/Vue/index.vue
+++ b/demos/src/Examples/Images/Vue/index.vue
@@ -43,8 +43,8 @@ export default {
       extensions: [Document, Paragraph, Text, Image, Dropcursor],
       content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://unsplash.it/600/400" />
+        <img src="https://unsplash.it/800/400" />
       `,
     })
   },

--- a/demos/src/Examples/ResizableImages/React/index.jsx
+++ b/demos/src/Examples/ResizableImages/React/index.jsx
@@ -24,8 +24,8 @@ export default () => {
     ],
     content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://unsplash.it/600/400" />
+        <img src="https://unsplash.it/800/400" />
       `,
   })
 

--- a/demos/src/Examples/ResizableImages/Vue/index.vue
+++ b/demos/src/Examples/ResizableImages/Vue/index.vue
@@ -54,8 +54,8 @@ export default {
       ],
       content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://unsplash.it/600/400" />
+        <img src="https://unsplash.it/800/400" />
       `,
     })
   },

--- a/demos/src/Nodes/Image/React/index.jsx
+++ b/demos/src/Nodes/Image/React/index.jsx
@@ -13,8 +13,8 @@ export default () => {
     extensions: [Document, Paragraph, Text, Image, Dropcursor],
     content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://unsplash.it/600/400" />
+        <img src="https://unsplash.it/800/400" />
       `,
   })
 

--- a/demos/src/Nodes/Image/Vue/index.vue
+++ b/demos/src/Nodes/Image/Vue/index.vue
@@ -43,8 +43,8 @@ export default {
       extensions: [Document, Paragraph, Text, Image, Dropcursor],
       content: `
         <p>This is a basic example of implementing images. Drag to re-order.</p>
-        <img src="https://placehold.co/600x400" />
-        <img src="https://placehold.co/800x400" />
+        <img src="https://unsplash.it/600/400" />
+        <img src="https://unsplash.it/800/400" />
       `,
     })
   },


### PR DESCRIPTION
## Fixes

- closes #8222 

## Changes and Review

This PR replaces the placehold.it image placeholders (which seems to be blocked by some adblocker list) with images that should not be blocked.

If the images are still blocked, well - deactivate your adblocker. 🤷

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
