### PR TITLE
fix(ci): fix formatting and lint failures blocking main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "true"
+          cache: 'true'
 
       - name: Install dependencies
         run: vp install --frozen-lockfile -- --strict-peer-dependencies
@@ -90,7 +90,7 @@ jobs:
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "true"
+          cache: 'true'
 
       - name: Update npm for trusted publishing
         run: npm install -g npm@11.6.2

--- a/packages/core/__tests__/renderNestedMarkdownContent.spec.ts
+++ b/packages/core/__tests__/renderNestedMarkdownContent.spec.ts
@@ -1,5 +1,5 @@
 import { renderNestedMarkdownContent } from '@tiptap/core'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vite-plus/test'
 
 const node = {
   type: 'listItem',

--- a/packages/markdown/__tests__/list-indentation.spec.ts
+++ b/packages/markdown/__tests__/list-indentation.spec.ts
@@ -3,7 +3,7 @@ import { BulletList, ListItem, OrderedList } from '@tiptap/extension-list'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
 import { MarkdownManager } from '@tiptap/markdown'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vite-plus/test'
 
 const manager = (indentation?: { style?: 'space' | 'tab'; size?: number }) =>
   new MarkdownManager({


### PR DESCRIPTION
## Problem

`Check linting & formatting` has failed on every push to `main` since 2e704831c. Two separate problems, stacked:

1. **Formatting** — `.github/workflows/publish.yml` had `cache: "true"` (double quotes) twice. oxfmt wants single quotes.
2. **Lint** — `packages/core/__tests__/renderNestedMarkdownContent.spec.ts` and `packages/markdown/__tests__/list-indentation.spec.ts` import from `vitest` instead of `vite-plus/test`. The `vite-plus(prefer-vite-plus-imports)` rule rejects that. The other 194 spec files already use `vite-plus/test`.

`vp check` stops after the formatting pass, so the lint errors stayed hidden behind the formatting error until it was fixed.

## Fix

- Ran `vp check --fix` on the workflow file.
- Switched the two specs to `vite-plus/test`.

## Verification

- `vp lint`: clean (reproduced both errors before the change, silent after)
- `vp check`: no tracked file reported
- `vp run test:unit`: 1956 passed