### PR TITLE
Fix/audio demo layout

### DIFF
--- a/demos/setup/style.scss
+++ b/demos/setup/style.scss
@@ -161,6 +161,13 @@ textarea {
   }
 }
 
+[popover] {
+  background-color: var(--white);
+  box-shadow: var(--shadow);
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
 /* Details */
 [data-type='details'] {
   display: flex;

--- a/demos/src/Nodes/Audio/React/index.jsx
+++ b/demos/src/Nodes/Audio/React/index.jsx
@@ -65,113 +65,125 @@ export default () => {
 
   return (
     <>
-      <div className="control-group">
-        <Control>
-          <label htmlFor="src">Audio source</label>
-          <input
-            id="src"
-            type="text"
-            value={src}
-            onChange={event => setSrc(event.target.value)}
-            placeholder="https://.../audio.mp3"
-          />
-        </Control>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+          alignItems: 'center',
+          padding: '1.5rem',
+        }}
+      >
+        <input
+          type="text"
+          style={{ flexGrow: 1 }}
+          value={src}
+          onChange={event => setSrc(event.target.value)}
+          placeholder="https://.../audio.mp3"
+          aria-label="Audio source"
+        />
 
-        <Control>
-          <label htmlFor="preload">Preload</label>
-          <select
-            id="preload"
-            value={preload ?? ''}
-            onChange={event => setPreload(event.target.value)}
-          >
-            <option value="metadata">metadata</option>
-            <option value="auto">auto</option>
-            <option value="none">none</option>
-            <option value="">(empty)</option>
-          </select>
-        </Control>
+        <button type="button" className="primary" onClick={insertAudio} disabled={!editor}>
+          Insert audio
+        </button>
 
-        <Control>
-          <label htmlFor="controlsList">controlslist</label>
-          <input
-            id="controlsList"
-            type="text"
-            value={controlsList}
-            onChange={event => setControlsList(event.target.value)}
-            placeholder="nodownload noplaybackrate"
-          />
-        </Control>
-
-        <Control>
-          <label htmlFor="crossorigin">crossorigin</label>
-          <select
-            id="crossorigin"
-            value={crossorigin}
-            onChange={event => setCrossorigin(event.target.value)}
-          >
-            <option value="">(unset)</option>
-            <option value="anonymous">anonymous</option>
-            <option value="use-credentials">use-credentials</option>
-          </select>
-        </Control>
+        <button type="button" popoverTarget="audio-options">
+          Additional Options
+        </button>
       </div>
 
-      <div className="control-group toggles">
-        <Control>
-          <label>
-            <input
-              type="checkbox"
-              checked={controls}
-              onChange={event => setControls(event.target.checked)}
-            />
-            Show controls
-          </label>
-        </Control>
-        <Control>
-          <label>
-            <input
-              type="checkbox"
-              checked={autoplay}
-              onChange={event => setAutoplay(event.target.checked)}
-            />
-            Autoplay
-          </label>
-        </Control>
-        <Control>
-          <label>
-            <input
-              type="checkbox"
-              checked={loop}
-              onChange={event => setLoop(event.target.checked)}
-            />
-            Loop
-          </label>
-        </Control>
-        <Control>
-          <label>
-            <input
-              type="checkbox"
-              checked={muted}
-              onChange={event => setMuted(event.target.checked)}
-            />
-            Muted
-          </label>
-        </Control>
-        <Control>
-          <label>
-            <input
-              type="checkbox"
-              checked={disableRemotePlayback}
-              onChange={event => setDisableRemotePlayback(event.target.checked)}
-            />
-            Disable remote playback
-          </label>
-        </Control>
-      </div>
+      <div id="audio-options" popover="auto" className="additional-options-popover">
+        <div className="control-group additional-options-group">
+          <Control>
+            <label htmlFor="preload">Preload</label>
+            <select
+              id="preload"
+              value={preload ?? ''}
+              onChange={event => setPreload(event.target.value)}
+            >
+              <option value="metadata">metadata</option>
+              <option value="auto">auto</option>
+              <option value="none">none</option>
+              <option value="">(empty)</option>
+            </select>
+          </Control>
 
-      <button className="insert" onClick={insertAudio} disabled={!editor}>
-        Insert audio
-      </button>
+          <Control>
+            <label htmlFor="controlsList">controlslist</label>
+            <input
+              id="controlsList"
+              type="text"
+              value={controlsList}
+              onChange={event => setControlsList(event.target.value)}
+              placeholder="nodownload noplaybackrate"
+            />
+          </Control>
+
+          <Control>
+            <label htmlFor="crossorigin">crossorigin</label>
+            <select
+              id="crossorigin"
+              value={crossorigin}
+              onChange={event => setCrossorigin(event.target.value)}
+            >
+              <option value="">(unset)</option>
+              <option value="anonymous">anonymous</option>
+              <option value="use-credentials">use-credentials</option>
+            </select>
+          </Control>
+
+          <Control>
+            <label>
+              <input
+                type="checkbox"
+                checked={controls}
+                onChange={event => setControls(event.target.checked)}
+              />
+              Show controls
+            </label>
+          </Control>
+          <Control>
+            <label>
+              <input
+                type="checkbox"
+                checked={autoplay}
+                onChange={event => setAutoplay(event.target.checked)}
+              />
+              Autoplay
+            </label>
+          </Control>
+          <Control>
+            <label>
+              <input
+                type="checkbox"
+                checked={loop}
+                onChange={event => setLoop(event.target.checked)}
+              />
+              Loop
+            </label>
+          </Control>
+          <Control>
+            <label>
+              <input
+                type="checkbox"
+                checked={muted}
+                onChange={event => setMuted(event.target.checked)}
+              />
+              Muted
+            </label>
+          </Control>
+          <Control>
+            <label>
+              <input
+                type="checkbox"
+                checked={disableRemotePlayback}
+                onChange={event => setDisableRemotePlayback(event.target.checked)}
+              />
+              Disable remote playback
+            </label>
+          </Control>
+        </div>
+      </div>
 
       <EditorContent editor={editor} />
     </>

--- a/demos/src/Nodes/Audio/React/styles.scss
+++ b/demos/src/Nodes/Audio/React/styles.scss
@@ -31,50 +31,25 @@
   font-weight: 600;
 }
 
-.control-group.toggles {
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+.additional-options-popover {
+  border: 0;
+  border-radius: 0.75rem;
+  inset: auto;
+  margin: 0.5rem 0 0;
+  max-width: calc(100vw - 3rem);
+  padding: 0;
+  position-area: bottom span-left;
 }
 
-.control-group.toggles .control {
-  align-self: center;
+.additional-options-group {
+  margin: 0;
 }
 
-.control-group.toggles label {
+.additional-options-group .control label {
   display: flex;
   align-items: center;
   gap: 0.35rem;
   font-weight: 500;
-}
-
-.insert {
-  background: #111827;
-  border: 1px solid #111827;
-  color: #fff;
-  border-radius: 0.75rem;
-  padding: 0.65rem 1rem;
-  font-weight: 600;
-  width: min(100%, 64rem);
-  margin-bottom: 1rem;
-  cursor: pointer;
-  display: block;
-}
-
-.insert:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.tiptap {
-  background-color: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.75rem;
-  padding: 1rem;
-  min-height: 12rem;
-  width: 100%;
-}
-
-.tiptap p {
-  margin: 0.5rem 0;
 }
 
 .tiptap audio {

--- a/demos/src/Nodes/Audio/Vue/index.vue
+++ b/demos/src/Nodes/Audio/Vue/index.vue
@@ -1,76 +1,83 @@
 <template>
-  <div class="control-group">
-    <div class="control">
-      <label for="src">Audio source</label>
-      <input id="src" v-model="src" type="text" placeholder="https://.../audio.mp3" />
-    </div>
+  <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; padding: 1.5rem">
+    <input
+      v-model="src"
+      type="text"
+      style="flex-grow: 1"
+      placeholder="https://.../audio.mp3"
+      aria-label="Audio source"
+    />
 
-    <div class="control">
-      <label for="preload">Preload</label>
-      <select id="preload" v-model="preload">
-        <option value="metadata">metadata</option>
-        <option value="auto">auto</option>
-        <option value="none">none</option>
-        <option value="">(empty)</option>
-      </select>
-    </div>
+    <button class="primary" type="button" @click="insertAudio" :disabled="!editor">
+      Insert audio
+    </button>
 
-    <div class="control">
-      <label for="controlsList">controlslist</label>
-      <input
-        id="controlsList"
-        v-model="controlsList"
-        type="text"
-        placeholder="nodownload noplaybackrate"
-      />
-    </div>
-
-    <div class="control">
-      <label for="crossorigin">crossorigin</label>
-      <select id="crossorigin" v-model="crossorigin">
-        <option value="">(unset)</option>
-        <option value="anonymous">anonymous</option>
-        <option value="use-credentials">use-credentials</option>
-      </select>
-    </div>
+    <button type="button" popovertarget="audio-options">Additional Options</button>
   </div>
 
-  <div class="control-group toggles">
-    <div class="control">
-      <label>
-        <input v-model="controls" type="checkbox" />
-        Show controls
-      </label>
-    </div>
-    <div class="control">
-      <label>
-        <input v-model="autoplay" type="checkbox" />
-        Autoplay
-      </label>
-    </div>
-    <div class="control">
-      <label>
-        <input v-model="loop" type="checkbox" />
-        Loop
-      </label>
-    </div>
-    <div class="control">
-      <label>
-        <input v-model="muted" type="checkbox" />
-        Muted
-      </label>
-    </div>
-    <div class="control">
-      <label>
-        <input v-model="disableRemotePlayback" type="checkbox" />
-        Disable remote playback
-      </label>
+  <div id="audio-options" popover="auto" class="additional-options-popover">
+    <div class="control-group additional-options-group">
+      <div class="control">
+        <label for="preload">Preload</label>
+        <select id="preload" v-model="preload">
+          <option value="metadata">metadata</option>
+          <option value="auto">auto</option>
+          <option value="none">none</option>
+          <option value="">(empty)</option>
+        </select>
+      </div>
+
+      <div class="control">
+        <label for="controlsList">controlslist</label>
+        <input
+          id="controlsList"
+          v-model="controlsList"
+          type="text"
+          placeholder="nodownload noplaybackrate"
+        />
+      </div>
+
+      <div class="control">
+        <label for="crossorigin">crossorigin</label>
+        <select id="crossorigin" v-model="crossorigin">
+          <option value="">(unset)</option>
+          <option value="anonymous">anonymous</option>
+          <option value="use-credentials">use-credentials</option>
+        </select>
+      </div>
+
+      <div class="control">
+        <label>
+          <input v-model="controls" type="checkbox" />
+          Show controls
+        </label>
+      </div>
+      <div class="control">
+        <label>
+          <input v-model="autoplay" type="checkbox" />
+          Autoplay
+        </label>
+      </div>
+      <div class="control">
+        <label>
+          <input v-model="loop" type="checkbox" />
+          Loop
+        </label>
+      </div>
+      <div class="control">
+        <label>
+          <input v-model="muted" type="checkbox" />
+          Muted
+        </label>
+      </div>
+      <div class="control">
+        <label>
+          <input v-model="disableRemotePlayback" type="checkbox" />
+          Disable remote playback
+        </label>
+      </div>
     </div>
   </div>
-
-  <button class="insert" type="button" @click="insertAudio" :disabled="!editor">
-    Insert audio
-  </button>
 
   <editor-content :editor="editor" />
 </template>
@@ -189,37 +196,25 @@ export default {
   font-weight: 600;
 }
 
-.control-group.toggles {
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+.additional-options-popover {
+  border: 0;
+  border-radius: 0.75rem;
+  inset: auto;
+  margin: 0.5rem 0 0;
+  max-width: calc(100vw - 3rem);
+  padding: 0;
+  position-area: bottom span-left;
 }
 
-.control-group.toggles .control {
-  align-self: center;
+.additional-options-group {
+  margin: 0;
 }
 
-.control-group.toggles label {
+.additional-options-group .control label {
   display: flex;
   align-items: center;
   gap: 0.35rem;
   font-weight: 500;
-}
-
-.insert {
-  background: #111827;
-  border: 1px solid #111827;
-  color: #fff;
-  border-radius: 0.75rem;
-  padding: 0.65rem 1rem;
-  font-weight: 600;
-  width: min(100%, 64rem);
-  margin-bottom: 1rem;
-  cursor: pointer;
-  display: block;
-}
-
-.insert:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 
 .tiptap {

--- a/demos/src/Nodes/Audio/Vue/index.vue
+++ b/demos/src/Nodes/Audio/Vue/index.vue
@@ -217,19 +217,6 @@ export default {
   font-weight: 500;
 }
 
-.tiptap {
-  background-color: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.75rem;
-  padding: 1rem;
-  min-height: 12rem;
-  width: 100%;
-}
-
-.tiptap p {
-  margin: 0.5rem 0;
-}
-
 .tiptap audio {
   width: 100%;
   max-width: 64rem;


### PR DESCRIPTION
## Fixes

- N/A

## Changes and Review

This PR fixes the Audio demo layout & adds generic popover styles for native HTML popover elements on demos.

## Checklist

- [ ] I have added a [changeset](https://github.com/changesets/changesets) if necessary.
- [ ] I have added tests if possible.
- [x] I have made sure to test my changes myself.
- [x] This is a critical bug or security fix that also needs to land on the current stable release (see [Branching](../CONTRIBUTING.md#branching) in CONTRIBUTING.md).

## Screenshots

<img width="786" height="385" alt="image" src="https://github.com/user-attachments/assets/3bb919b5-151e-429e-a0aa-4bc05901ad31" />
Screenshot of the new layout

<img width="792" height="435" alt="image" src="https://github.com/user-attachments/assets/47ef2849-acfb-40a7-9f2d-bfe25a3d3125" />
Screenshot of the new popover element

### Responsibility

- [x] I have reviewed and understand these changes, and I take responsibility for this PR, even if an AI agent created it.
