### PR TITLE
fix(core): skip cross-editor drop cleanup for a destroyed source editor

### DIFF
--- a/.changeset/2026-08-26-cross-editor-drop-destroyed-source.md
+++ b/.changeset/2026-08-26-cross-editor-drop-destroyed-source.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Fix a `TypeError` thrown after dragging content between editors when the source editor is destroyed right after the drop. A destroyed editor is also no longer kept referenced after a drag.

--- a/.changeset/2026-08-26-cross-editor-drop-destroyed-source.md
+++ b/.changeset/2026-08-26-cross-editor-drop-destroyed-source.md
@@ -2,4 +2,4 @@
 '@tiptap/core': patch
 ---
 
-Fix a `TypeError` thrown after dragging content between editors when the source editor is destroyed right after the drop. A destroyed editor is also no longer kept referenced after a drag.
+Fix a `TypeError` thrown after dragging content between editors when the source editor is destroyed right after the drop. Destroyed editors are also no longer leaked after such a drag.

--- a/.changeset/2026-08-26-cross-editor-drop-destroyed-source.md
+++ b/.changeset/2026-08-26-cross-editor-drop-destroyed-source.md
@@ -2,4 +2,4 @@
 '@tiptap/core': patch
 ---
 
-Fix a `TypeError` thrown after dragging content between editors when the source editor is destroyed right after the drop. Destroyed editors are also no longer leaked after such a drag.
+Fix a `TypeError` thrown when the source editor is destroyed right after dragging content into another editor.

--- a/packages/core/__tests__/crossEditorDrop.spec.ts
+++ b/packages/core/__tests__/crossEditorDrop.spec.ts
@@ -1,0 +1,75 @@
+import { Editor, Mark, markPasteRule } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+const editorElClass = 'tiptap-cross-editor-drop-test'
+
+const createEditorEl = () => {
+  const editorEl = document.createElement('div')
+
+  editorEl.classList.add(editorElClass)
+  document.body.appendChild(editorEl)
+
+  return editorEl
+}
+
+const PasteMark = Mark.create({
+  name: 'pasteMark',
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: /==(.*?)==/g,
+        type: this.type,
+      }),
+    ]
+  },
+})
+
+const createEditor = () =>
+  new Editor({
+    element: createEditorEl(),
+    extensions: [Document, Paragraph, Text, PasteMark],
+    content: '<p>content</p>',
+  })
+
+const dragBetween = (source: Editor, target: Editor) => {
+  source.view.dom.dispatchEvent(new Event('dragstart', { bubbles: true }))
+  target.view.dom.dispatchEvent(new Event('drop', { bubbles: true }))
+}
+
+describe('cross editor drop', () => {
+  let source: Editor
+  let target: Editor
+
+  afterEach(() => {
+    vi.useRealTimers()
+    source?.destroy()
+    target?.destroy()
+    document.querySelectorAll(`.${editorElClass}`).forEach(element => element.remove())
+  })
+
+  it('does not throw when the source editor is destroyed before the deferred delete runs', () => {
+    vi.useFakeTimers()
+    source = createEditor()
+    target = createEditor()
+
+    dragBetween(source, target)
+    source.destroy()
+
+    expect(() => vi.advanceTimersByTime(10)).not.toThrow()
+  })
+
+  it('deletes the dragged selection from a source editor that is still alive', () => {
+    vi.useFakeTimers()
+    source = createEditor()
+    target = createEditor()
+
+    source.commands.setTextSelection({ from: 1, to: 8 })
+    dragBetween(source, target)
+    vi.advanceTimersByTime(10)
+
+    expect(source.getHTML()).toBe('<p></p>')
+  })
+})

--- a/packages/core/__tests__/crossEditorDrop.spec.ts
+++ b/packages/core/__tests__/crossEditorDrop.spec.ts
@@ -2,6 +2,7 @@ import { Editor, Mark, markPasteRule } from '@tiptap/core'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
 
 const editorElClass = 'tiptap-cross-editor-drop-test'
