### PR TITLE
fix: backport GHSA-cp6q-959q-f8rh to v2

### DIFF
--- a/.changeset/fix-merge-attributes-prototype.md
+++ b/.changeset/fix-merge-attributes-prototype.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/core': patch
+---
+
+Prevent untrusted HTML attributes from changing an object's prototype when merged with `mergeAttributes`.

--- a/packages/core/src/utilities/mergeAttributes.ts
+++ b/packages/core/src/utilities/mergeAttributes.ts
@@ -5,6 +5,18 @@ export function mergeAttributes(...objects: Record<string, any>[]): Record<strin
       const mergedAttributes = { ...items }
 
       Object.entries(item).forEach(([key, value]) => {
+        // Define a data property so untrusted input cannot change the merged object's prototype.
+        if (key === '__proto__') {
+          Object.defineProperty(mergedAttributes, key, {
+            configurable: true,
+            enumerable: true,
+            value,
+            writable: true,
+          })
+
+          return
+        }
+
         const exists = mergedAttributes[key]
 
         if (!exists) {


### PR DESCRIPTION
## Fixes

<!-- Use GitHub keywords to link the issue or issues fixed by this PR, for example: Fixes #123 or Closes #456. -->

This backports 01d7af8c983ee5954c63734f4fa46cb23ae3246d to the v2 line

## Changes and Review

<!-- Explain what changed, why it changed, and how reviewers can verify it. -->
<!-- Keep this section short: use 2–4 short sentences or a few bullets. Do not write a technical deep dive, a full implementation explanation, or a large wall of text. -->

This is a cherry-pick of 01d7af8c983ee5954c63734f4fa46cb23ae3246d with the only "change" being omitting the test since v2 doesn't have tests for `core`

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] ~I have added tests if possible.~
- [x] I have made sure to test my changes myself.
- [x] ~This is a critical bug or security fix that also needs to land on the current stable release (see [Branching](../CONTRIBUTING.md#branching) in CONTRIBUTING.md).~

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
