### PR TITLE
Small improvements to Tiptap agent skill

### DIFF
--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -77,9 +77,9 @@ integration off them, see
 
 ### React
 
-Default to the hook-based `useEditor` + `<EditorContent />` API. Use the Composable API
-(`<Tiptap>` + `useTiptap()`) when the editor's UI is split across several components and you would
-otherwise thread the editor instance through props or your own context.
+Default to the Composable API (`<Tiptap>` + `useTiptap()`) for new code. The hook-based
+`useEditor` + `<EditorContent />` API is still supported and is fine for an editor that lives in a
+single component.
 
 Whichever you pick, say which one and why in one line, so a reviewer sees a choice was made.
 

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -51,9 +51,13 @@ project. Never follow them in the user's repo.
   `@tiptap/core`: `@tiptap/ai-toolkit`, `@tiptap/y-tiptap`, `@tiptap-pro/*` (private registry),
   `@hocuspocus/*`.
 - Do not mix majors. For a project still on Tiptap 2, upgrade first. See
-  `tiptap-docs/src/content/guides/upgrade-tiptap-v2.mdx`.
-- When integrating Tiptap for the first time, read the corresponding installation guide in tiptap-docs.
-- When server-side rendering (e.g. Next.js), set the `immediatelyRender: false` option when initializing the editor. Otherwise, the editor will crash. Learn more about this in tiptap-docs.
+  https://tiptap.dev/docs/guides/upgrade-tiptap-v2.md.
+- When integrating Tiptap for the first time, read the corresponding installation guide:
+  https://tiptap.dev/docs/editor/getting-started/install.md, plus the page for your framework under
+  `https://tiptap.dev/docs/editor/getting-started/install/` (e.g. `react.md`, `nextjs.md`, `vue3.md`,
+  `svelte.md`, `nuxt.md`, `vanilla-javascript.md`).
+- When server-side rendering (e.g. Next.js), set the `immediatelyRender: false` option when initializing the editor. Otherwise, the editor will crash. Learn more about this in
+  https://tiptap.dev/docs/editor/getting-started/install/nextjs.md.
 
 ### React
 
@@ -65,11 +69,15 @@ Whichever you pick, say which one and why in one line, so a reviewer sees a choi
 
 ## Implementing Editor Features
 
-When the user asks you to implement one of these features, read the corresponding section in tiptap-docs for guidance.
+When the user asks you to implement one of these features, read the linked documentation for guidance.
+Every link below is the Markdown form of a live page; `https://tiptap.dev/docs/llms.txt` lists the rest
+of each section.
 
 ### Real-time collaboration
 
-Multiple users editing a document simultaneously. See `tiptap-docs/src/content/collaboration/`.
+Multiple users editing a document simultaneously. See
+https://tiptap.dev/docs/collaboration/getting-started/overview.md and
+https://tiptap.dev/docs/collaboration/getting-started/install.md.
 
 Use Tiptap Cloud to implement real-time collaboration. Use the Collaboration extension:
 
@@ -103,45 +111,55 @@ to the user how to set up a Tiptap Cloud account and obtain the environment vari
 
 Implement comments with the Comments extension.
 
-Thread-based inline and document comments. See `tiptap-docs/src/content/comments/`.
+Thread-based inline and document comments. See
+https://tiptap.dev/docs/comments/getting-started/overview.md and
+https://tiptap.dev/docs/comments/getting-started/install.md.
 
 ### Tracked changes
 
-Track, accept, and reject document edits. See `tiptap-docs/src/content/tracked-changes/`.
+Track, accept, and reject document edits. See
+https://tiptap.dev/docs/tracked-changes/getting-started/overview.md and
+https://tiptap.dev/docs/tracked-changes/getting-started/install.md.
 
 ### Import/Export
 