@@ -68,6 +69,35 @@ describe('cross editor drop', () => {
 
     source.commands.setTextSelection({ from: 1, to: 8 })
     dragBetween(source, target)
+    vi.advanceTimersByTime(10)
+
+    expect(source.getHTML()).toBe('<p></p>')
+  })
+
+  it('does not queue a delete when the source editor was destroyed before the drop', () => {
+    vi.useFakeTimers()
+    source = createEditor()
+    target = createEditor()
+
+    source.view.dom.dispatchEvent(new Event('dragstart', { bubbles: true }))
+    source.destroy()
+
+    const queuedBeforeDrop = vi.getTimerCount()
+
+    target.view.dom.dispatchEvent(new Event('drop', { bubbles: true }))
+
+    expect(vi.getTimerCount()).toBe(queuedBeforeDrop)
+  })
+
+  it('keeps the queued delete when the source editor registers a plugin during the drag', () => {
+    vi.useFakeTimers()
+    source = createEditor()
+    target = createEditor()
+
+    source.commands.setTextSelection({ from: 1, to: 8 })
+    source.view.dom.dispatchEvent(new Event('dragstart', { bubbles: true }))
+    source.registerPlugin(new Plugin({ key: new PluginKey('noop') }))
+    target.view.dom.dispatchEvent(new Event('drop', { bubbles: true }))
     vi.advanceTimersByTime(10)
 
     expect(source.getHTML()).toBe('<p></p>')

--- a/packages/core/__tests__/crossEditorDrop.spec.ts
+++ b/packages/core/__tests__/crossEditorDrop.spec.ts
@@ -102,4 +102,20 @@ describe('cross editor drop', () => {
 
     expect(source.getHTML()).toBe('<p></p>')
   })
+
+  it('does not queue a delete when the source editor is unmounted then destroyed', () => {
+    vi.useFakeTimers()
+    source = createEditor()
+    target = createEditor()
+
+    source.view.dom.dispatchEvent(new Event('dragstart', { bubbles: true }))
+    source.unmount()
+    source.destroy()
+
+    const queuedBeforeDrop = vi.getTimerCount()
+
+    target.view.dom.dispatchEvent(new Event('drop', { bubbles: true }))
+
+    expect(vi.getTimerCount()).toBe(queuedBeforeDrop)
+  })
 })

--- a/packages/core/src/PasteRule.ts
+++ b/packages/core/src/PasteRule.ts
@@ -274,17 +274,21 @@ export function pasteRulesPlugin(props: { editor: Editor; rules: PasteRule[] }):
           }
         }
 
+        const handleEditorDestroy = () => {
+          if (tiptapDragFromOtherEditor === editor) {
+            tiptapDragFromOtherEditor = null
+          }
+        }
+
         window.addEventListener('dragstart', handleDragstart)
         window.addEventListener('dragend', handleDragend)
+        editor.on('destroy', handleEditorDestroy)
 
         return {
           destroy() {
             window.removeEventListener('dragstart', handleDragstart)
             window.removeEventListener('dragend', handleDragend)
-
-            if (tiptapDragFromOtherEditor === editor) {
-              tiptapDragFromOtherEditor = null
-            }
+            editor.off('destroy', handleEditorDestroy)
           },
         }
       },

--- a/packages/core/src/PasteRule.ts
+++ b/packages/core/src/PasteRule.ts
@@ -254,6 +254,12 @@ export function pasteRulesPlugin(props: { editor: Editor; rules: PasteRule[] }):
     return tr
   }
 
+  editor.on('destroy', () => {
+    if (tiptapDragFromOtherEditor === editor) {
+      tiptapDragFromOtherEditor = null
+    }
+  })
+
   const plugins = rules.map(rule => {
     return new Plugin({
       // we register a global drag handler to track the current drag source element
@@ -274,21 +280,13 @@ export function pasteRulesPlugin(props: { editor: Editor; rules: PasteRule[] }):
           }
         }
 
-        const handleEditorDestroy = () => {
-          if (tiptapDragFromOtherEditor === editor) {
-            tiptapDragFromOtherEditor = null
-          }
-        }
-
         window.addEventListener('dragstart', handleDragstart)
         window.addEventListener('dragend', handleDragend)
-        editor.on('destroy', handleEditorDestroy)
 
         return {
           destroy() {
             window.removeEventListener('dragstart', handleDragstart)
             window.removeEventListener('dragend', handleDragend)
-            editor.off('destroy', handleEditorDestroy)
           },
         }
       },

--- a/packages/core/src/PasteRule.ts
+++ b/packages/core/src/PasteRule.ts
@@ -281,6 +281,10 @@ export function pasteRulesPlugin(props: { editor: Editor; rules: PasteRule[] }):
           destroy() {
             window.removeEventListener('dragstart', handleDragstart)
             window.removeEventListener('dragend', handleDragend)
+
+            if (tiptapDragFromOtherEditor === editor) {
+              tiptapDragFromOtherEditor = null
+            }
           },
         }
       },
@@ -297,6 +301,10 @@ export function pasteRulesPlugin(props: { editor: Editor; rules: PasteRule[] }):
               if (dragFromOtherEditor?.isEditable) {
                 // setTimeout to avoid the wrong content after drop, timeout arg can't be empty or 0
                 setTimeout(() => {
+                  if (dragFromOtherEditor.isDestroyed) {
+                    return
+                  }
+
                   const selection = dragFromOtherEditor.state.selection
 
                   if (selection) {


### PR DESCRIPTION
## Fixes

Fixes #8265

## Changes and Review

Dragging between editors queues a delete on the source editor 10ms after the drop, and that callback threw `Cannot read properties of null (reading 'commands')` when the source editor was destroyed in the meantime. It now returns early for a destroyed editor, and the plugin drops its module-level reference to the source editor when that editor is destroyed.

To verify, run `packages/core/__tests__/crossEditorDrop.spec.ts`. The first and third tests fail on `main`; the other two guard the normal drag, including a drag that spans a `registerPlugin` call.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
