### PR TITLE
fix(react): stop importing Editor through the package barrel

### DIFF
--- a/.changeset/2026-09-04-react-editor-namespace-ts2694.md
+++ b/.changeset/2026-09-04-react-editor-namespace-ts2694.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/react': patch
+---
+
+Fixed a TypeScript error (TS2694) in the shipped type declarations when `skipLibCheck` is turned off.

--- a/.changeset/2026-09-04-react-editor-namespace-ts2694.md
+++ b/.changeset/2026-09-04-react-editor-namespace-ts2694.md
@@ -2,4 +2,4 @@
 '@tiptap/react': patch
 ---
 
-Fixed a TypeScript error (TS2694) in the shipped type declarations when `skipLibCheck` is turned off.
+Fix a TypeScript error (TS2694) in the shipped type declarations when `skipLibCheck` is turned off.

--- a/packages/react/src/Tiptap.tsx
+++ b/packages/react/src/Tiptap.tsx
@@ -1,8 +1,9 @@
+import type { Editor } from '@tiptap/core'
 import type { ReactNode } from 'react'
 import { createContext, useContext, useMemo } from 'react'
 
 import { EditorContext } from './Context.js'
-import type { Editor, EditorContentProps, EditorStateSnapshot } from './index.js'
+import type { EditorContentProps, EditorStateSnapshot } from './index.js'
 import { EditorContent, useEditorState } from './index.js'
 
 /**


### PR DESCRIPTION
## Fixes

Fixes #8307

## Changes and Review

`Tiptap.tsx` imported the `Editor` type through the package's own barrel, which left `Editor` missing from the generated `index.d.ts` namespace and produced four TS2694 errors with `skipLibCheck: false`. Importing it directly from `@tiptap/core`, like every other file in this package, removes the namespace and the errors.

Verified by building `@tiptap/react` and running `tsc --noEmit` with `skipLibCheck: false` against a small consumer importing `useEditor`/`Editor`: all four errors are gone after the fix, still present before it.

## Checklist

- [x] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.
- [ ] This is a critical bug or security fix that also needs to land on the current stable release (see [Branching](../CONTRIBUTING.md#branching) in CONTRIBUTING.md).

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