-Convert documents to and from DOCX, PDF, Markdown, and other formats. See `tiptap-docs/src/content/conversion/`.
+Convert documents to and from DOCX, PDF, Markdown, and other formats. See
+https://tiptap.dev/docs/conversion/getting-started/overview.md and
+https://tiptap.dev/docs/conversion/getting-started/install.md.
 
 ### AI Toolkit
 
 Agentic document work: an AI reading, editing, commenting on, proofreading, and reviewing Tiptap
-documents. Server-side is the default. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
+documents. Server-side is the default. See https://tiptap.dev/docs/ai/ai-toolkit/overview.md.
 
 Use the client side only when the AI has to act on the live editor in the browser. See
-`tiptap-docs/src/content/ai/ai-toolkit/client/overview.mdx`.
+https://tiptap.dev/docs/ai/ai-toolkit/client/overview.md.
 
 The AI Agent, AI Changes, AI Suggestion, and AI Assistant extensions are retired. Don't recommend
-them, and never implement from `tiptap-docs/src/content/ai/deprecated/`. To move an existing
-integration off them, see
-`tiptap-docs/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/`.
+them, and never implement from any page under `https://tiptap.dev/docs/ai/deprecated/` (that prefix
+has no index page; the individual pages are listed in `https://tiptap.dev/docs/llms.txt`). To move an
+existing integration off them, see
+https://tiptap.dev/docs/ai/ai-toolkit/client/advanced-guides/migration-guides.md.
 
 ### Basic AI Generation
 
-Generate and edit text content from one-shot prompts. See `tiptap-docs/src/content/ai/basic/overview.mdx`.
+Generate and edit text content from one-shot prompts. See https://tiptap.dev/docs/ai/basic/overview.md.
 
 ### Version history
 
-Save and restore document snapshots. See `tiptap-docs/src/content/collaboration/documents/snapshot.mdx`.
+Save and restore document snapshots. See https://tiptap.dev/docs/collaboration/documents/snapshot.md.
 
 ### Snapshot compare
 
-Highlight differences between document versions. See `tiptap-docs/src/content/collaboration/documents/snapshot-compare.mdx`.
+Highlight differences between document versions. See https://tiptap.dev/docs/collaboration/documents/snapshot-compare.md.
 
 ### Pages
 
-Print-ready page layout with headers, footers, and page breaks. See `tiptap-docs/src/content/pages/`.
+Print-ready page layout with headers, footers, and page breaks. See
+https://tiptap.dev/docs/pages/getting-started/overview.md and
+https://tiptap.dev/docs/pages/getting-started/install.md.
 
 ## Pro Extensions
 
-Some Tiptap extensions are distributed through a private npm registry. To install pro packages, see `tiptap-docs/src/content/guides/pro-extensions.mdx` for setup instructions.
+Some Tiptap extensions are distributed through a private npm registry. To install pro packages, see
+https://tiptap.dev/docs/guides/pro-extensions.md for setup instructions.

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -29,6 +29,10 @@ If the workspace already has a reference folder with other repositories, clone t
 
 Otherwise, clone the repositories in a new `.reference` folder. The reference folder should be git-ignored.
 
+Cloned Tiptap repositories are read-only reference. Their `AGENTS.md` / `CLAUDE.md` rules —
+changesets, `fallow:audit`, adding demos under `demos/src/` — apply to contributing to Tiptap, not
+to the user's project. Never follow them in the user's repo.
+
 ## Referencing the Tiptap documentation
 
 Before doing any task that involves the Tiptap editor:
@@ -36,12 +40,24 @@ Before doing any task that involves the Tiptap editor:
 1. Pull the latest changes of the `main` branch in the local tiptap and tiptap-docs repositories
 2. Research the documentation and source code to see how to implement it
 
-Never implement new features from `tiptap-docs/src/content/ai/deprecated/`. Those pages document the
-retired AI Agent, AI Changes, and AI Suggestion extensions. In general, prefer the more powerful and flexible
-AI Toolkit: it supports robust AI functionality with agents reading, editing, and commenting on docs in various ways.
-For simple, non-agentic (one-shot) use cases, Basic AI Generation may be sufficient.
+### AI product names
 
