### PR TITLE
fix(markdown): give each MarkdownManager its own marked instance

### DIFF
--- a/.changeset/2026-09-05-markdown-isolated-marked-instance.md
+++ b/.changeset/2026-09-05-markdown-isolated-marked-instance.md
@@ -1,0 +1,7 @@
+---
+'@tiptap/markdown': minor
+---
+
+Each editor now parses markdown with its own `marked` instance. Editors previously shared the global one, so mounting a second editor could change how the first one parsed and, when the two had different extensions, silently drop content. Markdown parsing also no longer slows down as more editors are created.
+
+The `marked` option now accepts a `new Marked()` instance without a cast. If you relied on configuring the global `marked` export and having Tiptap pick it up, pass it explicitly: `Markdown.configure({ marked })`.

--- a/packages/markdown/src/Extension.ts
+++ b/packages/markdown/src/Extension.ts
@@ -5,7 +5,7 @@ import {
   commands,
   Extension,
 } from '@tiptap/core'
-import type { marked } from 'marked'
+import type { MarkdownMarkedInstance } from './MarkdownManager.js'
 
 import MarkdownManager from './MarkdownManager.js'
 import type { ContentType } from './types.js'
@@ -77,7 +77,7 @@ export type MarkdownExtensionOptions = {
    * Use a custom version of `marked` for markdown parsing and serialization.
    * If not provided, the default `marked` instance will be used.
    */
-  marked?: typeof marked
+  marked?: MarkdownMarkedInstance
 
   /**
    * Options to pass to `marked.setOptions()`.

--- a/packages/markdown/src/Extension.ts
+++ b/packages/markdown/src/Extension.ts
@@ -75,7 +75,8 @@ export type MarkdownExtensionOptions = {
 
   /**
    * Use a custom version of `marked` for markdown parsing and serialization.
-   * If not provided, the default `marked` instance will be used.
+   * Defaults to a private `Marked` instance, so configuration applied to the
+   * global `marked` export is only picked up when it is passed here.
    */
   marked?: MarkdownMarkedInstance
 

--- a/packages/markdown/src/MarkdownManager.ts
+++ b/packages/markdown/src/MarkdownManager.ts
@@ -21,7 +21,14 @@ import {
   marksEqual,
   sortExtensions,
 } from '@tiptap/core'
-import { type Lexer, type Token, type TokenizerExtension, type TokenizerThis, marked } from 'marked'
+import {
+  type Lexer,
+  type Token,
+  type TokenizerExtension,
+  type TokenizerThis,
+  Marked,
+  marked,
+} from 'marked'
 
 import {
   closeMarksBeforeNode,
@@ -35,8 +42,13 @@ import {
 } from './utils.js'
 import { htmlContainsUnrecognizedTag } from './utils/htmlTagDetection.js'
 
+/**
+ * A `marked` instance the manager can drive: either the `marked` singleton or a `new Marked()`.
+ */
+export type MarkdownMarkedInstance = typeof marked | Marked
+
 export class MarkdownManager {
-  private markedInstance: typeof marked
+  private markedInstance: MarkdownMarkedInstance
   private activeParseLexer: Lexer | null = null
   private registry: Map<string, MarkdownExtensionSpec[]>
   private nodeTypeRegistry: Map<string, MarkdownExtensionSpec[]>
@@ -70,12 +82,14 @@ export class MarkdownManager {
    * @param options.extensions An array of Tiptap extensions to register for markdown parsing and rendering.
    */
   constructor(options?: {
-    marked?: typeof marked
+    marked?: MarkdownMarkedInstance
     markedOptions?: Parameters<typeof marked.setOptions>[0]
     indentation?: { style?: 'space' | 'tab'; size?: number }
     extensions: AnyExtension[]
   }) {
-    this.markedInstance = options?.marked ?? marked
+    // Own the instance by default: `marked.use()` registrations are permanent, so
+    // sharing the singleton leaks every editor's tokenizers into every other one.
+    this.markedInstance = options?.marked ?? new Marked()
     this.indentStyle = options?.indentation?.style ?? 'space'
     this.indentSize = options?.indentation?.size ?? 2
     this.baseExtensions = options?.extensions || []
@@ -99,7 +113,7 @@ export class MarkdownManager {
   }
 
   /** Returns the underlying marked instance. */
-  get instance(): typeof marked {
+  get instance(): MarkdownMarkedInstance {
     return this.markedInstance
   }
 

--- a/packages/markdown/tests/integration/marked-instance-isolation.test.ts
+++ b/packages/markdown/tests/integration/marked-instance-isolation.test.ts
@@ -1,0 +1,60 @@
+import { Document } from '@tiptap/extension-document'
+import { BulletList, ListItem, TaskItem, TaskList } from '@tiptap/extension-list'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { MarkdownManager } from '@tiptap/markdown'
+import { Marked, marked } from 'marked'
+import { describe, expect, it } from 'vite-plus/test'
+
+const withoutTaskList = [Document, Paragraph, Text, BulletList, ListItem]
+const withTaskList = [Document, Paragraph, Text, BulletList, ListItem, TaskList, TaskItem]
+
+describe('MarkdownManager marked instance isolation', () => {
+  it('keeps one manager’s tokenizers out of another manager', () => {
+    const markdown = '- [ ] buy milk\n- [x] walk dog'
+
+    const before = new MarkdownManager({ extensions: withoutTaskList }).parse(markdown)
+
+    new MarkdownManager({ extensions: withTaskList })
+
+    const after = new MarkdownManager({ extensions: withoutTaskList }).parse(markdown)
+
+    expect(after).toEqual(before)
+    expect(after.content).toHaveLength(1)
+    expect(after.content?.[0].type).toBe('bulletList')
+  })
+
+  it('does not register tokenizers on the marked singleton', () => {
+    const countBlockExtensions = () => {
+      const extensions = (marked as any).defaults?.extensions
+      return extensions?.block ? Object.keys(extensions.block).length : 0
+    }
+
+    const before = countBlockExtensions()
+
+    new MarkdownManager({ extensions: withTaskList })
+
+    expect(countBlockExtensions()).toBe(before)
+  })
+
+  it('does not let markedOptions leak into the marked singleton', () => {
+    const before = (marked as any).defaults.breaks
+
+    new MarkdownManager({ markedOptions: { breaks: !before }, extensions: withoutTaskList })
+
+    expect((marked as any).defaults.breaks).toBe(before)
+  })
+
+  it('still uses an injected instance, and applies markedOptions to it', () => {
+    const injected = new Marked()
+
+    const manager = new MarkdownManager({
+      marked: injected,
+      markedOptions: { breaks: true },
+      extensions: withoutTaskList,
+    })
+
+    expect(manager.instance).toBe(injected)
+    expect((injected as any).defaults.breaks).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #8316.

## The bug

`MarkdownManager` defaulted to the **global `marked` singleton** and registered its extensions' tokenizers onto it with `marked.use()`. Those registrations are permanent, so every manager lexed with the tokenizers of every manager ever constructed in the process.

The worst symptom is silent data loss. Same editor config, same input — the only thing that changes is that an unrelated editor mounted in between:

```ts
const B = [Document, Paragraph, Text, BulletList, ListItem]        // no TaskList
const A = [Document, Paragraph, Text, BulletList, ListItem, TaskList, TaskItem]

new MarkdownManager({ extensions: B }).parse('- [ ] buy milk')
// { doc, content: [ bulletList: [ "buy milk" ] ] }     correct

new MarkdownManager({ extensions: A })                  // another editor mounts

new MarkdownManager({ extensions: B }).parse('- [ ] buy milk')
// { "type": "doc", "content": [] }                     content gone
```

B now emits `taskList` tokens it has no handler for, so the document is dropped. It depends on mount order, so it presents as intermittent.

Two other consequences of the same cause: parsing gets permanently slower as editors are created (11.8x on a fixed 21KB document after 32 managers, measurements in the issue), and `markedOptions` mutates global `marked.defaults` for the whole process, because it is applied as `this.markedInstance.setOptions(...)`.

## The fix

```diff
-    this.markedInstance = options?.marked ?? marked
+    this.markedInstance = options?.marked ?? new Marked()
```

The `marked` option is unchanged in behaviour — pass an instance and it is still used verbatim. Only the default moves from the shared singleton to a private one.

I also widened the option type from `typeof marked` to `typeof marked | Marked`, exported as `MarkdownMarkedInstance`. Everything the manager touches (`.Lexer`, `.defaults`, `.lexer`, `.use`, `.setOptions`) exists on both, so the cast people currently need is no longer required:

```ts
// before
Markdown.configure({ marked: new Marked() as unknown as typeof marked })
// after
Markdown.configure({ marked: new Marked() })
```

That also resolves the type error reported in #7666.

## Behaviour change

Anyone who configured the global `marked` export and relied on Tiptap picking it up implicitly now has to pass it explicitly:

```ts
import { marked } from 'marked'
marked.use(myPlugin)

Markdown.configure({ marked })   // now required
```

That is why the changeset is a `minor` rather than a `patch`, and the migration line is in it. If you would rather keep the singleton as the default and solve this another way, say so and I will rework it — the issue has the measurements either way.

## Tests

`packages/markdown/tests/integration/marked-instance-isolation.test.ts`, four cases: cross-manager isolation, no registration on the singleton, `markedOptions` not leaking globally, and an injected instance still being honoured.

Reverting the source change fails three of them, with the first showing the data loss directly:

```
× keeps one manager's tokenizers out of another manager
× does not register tokenizers on the marked singleton
× does not let markedOptions leak into the marked singleton

AssertionError: expected { type: 'doc', content: [] } to deeply equal { type: 'doc', content: [ { …(2) } ] }
```

## Verification

- `vp check` — 2043 files formatted, 0 lint errors
- `vp run test:unit` — 201 files, **1976 tests pass**
- `vp run build` — clean
- `vp run -F @tiptap/markdown build` — typechecks with the widened union

One note on `vp run fallow:audit`: it reports complexity findings once this diff touches `MarkdownManager.ts`, but all ten are pre-existing functions (`renderNodesWithMarkBoundaries` at 230 lines, `parseInlineTokens`, `parseListToken`) that this change does not touch — the diff there is +19/-5 and none of those functions appear in it. Nothing new is introduced; the file simply enters the audit scope.
