### PR TITLE
fix(core): validate splitBlock against the post-deleteSelection document

### DIFF
--- a/.changeset/2026-08-31-splitblock-stale-cansplit.md
+++ b/.changeset/2026-08-31-splitblock-stale-cansplit.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+`splitBlock` no longer throws `TransformError: Inserted content deeper than insertion position` when the selection spans block boundaries (for example from the start of one paragraph into another block, or across an isolating node). The command now returns `false` when the split is not possible.

--- a/packages/core/__tests__/splitBlock.spec.ts
+++ b/packages/core/__tests__/splitBlock.spec.ts
@@ -1,0 +1,98 @@
+import { Editor, Node } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { describe, expect, it } from 'vite-plus/test'
+
+const Callout = Node.create({
+  name: 'callout',
+  group: 'block',
+  content: 'paragraph+',
+  isolating: true,
+  renderHTML() {
+    return ['div', { 'data-callout': '' }, 0]
+  },
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-callout]',
+      },
+    ]
+  },
+})
+
+const createEditor = (content: string) =>
+  new Editor({
+    extensions: [Document, Paragraph, Text, Callout],
+    content,
+  })
+
+describe('splitBlock', () => {
+  it('splits a paragraph at the cursor', () => {
+    const editor = createEditor('<p>onetwo</p>')
+
+    editor.commands.setTextSelection(4)
+
+    expect(editor.commands.splitBlock()).toBe(true)
+    expect(editor.getHTML()).toBe('<p>one</p><p>two</p>')
+  })
+
+  it('deletes the selection before splitting when the blocks can merge', () => {
+    const editor = createEditor('<p>one</p><p>two</p>')
+
+    // from inside the first paragraph to inside the second one
+    editor.commands.setTextSelection({ from: 3, to: 7 })
+
+    expect(editor.commands.splitBlock()).toBe(true)
+    expect(editor.getHTML()).toBe('<p>on</p><p>wo</p>')
+  })
+
+  it('does not throw when the selection starts at the start of a block and ends in another block', () => {
+    const editor = createEditor('<p>one</p><p>two</p>')
+
+    // start of the first paragraph to start of the second one: deleting this
+    // selection removes the first paragraph entirely, so the mapped split
+    // position resolves at depth 0
+    editor.commands.setTextSelection({ from: 1, to: 6 })
+
+    expect(() => editor.commands.splitBlock()).not.toThrow()
+  })
+
+  it('returns false and leaves the document unchanged when the split position is invalid after deleting the selection', () => {
+    const editor = createEditor('<p>one</p><p>two</p>')
+
+    editor.commands.setTextSelection({ from: 1, to: 6 })
+
+    expect(editor.commands.splitBlock()).toBe(false)
+    expect(editor.getHTML()).toBe('<p>one</p><p>two</p>')
+  })
+
+  it('does not throw when the selection spans from a paragraph into an isolating node', () => {
+    const editor = createEditor('<p>one</p><div data-callout><p>two</p></div>')
+
+    // start of the paragraph to the start of the isolating node's content:
+    // deleting this selection removes the paragraph, and splitting at the
+    // stale position throws "Invalid content for node callout" (same root
+    // cause, different message)
+    editor.commands.setTextSelection({ from: 1, to: 6 })
+
+    expect(() => editor.commands.splitBlock()).not.toThrow()
+  })
+
+  it('does not throw when pressing Enter with a selection spanning block boundaries', () => {
+    const editor = createEditor('<p>one</p><p>two</p>')
+
+    editor.commands.setTextSelection({ from: 1, to: 6 })
+
+    expect(() => editor.commands.keyboardShortcut('Enter')).not.toThrow()
+  })
+
+  it('can().splitBlock() returns false without mutating the document', () => {
+    const editor = createEditor('<p>one</p><p>two</p>')
+
+    editor.commands.setTextSelection({ from: 1, to: 6 })
+
+    expect(editor.can().splitBlock()).toBe(false)
+    expect(editor.getHTML()).toBe('<p>one</p><p>two</p>')
+  })
+})