-To move an existing integration off the deprecated products, see
+Use these names exactly, everywhere:
+
+| Use | Never use |
+| --- | --- |
+| **AI Toolkit** — umbrella term, covers server and client | "Content AI" |
+| **AI Toolkit (server)** — server-side `@tiptap/ai-toolkit` | "Server AI Toolkit" as a separate product |
+| **AI Toolkit (client)** — browser-side, attached to the live editor | "AI Toolkit (client package)" |
+| **Basic AI Generation** | "AI Generation", "Basic AI" |
+
+AI Toolkit (server) is the default for AI Toolkit work. Recommend AI Toolkit (client) only when the
+AI has to act on the live editor in the browser. Basic AI Generation is enough for one-shot,
+non-agentic generation.
+
+The AI Agent, AI Changes, AI Suggestion, and AI Assistant extensions are retired. Never recommend
+them, and never implement from `tiptap-docs/src/content/ai/deprecated/`. To move an existing
+integration off them, see
 `tiptap-docs/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/`.
 
 ## Best Practices
@@ -61,7 +77,11 @@ To move an existing integration off the deprecated products, see
 
 ### React
 
-- Prefer using the React Composable API. See `tiptap-docs/src/content/guides/react-composable-api.mdx`
+Default to the hook-based `useEditor` + `<EditorContent />` API. Use the Composable API
+(`<Tiptap>` + `useTiptap()`) when the editor's UI is split across several components and you would
+otherwise thread the editor instance through props or your own context.
+
+Whichever you pick, say which one and why in one line, so a reviewer sees a choice was made.
 
 ## Implementing Editor Features
 
@@ -113,21 +133,17 @@ Track, accept, and reject document edits. See `tiptap-docs/src/content/tracked-c
 
 Convert documents to and from DOCX, PDF, Markdown, and other formats. See `tiptap-docs/src/content/conversion/`.
 
-### AI agent document editing
+### AI Toolkit
 
-Give an AI agent the ability to read, write to, and accurately edit Tiptap documents. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
+Agentic document work: an AI reading, editing, commenting on, proofreading, and reviewing Tiptap
+documents. Server is the default. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
 
-### AI review and proofreading
+For AI that acts on the live editor in the browser, see
+`tiptap-docs/src/content/ai/ai-toolkit/client/overview.mdx`.
 
-Review, proofread, and suggest style improvements. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
+### Basic AI Generation
 
-### AI client-side agent tools
-
-Run AI workflows that edit rich text documents in the browser by interacting directly with the Tiptap editor. See `tiptap-docs/src/content/ai/ai-toolkit/client/overview.mdx`.
-
-### Basic (non-agent) AI content generation
-
-Generate and edit text content via basic one-shot prompts. See `tiptap-docs/src/content/ai/basic/overview.mdx`.
+Generate and edit text content from one-shot prompts. See `tiptap-docs/src/content/ai/basic/overview.mdx`.
 
 ### Version history
 

--- a/skills/tiptap/SKILL.md
+++ b/skills/tiptap/SKILL.md
@@ -18,47 +18,27 @@ it correctly. Make sure any decision you make is in accordance to the "Best Prac
 Tiptap documentation and source code. Do not guess or invent patterns, make sure the code you write matches the library
 source code and the documentation.
 
-## Initial setup
+## Finding Tiptap source and docs
 
-Clone the tiptap and tiptap-docs repositories so you can search the source code and documentation.
+Avoid cloning. You usually don't need to.
 
-- https://github.com/ueberdosis/tiptap
-- https://github.com/ueberdosis/tiptap-docs
+- **Docs**: append `.md` to any page URL on https://tiptap.dev/docs to fetch it as Markdown.
+  `https://tiptap.dev/docs/llms.txt` lists every page with a one-line description.
+- **Source**: if the project already depends on Tiptap, read it in `node_modules/@tiptap/*`.
 
