### PR TITLE
Update test file conventions

### DIFF
--- a/.github/instructions/tiptap.instructions.md
+++ b/.github/instructions/tiptap.instructions.md
@@ -64,7 +64,7 @@ Scripts defined at the repo root. Run them with `vp run <script>` (or `pnpm run 
 - `vp run test:e2e:open:firefox` - UI mode, Firefox tests
 - `vp run test:e2e:open:all` - UI mode, both browsers selectable
 - `vp run test:e2e:report` - open the HTML report from the last run
-- `vp run test:unit` - run Vitest unit tests in `packages/**/__tests__/`
+- `vp run test:unit` - run Vitest unit tests
 - `vp run test` - build then run all tests
 - `vp run serve` - build and serve the demos on port 3000
 - `vp run publish` - build and publish with Changesets
@@ -118,7 +118,7 @@ When adding a demo, keep it small and self-contained, with imports from publishe
 
 Two layers:
 
-- **Unit tests** with Vitest in `packages/**/__tests__/` (happy-dom). These test `@tiptap/core` and individual extensions in isolation.
+- **Unit tests** with Vitest (happy-dom). Place file-specific tests next to the file they cover and name them `<file-name>.spec.ts`. Put package-wide tests and test utilities in `packages/**/__tests__/`.
 - **E2E tests** with Playwright, colocated next to their demos as `demos/src/**/index.spec.ts`. They drive the real Vite-served demo pages in Chromium.
 
 Run them:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ Then run `pnpm fallow` for complexity and dead code, `pnpm fallow:health` for re
 
 ## Tests
 
-- Unit: Vitest, in `packages/**/__tests__/`, running on happy-dom.
+- Unit: Vitest, running on happy-dom. Place file-specific tests next to the file they cover and name them `<file-name>.spec.ts`. Put package-wide tests and test utilities in `packages/**/__tests__/`.
 - E2E: Playwright, next to the demo it drives as `demos/src/**/index.spec.ts`. Playwright starts the demo server itself on port 4080, no separate terminal. Helpers live in `demos/test/helpers.ts`. Copy `demos/src/Commands/Cut/index.spec.ts` as a template.
 
 ## Demos


### PR DESCRIPTION
## Changes and Review

Updates to test file conventions following an internal discussion we had with the team. 

This pull request updates the AGENTS.md file and the `.github/instructions/tiptap.instructions.md`. It does not modify the location of existing tests in the codebase. 

The change in testing conventions is that we'll put file-specific tests next to the file they cover and name them `<file-name>.spec.ts`. And we'll put package-wide tests and test utilities in `packages/**/__tests__/`.

This is a proposal and the change is still pending confirmation by everybody in the team. The goal is to have a common guideline that we can use in all our projects. 

This is not a change in functionality in the packages or the Tiptap library, so I didn't add a changeset. 

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [x] I have added tests if possible.
- [x] I have made sure to test my changes myself.
- [ ] This is a critical bug or security fix that also needs to land on the current stable release (see [Branching](../CONTRIBUTING.md#branching) in CONTRIBUTING.md).

### Responsibility

<!-- This checkbox is checked by default on purpose. The PR author is responsible for reviewing and understanding the changes, even when an AI agent created them. -->

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
