### PR TITLE
chore: format changeset frontmatter so vp check passes on main

### DIFF
--- a/.changeset/fix-ios-ignore-mutation-contentdom.md
+++ b/.changeset/fix-ios-ignore-mutation-contentdom.md
@@ -1,5 +1,5 @@
 ---
-"@tiptap/core": patch
+'@tiptap/core': patch
 ---
 
 Fix freezes in framework-based node views on iOS and Android


### PR DESCRIPTION
`main` currently fails the `Check linting & formatting` job, so every open PR is red through no fault of its own.

```console
$ git checkout main && vp check
error: Formatting issues found
.changeset/fix-ios-ignore-mutation-contentdom.md (173ms)

Found formatting issues in 1 file
```

The changeset added in #8221 uses double quotes in its frontmatter where oxfmt wants single quotes, matching every other changeset in the directory. It is a one-character change, produced by `vp check --fix`.

After:

```console
$ vp check
pass: All 2033 files are correctly formatted
pass: Found no warnings or lint errors in 1447 files
```

`changeset status` still resolves the release plan, so the bump is unaffected.