--- a/packages/core/src/commands/splitBlock.ts
+++ b/packages/core/src/commands/splitBlock.ts
@@ -1,5 +1,4 @@
-import type { EditorState } from '@tiptap/pm/state'
-import { NodeSelection, TextSelection } from '@tiptap/pm/state'
+import { EditorState, NodeSelection, TextSelection } from '@tiptap/pm/state'
 import { canSplit } from '@tiptap/pm/transform'
 
 import { defaultBlockAt } from '../helpers/defaultBlockAt.js'
@@ -80,13 +79,21 @@ export const splitBlock: RawCommands['splitBlock'] =
           ]
         : undefined
 
-    let can = canSplit(tr.doc, tr.mapping.map($from.pos), 1, types)
+    // Deleting the selection can restructure the document, so the split has to
+    // be validated against the document as it will look after the deletion.
+    // Simulate the deletion on a scratch transaction instead of mutating `tr`:
+    // the shared transaction is dispatched even when a command returns `false`,
+    // so it must stay untouched until the split is known to be possible.
+    const willDeleteSelection = selection instanceof TextSelection && !selection.empty
+    const deletedTr = willDeleteSelection
+      ? EditorState.create({ doc: tr.doc, selection }).tr.deleteSelection()
+      : null
+    const splitDoc = deletedTr ? deletedTr.doc : tr.doc
+    const splitPos = deletedTr ? deletedTr.mapping.map($from.pos) : $from.pos
 