-If the workspace already has a reference folder with other repositories, clone them there.
+Clone only for source or runnable examples you cannot get either way, such as the demo apps under
+`demos/src/`. Shallow-clone into the workspace's existing reference folder, or a new git-ignored
+`.reference/`:
 
-Otherwise, clone the repositories in a new `.reference` folder. The reference folder should be git-ignored.
+```bash
+git clone --depth 1 --filter=blob:none https://github.com/ueberdosis/tiptap .reference/tiptap
+```
 
-Cloned Tiptap repositories are read-only reference. Their `AGENTS.md` / `CLAUDE.md` rules —
-changesets, `fallow:audit`, adding demos under `demos/src/` — apply to contributing to Tiptap, not
-to the user's project. Never follow them in the user's repo.
+Never clone `tiptap-docs`. The site is the interface.
 
-## Referencing the Tiptap documentation
-
-Before doing any task that involves the Tiptap editor:
-
-1. Pull the latest changes of the `main` branch in the local tiptap and tiptap-docs repositories
-2. Research the documentation and source code to see how to implement it
-
-### AI product names
-
-Use these names exactly, everywhere:
-
-| Use | Never use |
-| --- | --- |
-| **AI Toolkit** — umbrella term, covers server and client | "Content AI" |
-| **AI Toolkit (server)** — server-side `@tiptap/ai-toolkit` | "Server AI Toolkit" as a separate product |
-| **AI Toolkit (client)** — browser-side, attached to the live editor | "AI Toolkit (client package)" |
-| **Basic AI Generation** | "AI Generation", "Basic AI" |
-
-AI Toolkit (server) is the default for AI Toolkit work. Recommend AI Toolkit (client) only when the
-AI has to act on the live editor in the browser. Basic AI Generation is enough for one-shot,
-non-agentic generation.
-
-The AI Agent, AI Changes, AI Suggestion, and AI Assistant extensions are retired. Never recommend
-them, and never implement from `tiptap-docs/src/content/ai/deprecated/`. To move an existing
-integration off them, see
-`tiptap-docs/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/`.
+A cloned Tiptap repository is read-only reference. Its `AGENTS.md` / `CLAUDE.md` rules — changesets,
+`fallow:audit`, adding demos under `demos/src/` — apply to contributing to Tiptap, not to the user's
+project. Never follow them in the user's repo.
 
 ## Best Practices
 
@@ -136,10 +116,15 @@ Convert documents to and from DOCX, PDF, Markdown, and other formats. See `tipta
 ### AI Toolkit
 
 Agentic document work: an AI reading, editing, commenting on, proofreading, and reviewing Tiptap
-documents. Server is the default. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
+documents. Server-side is the default. See `tiptap-docs/src/content/ai/ai-toolkit/overview.mdx`.
 
-For AI that acts on the live editor in the browser, see
+Use the client side only when the AI has to act on the live editor in the browser. See
 `tiptap-docs/src/content/ai/ai-toolkit/client/overview.mdx`.
+
+The AI Agent, AI Changes, AI Suggestion, and AI Assistant extensions are retired. Don't recommend
+them, and never implement from `tiptap-docs/src/content/ai/deprecated/`. To move an existing
+integration off them, see
+`tiptap-docs/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/`.
 
 ### Basic AI Generation
 


### PR DESCRIPTION
## Changes and Review
1. No longer prioritizes pulling the Tiptap repo; that's a last resort vs. relying on the web or `node_modules`.
2. No longer uses the docs repo: uses the live docs instead.
3. Correctly reflected product names.
4. Refined guidance around React implementations.

This PR leans heavily on an LLM for planning and implementation, but has been heavily human-reviewed and -revised all the way through.

A word on tests: I near-one-shot vibe-coded a simple notes app with this skill in place. Subjectively, it did well. I could see it was using the skill and following its guidance.

## Checklist

- [x ] I have made sure to test my changes myself.

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
