### PR TITLE
fix(extension-table): escape pipe characters in serialized table cells

### DIFF
--- a/.changeset/2026-09-02-table-cell-pipe-escape.md
+++ b/.changeset/2026-09-02-table-cell-pipe-escape.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/extension-table': patch
+---
+
+Table cells exported to Markdown now escape literal pipe characters, so the cell content survives when the output is read back.

--- a/packages/extension-table/__tests__/tableMarkdown.spec.ts
+++ b/packages/extension-table/__tests__/tableMarkdown.spec.ts
@@ -298,3 +298,34 @@ describe('escapeTableCellPipes — pipe escaping inside code spans', () => {
     expect(escapeTableCellPipes('| `|\\||` |')).toBe('| `\\|\\|\\|` |')
   })
 })
+
+describe('table markdown — pipe escaping when serializing cells', () => {
+  const manager = new MarkdownManager({
+    extensions: [Document, Paragraph, Text, Code, TableKit],
+  })
+
+  it('escapes a bare pipe in cell text', () => {
+    const markdown = '| Col | Value |\n| --- | --- |\n| a | uses \\| pipe |'
+    const serialized = manager.serialize(manager.parse(markdown))
+
+    expect(serialized).toContain('uses \\| pipe')
+  })
+
+  it('round trips a cell with an escaped pipe', () => {
+    const markdown = '| Col | Value |\n| --- | --- |\n| a | uses \\| pipe |'
+    const pass1 = manager.serialize(manager.parse(markdown))
+    const pass2 = manager.serialize(manager.parse(pass1))
+
+    expect(pass2).toBe(pass1)
+
+    const cell = manager.parse(pass1).content?.[0]?.content?.[1]?.content?.[1]
+    expect(cell?.content?.[0]?.content?.[0]?.text).toBe('uses | pipe')
+  })
+
+  it('escapes pipes inside a code span in a cell', () => {
+    const markdown = '| H |\n| - |\n| `a || b` |'
+    const serialized = manager.serialize(manager.parse(markdown))
+
+    expect(serialized).toContain('`a \\|\\| b`')
+  })
+})

--- a/packages/extension-table/__tests__/tableMarkdown.spec.ts
+++ b/packages/extension-table/__tests__/tableMarkdown.spec.ts
@@ -304,27 +304,27 @@ describe('table markdown — pipe escaping when serializing cells', () => {
     extensions: [Document, Paragraph, Text, Code, TableKit],
   })
 
+  const markdown = '| Col | Value |\n| --- | --- |\n| a | uses \\| pipe |'
+
   it('escapes a bare pipe in cell text', () => {
-    const markdown = '| Col | Value |\n| --- | --- |\n| a | uses \\| pipe |'
     const serialized = manager.serialize(manager.parse(markdown))
 
     expect(serialized).toContain('uses \\| pipe')
   })
 
   it('round trips a cell with an escaped pipe', () => {
-    const markdown = '| Col | Value |\n| --- | --- |\n| a | uses \\| pipe |'
-    const pass1 = manager.serialize(manager.parse(markdown))
-    const pass2 = manager.serialize(manager.parse(pass1))
+    const serialized = manager.serialize(manager.parse(markdown))
+    const reparsed = manager.parse(serialized)
 
-    expect(pass2).toBe(pass1)
+    expect(manager.serialize(reparsed)).toBe(serialized)
 
-    const cell = manager.parse(pass1).content?.[0]?.content?.[1]?.content?.[1]
+    const cell = reparsed.content?.[0]?.content?.[1]?.content?.[1]
     expect(cell?.content?.[0]?.content?.[0]?.text).toBe('uses | pipe')
   })
 
   it('escapes pipes inside a code span in a cell', () => {
-    const markdown = '| H |\n| - |\n| `a || b` |'
-    const serialized = manager.serialize(manager.parse(markdown))
+    const codeSpanMarkdown = '| H |\n| - |\n| `a || b` |'
+    const serialized = manager.serialize(manager.parse(codeSpanMarkdown))
 
     expect(serialized).toContain('`a \\|\\| b`')
   })

--- a/packages/extension-table/src/table/utilities/markdown.ts
+++ b/packages/extension-table/src/table/utilities/markdown.ts
@@ -85,6 +85,11 @@ function collapseWhitespace(s: string) {
   return (s || '').replace(/\s+/g, ' ').trim()
 }
 
+function escapeCellPipes(text: string) {
+  // Stepping over backslash escapes keeps an already escaped pipe untouched.
+  return text.replace(/\\.|\|/g, match => (match === '|' ? '\\|' : match))
+}
+
 export function renderTableToMarkdown(
   node: JSONContent,
   h: MarkdownRendererHelpers,
@@ -120,11 +125,13 @@ export function renderTableToMarkdown(
 
         // Cells have to stay on a single line, so line breaks become <br> tags.
         // The parser already turns <br> back into hard breaks, so this round trips.
-        const text = collapseWhitespace(
-          raw
-            .split(cellSep)
-            .join('\n')
-            .replace(/[ \t]*\r?\n[ \t]*/g, '<br>'),
+        const text = escapeCellPipes(
+          collapseWhitespace(
+            raw
+              .split(cellSep)
+              .join('\n')
+              .replace(/[ \t]*\r?\n[ \t]*/g, '<br>'),
+          ),
         )
         const isHeader = cellNode.type === 'tableHeader'
         const align = normalizeTableCellAlignFromAttributes(cellNode.attrs)

--- a/packages/extension-table/src/table/utilities/markdown.ts
+++ b/packages/extension-table/src/table/utilities/markdown.ts
@@ -85,8 +85,8 @@ function collapseWhitespace(s: string) {
   return (s || '').replace(/\s+/g, ' ').trim()
 }
 
-function escapeCellPipes(text: string) {
-  // Stepping over backslash escapes keeps an already escaped pipe untouched.
+function escapePipesInCellText(text: string) {
+  // Keep already escaped pipes as they are
   return text.replace(/\\.|\|/g, match => (match === '|' ? '\\|' : match))
 }
 
@@ -125,14 +125,13 @@ export function renderTableToMarkdown(
 
         // Cells have to stay on a single line, so line breaks become <br> tags.
         // The parser already turns <br> back into hard breaks, so this round trips.
-        const text = escapeCellPipes(
-          collapseWhitespace(
-            raw
-              .split(cellSep)
-              .join('\n')
-              .replace(/[ \t]*\r?\n[ \t]*/g, '<br>'),
-          ),
+        const singleLine = collapseWhitespace(
+          raw
+            .split(cellSep)
+            .join('\n')
+            .replace(/[ \t]*\r?\n[ \t]*/g, '<br>'),
         )
+        const text = escapePipesInCellText(singleLine)
         const isHeader = cellNode.type === 'tableHeader'
         const align = normalizeTableCellAlignFromAttributes(cellNode.attrs)
 


### PR DESCRIPTION
## Fixes

Fixes #8294

## Changes and Review

A literal `|` in a table cell was written out raw, so re-parsing the output split the cell at that pipe and dropped everything after it. Cell text is now pipe-escaped when the table is serialized, with existing backslash escapes left alone so nothing gets escaped twice.

To verify, parse `| a | uses \| pipe |` and serialize it: the pipe stays escaped and a second round trip gives the same output. Covered by unit tests in `packages/extension-table/__tests__/tableMarkdown.spec.ts`.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.
- [ ] This is a critical bug or security fix that also needs to land on the current stable release (see [Branching](../CONTRIBUTING.md#branching) in CONTRIBUTING.md).

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
