### PR TITLE
fix(extension-youtube): guard isValidYoutubeUrl against a missing url (#8229)

### DIFF
--- a/.changeset/2026-08-23-youtube-missing-src.md
+++ b/.changeset/2026-08-23-youtube-missing-src.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-youtube': patch
+---
+
+Pasting a YouTube iframe without a `src` attribute no longer crashes the editor. The embed is kept without a source.

--- a/packages/extension-youtube/__tests__/youtube.spec.ts
+++ b/packages/extension-youtube/__tests__/youtube.spec.ts
@@ -5,7 +5,11 @@ import Text from '@tiptap/extension-text'
 import Youtube from '@tiptap/extension-youtube'
 import { describe, expect, it } from 'vite-plus/test'
 
-import { getAttributesFromYoutubeEmbedUrl, getEmbedUrlFromYoutubeUrl } from '../src/utils.ts'
+import {
+  getAttributesFromYoutubeEmbedUrl,
+  getEmbedUrlFromYoutubeUrl,
+  isValidYoutubeUrl,
+} from '../src/utils.ts'
 
 /**
  * Most youtube tests should actually exist in the demo/ app folder
@@ -440,5 +444,52 @@ describe('extension-youtube', () => {
     'https://example.com/embed/dQw4w9WgXcQ',
   ])('returns null for unsupported youtube embed urls: %s', embedUrl => {
     expect(getAttributesFromYoutubeEmbedUrl(embedUrl)).toBeNull()
+  })
+
+  describe('missing src attribute', () => {
+    // The `src` attribute is declared with `default: null` and its `parseHTML` returns
+    // `undefined` when the iframe carries no `src`, so a node with a null `src` is a
+    // legitimate parse result rather than a malformed document.
+    const iframeWithoutSrc =
+      '<div data-youtube-video=""><iframe class="w-full aspect-video" width="640" height="480" allowfullscreen="true" start="0"></iframe></div>'
+
+    it('accepts a well-formed youtube url', () => {
+      expect(isValidYoutubeUrl('https://www.youtube.com/watch?v=EkRHhOCdZjw')).toBeTruthy()
+    })
+
+    it('returns null for a missing url instead of throwing', () => {
+      expect(isValidYoutubeUrl(null)).toBe(null)
+    })
+
+    it('returns null from getEmbedUrlFromYoutubeUrl when the url is missing', () => {
+      expect(getEmbedUrlFromYoutubeUrl({ url: null as unknown as string })).toBe(null)
+    })
+
+    it('refuses setYoutubeVideo with a missing src instead of throwing', () => {
+      editor = new Editor({
+        element: createEditorEl(),
+        extensions: [Document, Text, Paragraph, Youtube],
+      })
+
+      expect(editor.commands.setYoutubeVideo({ src: null as unknown as string })).toBe(false)
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
+
+    it('parses an iframe without a src attribute without throwing', () => {
+      expect(() => {
+        editor = new Editor({
+          element: createEditorEl(),
+          extensions: [Document, Text, Paragraph, Youtube],
+          content: iframeWithoutSrc,
+        })
+      }).not.toThrow()
+
+      expect(editor?.getHTML()).not.toContain('src=')
+
+      editor?.destroy()
+      getEditorEl()?.remove()
+    })
   })
 })

--- a/packages/extension-youtube/src/utils.ts
+++ b/packages/extension-youtube/src/utils.ts
@@ -3,7 +3,18 @@ export const YOUTUBE_REGEX =
 export const YOUTUBE_REGEX_GLOBAL =
   /^((?:https?:)?\/\/)?((?:www|m|music)\.)?((?:youtube\.com|youtu\.be|youtube-nocookie\.com))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/g
 
-export const isValidYoutubeUrl = (url: string) => {
+/**
+ * Checks whether a url is a youtube url that the extension can embed.
+ *
+ * The `src` attribute of a youtube node is declared with `default: null`, so a node
+ * parsed from an iframe without a `src` attribute legitimately carries no url. Guard
+ * against that here instead of letting the caller dereference it.
+ */
+export const isValidYoutubeUrl = (url: string | null | undefined) => {
+  if (!url) {
+    return null
+  }
+
   return url.match(YOUTUBE_REGEX)
 }
 


### PR DESCRIPTION
backport for #8229

---

* fix(extension-youtube): guard isValidYoutubeUrl against a missing url

The `src` attribute is declared with `default: null` and its `parseHTML`
returns `undefined` for an iframe without a `src`, so a youtube node can
legitimately carry no url. `renderHTML` then passed that null through
`getEmbedUrlFromYoutubeUrl` into `isValidYoutubeUrl`, which dereferenced
it with `url.match(...)` and threw `Cannot read properties of null
(reading 'match')`, breaking the whole editor for a document that could
only be repaired outside the app.

Guard the url in `isValidYoutubeUrl` and widen its parameter type to
match what callers can actually pass. `getEmbedUrlFromYoutubeUrl` and
`setYoutubeVideo` already handle a falsy result, so the node now renders
without a source instead of throwing.

* test(extension-youtube): pass null to isValidYoutubeUrl without a cast

The cast made the test compile even if the parameter type were narrowed back to
string, so it did not pin the widened signature. Also reword the changeset to
describe the paste behaviour instead of the thrown exception.
