### PR TITLE
fix(extension-table): clear stale inline width on <col> when colwidth reverts

### DIFF
--- a/.changeset/2026-08-29-extension-table-col-stale-width-undo.md
+++ b/.changeset/2026-08-29-extension-table-col-stale-width-undo.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Undoing a column resize now clears the stale inline width on the `<col>` element, so the column visually snaps back to its previous width.

--- a/packages/extension-table/__tests__/colgroupUpdate.spec.ts
+++ b/packages/extension-table/__tests__/colgroupUpdate.spec.ts
@@ -3,6 +3,7 @@ import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
 import Text from '@tiptap/extension-text'
+import { UndoRedo } from '@tiptap/extensions'
 import { afterEach, describe, expect, it } from 'vite-plus/test'
 
 describe('colgroup updates after column commands', () => {
@@ -191,6 +192,60 @@ describe('colgroup updates after column commands', () => {
       // remaining widths must be the original 200 and 300, not 100/200 (which would
       // indicate widths got reassigned to the wrong columns after the deletion)
       expect(widthsOf()).toEqual(['200px', '300px'])
+    })
+
+    it('clears the stale inline width on <col> when a resize is undone', async () => {
+      const undoEditor = new Editor({
+        element: createEditorEl(),
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          UndoRedo,
+          TableCell,
+          TableHeader,
+          TableRow,
+          Table.configure({ resizable: true }),
+        ],
+      })
+
+      try {
+        undoEditor.commands.insertTable({ rows: 2, cols: 2, withHeaderRow: false })
+
+        const firstCol = () =>
+          undoEditor.view.dom.querySelectorAll<HTMLTableColElement>('colgroup > col')[0]
+
+        // no width stored initially
+        expect(firstCol().style.width).toBe('')
+
+        // A resize lands in its own history group only after the newGroupDelay
+        // (500ms by default) has elapsed since the insert
+        await new Promise(resolve => setTimeout(resolve, 600))
+
+        // Simulate the transaction updateColumnWidth dispatches on mouseup:
+        // setNodeMarkup on the first cell (pos 2 in a doc that starts with the table)
+        const cell = undoEditor.state.doc.nodeAt(2)
+
+        expect(cell).not.toBeNull()
+
+        const tr = undoEditor.state.tr.setNodeMarkup(2, undefined, {
+          ...cell!.attrs,
+          colwidth: [150],
+        })
+
+        undoEditor.view.dispatch(tr)
+
+        expect(firstCol().style.width).toBe('150px')
+
+        undoEditor.commands.undo()
+
+        // the document state reverted…
+        expect(undoEditor.state.doc.nodeAt(2)!.attrs.colwidth).toBeNull()
+        // …and the <col> must not keep forcing the dragged width
+        expect(firstCol().style.width).toBe('')
+      } finally {
+        undoEditor.destroy()
+      }
     })
   })
 })

--- a/packages/extension-table/src/table/TableView.ts
+++ b/packages/extension-table/src/table/TableView.ts
@@ -41,6 +41,12 @@ export function updateColumns(
           colgroup.appendChild(colElement)
         } else {
           if ((nextDOM as HTMLTableColElement).style.width !== cssWidth) {
+            if (!hasWidth) {
+              // clear a stale inline width left by a previous resize,
+              // e.g. when an undo reverts colwidth back to null
+              ;(nextDOM as HTMLTableColElement).style.removeProperty('width')
+            }
+
             const [propertyKey, propertyValue] = getColStyleDeclaration(cellMinWidth, hasWidth)
 
             ;(nextDOM as HTMLTableColElement).style.setProperty(propertyKey, propertyValue)


### PR DESCRIPTION
## Affected Packages

- `@tiptap/extension-table` (3.22.3 → current main)

## Bug

With `resizable: true`, undoing a column resize appears to do nothing: the document state reverts (`colwidth` back to `null`), but the `<col>` element keeps the inline `width` set during the drag, so visually the column never snaps back.

## Root cause

In `updateColumns` (`src/table/TableView.ts`), when `colwidth` reverts to undefined the branch is entered (`style.width !== cssWidth` with `cssWidth = ""`), but `getColStyleDeclaration` then only sets `min-width` — the previously applied `width` property is never removed.

prosemirror-tables' own `updateColumnsOnResize` does not have this bug — it assigns `nextDOM.style.width = cssWidth`, which clears the property when empty.

## Fix

Remove the `width` property when updating a column whose `hasWidth` is undefined:

```ts
if ((nextDOM as HTMLTableColElement).style.width !== cssWidth) {
  if (!hasWidth) {
    // clear a stale inline width left by a previous resize,
    // e.g. when an undo reverts colwidth back to null
    ;(nextDOM as HTMLTableColElement).style.removeProperty('width')
  }

  const [propertyKey, propertyValue] = getColStyleDeclaration(cellMinWidth, hasWidth)

  ;(nextDOM as HTMLTableColElement).style.setProperty(propertyKey, propertyValue)
}
```

## Test

Added a regression test to `__tests__/colgroupUpdate.spec.ts` that dispatches the same `setNodeMarkup` transaction `updateColumnWidth` dispatches on mouseup, undoes it, and asserts both the state revert and the cleared inline width. The test uses a 600 ms gap so the resize lands in its own history group (mirroring the manual repro).

- Without the fix: `1 failed | 9 passed`
- With the fix: `10 passed`
- Full `packages/extension-table` suite: `93 passed`

Fixes #8122