-    if (
-      !types &&
-      !can &&
-      canSplit(tr.doc, tr.mapping.map($from.pos), 1, deflt ? [{ type: deflt }] : undefined)
-    ) {
+    let can = canSplit(splitDoc, splitPos, 1, types)
+
+    if (!types && !can && canSplit(splitDoc, splitPos, 1, deflt ? [{ type: deflt }] : undefined)) {
       can = true
       types = deflt
         ? [
@@ -100,18 +107,20 @@ export const splitBlock: RawCommands['splitBlock'] =
 
     if (dispatch) {
       if (can) {
+        const mapFrom = tr.steps.length
+
         if (selection instanceof TextSelection) {
           tr.deleteSelection()
         }
 
-        tr.split(tr.mapping.map($from.pos), 1, types)
+        tr.split(tr.mapping.slice(mapFrom).map($from.pos), 1, types)
 
         if (deflt && !atEnd && !$from.parentOffset && $from.parent.type !== deflt) {
-          const first = tr.mapping.map($from.before())
+          const first = tr.mapping.slice(mapFrom).map($from.before())
           const $first = tr.doc.resolve(first)
 
           if ($from.node(-1).canReplaceWith($first.index(), $first.index() + 1, deflt)) {
-            tr.setNodeMarkup(tr.mapping.map($from.before()), deflt)
+            tr.setNodeMarkup(tr.mapping.slice(mapFrom).map($from.before()), deflt)
           }
         }
       }


### PR DESCRIPTION
## Fixes

Fixes #7734 (also reported in #8156, closed as duplicate)

Alternative to #7990 — cc @bdbch: this is an attempt to address your review feedback there by never touching the shared transaction on the failure path, so there is no `ReplaceStep` to invert.

## The bug

`splitBlock` validates `canSplit` against the document **before** `deleteSelection` runs, then executes the split on the document **after** the deletion:

```ts
let can = canSplit(tr.doc, tr.mapping.map($from.pos), 1, types) // pre-delete doc
// ...
if (dispatch) {
  if (can) {
    if (selection instanceof TextSelection) {
      tr.deleteSelection() // restructures the document
    }
    tr.split(tr.mapping.map($from.pos), 1, types) // runs on post-delete doc
```

When deleting the selection restructures the document (e.g. a selection from the start of one block into another block, or across an isolating node), the validated position no longer exists after the deletion. With `<p>one</p><p>two</p>` and a selection from 1 to 6, `deleteSelection` removes the whole first paragraph, position 1 maps to 0 (depth 0), and `tr.split(0, ...)` throws an uncaught `TransformError: Inserted content deeper than insertion position` on a plain Enter keypress. #7734 traces the regression to v2.6.0, when `canSplit` was hoisted out of `if (dispatch)` to support `can()`.

`prosemirror-commands` `splitBlockAs` does it in the other order — `tr.deleteSelection()` first, then `canSplit` on the post-delete document, returning `false` if the split isn't possible.

## The fix

Restore the prosemirror-commands ordering semantically, without mutating the shared transaction before the outcome is known:

- If the selection is a non-empty `TextSelection`, simulate `deleteSelection` on a **scratch transaction** (`EditorState.create({ doc: tr.doc, selection }).tr.deleteSelection()`) and run both `canSplit` checks against the scratch document and the mapped position. Otherwise validate directly against `tr.doc` at `$from.pos` as before.
- Only when `can` is true does the dispatch path apply `deleteSelection` and `split` to `tr`. The executed split position is mapped through `tr.mapping.slice(mapFrom)` (steps added by this command only), so the executed position is exactly the validated one — including when the command runs inside a chain whose transaction already carries earlier steps. Previously, mapping current-document positions through the transaction's *entire* mapping silently remapped them through unrelated earlier steps.
- The `NodeSelection` early path, the `types`/`deflt` fallback, and the `ensureMarks`/`scrollIntoView` behavior are unchanged.

### Why simulate instead of delete-then-invert

The command must behave correctly in three situations, and mutating `tr` before validation breaks two of them:

1. **`dispatch` is set (single command / chain):** `CommandManager` dispatches the shared `tr` even when the command returns `false`, and a chain keeps appending to it. A naive delete-then-check reorder would leak the deletion into the dispatched transaction whenever the re-check fails. Inverting the steps restores the document, but still dispatches a `docChanged` transaction with a delete + inverse pair in it — which creates history undo entries, sends steps to collab peers, and fires update events for a command that reported failure.
2. **`dispatch` is `undefined` (`can().splitBlock()`):** `createCan` passes `dispatch: undefined` but still hands the command a real transaction — and inside `buildProps`, `can()` shares the *live* transaction of the surrounding command. Mutating `tr` in the non-dispatch path is therefore not safe either.
3. **Failure path:** the command now returns `false` cleanly with `tr` untouched, matching `prosemirror-commands` (which discards its transaction on failure).

Simulating the deletion on a scratch transaction satisfies all three with one code path. The scratch `EditorState` is only created when the selection is a non-empty `TextSelection` (i.e. never on a plain cursor Enter), so the hot path allocates nothing extra.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| Enter with cursor in a paragraph | splits | splits (unchanged) |
| Enter with selection inside/across blocks that can merge | deletes + splits | deletes + splits (unchanged) |
| Enter with selection whose deletion removes the `$from` block (e.g. start-of-block to another block, or across an isolating node) | uncaught `TransformError`, keypress lost | returns `false`, document untouched, no throw |
| `can().splitBlock()` on such a selection | `true` (wrong) | `false` |

## Tests

`packages/core/__tests__/splitBlock.spec.ts` (new):

- splits a paragraph at the cursor (guard against regressions)
- deletes the selection before splitting when blocks can merge (cross-block selection mid-text)
- does not throw for the start-of-block → next-block selection (#8156 repro)
- returns `false` and leaves the document unchanged for that selection
- does not throw when the selection spans from a paragraph into an `isolating` node (pre-fix this throws `TransformError: Invalid content for node callout` — same stale-position root cause, different message)
- does not throw on `keyboardShortcut('Enter')` with a cross-boundary selection
- `can().splitBlock()` returns `false` without mutating the document

Red/green verified: with the fix reverted, 5 of the 7 tests fail with uncaught `TransformError`s. With the fix, all pass. Full unit suite passes locally.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
